### PR TITLE
ci(kernel): check semantic crates on AArch64 and RISC-V

### DIFF
--- a/.github/workflows/native-kernel.yml
+++ b/.github/workflows/native-kernel.yml
@@ -56,7 +56,35 @@ jobs:
         working-directory: kernel
         run: |
           rustup show
-          ./check.sh
+          ./check.sh x86
+
+  semantic-portability:
+    name: Compile-only semantic targets (AArch64 + RISC-V)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install stable Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: "1.95.0"
+          targets: x86_64-unknown-none,aarch64-unknown-none,riscv64gc-unknown-none-elf
+          components: rust-src, clippy, rustfmt
+
+      - name: Run compile-only portability checks
+        working-directory: kernel
+        run: |
+          rustup show
+          ./check.sh portability
 
   qemu-tcg:
     name: QEMU TCG boot (emulator evidence only)

--- a/.github/workflows/native-kernel.yml
+++ b/.github/workflows/native-kernel.yml
@@ -1,5 +1,5 @@
 name: Native kernel
-run-name: Native kernel (TCG emulator evidence only)
+run-name: Native kernel (split checks, compile-only semantic targets, TCG emulator evidence)
 
 on:
   pull_request:

--- a/changes/1564.fixed.md
+++ b/changes/1564.fixed.md
@@ -34,6 +34,8 @@ Bounded native init/recovery now lives in `astrid-init-plan`. Every driver
 invocation including compensating stop() consumes the same step() budget, a
 private StartedMask owns started-bit capacity, and recover(fresh) tears down
 before replacement without exceeding the per-run bound. Refs #1564
+Semantic crates now run compile-only check/clippy on `aarch64-unknown-none` and
+`riscv64gc-unknown-none-elf`. Refs #1564
 
 Trusted first boot now packs the canonical 1282-byte `[ASTRIDPH][ASTRIDDC][ASTRIDSG]`
 ramdisk. The loader requires the exact length and binds `ASTRIDDC`'s signed

--- a/kernel/.cargo/config.toml
+++ b/kernel/.cargo/config.toml
@@ -1,8 +1,5 @@
 # Ring-0 builds pin curve25519-dalek's serial backend explicitly. SIMD cannot
 # activate on these arches; this is a code-generation choice, not a crypto
 # claim.
-[target.x86_64-unknown-none]
-rustflags = ['--cfg', 'curve25519_dalek_backend="serial"']
-
 [target.'cfg(all(target_os = "none", any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "riscv64")))']
 rustflags = ['--cfg', 'curve25519_dalek_backend="serial"']

--- a/kernel/.cargo/config.toml
+++ b/kernel/.cargo/config.toml
@@ -1,5 +1,8 @@
-# Fiat/serial backends keep ring-0 Ed25519 off the x86 SIMD codegen path.
-# SIMD curve25519-dalek is a compile-time hazard on this host and is not an
-# M1 or dual-closure claim.
+# Ring-0 builds pin curve25519-dalek's serial backend explicitly. SIMD cannot
+# activate on these arches; this is a code-generation choice, not a crypto
+# claim.
 [target.x86_64-unknown-none]
+rustflags = ['--cfg', 'curve25519_dalek_backend="serial"']
+
+[target.'cfg(all(target_os = "none", any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "riscv64")))']
 rustflags = ['--cfg', 'curve25519_dalek_backend="serial"']

--- a/kernel/README.md
+++ b/kernel/README.md
@@ -191,6 +191,7 @@ the non-claims above.
 Pinned to stable Rust 1.95.0. Interrupt handlers use stable naked-function
 ISR stubs via `x86_64`'s `Entry::set_handler_addr`.
 
-`x86_64-unknown-none` builds set `curve25519_dalek_backend="serial"` so
-ring-0 Ed25519 does not take the x86 SIMD codegen path. That is a compile
-choice, not a cryptography or timing claim.
+`x86_64-unknown-none`, `aarch64-unknown-none`, and
+`riscv64gc-unknown-none-elf` builds set
+`curve25519_dalek_backend="serial"`. SIMD cannot activate on the AArch64 and
+RISC-V arches; this is a compile choice, not a crypto claim.

--- a/kernel/check.sh
+++ b/kernel/check.sh
@@ -42,10 +42,6 @@ require_target() {
 run_portability() {
   local target spec package feature_spec
   local -a package_args
-  local -a required_targets=(
-    "aarch64-unknown-none"
-    "riscv64gc-unknown-none-elf"
-  )
   local -a targets=(
     "aarch64-unknown-none"
     "riscv64gc-unknown-none-elf"
@@ -57,11 +53,8 @@ run_portability() {
     "astrid-init-plan|"
   )
 
-  for target in "${required_targets[@]}"; do
-    require_target "$target"
-  done
-
   for target in "${targets[@]}"; do
+    require_target "$target"
     for spec in "${packages[@]}"; do
       package="${spec%%|*}"
       feature_spec="${spec#*|}"

--- a/kernel/check.sh
+++ b/kernel/check.sh
@@ -11,6 +11,91 @@ toolchain="${KTEST_TOOLCHAIN:-nightly-2026-07-21}"
 host="$root/target/kimage-host"
 nested="$root/target/bootloader-nested"
 
+mode="${1:-all}"
+if [[ $# -gt 1 ]]; then
+  echo "usage: $0 [x86|portability]" >&2
+  exit 2
+fi
+
+require_target() {
+  local target="$1"
+  local cfg installed_targets installed_target
+  if ! cfg="$(rustc --print cfg --target "$target" 2>&1)"; then
+    echo "check.sh: required target $target is not recognized by the active rustc" >&2
+    echo "$cfg" >&2
+    exit 1
+  fi
+  if ! installed_targets="$(rustup target list --installed 2>&1)"; then
+    echo "check.sh: unable to query installed Rust targets" >&2
+    echo "$installed_targets" >&2
+    exit 1
+  fi
+  while IFS= read -r installed_target; do
+    if [[ "$installed_target" == "$target" ]]; then
+      return 0
+    fi
+  done <<< "$installed_targets"
+  echo "check.sh: required target $target is missing; install it with 'rustup target add $target'" >&2
+  exit 1
+}
+
+run_portability() {
+  local target spec package feature_spec
+  local -a package_args
+  local -a required_targets=(
+    "x86_64-unknown-none"
+    "aarch64-unknown-none"
+    "riscv64gc-unknown-none-elf"
+  )
+  local -a targets=(
+    "aarch64-unknown-none"
+    "riscv64gc-unknown-none-elf"
+  )
+  local -a packages=(
+    "astrid-native-closure|--no-default-features"
+    "astrid-system-generation|--no-default-features"
+    "astrid-boot-selection|--no-default-features"
+    "astrid-init-plan|"
+  )
+
+  for target in "${required_targets[@]}"; do
+    require_target "$target"
+  done
+
+  for target in "${targets[@]}"; do
+    for spec in "${packages[@]}"; do
+      package="${spec%%|*}"
+      feature_spec="${spec#*|}"
+      package_args=(-p "$package")
+      if [[ -n "$feature_spec" ]]; then
+        package_args+=(--no-default-features)
+      fi
+
+      echo "== stable cargo check -p $package ${feature_spec:+$feature_spec }--target $target (compile-only) =="
+      cargo check "${package_args[@]}" --target "$target" --locked
+
+      echo "== stable cargo clippy -p $package ${feature_spec:+$feature_spec }--target $target (compile-only) =="
+      cargo clippy "${package_args[@]}" --target "$target" --locked -- -D warnings
+    done
+  done
+
+  echo "check.sh: PASS (compile-only portability checks; not boot or hardware evidence)"
+}
+
+case "$mode" in
+  x86|all)
+    require_target "x86_64-unknown-none"
+    ;;
+  portability)
+    run_portability
+    exit 0
+    ;;
+  *)
+    echo "usage: $0 [x86|portability]" >&2
+    exit 2
+    ;;
+esac
+
 echo "== cargo fmt (kernel packages; vendored bootloader uses its own pinned toolchain) =="
 cargo fmt -p astrid-native-closure -p astrid-native-kernel -p astrid-boot-selection -p astrid-init-plan -p astrid-system-generation -p kimage -p ktest -- --check
 
@@ -80,3 +165,7 @@ env -u CARGO_BUILD_TARGET_DIR \
   rustup run "$toolchain" cargo clippy -p kimage --all-targets --locked --target-dir "$host" -- -D warnings
 
 echo "check.sh: PASS (split checks only; not workspace clippy)"
+
+if [[ "$mode" == all ]]; then
+  run_portability
+fi

--- a/kernel/check.sh
+++ b/kernel/check.sh
@@ -13,7 +13,7 @@ nested="$root/target/bootloader-nested"
 
 mode="${1:-all}"
 if [[ $# -gt 1 ]]; then
-  echo "usage: $0 [x86|portability]" >&2
+  echo "usage: $0 [x86|portability|all]" >&2
   exit 2
 fi
 
@@ -43,7 +43,6 @@ run_portability() {
   local target spec package feature_spec
   local -a package_args
   local -a required_targets=(
-    "x86_64-unknown-none"
     "aarch64-unknown-none"
     "riscv64gc-unknown-none-elf"
   )
@@ -91,7 +90,7 @@ case "$mode" in
     exit 0
     ;;
   *)
-    echo "usage: $0 [x86|portability]" >&2
+    echo "usage: $0 [x86|portability|all]" >&2
     exit 2
     ;;
 esac

--- a/kernel/rust-toolchain.toml
+++ b/kernel/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "1.95.0"
-targets = ["x86_64-unknown-none"]
+targets = ["x86_64-unknown-none", "aarch64-unknown-none", "riscv64gc-unknown-none-elf"]
 components = ["rust-src", "clippy", "rustfmt"]

--- a/kernel/rust-toolchain.toml
+++ b/kernel/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "1.95.0"
-targets = ["x86_64-unknown-none", "aarch64-unknown-none", "riscv64gc-unknown-none-elf"]
+targets = ["x86_64-unknown-none"]
 components = ["rust-src", "clippy", "rustfmt"]


### PR DESCRIPTION
## Linked Issue

Tracking #1667. Refs #1564.

## Summary

Adds compile-only `cargo check` and strict `clippy -D warnings` coverage for the four kernel semantic crates (`astrid-native-closure`, `astrid-system-generation`, `astrid-boot-selection`, `astrid-init-plan`) on exact compiler targets `aarch64-unknown-none` and `riscv64gc-unknown-none-elf`, in addition to the existing x86_64 split checks.

A distinct Native kernel job named **Compile-only semantic targets (AArch64 + RISC-V)** installs the three bare-metal targets that job uses and runs `./check.sh portability`. Existing `split-checks` continue to run `./check.sh x86` and install only `x86_64-unknown-none`. The QEMU TCG job remains emulator-evidence-only, installs only `x86_64-unknown-none`, and is not a non-x86 boot or hardware proof.

`kernel/rust-toolchain.toml` lists only `x86_64-unknown-none`, so jobs whose working directory is `kernel/` do not auto-install AArch64 or RISC-V. Semantic crate sources and native-kernel/bootloader sources are unchanged.

Dalek serial backend policy is a single `target_os = "none"` family cfg covering the three exact triples.

This is compiler-target check/clippy evidence only. It does not establish native-kernel boot, firmware, hardware, RV64I conformance, QEMU-virt, KVM, or physical-machine support on AArch64 or RISC-V.

Campaign text is retained in the modified existing `changes/1564.fixed.md`. Local exact-head changelog check against `0bb7ba1c` sees a modified fragment, not a newly added issue/kind, so `skip-changelog` applies.

## Changes

- `kernel/check.sh`: `x86|portability|all` modes; 4 crates × 2 added targets × `{check,clippy}`; x86 matrix retained; portability uses one `targets` array and requires each target immediately before compiling it
- `kernel/rust-toolchain.toml`: `targets` lists only `x86_64-unknown-none`
- `kernel/.cargo/config.toml`: one family serial cfg for the three `none` triples
- `.github/workflows/native-kernel.yml`: compile-only semantic job; run-name covers split checks, compile-only semantic targets, and TCG emulator evidence
- `kernel/README.md` and `changes/1564.fixed.md`: compile/check wording only

## Verification

- exact head `b4e5c1063714737beb6e28718033a2a5d5953d23` (parent `ff1c36d8cac17d8bdcfbd7f3216a860b33fa3422`)
- GPG Good (`FA53358CB4127512`) + DCO `Signed-off-by: Joshua J. Bouw <jjb@unicity-labs.com>`
- exact-head review ACCEPT on `b4e5c106` (astrid-quality; no P0–P3)
- isolated rustup in a throwaway home: `kernel/rust-toolchain.toml` installs only host + x86; does not auto-install `aarch64-unknown-none` or `riscv64gc-unknown-none-elf`
- missing AArch64/RISC-V: `./check.sh portability` fail-closed with install hint
- `./check.sh portability` with both targets present: 16/16 check+clippy cells
- `./check.sh x86`: existing split path retained; requires only x86
- no `cargo test` on no_std targets

## AI / Tool Assistance

Assisted-by: Codex:gpt-5.6-luna

Implementation is CI/check-script and workflow target lists. Reviewed against issue #1667 (compile/check coverage plus each job installs only the targets it uses) and validated with `./check.sh portability` and `./check.sh x86`.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/{issue}.{kind}.md` (docs/CI-only may skip; release PRs roll fragments into the version section instead of adding one)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
