### PR TITLE
fix(kernel): require env:write for Shared-scope env mutations

### DIFF
--- a/changes/1544.security.md
+++ b/changes/1544.security.md
@@ -1,0 +1,1 @@
+Require global `env:write` for `Shared`-scope env/secret admin mutations, so a self-scoped agent cannot write host-wide `system:control:*` namespaces.

--- a/crates/astrid-kernel/src/kernel_router/admin/mod.rs
+++ b/crates/astrid-kernel/src/kernel_router/admin/mod.rs
@@ -67,7 +67,7 @@ use astrid_audit::{AuditOutcome, AuthorizationProof};
 use astrid_core::principal::PrincipalId;
 use astrid_events::ipc::{IpcPayload, Topic};
 use astrid_events::kernel_api::{
-    AdminKernelRequest, AdminKernelResponse, AdminRequestKind, AdminResponseBody,
+    AdminKernelRequest, AdminKernelResponse, AdminRequestKind, AdminResponseBody, EnvStorageScope,
 };
 use tracing::warn;
 
@@ -227,12 +227,32 @@ fn admin_response_topic(input_topic: &str) -> Topic {
 #[must_use]
 pub fn resolve_admin_scope(req: &AdminRequestKind, caller: &PrincipalId) -> AuthorityScope {
     match req {
+        // Host-wide shared env/secret namespaces are not principal-scoped
+        // storage: the `principal` field is ignored for `Shared` writes and
+        // every capsule falls back to `system:control:*` on miss. Require the
+        // global `env:write` form even when the caller names themselves —
+        // otherwise `self:*` (builtin agent) can poison every principal's
+        // shared secret resolution for a capsule.
+        AdminRequestKind::EnvSet {
+            principal,
+            scope,
+            ..
+        }
+        | AdminRequestKind::EnvDelete {
+            principal,
+            scope,
+            ..
+        } => {
+            if *scope == EnvStorageScope::Shared || principal != caller {
+                AuthorityScope::Global
+            } else {
+                AuthorityScope::Self_
+            }
+        }
         AdminRequestKind::QuotaGet { principal }
         | AdminRequestKind::QuotaSet { principal, .. }
         | AdminRequestKind::UsageGet { principal }
-        | AdminRequestKind::EnvSet { principal, .. }
         | AdminRequestKind::EnvList { principal, .. }
-        | AdminRequestKind::EnvDelete { principal, .. }
         | AdminRequestKind::DistroLockGet { principal }
         | AdminRequestKind::DistroLockSet { principal, .. }
         // Device management is self-scoped when the target IS the caller —

--- a/crates/astrid-kernel/src/kernel_router/admin/tests.rs
+++ b/crates/astrid-kernel/src/kernel_router/admin/tests.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use astrid_capabilities::CapabilityCheck;
 use astrid_core::principal::PrincipalId;
 use astrid_core::{GroupConfig, PrincipalProfile};
-use astrid_events::kernel_api::{AdminRequestKind, PairScopeArg};
+use astrid_events::kernel_api::{AdminRequestKind, EnvStorageScope, EnvValueKind, PairScopeArg};
 
 use super::{
     AuthorityScope, admin_request_method, admin_response_topic, admin_target_principal,
@@ -231,6 +231,68 @@ fn resolve_admin_scope_global_when_target_differs() {
         quotas: astrid_core::profile::Quotas::default(),
     };
     assert_eq!(resolve_admin_scope(&req, &caller), AuthorityScope::Global);
+}
+
+#[test]
+fn shared_env_mutations_are_always_global_authority() {
+    let caller = pid("alice");
+    let shared_set = AdminRequestKind::EnvSet {
+        principal: caller.clone(),
+        capsule: "provider".into(),
+        key: "api_key".into(),
+        value: "secret".into(),
+        kind: EnvValueKind::Secret,
+        scope: EnvStorageScope::Shared,
+        append: false,
+    };
+    let shared_delete = AdminRequestKind::EnvDelete {
+        principal: caller.clone(),
+        capsule: "provider".into(),
+        key: "api_key".into(),
+        kind: EnvValueKind::Secret,
+        scope: EnvStorageScope::Shared,
+    };
+    let agent_set = AdminRequestKind::EnvSet {
+        principal: caller.clone(),
+        capsule: "provider".into(),
+        key: "api_key".into(),
+        value: "secret".into(),
+        kind: EnvValueKind::Secret,
+        scope: EnvStorageScope::Agent,
+        append: false,
+    };
+
+    assert_eq!(
+        resolve_admin_scope(&shared_set, &caller),
+        AuthorityScope::Global,
+        "Shared env write is host-wide even when principal == caller"
+    );
+    assert_eq!(
+        resolve_admin_scope(&shared_delete, &caller),
+        AuthorityScope::Global,
+        "Shared env delete is host-wide even when principal == caller"
+    );
+    assert_eq!(
+        resolve_admin_scope(&agent_set, &caller),
+        AuthorityScope::Self_,
+        "Agent-scoped env write stays self when principal == caller"
+    );
+    assert_eq!(
+        required_capability_for_admin_request(&shared_set, AuthorityScope::Global),
+        "env:write"
+    );
+    assert!(!authorize_with(
+        &agent_profile(),
+        &GroupConfig::builtin_only(),
+        &caller,
+        "env:write"
+    ));
+    assert!(authorize_with(
+        &agent_profile(),
+        &GroupConfig::builtin_only(),
+        &caller,
+        "self:env:write"
+    ));
 }
 
 #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Linked Issue

Closes #1544

This lands one public-runtime hardening item from the adversarial audit: Shared-scope env/secret mutations must require global `env:write`. Remaining #1544 sub-issues are tracked separately (#1545–#1552).

## Summary

Host-wide `EnvStorageScope::Shared` namespaces are not principal-private storage. The kernel previously treated `EnvSet`/`EnvDelete` as self-scoped whenever the caller named themselves, so a builtin `self:*` agent could write `system:control:*` secrets that every principal's capsule resolution falls back to.

This change gates Shared-scope env mutations on global `env:write`. Agent-scoped self writes stay on `self:env:write`.

## Changes

- Resolve `EnvSet`/`EnvDelete` with `EnvStorageScope::Shared` as `AuthorityScope::Global`, even when `principal == caller`.
- Keep Agent-scoped env writes self-scoped when the caller targets themselves.
- Add a regression test that builtin agent profiles cannot authorize Shared writes and still can authorize `self:env:write`.
- Changelog fragment: `changes/1544.security.md`.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p astrid-kernel --lib shared_env_mutations --locked`
- `cargo clippy -p astrid-kernel --locked --all-targets -- -D warnings`

## AI / Tool Assistance

Assisted-by: Cursor Grok 4.6

Cursor drafted the Shared-scope authority gate, the regression test, rustfmt/clippy cleanups, and this PR template. I reviewed that Shared writes require `env:write`, Agent-scoped self writes remain `self:env:write`, and the previous dedicated Shared match arm is gone so `clippy::match_same_arms` does not fire.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/1544.security.md`
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-559fc40c-f4e0-4341-8d04-dee0e9946131?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-559fc40c-f4e0-4341-8d04-dee0e9946131&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

