### PR TITLE
feat: add private ActionDescriptor projection contract

### DIFF
--- a/changes/1661.added.md
+++ b/changes/1661.added.md
@@ -1,6 +1,6 @@
 Add a private, non-authoritative `ActionDescriptor` projection contract. The
-fixed descriptor binds an opaque action digest, projection revision, scope,
-principal, generation, and expiry; independent consumers can check the same
-eligibility without obtaining a handle or lease. Stale, substituted,
-cross-principal, drifted, expired, and presentation-forged observations fail
-closed. Tracking #1661
+fixed descriptor binds a typed `SemanticObjectId`, opaque action digest,
+projection revision, scope, principal, generation, and expiry; independent
+consumers can check the same object-bound eligibility without obtaining a
+handle or lease. Stale, substituted, cross-object, cross-principal, drifted,
+expired, and presentation-forged observations fail closed. Tracking #1661

--- a/changes/1661.added.md
+++ b/changes/1661.added.md
@@ -1,0 +1,6 @@
+Add a private, non-authoritative `ActionDescriptor` projection contract. The
+fixed descriptor binds an opaque action digest, projection revision, scope,
+principal, generation, and expiry; independent consumers can check the same
+eligibility without obtaining a handle or lease. Stale, substituted,
+cross-principal, drifted, expired, and presentation-forged observations fail
+closed. Tracking #1661

--- a/crates/astrid-projection/src/action_descriptor.rs
+++ b/crates/astrid-projection/src/action_descriptor.rs
@@ -128,7 +128,7 @@ impl fmt::Debug for ActionGeneration {
 ///
 /// The projection crate does not read a clock. A host supplies this value as
 /// part of an observation context, so tests and consumers remain deterministic.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ActionExpiry(u64);
 
 impl ActionExpiry {
@@ -154,6 +154,13 @@ impl ActionExpiry {
 impl From<u64> for ActionExpiry {
     fn from(raw: u64) -> Self {
         Self::from_raw(raw)
+    }
+}
+
+impl fmt::Debug for ActionExpiry {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let _ = self;
+        formatter.write_str("ActionExpiry")
     }
 }
 
@@ -557,10 +564,7 @@ impl ActionDescriptor {
             ActionEligibility::CrossPrincipal => Err(ProjectionError::ActionCrossPrincipal),
             ActionEligibility::ObjectMismatch => Err(ProjectionError::ActionObjectMismatch),
             ActionEligibility::DigestMismatch => Err(ProjectionError::ActionDigestMismatch),
-            ActionEligibility::StaleRevision => Err(ProjectionError::StaleRevision {
-                found: self.revision.get(),
-                requested: observation.revision.get(),
-            }),
+            ActionEligibility::StaleRevision => Err(ProjectionError::ActionStaleRevision),
             ActionEligibility::ScopeMismatch => Err(ProjectionError::ActionScopeMismatch),
             ActionEligibility::GenerationDrift => Err(ProjectionError::ActionGenerationDrift),
             ActionEligibility::Expired => Err(ProjectionError::ActionExpired),

--- a/crates/astrid-projection/src/action_descriptor.rs
+++ b/crates/astrid-projection/src/action_descriptor.rs
@@ -1,0 +1,789 @@
+//! Private, non-authoritative action eligibility descriptors.
+//!
+//! [`ActionDescriptor`] binds an opaque action digest to one projection
+//! revision, scope, principal, generation, and expiry. It is an observation
+//! contract only: it has no handle, lease, issuer, refresh operation, or path
+//! to a live invocation. A caller must supply the current observation context
+//! to [`ActionDescriptor::eligibility`]; presentation labels and metadata are
+//! deliberately absent from that context.
+
+use core::fmt;
+use core::num::NonZeroU64;
+
+use crate::encoding::{
+    DescriptorDecode, DescriptorEncode, ProjectionTypeTag, check_header, write_header,
+};
+use crate::error::ProjectionError;
+use crate::revision::ProjectionRevision;
+
+/// Width of an opaque action binding value.
+pub const ACTION_BINDING_BYTES: usize = 32;
+
+/// Exact version-one encoded size of an [`ActionDescriptor`].
+pub const ACTION_DESCRIPTOR_ENCODED_LEN: usize = 126;
+
+macro_rules! opaque_binding {
+    ($(#[$meta:meta])* $name:ident, $debug:literal) => {
+        $(#[$meta])*
+        #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        pub struct $name([u8; ACTION_BINDING_BYTES]);
+
+        impl $name {
+            /// Construct the binding from its exact opaque bytes.
+            #[must_use]
+            pub const fn from_bytes(bytes: [u8; ACTION_BINDING_BYTES]) -> Self {
+                Self(bytes)
+            }
+
+            /// Borrow the exact opaque bytes without interpreting them.
+            #[must_use]
+            pub const fn as_bytes(&self) -> &[u8; ACTION_BINDING_BYTES] {
+                &self.0
+            }
+        }
+
+        impl From<[u8; ACTION_BINDING_BYTES]> for $name {
+            fn from(bytes: [u8; ACTION_BINDING_BYTES]) -> Self {
+                Self::from_bytes(bytes)
+            }
+        }
+
+        impl fmt::Debug for $name {
+            fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                let _ = self;
+                formatter.write_str($debug)
+            }
+        }
+    };
+}
+
+opaque_binding!(
+    /// Opaque digest of the action arguments and target.
+    ActionDigest,
+    "ActionDigest"
+);
+
+opaque_binding!(
+    /// Opaque scope binding for one action observation domain.
+    ActionScope,
+    "ActionScope"
+);
+
+opaque_binding!(
+    /// Opaque principal binding. It is descriptive identity, not authority.
+    ActionPrincipal,
+    "ActionPrincipal"
+);
+
+/// Non-zero incarnation generation bound into an action descriptor.
+///
+/// This is a projection-local generation domain. It must not be confused with
+/// an authority table generation, provider generation, or lifecycle counter.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ActionGeneration(NonZeroU64);
+
+impl ActionGeneration {
+    /// First valid generation.
+    pub const INITIAL: Self = Self(NonZeroU64::MIN);
+
+    /// Construct a non-zero generation.
+    #[must_use]
+    pub const fn from_raw(raw: u64) -> Option<Self> {
+        match NonZeroU64::new(raw) {
+            Some(value) => Some(Self(value)),
+            None => None,
+        }
+    }
+
+    /// Return the raw generation value.
+    #[must_use]
+    pub const fn get(self) -> u64 {
+        self.0.get()
+    }
+
+    /// Return the next generation without wrapping.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProjectionError::ExhaustedRevision`] at `u64::MAX` so this
+    /// private domain has the same no-wrap invariant as projection revisions.
+    pub fn checked_next(self) -> Result<Self, ProjectionError> {
+        self.get()
+            .checked_add(1)
+            .and_then(Self::from_raw)
+            .ok_or(ProjectionError::ExhaustedRevision)
+    }
+}
+
+impl fmt::Debug for ActionGeneration {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let _ = self;
+        formatter.write_str("ActionGeneration")
+    }
+}
+
+/// Observation time used when checking descriptor expiry.
+///
+/// The projection crate does not read a clock. A host supplies this value as
+/// part of an observation context, so tests and consumers remain deterministic.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ActionExpiry(u64);
+
+impl ActionExpiry {
+    /// Construct an expiry at the supplied monotonic observation tick.
+    #[must_use]
+    pub const fn from_raw(raw: u64) -> Self {
+        Self(raw)
+    }
+
+    /// Return the raw expiry tick.
+    #[must_use]
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+
+    /// Whether an observation at `now` is at or after expiry.
+    #[must_use]
+    pub const fn is_expired_at(self, now: u64) -> bool {
+        now >= self.0
+    }
+}
+
+impl From<u64> for ActionExpiry {
+    fn from(raw: u64) -> Self {
+        Self::from_raw(raw)
+    }
+}
+
+/// Current context supplied by a non-authoritative consumer.
+///
+/// Every field is required. There is no default context and no method that
+/// derives one from presentation text, so omission or substitution fails
+/// closed at the descriptor boundary.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ActionObservation {
+    digest: ActionDigest,
+    revision: ProjectionRevision,
+    scope: ActionScope,
+    generation: ActionGeneration,
+    principal: ActionPrincipal,
+    now: u64,
+}
+
+impl ActionObservation {
+    /// Bind an observation to all descriptor-controlled identity facts.
+    #[must_use]
+    pub const fn new(
+        digest: ActionDigest,
+        revision: ProjectionRevision,
+        scope: ActionScope,
+        generation: ActionGeneration,
+        principal: ActionPrincipal,
+        now: u64,
+    ) -> Self {
+        Self {
+            digest,
+            revision,
+            scope,
+            generation,
+            principal,
+            now,
+        }
+    }
+
+    /// Alternate constructor with principal first for call sites that resolve
+    /// caller identity before the projected action fields.
+    #[must_use]
+    pub const fn for_principal(
+        principal: ActionPrincipal,
+        digest: ActionDigest,
+        revision: ProjectionRevision,
+        scope: ActionScope,
+        generation: ActionGeneration,
+        now: u64,
+    ) -> Self {
+        Self::new(digest, revision, scope, generation, principal, now)
+    }
+
+    /// Digest observed for the action arguments and target.
+    #[must_use]
+    pub const fn digest(self) -> ActionDigest {
+        self.digest
+    }
+
+    /// Projection revision observed by the consumer.
+    #[must_use]
+    pub const fn revision(self) -> ProjectionRevision {
+        self.revision
+    }
+
+    /// Scope observed by the consumer.
+    #[must_use]
+    pub const fn scope(self) -> ActionScope {
+        self.scope
+    }
+
+    /// Incarnation generation observed by the consumer.
+    #[must_use]
+    pub const fn generation(self) -> ActionGeneration {
+        self.generation
+    }
+
+    /// Principal observed on the current invocation boundary.
+    #[must_use]
+    pub const fn principal(self) -> ActionPrincipal {
+        self.principal
+    }
+
+    /// Monotonic observation tick supplied by the host.
+    #[must_use]
+    pub const fn now(self) -> u64 {
+        self.now
+    }
+}
+
+/// Publicly inspectable, read-only facts carried by an action descriptor.
+///
+/// This is a value snapshot, not a minting request. Its fields remain private
+/// and it has no constructor, refresh, or conversion into a live invocation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ActionDescriptorFacts {
+    digest: ActionDigest,
+    revision: ProjectionRevision,
+    scope: ActionScope,
+    generation: ActionGeneration,
+    expiry: ActionExpiry,
+    principal: ActionPrincipal,
+}
+
+impl ActionDescriptorFacts {
+    /// Opaque action digest.
+    #[must_use]
+    pub const fn digest(self) -> ActionDigest {
+        self.digest
+    }
+
+    /// Bound projection revision.
+    #[must_use]
+    pub const fn revision(self) -> ProjectionRevision {
+        self.revision
+    }
+
+    /// Bound scope.
+    #[must_use]
+    pub const fn scope(self) -> ActionScope {
+        self.scope
+    }
+
+    /// Bound incarnation generation.
+    #[must_use]
+    pub const fn generation(self) -> ActionGeneration {
+        self.generation
+    }
+
+    /// Bound expiry tick.
+    #[must_use]
+    pub const fn expiry(self) -> ActionExpiry {
+        self.expiry
+    }
+
+    /// Bound principal identity.
+    #[must_use]
+    pub const fn principal(self) -> ActionPrincipal {
+        self.principal
+    }
+}
+
+/// Result of comparing a descriptor with a current observation context.
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ActionEligibility {
+    /// Every descriptor binding matched and the observation precedes expiry.
+    Eligible = 1,
+    /// The caller principal differs from the descriptor principal.
+    CrossPrincipal = 2,
+    /// The opaque action digest differs.
+    DigestMismatch = 3,
+    /// The projection revision differs.
+    StaleRevision = 4,
+    /// The scope differs.
+    ScopeMismatch = 5,
+    /// The incarnation generation differs.
+    GenerationDrift = 6,
+    /// The observation is at or after expiry.
+    Expired = 7,
+}
+
+/// Immutable, non-authoritative action description.
+///
+/// The descriptor contains no capability, handle, lease, issuer, or mutable
+/// state. Cloning or decoding it only repeats an observation; eligibility is
+/// recomputed against the caller-supplied context every time.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct ActionDescriptor {
+    digest: ActionDigest,
+    revision: ProjectionRevision,
+    scope: ActionScope,
+    generation: ActionGeneration,
+    expiry: ActionExpiry,
+    principal: ActionPrincipal,
+}
+
+impl fmt::Debug for ActionDescriptor {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let _ = self;
+        formatter.write_str("ActionDescriptor")
+    }
+}
+
+impl ActionDescriptor {
+    /// Bind an action digest to a projection revision, scope, generation,
+    /// expiry, and principal.
+    #[must_use]
+    pub const fn new(
+        digest: ActionDigest,
+        revision: ProjectionRevision,
+        scope: ActionScope,
+        generation: ActionGeneration,
+        expiry: ActionExpiry,
+        principal: ActionPrincipal,
+    ) -> Self {
+        Self {
+            digest,
+            revision,
+            scope,
+            generation,
+            expiry,
+            principal,
+        }
+    }
+
+    /// Bind a descriptor with principal-first argument order.
+    #[must_use]
+    pub const fn for_principal(
+        principal: ActionPrincipal,
+        digest: ActionDigest,
+        revision: ProjectionRevision,
+        scope: ActionScope,
+        generation: ActionGeneration,
+        expiry: ActionExpiry,
+    ) -> Self {
+        Self::new(digest, revision, scope, generation, expiry, principal)
+    }
+
+    /// Opaque action digest bound into this descriptor.
+    #[must_use]
+    pub const fn digest(self) -> ActionDigest {
+        self.digest
+    }
+
+    /// Projection revision bound into this descriptor.
+    #[must_use]
+    pub const fn revision(self) -> ProjectionRevision {
+        self.revision
+    }
+
+    /// Scope bound into this descriptor.
+    #[must_use]
+    pub const fn scope(self) -> ActionScope {
+        self.scope
+    }
+
+    /// Incarnation generation bound into this descriptor.
+    #[must_use]
+    pub const fn generation(self) -> ActionGeneration {
+        self.generation
+    }
+
+    /// Expiry tick bound into this descriptor.
+    #[must_use]
+    pub const fn expiry(self) -> ActionExpiry {
+        self.expiry
+    }
+
+    /// Principal identity bound into this descriptor.
+    #[must_use]
+    pub const fn principal(self) -> ActionPrincipal {
+        self.principal
+    }
+
+    /// Return a read-only copy of every descriptor fact.
+    #[must_use]
+    pub const fn facts(self) -> ActionDescriptorFacts {
+        ActionDescriptorFacts {
+            digest: self.digest,
+            revision: self.revision,
+            scope: self.scope,
+            generation: self.generation,
+            expiry: self.expiry,
+            principal: self.principal,
+        }
+    }
+
+    /// Compare this descriptor with one current observation context.
+    #[must_use]
+    pub fn eligibility(&self, observation: &ActionObservation) -> ActionEligibility {
+        if self.principal != observation.principal {
+            return ActionEligibility::CrossPrincipal;
+        }
+        if self.digest != observation.digest {
+            return ActionEligibility::DigestMismatch;
+        }
+        if self.revision != observation.revision {
+            return ActionEligibility::StaleRevision;
+        }
+        if self.scope != observation.scope {
+            return ActionEligibility::ScopeMismatch;
+        }
+        if self.generation != observation.generation {
+            return ActionEligibility::GenerationDrift;
+        }
+        if self.expiry.is_expired_at(observation.now) {
+            return ActionEligibility::Expired;
+        }
+        ActionEligibility::Eligible
+    }
+
+    /// Whether one current observation is eligible.
+    #[must_use]
+    pub fn is_eligible(&self, observation: &ActionObservation) -> bool {
+        matches!(self.eligibility(observation), ActionEligibility::Eligible)
+    }
+
+    /// Validate one observation and retain a typed failure reason.
+    ///
+    /// # Errors
+    ///
+    /// Returns a projection error for stale, substituted, expired, or
+    /// cross-principal observations. Presentation values are not consulted.
+    pub fn check(&self, observation: &ActionObservation) -> Result<(), ProjectionError> {
+        match self.eligibility(observation) {
+            ActionEligibility::Eligible => Ok(()),
+            ActionEligibility::CrossPrincipal => Err(ProjectionError::ActionCrossPrincipal),
+            ActionEligibility::DigestMismatch => Err(ProjectionError::ActionDigestMismatch),
+            ActionEligibility::StaleRevision => Err(ProjectionError::StaleRevision {
+                found: self.revision.get(),
+                requested: observation.revision.get(),
+            }),
+            ActionEligibility::ScopeMismatch => Err(ProjectionError::ActionScopeMismatch),
+            ActionEligibility::GenerationDrift => Err(ProjectionError::ActionGenerationDrift),
+            ActionEligibility::Expired => Err(ProjectionError::ActionExpired),
+        }
+    }
+}
+
+impl DescriptorEncode for ActionDescriptor {
+    fn encoded_len(&self) -> usize {
+        ACTION_DESCRIPTOR_ENCODED_LEN
+    }
+
+    fn encode_descriptor(&self, output: &mut [u8]) -> Result<(), ProjectionError> {
+        if output.len() != ACTION_DESCRIPTOR_ENCODED_LEN {
+            return Err(ProjectionError::InvalidLength);
+        }
+        write_header(output, ProjectionTypeTag::ActionDescriptor)?;
+        output[3..35].copy_from_slice(self.digest.as_bytes());
+        self.revision.encode_descriptor(&mut output[35..46])?;
+        output[46..78].copy_from_slice(self.scope.as_bytes());
+        output[78..86].copy_from_slice(&self.generation.get().to_le_bytes());
+        output[86..94].copy_from_slice(&self.expiry.get().to_le_bytes());
+        output[94..126].copy_from_slice(self.principal.as_bytes());
+        Ok(())
+    }
+}
+
+impl DescriptorDecode for ActionDescriptor {
+    fn decode_descriptor(input: &[u8]) -> Result<Self, ProjectionError> {
+        if input.len() != ACTION_DESCRIPTOR_ENCODED_LEN {
+            return Err(ProjectionError::InvalidLength);
+        }
+        check_header(input, ProjectionTypeTag::ActionDescriptor)?;
+
+        let mut digest = [0_u8; ACTION_BINDING_BYTES];
+        digest.copy_from_slice(&input[3..35]);
+        let revision = ProjectionRevision::decode_descriptor(&input[35..46])?;
+        let mut scope = [0_u8; ACTION_BINDING_BYTES];
+        scope.copy_from_slice(&input[46..78]);
+        let generation_raw = u64::from_le_bytes(
+            input[78..86]
+                .try_into()
+                .map_err(|_| ProjectionError::InvalidLength)?,
+        );
+        let generation = ActionGeneration::from_raw(generation_raw)
+            .ok_or(ProjectionError::InvalidActionGeneration)?;
+        let expiry = ActionExpiry::from_raw(u64::from_le_bytes(
+            input[86..94]
+                .try_into()
+                .map_err(|_| ProjectionError::InvalidLength)?,
+        ));
+        let mut principal = [0_u8; ACTION_BINDING_BYTES];
+        principal.copy_from_slice(&input[94..126]);
+        Ok(Self::new(
+            ActionDigest::from_bytes(digest),
+            revision,
+            ActionScope::from_bytes(scope),
+            generation,
+            expiry,
+            ActionPrincipal::from_bytes(principal),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate alloc;
+
+    use super::*;
+    use crate::presentation::{PresentationLabel, PresentationMetadata};
+    use crate::snapshot::ProjectionSnapshot;
+    use alloc::string::ToString;
+    use astrid_resource_types::{ResourceId, ResourceTypeId};
+
+    fn descriptor() -> ActionDescriptor {
+        ActionDescriptor::new(
+            ActionDigest::from_bytes([0x11; ACTION_BINDING_BYTES]),
+            ProjectionRevision::from_raw(7).unwrap(),
+            ActionScope::from_bytes([0x22; ACTION_BINDING_BYTES]),
+            ActionGeneration::from_raw(3).unwrap(),
+            ActionExpiry::from_raw(100),
+            ActionPrincipal::from_bytes([0x33; ACTION_BINDING_BYTES]),
+        )
+    }
+
+    fn observation() -> ActionObservation {
+        ActionObservation::new(
+            ActionDigest::from_bytes([0x11; ACTION_BINDING_BYTES]),
+            ProjectionRevision::from_raw(7).unwrap(),
+            ActionScope::from_bytes([0x22; ACTION_BINDING_BYTES]),
+            ActionGeneration::from_raw(3).unwrap(),
+            ActionPrincipal::from_bytes([0x33; ACTION_BINDING_BYTES]),
+            99,
+        )
+    }
+
+    fn snapshot(label: &[u8], metadata: &PresentationMetadata) -> ProjectionSnapshot {
+        ProjectionSnapshot::new(
+            crate::SemanticObjectId::for_resource(ResourceId::from_bytes([0x44; 32])),
+            ResourceTypeId::from_bytes([0x55; 32]),
+            ProjectionRevision::from_raw(7).unwrap(),
+            PresentationLabel::from_utf8(label).unwrap(),
+            *metadata,
+        )
+    }
+
+    #[test]
+    fn descriptor_roundtrip_is_fixed_and_debug_is_opaque() {
+        let descriptor = descriptor();
+        let mut encoded = [0_u8; ACTION_DESCRIPTOR_ENCODED_LEN];
+        assert_eq!(descriptor.encoded_len(), ACTION_DESCRIPTOR_ENCODED_LEN);
+        descriptor.encode_descriptor(&mut encoded).unwrap();
+        assert_eq!(
+            ActionDescriptor::decode_descriptor(&encoded),
+            Ok(descriptor)
+        );
+        assert_eq!(
+            format_args!("{descriptor:?}").to_string(),
+            "ActionDescriptor"
+        );
+        assert_eq!(
+            ActionDescriptor::decode_descriptor(&encoded[..125]),
+            Err(ProjectionError::InvalidLength)
+        );
+        encoded[78..86].fill(0);
+        assert_eq!(
+            ActionDescriptor::decode_descriptor(&encoded),
+            Err(ProjectionError::InvalidActionGeneration)
+        );
+    }
+
+    #[test]
+    fn descriptor_rejects_stale_expired_drift_and_cross_principal_observations() {
+        let descriptor = descriptor();
+        let honest = observation();
+        assert_eq!(descriptor.eligibility(&honest), ActionEligibility::Eligible);
+        assert!(descriptor.is_eligible(&honest));
+        assert_eq!(descriptor.check(&honest), Ok(()));
+
+        let digest = ActionObservation::new(
+            ActionDigest::from_bytes([0xee; ACTION_BINDING_BYTES]),
+            honest.revision(),
+            honest.scope(),
+            honest.generation(),
+            honest.principal(),
+            honest.now(),
+        );
+        assert_eq!(
+            descriptor.check(&digest),
+            Err(ProjectionError::ActionDigestMismatch)
+        );
+
+        let stale = ActionObservation::new(
+            honest.digest(),
+            ProjectionRevision::from_raw(8).unwrap(),
+            honest.scope(),
+            honest.generation(),
+            honest.principal(),
+            honest.now(),
+        );
+        assert_eq!(
+            descriptor.eligibility(&stale),
+            ActionEligibility::StaleRevision
+        );
+        assert_eq!(
+            descriptor.check(&stale),
+            Err(ProjectionError::StaleRevision {
+                found: 7,
+                requested: 8,
+            })
+        );
+
+        let scope = ActionObservation::new(
+            honest.digest(),
+            honest.revision(),
+            ActionScope::from_bytes([0xef; ACTION_BINDING_BYTES]),
+            honest.generation(),
+            honest.principal(),
+            honest.now(),
+        );
+        assert_eq!(
+            descriptor.check(&scope),
+            Err(ProjectionError::ActionScopeMismatch)
+        );
+
+        let generation = ActionObservation::new(
+            honest.digest(),
+            honest.revision(),
+            honest.scope(),
+            ActionGeneration::from_raw(4).unwrap(),
+            honest.principal(),
+            honest.now(),
+        );
+        assert_eq!(
+            descriptor.check(&generation),
+            Err(ProjectionError::ActionGenerationDrift)
+        );
+
+        let principal = ActionObservation::new(
+            honest.digest(),
+            honest.revision(),
+            honest.scope(),
+            honest.generation(),
+            ActionPrincipal::from_bytes([0xaa; ACTION_BINDING_BYTES]),
+            honest.now(),
+        );
+        assert_eq!(
+            descriptor.check(&principal),
+            Err(ProjectionError::ActionCrossPrincipal)
+        );
+
+        let expired = ActionObservation::new(
+            honest.digest(),
+            honest.revision(),
+            honest.scope(),
+            honest.generation(),
+            honest.principal(),
+            100,
+        );
+        assert_eq!(
+            descriptor.check(&expired),
+            Err(ProjectionError::ActionExpired)
+        );
+    }
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    struct PresenterResult {
+        eligible: bool,
+        label: PresentationLabel,
+        metadata: PresentationMetadata,
+        facts: ActionDescriptorFacts,
+    }
+
+    // This consumer is presentation-shaped: it carries labels and metadata,
+    // and treats descriptor eligibility as an opaque boolean decision.
+    fn presenter_consumer(
+        snapshot: &ProjectionSnapshot,
+        descriptor: &ActionDescriptor,
+        observation: &ActionObservation,
+    ) -> PresenterResult {
+        PresenterResult {
+            eligible: descriptor.is_eligible(observation),
+            label: snapshot.label(),
+            metadata: snapshot.metadata(),
+            facts: descriptor.facts(),
+        }
+    }
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    struct EligibilityResult {
+        eligible: bool,
+        facts: ActionDescriptorFacts,
+    }
+
+    // This consumer is structurally different: it reads each bound fact and
+    // derives eligibility without consulting presentation values.
+    fn eligibility_consumer(
+        descriptor: &ActionDescriptor,
+        observation: &ActionObservation,
+    ) -> EligibilityResult {
+        let facts = descriptor.facts();
+        let eligible = facts.principal() == observation.principal()
+            && facts.digest() == observation.digest()
+            && facts.revision() == observation.revision()
+            && facts.scope() == observation.scope()
+            && facts.generation() == observation.generation()
+            && !facts.expiry().is_expired_at(observation.now());
+        EligibilityResult { eligible, facts }
+    }
+
+    #[test]
+    fn independent_consumers_agree_and_presentation_cannot_mint_or_widen() {
+        let descriptor = descriptor();
+        let observation = observation();
+        let plain = snapshot(b"safe", &PresentationMetadata::EMPTY);
+        let hostile_metadata = PresentationMetadata::try_from_pairs(&[
+            ("action_handle", "forged"),
+            ("invoke", "true"),
+            ("rights", "root"),
+        ])
+        .unwrap();
+        let hostile = snapshot(b"ADMIN GRANT", &hostile_metadata);
+
+        let first = presenter_consumer(&plain, &descriptor, &observation);
+        let second = eligibility_consumer(&descriptor, &observation);
+        assert!(first.eligible);
+        assert_eq!(first.eligible, second.eligible);
+        assert_eq!(first.facts, second.facts);
+
+        // A malicious presentation changes only display fields; eligibility
+        // and all descriptor facts remain exactly those of the bound action.
+        let hostile_result = presenter_consumer(&hostile, &descriptor, &observation);
+        assert!(hostile_result.eligible);
+        assert_eq!(hostile_result.facts, first.facts);
+        assert_eq!(hostile_result.label.as_str(), "ADMIN GRANT");
+        assert!(
+            hostile_result
+                .metadata
+                .iter()
+                .any(|(key, value)| key == "action_handle" && value == "forged")
+        );
+
+        // A copied descriptor cannot refresh itself after the projection moves
+        // to a new revision; replay fails against the new observation.
+        let replayed = descriptor;
+        let moved = ActionObservation::new(
+            observation.digest(),
+            observation.revision().checked_next().unwrap(),
+            observation.scope(),
+            observation.generation(),
+            observation.principal(),
+            observation.now(),
+        );
+        assert_eq!(
+            replayed.check(&moved),
+            Err(ProjectionError::StaleRevision {
+                found: 7,
+                requested: 8,
+            })
+        );
+    }
+}

--- a/crates/astrid-projection/src/action_descriptor.rs
+++ b/crates/astrid-projection/src/action_descriptor.rs
@@ -1,11 +1,11 @@
 //! Private, non-authoritative action eligibility descriptors.
 //!
-//! [`ActionDescriptor`] binds an opaque action digest to one projection
-//! revision, scope, principal, generation, and expiry. It is an observation
-//! contract only: it has no handle, lease, issuer, refresh operation, or path
-//! to a live invocation. A caller must supply the current observation context
-//! to [`ActionDescriptor::eligibility`]; presentation labels and metadata are
-//! deliberately absent from that context.
+//! [`ActionDescriptor`] binds a [`SemanticObjectId`], opaque action digest,
+//! projection revision, scope, principal, generation, and expiry. It is an
+//! observation contract only: it has no handle, lease, issuer, refresh
+//! operation, or path to a live invocation. A caller must supply the current
+//! object-bound observation context to [`ActionDescriptor::eligibility`];
+//! presentation labels and metadata are deliberately absent from that context.
 
 use core::fmt;
 use core::num::NonZeroU64;
@@ -14,13 +14,15 @@ use crate::encoding::{
     DescriptorDecode, DescriptorEncode, ProjectionTypeTag, check_header, write_header,
 };
 use crate::error::ProjectionError;
+use crate::object::SemanticObjectId;
 use crate::revision::ProjectionRevision;
+use crate::snapshot::ProjectionSnapshot;
 
 /// Width of an opaque action binding value.
 pub const ACTION_BINDING_BYTES: usize = 32;
 
 /// Exact version-one encoded size of an [`ActionDescriptor`].
-pub const ACTION_DESCRIPTOR_ENCODED_LEN: usize = 126;
+pub const ACTION_DESCRIPTOR_ENCODED_LEN: usize = 164;
 
 macro_rules! opaque_binding {
     ($(#[$meta:meta])* $name:ident, $debug:literal) => {
@@ -160,8 +162,9 @@ impl From<u64> for ActionExpiry {
 /// Every field is required. There is no default context and no method that
 /// derives one from presentation text, so omission or substitution fails
 /// closed at the descriptor boundary.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub struct ActionObservation {
+    object: SemanticObjectId,
     digest: ActionDigest,
     revision: ProjectionRevision,
     scope: ActionScope,
@@ -171,9 +174,11 @@ pub struct ActionObservation {
 }
 
 impl ActionObservation {
-    /// Bind an observation to all descriptor-controlled identity facts.
+    /// Bind an observation to one semantic object and all descriptor-controlled
+    /// identity facts.
     #[must_use]
     pub const fn new(
+        object: SemanticObjectId,
         digest: ActionDigest,
         revision: ProjectionRevision,
         scope: ActionScope,
@@ -182,6 +187,7 @@ impl ActionObservation {
         now: u64,
     ) -> Self {
         Self {
+            object,
             digest,
             revision,
             scope,
@@ -196,13 +202,41 @@ impl ActionObservation {
     #[must_use]
     pub const fn for_principal(
         principal: ActionPrincipal,
+        object: SemanticObjectId,
         digest: ActionDigest,
         revision: ProjectionRevision,
         scope: ActionScope,
         generation: ActionGeneration,
         now: u64,
     ) -> Self {
-        Self::new(digest, revision, scope, generation, principal, now)
+        Self::new(object, digest, revision, scope, generation, principal, now)
+    }
+
+    /// Bind an observation directly to a typed projection snapshot.
+    #[must_use]
+    pub const fn for_snapshot(
+        snapshot: ProjectionSnapshot,
+        digest: ActionDigest,
+        scope: ActionScope,
+        generation: ActionGeneration,
+        principal: ActionPrincipal,
+        now: u64,
+    ) -> Self {
+        Self::new(
+            snapshot.object(),
+            digest,
+            snapshot.revision(),
+            scope,
+            generation,
+            principal,
+            now,
+        )
+    }
+
+    /// Semantic object observed at this projection boundary.
+    #[must_use]
+    pub const fn object(self) -> SemanticObjectId {
+        self.object
     }
 
     /// Digest observed for the action arguments and target.
@@ -242,12 +276,20 @@ impl ActionObservation {
     }
 }
 
+impl fmt::Debug for ActionObservation {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let _ = self;
+        formatter.write_str("ActionObservation")
+    }
+}
+
 /// Publicly inspectable, read-only facts carried by an action descriptor.
 ///
 /// This is a value snapshot, not a minting request. Its fields remain private
 /// and it has no constructor, refresh, or conversion into a live invocation.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub struct ActionDescriptorFacts {
+    object: SemanticObjectId,
     digest: ActionDigest,
     revision: ProjectionRevision,
     scope: ActionScope,
@@ -257,6 +299,12 @@ pub struct ActionDescriptorFacts {
 }
 
 impl ActionDescriptorFacts {
+    /// Semantic object bound into this descriptor.
+    #[must_use]
+    pub const fn object(self) -> SemanticObjectId {
+        self.object
+    }
+
     /// Opaque action digest.
     #[must_use]
     pub const fn digest(self) -> ActionDigest {
@@ -294,6 +342,13 @@ impl ActionDescriptorFacts {
     }
 }
 
+impl fmt::Debug for ActionDescriptorFacts {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let _ = self;
+        formatter.write_str("ActionDescriptorFacts")
+    }
+}
+
 /// Result of comparing a descriptor with a current observation context.
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -312,6 +367,8 @@ pub enum ActionEligibility {
     GenerationDrift = 6,
     /// The observation is at or after expiry.
     Expired = 7,
+    /// The semantic object differs.
+    ObjectMismatch = 8,
 }
 
 /// Immutable, non-authoritative action description.
@@ -321,6 +378,7 @@ pub enum ActionEligibility {
 /// recomputed against the caller-supplied context every time.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct ActionDescriptor {
+    object: SemanticObjectId,
     digest: ActionDigest,
     revision: ProjectionRevision,
     scope: ActionScope,
@@ -337,10 +395,11 @@ impl fmt::Debug for ActionDescriptor {
 }
 
 impl ActionDescriptor {
-    /// Bind an action digest to a projection revision, scope, generation,
-    /// expiry, and principal.
+    /// Bind an action digest to one semantic object, projection revision,
+    /// scope, generation, expiry, and principal.
     #[must_use]
     pub const fn new(
+        object: SemanticObjectId,
         digest: ActionDigest,
         revision: ProjectionRevision,
         scope: ActionScope,
@@ -349,6 +408,7 @@ impl ActionDescriptor {
         principal: ActionPrincipal,
     ) -> Self {
         Self {
+            object,
             digest,
             revision,
             scope,
@@ -362,13 +422,43 @@ impl ActionDescriptor {
     #[must_use]
     pub const fn for_principal(
         principal: ActionPrincipal,
+        object: SemanticObjectId,
         digest: ActionDigest,
         revision: ProjectionRevision,
         scope: ActionScope,
         generation: ActionGeneration,
         expiry: ActionExpiry,
     ) -> Self {
-        Self::new(digest, revision, scope, generation, expiry, principal)
+        Self::new(
+            object, digest, revision, scope, generation, expiry, principal,
+        )
+    }
+
+    /// Bind a descriptor directly to a typed projection snapshot.
+    #[must_use]
+    pub const fn for_snapshot(
+        snapshot: ProjectionSnapshot,
+        digest: ActionDigest,
+        scope: ActionScope,
+        generation: ActionGeneration,
+        expiry: ActionExpiry,
+        principal: ActionPrincipal,
+    ) -> Self {
+        Self::new(
+            snapshot.object(),
+            digest,
+            snapshot.revision(),
+            scope,
+            generation,
+            expiry,
+            principal,
+        )
+    }
+
+    /// Semantic object bound into this descriptor.
+    #[must_use]
+    pub const fn object(self) -> SemanticObjectId {
+        self.object
     }
 
     /// Opaque action digest bound into this descriptor.
@@ -411,6 +501,7 @@ impl ActionDescriptor {
     #[must_use]
     pub const fn facts(self) -> ActionDescriptorFacts {
         ActionDescriptorFacts {
+            object: self.object,
             digest: self.digest,
             revision: self.revision,
             scope: self.scope,
@@ -425,6 +516,9 @@ impl ActionDescriptor {
     pub fn eligibility(&self, observation: &ActionObservation) -> ActionEligibility {
         if self.principal != observation.principal {
             return ActionEligibility::CrossPrincipal;
+        }
+        if self.object != observation.object {
+            return ActionEligibility::ObjectMismatch;
         }
         if self.digest != observation.digest {
             return ActionEligibility::DigestMismatch;
@@ -454,12 +548,14 @@ impl ActionDescriptor {
     ///
     /// # Errors
     ///
-    /// Returns a projection error for stale, substituted, expired, or
-    /// cross-principal observations. Presentation values are not consulted.
+    /// Returns a projection error for stale, substituted, expired,
+    /// cross-object, or cross-principal observations. Presentation values are
+    /// not consulted.
     pub fn check(&self, observation: &ActionObservation) -> Result<(), ProjectionError> {
         match self.eligibility(observation) {
             ActionEligibility::Eligible => Ok(()),
             ActionEligibility::CrossPrincipal => Err(ProjectionError::ActionCrossPrincipal),
+            ActionEligibility::ObjectMismatch => Err(ProjectionError::ActionObjectMismatch),
             ActionEligibility::DigestMismatch => Err(ProjectionError::ActionDigestMismatch),
             ActionEligibility::StaleRevision => Err(ProjectionError::StaleRevision {
                 found: self.revision.get(),
@@ -482,12 +578,13 @@ impl DescriptorEncode for ActionDescriptor {
             return Err(ProjectionError::InvalidLength);
         }
         write_header(output, ProjectionTypeTag::ActionDescriptor)?;
-        output[3..35].copy_from_slice(self.digest.as_bytes());
-        self.revision.encode_descriptor(&mut output[35..46])?;
-        output[46..78].copy_from_slice(self.scope.as_bytes());
-        output[78..86].copy_from_slice(&self.generation.get().to_le_bytes());
-        output[86..94].copy_from_slice(&self.expiry.get().to_le_bytes());
-        output[94..126].copy_from_slice(self.principal.as_bytes());
+        self.object.encode_descriptor(&mut output[3..41])?;
+        output[41..73].copy_from_slice(self.digest.as_bytes());
+        self.revision.encode_descriptor(&mut output[73..84])?;
+        output[84..116].copy_from_slice(self.scope.as_bytes());
+        output[116..124].copy_from_slice(&self.generation.get().to_le_bytes());
+        output[124..132].copy_from_slice(&self.expiry.get().to_le_bytes());
+        output[132..164].copy_from_slice(self.principal.as_bytes());
         Ok(())
     }
 }
@@ -499,26 +596,28 @@ impl DescriptorDecode for ActionDescriptor {
         }
         check_header(input, ProjectionTypeTag::ActionDescriptor)?;
 
+        let object = SemanticObjectId::decode_descriptor(&input[3..41])?;
         let mut digest = [0_u8; ACTION_BINDING_BYTES];
-        digest.copy_from_slice(&input[3..35]);
-        let revision = ProjectionRevision::decode_descriptor(&input[35..46])?;
+        digest.copy_from_slice(&input[41..73]);
+        let revision = ProjectionRevision::decode_descriptor(&input[73..84])?;
         let mut scope = [0_u8; ACTION_BINDING_BYTES];
-        scope.copy_from_slice(&input[46..78]);
+        scope.copy_from_slice(&input[84..116]);
         let generation_raw = u64::from_le_bytes(
-            input[78..86]
+            input[116..124]
                 .try_into()
                 .map_err(|_| ProjectionError::InvalidLength)?,
         );
         let generation = ActionGeneration::from_raw(generation_raw)
             .ok_or(ProjectionError::InvalidActionGeneration)?;
         let expiry = ActionExpiry::from_raw(u64::from_le_bytes(
-            input[86..94]
+            input[124..132]
                 .try_into()
                 .map_err(|_| ProjectionError::InvalidLength)?,
         ));
         let mut principal = [0_u8; ACTION_BINDING_BYTES];
-        principal.copy_from_slice(&input[94..126]);
+        principal.copy_from_slice(&input[132..164]);
         Ok(Self::new(
+            object,
             ActionDigest::from_bytes(digest),
             revision,
             ActionScope::from_bytes(scope),
@@ -530,260 +629,5 @@ impl DescriptorDecode for ActionDescriptor {
 }
 
 #[cfg(test)]
-mod tests {
-    extern crate alloc;
-
-    use super::*;
-    use crate::presentation::{PresentationLabel, PresentationMetadata};
-    use crate::snapshot::ProjectionSnapshot;
-    use alloc::string::ToString;
-    use astrid_resource_types::{ResourceId, ResourceTypeId};
-
-    fn descriptor() -> ActionDescriptor {
-        ActionDescriptor::new(
-            ActionDigest::from_bytes([0x11; ACTION_BINDING_BYTES]),
-            ProjectionRevision::from_raw(7).unwrap(),
-            ActionScope::from_bytes([0x22; ACTION_BINDING_BYTES]),
-            ActionGeneration::from_raw(3).unwrap(),
-            ActionExpiry::from_raw(100),
-            ActionPrincipal::from_bytes([0x33; ACTION_BINDING_BYTES]),
-        )
-    }
-
-    fn observation() -> ActionObservation {
-        ActionObservation::new(
-            ActionDigest::from_bytes([0x11; ACTION_BINDING_BYTES]),
-            ProjectionRevision::from_raw(7).unwrap(),
-            ActionScope::from_bytes([0x22; ACTION_BINDING_BYTES]),
-            ActionGeneration::from_raw(3).unwrap(),
-            ActionPrincipal::from_bytes([0x33; ACTION_BINDING_BYTES]),
-            99,
-        )
-    }
-
-    fn snapshot(label: &[u8], metadata: &PresentationMetadata) -> ProjectionSnapshot {
-        ProjectionSnapshot::new(
-            crate::SemanticObjectId::for_resource(ResourceId::from_bytes([0x44; 32])),
-            ResourceTypeId::from_bytes([0x55; 32]),
-            ProjectionRevision::from_raw(7).unwrap(),
-            PresentationLabel::from_utf8(label).unwrap(),
-            *metadata,
-        )
-    }
-
-    #[test]
-    fn descriptor_roundtrip_is_fixed_and_debug_is_opaque() {
-        let descriptor = descriptor();
-        let mut encoded = [0_u8; ACTION_DESCRIPTOR_ENCODED_LEN];
-        assert_eq!(descriptor.encoded_len(), ACTION_DESCRIPTOR_ENCODED_LEN);
-        descriptor.encode_descriptor(&mut encoded).unwrap();
-        assert_eq!(
-            ActionDescriptor::decode_descriptor(&encoded),
-            Ok(descriptor)
-        );
-        assert_eq!(
-            format_args!("{descriptor:?}").to_string(),
-            "ActionDescriptor"
-        );
-        assert_eq!(
-            ActionDescriptor::decode_descriptor(&encoded[..125]),
-            Err(ProjectionError::InvalidLength)
-        );
-        encoded[78..86].fill(0);
-        assert_eq!(
-            ActionDescriptor::decode_descriptor(&encoded),
-            Err(ProjectionError::InvalidActionGeneration)
-        );
-    }
-
-    #[test]
-    fn descriptor_rejects_stale_expired_drift_and_cross_principal_observations() {
-        let descriptor = descriptor();
-        let honest = observation();
-        assert_eq!(descriptor.eligibility(&honest), ActionEligibility::Eligible);
-        assert!(descriptor.is_eligible(&honest));
-        assert_eq!(descriptor.check(&honest), Ok(()));
-
-        let digest = ActionObservation::new(
-            ActionDigest::from_bytes([0xee; ACTION_BINDING_BYTES]),
-            honest.revision(),
-            honest.scope(),
-            honest.generation(),
-            honest.principal(),
-            honest.now(),
-        );
-        assert_eq!(
-            descriptor.check(&digest),
-            Err(ProjectionError::ActionDigestMismatch)
-        );
-
-        let stale = ActionObservation::new(
-            honest.digest(),
-            ProjectionRevision::from_raw(8).unwrap(),
-            honest.scope(),
-            honest.generation(),
-            honest.principal(),
-            honest.now(),
-        );
-        assert_eq!(
-            descriptor.eligibility(&stale),
-            ActionEligibility::StaleRevision
-        );
-        assert_eq!(
-            descriptor.check(&stale),
-            Err(ProjectionError::StaleRevision {
-                found: 7,
-                requested: 8,
-            })
-        );
-
-        let scope = ActionObservation::new(
-            honest.digest(),
-            honest.revision(),
-            ActionScope::from_bytes([0xef; ACTION_BINDING_BYTES]),
-            honest.generation(),
-            honest.principal(),
-            honest.now(),
-        );
-        assert_eq!(
-            descriptor.check(&scope),
-            Err(ProjectionError::ActionScopeMismatch)
-        );
-
-        let generation = ActionObservation::new(
-            honest.digest(),
-            honest.revision(),
-            honest.scope(),
-            ActionGeneration::from_raw(4).unwrap(),
-            honest.principal(),
-            honest.now(),
-        );
-        assert_eq!(
-            descriptor.check(&generation),
-            Err(ProjectionError::ActionGenerationDrift)
-        );
-
-        let principal = ActionObservation::new(
-            honest.digest(),
-            honest.revision(),
-            honest.scope(),
-            honest.generation(),
-            ActionPrincipal::from_bytes([0xaa; ACTION_BINDING_BYTES]),
-            honest.now(),
-        );
-        assert_eq!(
-            descriptor.check(&principal),
-            Err(ProjectionError::ActionCrossPrincipal)
-        );
-
-        let expired = ActionObservation::new(
-            honest.digest(),
-            honest.revision(),
-            honest.scope(),
-            honest.generation(),
-            honest.principal(),
-            100,
-        );
-        assert_eq!(
-            descriptor.check(&expired),
-            Err(ProjectionError::ActionExpired)
-        );
-    }
-
-    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-    struct PresenterResult {
-        eligible: bool,
-        label: PresentationLabel,
-        metadata: PresentationMetadata,
-        facts: ActionDescriptorFacts,
-    }
-
-    // This consumer is presentation-shaped: it carries labels and metadata,
-    // and treats descriptor eligibility as an opaque boolean decision.
-    fn presenter_consumer(
-        snapshot: &ProjectionSnapshot,
-        descriptor: &ActionDescriptor,
-        observation: &ActionObservation,
-    ) -> PresenterResult {
-        PresenterResult {
-            eligible: descriptor.is_eligible(observation),
-            label: snapshot.label(),
-            metadata: snapshot.metadata(),
-            facts: descriptor.facts(),
-        }
-    }
-
-    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-    struct EligibilityResult {
-        eligible: bool,
-        facts: ActionDescriptorFacts,
-    }
-
-    // This consumer is structurally different: it reads each bound fact and
-    // derives eligibility without consulting presentation values.
-    fn eligibility_consumer(
-        descriptor: &ActionDescriptor,
-        observation: &ActionObservation,
-    ) -> EligibilityResult {
-        let facts = descriptor.facts();
-        let eligible = facts.principal() == observation.principal()
-            && facts.digest() == observation.digest()
-            && facts.revision() == observation.revision()
-            && facts.scope() == observation.scope()
-            && facts.generation() == observation.generation()
-            && !facts.expiry().is_expired_at(observation.now());
-        EligibilityResult { eligible, facts }
-    }
-
-    #[test]
-    fn independent_consumers_agree_and_presentation_cannot_mint_or_widen() {
-        let descriptor = descriptor();
-        let observation = observation();
-        let plain = snapshot(b"safe", &PresentationMetadata::EMPTY);
-        let hostile_metadata = PresentationMetadata::try_from_pairs(&[
-            ("action_handle", "forged"),
-            ("invoke", "true"),
-            ("rights", "root"),
-        ])
-        .unwrap();
-        let hostile = snapshot(b"ADMIN GRANT", &hostile_metadata);
-
-        let first = presenter_consumer(&plain, &descriptor, &observation);
-        let second = eligibility_consumer(&descriptor, &observation);
-        assert!(first.eligible);
-        assert_eq!(first.eligible, second.eligible);
-        assert_eq!(first.facts, second.facts);
-
-        // A malicious presentation changes only display fields; eligibility
-        // and all descriptor facts remain exactly those of the bound action.
-        let hostile_result = presenter_consumer(&hostile, &descriptor, &observation);
-        assert!(hostile_result.eligible);
-        assert_eq!(hostile_result.facts, first.facts);
-        assert_eq!(hostile_result.label.as_str(), "ADMIN GRANT");
-        assert!(
-            hostile_result
-                .metadata
-                .iter()
-                .any(|(key, value)| key == "action_handle" && value == "forged")
-        );
-
-        // A copied descriptor cannot refresh itself after the projection moves
-        // to a new revision; replay fails against the new observation.
-        let replayed = descriptor;
-        let moved = ActionObservation::new(
-            observation.digest(),
-            observation.revision().checked_next().unwrap(),
-            observation.scope(),
-            observation.generation(),
-            observation.principal(),
-            observation.now(),
-        );
-        assert_eq!(
-            replayed.check(&moved),
-            Err(ProjectionError::StaleRevision {
-                found: 7,
-                requested: 8,
-            })
-        );
-    }
-}
+#[path = "action_descriptor_tests.rs"]
+mod tests;

--- a/crates/astrid-projection/src/action_descriptor_tests.rs
+++ b/crates/astrid-projection/src/action_descriptor_tests.rs
@@ -178,7 +178,10 @@ fn descriptor_rejects_stale_expired_drift_and_cross_principal_observations() {
     let stale_debug = format_args!("{stale_error:?}").to_string();
     let stale_display = format_args!("{stale_error}").to_string();
     assert_eq!(stale_debug, "ActionStaleRevision");
-    assert_eq!(stale_display, "invalid projection descriptor: ActionStaleRevision");
+    assert_eq!(
+        stale_display,
+        "invalid projection descriptor: ActionStaleRevision"
+    );
     for rendered in [&stale_debug, &stale_display] {
         assert!(!rendered.contains('7'));
         assert!(!rendered.contains('8'));

--- a/crates/astrid-projection/src/action_descriptor_tests.rs
+++ b/crates/astrid-projection/src/action_descriptor_tests.rs
@@ -1,0 +1,373 @@
+extern crate alloc;
+
+use super::*;
+use crate::presentation::{PresentationLabel, PresentationMetadata};
+use crate::snapshot::ProjectionSnapshot;
+use alloc::string::ToString;
+use astrid_resource_types::{ResourceId, ResourceTypeId};
+
+fn object(byte: u8) -> SemanticObjectId {
+    SemanticObjectId::for_resource(ResourceId::from_bytes([byte; 32]))
+}
+
+fn descriptor() -> ActionDescriptor {
+    ActionDescriptor::new(
+        object(0x44),
+        ActionDigest::from_bytes([0x11; ACTION_BINDING_BYTES]),
+        ProjectionRevision::from_raw(7).unwrap(),
+        ActionScope::from_bytes([0x22; ACTION_BINDING_BYTES]),
+        ActionGeneration::from_raw(3).unwrap(),
+        ActionExpiry::from_raw(100),
+        ActionPrincipal::from_bytes([0x33; ACTION_BINDING_BYTES]),
+    )
+}
+
+fn observation() -> ActionObservation {
+    ActionObservation::new(
+        object(0x44),
+        ActionDigest::from_bytes([0x11; ACTION_BINDING_BYTES]),
+        ProjectionRevision::from_raw(7).unwrap(),
+        ActionScope::from_bytes([0x22; ACTION_BINDING_BYTES]),
+        ActionGeneration::from_raw(3).unwrap(),
+        ActionPrincipal::from_bytes([0x33; ACTION_BINDING_BYTES]),
+        99,
+    )
+}
+
+fn snapshot(object_byte: u8, label: &[u8], metadata: &PresentationMetadata) -> ProjectionSnapshot {
+    ProjectionSnapshot::new(
+        object(object_byte),
+        ResourceTypeId::from_bytes([0x55; 32]),
+        ProjectionRevision::from_raw(7).unwrap(),
+        PresentationLabel::from_utf8(label).unwrap(),
+        *metadata,
+    )
+}
+
+#[test]
+fn descriptor_roundtrip_is_fixed_and_debug_is_opaque() {
+    let descriptor = descriptor();
+    let mut encoded = [0_u8; ACTION_DESCRIPTOR_ENCODED_LEN];
+    assert_eq!(descriptor.encoded_len(), ACTION_DESCRIPTOR_ENCODED_LEN);
+    descriptor.encode_descriptor(&mut encoded).unwrap();
+    assert_eq!(
+        ActionDescriptor::decode_descriptor(&encoded),
+        Ok(descriptor)
+    );
+    assert_eq!(
+        format_args!("{descriptor:?}").to_string(),
+        "ActionDescriptor"
+    );
+    assert_eq!(
+        format_args!("{:?}", descriptor.facts()).to_string(),
+        "ActionDescriptorFacts"
+    );
+    assert_eq!(
+        format_args!("{:?}", observation()).to_string(),
+        "ActionObservation"
+    );
+    assert_eq!(
+        ActionDescriptor::decode_descriptor(&encoded[..125]),
+        Err(ProjectionError::InvalidLength)
+    );
+    let mut with_trailing = [0_u8; ACTION_DESCRIPTOR_ENCODED_LEN + 1];
+    with_trailing[..ACTION_DESCRIPTOR_ENCODED_LEN].copy_from_slice(&encoded);
+    assert_eq!(
+        ActionDescriptor::decode_descriptor(&with_trailing),
+        Err(ProjectionError::InvalidLength)
+    );
+    let mut wrong_outer_tag = encoded;
+    wrong_outer_tag[1..3]
+        .copy_from_slice(&ProjectionTypeTag::SemanticObjectId.code().to_le_bytes());
+    assert_eq!(
+        ActionDescriptor::decode_descriptor(&wrong_outer_tag),
+        Err(ProjectionError::WrongTypeTag {
+            expected: ProjectionTypeTag::ActionDescriptor.code(),
+            actual: ProjectionTypeTag::SemanticObjectId.code(),
+        })
+    );
+    let mut wrong_object_tag = encoded;
+    wrong_object_tag[4..6]
+        .copy_from_slice(&ProjectionTypeTag::ProjectionRevision.code().to_le_bytes());
+    assert_eq!(
+        ActionDescriptor::decode_descriptor(&wrong_object_tag),
+        Err(ProjectionError::WrongTypeTag {
+            expected: ProjectionTypeTag::SemanticObjectId.code(),
+            actual: ProjectionTypeTag::ProjectionRevision.code(),
+        })
+    );
+    assert_eq!(
+        SemanticObjectId::decode_descriptor(&encoded[3..41]),
+        Ok(descriptor.object())
+    );
+    encoded[116..124].fill(0);
+    assert_eq!(
+        ActionDescriptor::decode_descriptor(&encoded),
+        Err(ProjectionError::InvalidActionGeneration)
+    );
+}
+
+#[test]
+fn descriptor_rejects_stale_expired_drift_and_cross_principal_observations() {
+    let descriptor = descriptor();
+    let honest = observation();
+    assert_eq!(descriptor.eligibility(&honest), ActionEligibility::Eligible);
+    assert!(descriptor.is_eligible(&honest));
+    assert_eq!(descriptor.check(&honest), Ok(()));
+
+    let digest = ActionObservation::new(
+        honest.object(),
+        ActionDigest::from_bytes([0xee; ACTION_BINDING_BYTES]),
+        honest.revision(),
+        honest.scope(),
+        honest.generation(),
+        honest.principal(),
+        honest.now(),
+    );
+    assert_eq!(
+        descriptor.check(&digest),
+        Err(ProjectionError::ActionDigestMismatch)
+    );
+
+    let stale = ActionObservation::new(
+        honest.object(),
+        honest.digest(),
+        ProjectionRevision::from_raw(8).unwrap(),
+        honest.scope(),
+        honest.generation(),
+        honest.principal(),
+        honest.now(),
+    );
+    assert_eq!(
+        descriptor.eligibility(&stale),
+        ActionEligibility::StaleRevision
+    );
+    assert_eq!(
+        descriptor.check(&stale),
+        Err(ProjectionError::StaleRevision {
+            found: 7,
+            requested: 8,
+        })
+    );
+
+    let scope = ActionObservation::new(
+        honest.object(),
+        honest.digest(),
+        honest.revision(),
+        ActionScope::from_bytes([0xef; ACTION_BINDING_BYTES]),
+        honest.generation(),
+        honest.principal(),
+        honest.now(),
+    );
+    assert_eq!(
+        descriptor.check(&scope),
+        Err(ProjectionError::ActionScopeMismatch)
+    );
+
+    let generation = ActionObservation::new(
+        honest.object(),
+        honest.digest(),
+        honest.revision(),
+        honest.scope(),
+        ActionGeneration::from_raw(4).unwrap(),
+        honest.principal(),
+        honest.now(),
+    );
+    assert_eq!(
+        descriptor.check(&generation),
+        Err(ProjectionError::ActionGenerationDrift)
+    );
+
+    let principal = ActionObservation::new(
+        honest.object(),
+        honest.digest(),
+        honest.revision(),
+        honest.scope(),
+        honest.generation(),
+        ActionPrincipal::from_bytes([0xaa; ACTION_BINDING_BYTES]),
+        honest.now(),
+    );
+    assert_eq!(
+        descriptor.check(&principal),
+        Err(ProjectionError::ActionCrossPrincipal)
+    );
+
+    let expired = ActionObservation::new(
+        honest.object(),
+        honest.digest(),
+        honest.revision(),
+        honest.scope(),
+        honest.generation(),
+        honest.principal(),
+        100,
+    );
+    assert_eq!(
+        descriptor.check(&expired),
+        Err(ProjectionError::ActionExpired)
+    );
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct PresenterResult {
+    eligible: bool,
+    label: PresentationLabel,
+    metadata: PresentationMetadata,
+    facts: ActionDescriptorFacts,
+}
+
+// This consumer is presentation-shaped: it carries labels and metadata,
+// and treats descriptor eligibility as an opaque boolean decision.
+fn presenter_consumer(
+    snapshot: &ProjectionSnapshot,
+    descriptor: &ActionDescriptor,
+    observation: &ActionObservation,
+) -> PresenterResult {
+    let object_matches =
+        snapshot.object() == descriptor.object() && snapshot.object() == observation.object();
+    PresenterResult {
+        eligible: object_matches && descriptor.is_eligible(observation),
+        label: snapshot.label(),
+        metadata: snapshot.metadata(),
+        facts: descriptor.facts(),
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct EligibilityResult {
+    eligible: bool,
+    facts: ActionDescriptorFacts,
+}
+
+// This consumer is structurally different: it reads each bound fact and
+// derives eligibility without consulting presentation values.
+fn eligibility_consumer(
+    snapshot: &ProjectionSnapshot,
+    descriptor: &ActionDescriptor,
+    observation: &ActionObservation,
+) -> EligibilityResult {
+    let facts = descriptor.facts();
+    let eligible = snapshot.object() == facts.object()
+        && snapshot.object() == observation.object()
+        && snapshot.revision() == facts.revision()
+        && facts.principal() == observation.principal()
+        && facts.object() == observation.object()
+        && facts.digest() == observation.digest()
+        && facts.revision() == observation.revision()
+        && facts.scope() == observation.scope()
+        && facts.generation() == observation.generation()
+        && !facts.expiry().is_expired_at(observation.now());
+    EligibilityResult { eligible, facts }
+}
+
+#[test]
+fn independent_consumers_agree_and_presentation_cannot_mint_or_widen() {
+    let descriptor = descriptor();
+    let observation = observation();
+    let plain = snapshot(0x44, b"safe", &PresentationMetadata::EMPTY);
+    let hostile_metadata = PresentationMetadata::try_from_pairs(&[
+        ("action_handle", "forged"),
+        ("invoke", "true"),
+        ("rights", "root"),
+    ])
+    .unwrap();
+    let hostile = snapshot(0x44, b"ADMIN GRANT", &hostile_metadata);
+
+    let first = presenter_consumer(&plain, &descriptor, &observation);
+    let second = eligibility_consumer(&plain, &descriptor, &observation);
+    assert!(first.eligible);
+    assert_eq!(first.eligible, second.eligible);
+    assert_eq!(first.facts, second.facts);
+
+    // A malicious presentation changes only display fields; eligibility
+    // and all descriptor facts remain exactly those of the bound action.
+    let hostile_result = presenter_consumer(&hostile, &descriptor, &observation);
+    assert!(hostile_result.eligible);
+    assert_eq!(hostile_result.facts, first.facts);
+    assert_eq!(hostile_result.label.as_str(), "ADMIN GRANT");
+    assert!(
+        hostile_result
+            .metadata
+            .iter()
+            .any(|(key, value)| key == "action_handle" && value == "forged")
+    );
+
+    // A copied descriptor cannot refresh itself after the projection moves
+    // to a new revision; replay fails against the new observation.
+    let replayed = descriptor;
+    let moved = ActionObservation::new(
+        observation.object(),
+        observation.digest(),
+        observation.revision().checked_next().unwrap(),
+        observation.scope(),
+        observation.generation(),
+        observation.principal(),
+        observation.now(),
+    );
+    assert_eq!(
+        replayed.check(&moved),
+        Err(ProjectionError::StaleRevision {
+            found: 7,
+            requested: 8,
+        })
+    );
+}
+
+#[test]
+fn object_identity_joins_snapshots_and_rejects_cross_object_replay() {
+    let first_snapshot = snapshot(0x44, b"first", &PresentationMetadata::EMPTY);
+    let second_snapshot = snapshot(0x66, b"second", &PresentationMetadata::EMPTY);
+    assert_ne!(first_snapshot.object(), second_snapshot.object());
+    assert_eq!(first_snapshot.type_id(), second_snapshot.type_id());
+    assert_eq!(first_snapshot.revision(), second_snapshot.revision());
+
+    let descriptor = ActionDescriptor::for_snapshot(
+        first_snapshot,
+        ActionDigest::from_bytes([0x11; ACTION_BINDING_BYTES]),
+        ActionScope::from_bytes([0x22; ACTION_BINDING_BYTES]),
+        ActionGeneration::from_raw(3).unwrap(),
+        ActionExpiry::from_raw(100),
+        ActionPrincipal::from_bytes([0x33; ACTION_BINDING_BYTES]),
+    );
+    let matching = ActionObservation::for_snapshot(
+        first_snapshot,
+        descriptor.digest(),
+        descriptor.scope(),
+        descriptor.generation(),
+        descriptor.principal(),
+        99,
+    );
+    let cross_object = ActionObservation::for_snapshot(
+        second_snapshot,
+        descriptor.digest(),
+        descriptor.scope(),
+        descriptor.generation(),
+        descriptor.principal(),
+        99,
+    );
+
+    assert_eq!(
+        descriptor.eligibility(&matching),
+        ActionEligibility::Eligible
+    );
+    assert_eq!(descriptor.check(&matching), Ok(()));
+    assert_eq!(
+        descriptor.eligibility(&cross_object),
+        ActionEligibility::ObjectMismatch
+    );
+    assert_eq!(
+        descriptor.check(&cross_object),
+        Err(ProjectionError::ActionObjectMismatch)
+    );
+
+    let first_presenter = presenter_consumer(&first_snapshot, &descriptor, &matching);
+    let second_presenter = presenter_consumer(&second_snapshot, &descriptor, &cross_object);
+    assert!(first_presenter.eligible);
+    assert!(!second_presenter.eligible);
+    assert_eq!(first_presenter.facts, second_presenter.facts);
+
+    let first_eligibility = eligibility_consumer(&first_snapshot, &descriptor, &matching);
+    let second_eligibility = eligibility_consumer(&second_snapshot, &descriptor, &cross_object);
+    assert!(first_eligibility.eligible);
+    assert!(!second_eligibility.eligible);
+    assert_eq!(first_eligibility.facts, second_eligibility.facts);
+}

--- a/crates/astrid-projection/src/action_descriptor_tests.rs
+++ b/crates/astrid-projection/src/action_descriptor_tests.rs
@@ -44,6 +44,22 @@ fn snapshot(object_byte: u8, label: &[u8], metadata: &PresentationMetadata) -> P
     )
 }
 
+fn assert_stale_error_rendering_is_opaque(error: &ProjectionError) {
+    let stale_debug = format_args!("{error:?}").to_string();
+    let stale_display = format_args!("{error}").to_string();
+    assert_eq!(stale_debug, "ActionStaleRevision");
+    assert_eq!(
+        stale_display,
+        "invalid projection descriptor: ActionStaleRevision"
+    );
+    for rendered in [&stale_debug, &stale_display] {
+        assert!(!rendered.contains('7'));
+        assert!(!rendered.contains('8'));
+        assert!(!rendered.contains("found"));
+        assert!(!rendered.contains("requested"));
+    }
+}
+
 #[test]
 fn descriptor_roundtrip_is_fixed_and_debug_is_opaque() {
     let descriptor = descriptor();
@@ -175,19 +191,7 @@ fn descriptor_rejects_stale_expired_drift_and_cross_principal_observations() {
         Err(ProjectionError::ActionStaleRevision)
     );
     let stale_error = descriptor.check(&stale).unwrap_err();
-    let stale_debug = format_args!("{stale_error:?}").to_string();
-    let stale_display = format_args!("{stale_error}").to_string();
-    assert_eq!(stale_debug, "ActionStaleRevision");
-    assert_eq!(
-        stale_display,
-        "invalid projection descriptor: ActionStaleRevision"
-    );
-    for rendered in [&stale_debug, &stale_display] {
-        assert!(!rendered.contains('7'));
-        assert!(!rendered.contains('8'));
-        assert!(!rendered.contains("found"));
-        assert!(!rendered.contains("requested"));
-    }
+    assert_stale_error_rendering_is_opaque(&stale_error);
 
     let scope = ActionObservation::new(
         honest.object(),

--- a/crates/astrid-projection/src/action_descriptor_tests.rs
+++ b/crates/astrid-projection/src/action_descriptor_tests.rs
@@ -67,6 +67,34 @@ fn descriptor_roundtrip_is_fixed_and_debug_is_opaque() {
         "ActionObservation"
     );
     assert_eq!(
+        format_args!("{:?}", descriptor.expiry()).to_string(),
+        "ActionExpiry"
+    );
+    assert_eq!(
+        format_args!("{:?}", descriptor.digest()).to_string(),
+        "ActionDigest"
+    );
+    assert_eq!(
+        format_args!("{:?}", descriptor.scope()).to_string(),
+        "ActionScope"
+    );
+    assert_eq!(
+        format_args!("{:?}", descriptor.principal()).to_string(),
+        "ActionPrincipal"
+    );
+    assert_eq!(
+        format_args!("{:?}", descriptor.generation()).to_string(),
+        "ActionGeneration"
+    );
+    assert_eq!(
+        format_args!("{:?}", descriptor.revision()).to_string(),
+        "ProjectionRevision"
+    );
+    assert_eq!(
+        format_args!("{:?}", descriptor.object()).to_string(),
+        "SemanticObjectId"
+    );
+    assert_eq!(
         ActionDescriptor::decode_descriptor(&encoded[..125]),
         Err(ProjectionError::InvalidLength)
     );
@@ -144,11 +172,19 @@ fn descriptor_rejects_stale_expired_drift_and_cross_principal_observations() {
     );
     assert_eq!(
         descriptor.check(&stale),
-        Err(ProjectionError::StaleRevision {
-            found: 7,
-            requested: 8,
-        })
+        Err(ProjectionError::ActionStaleRevision)
     );
+    let stale_error = descriptor.check(&stale).unwrap_err();
+    let stale_debug = format_args!("{stale_error:?}").to_string();
+    let stale_display = format_args!("{stale_error}").to_string();
+    assert_eq!(stale_debug, "ActionStaleRevision");
+    assert_eq!(stale_display, "invalid projection descriptor: ActionStaleRevision");
+    for rendered in [&stale_debug, &stale_display] {
+        assert!(!rendered.contains('7'));
+        assert!(!rendered.contains('8'));
+        assert!(!rendered.contains("found"));
+        assert!(!rendered.contains("requested"));
+    }
 
     let scope = ActionObservation::new(
         honest.object(),
@@ -305,10 +341,7 @@ fn independent_consumers_agree_and_presentation_cannot_mint_or_widen() {
     );
     assert_eq!(
         replayed.check(&moved),
-        Err(ProjectionError::StaleRevision {
-            found: 7,
-            requested: 8,
-        })
+        Err(ProjectionError::ActionStaleRevision)
     );
 }
 

--- a/crates/astrid-projection/src/encoding.rs
+++ b/crates/astrid-projection/src/encoding.rs
@@ -24,6 +24,8 @@ pub enum ProjectionTypeTag {
     ProjectionSnapshot = 5,
     /// [`crate::ProjectionUpdate`].
     ProjectionUpdate = 6,
+    /// [`crate::ActionDescriptor`].
+    ActionDescriptor = 7,
 }
 
 impl ProjectionTypeTag {
@@ -43,6 +45,7 @@ impl ProjectionTypeTag {
             4 => Some(Self::PresentationMetadata),
             5 => Some(Self::ProjectionSnapshot),
             6 => Some(Self::ProjectionUpdate),
+            7 => Some(Self::ActionDescriptor),
             _ => None,
         }
     }
@@ -132,6 +135,7 @@ mod tests {
             (ProjectionTypeTag::PresentationMetadata, 4),
             (ProjectionTypeTag::ProjectionSnapshot, 5),
             (ProjectionTypeTag::ProjectionUpdate, 6),
+            (ProjectionTypeTag::ActionDescriptor, 7),
         ];
         for (tag, code) in golden {
             assert_eq!(tag.code(), code);

--- a/crates/astrid-projection/src/error.rs
+++ b/crates/astrid-projection/src/error.rs
@@ -56,6 +56,18 @@ pub enum ProjectionError {
     NotAnInvocation,
     /// Nested `astrid-resource-types` bytes failed to decode.
     ResourceEncoding,
+    /// An action descriptor carried an impossible zero generation.
+    InvalidActionGeneration,
+    /// An action descriptor's digest did not match the observed action.
+    ActionDigestMismatch,
+    /// An action descriptor's scope did not match the observed scope.
+    ActionScopeMismatch,
+    /// The observed action generation did not match the descriptor.
+    ActionGenerationDrift,
+    /// The descriptor was observed at or after its expiry.
+    ActionExpired,
+    /// The descriptor was presented by a different principal.
+    ActionCrossPrincipal,
 }
 
 impl fmt::Display for ProjectionError {

--- a/crates/astrid-projection/src/error.rs
+++ b/crates/astrid-projection/src/error.rs
@@ -66,6 +66,8 @@ pub enum ProjectionError {
     ActionGenerationDrift,
     /// The descriptor was observed at or after its expiry.
     ActionExpired,
+    /// The action observation used a different projection revision.
+    ActionStaleRevision,
     /// The descriptor was presented by a different principal.
     ActionCrossPrincipal,
     /// The descriptor and observation named different semantic objects.

--- a/crates/astrid-projection/src/error.rs
+++ b/crates/astrid-projection/src/error.rs
@@ -68,6 +68,8 @@ pub enum ProjectionError {
     ActionExpired,
     /// The descriptor was presented by a different principal.
     ActionCrossPrincipal,
+    /// The descriptor and observation named different semantic objects.
+    ActionObjectMismatch,
 }
 
 impl fmt::Display for ProjectionError {

--- a/crates/astrid-projection/src/lib.rs
+++ b/crates/astrid-projection/src/lib.rs
@@ -20,6 +20,7 @@
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
+mod action_descriptor;
 mod encoding;
 mod error;
 mod fixtures;
@@ -29,6 +30,11 @@ mod revision;
 mod snapshot;
 mod view;
 
+pub use action_descriptor::{
+    ACTION_BINDING_BYTES, ACTION_DESCRIPTOR_ENCODED_LEN, ActionDescriptor, ActionDescriptorFacts,
+    ActionDigest, ActionEligibility, ActionExpiry, ActionGeneration, ActionObservation,
+    ActionPrincipal, ActionScope,
+};
 pub use encoding::{CANONICAL_VERSION, DescriptorDecode, DescriptorEncode, ProjectionTypeTag};
 pub use error::ProjectionError;
 pub use fixtures::{honest_snapshot, honest_two_object_view};

--- a/crates/astrid-projection/src/object.rs
+++ b/crates/astrid-projection/src/object.rs
@@ -1,5 +1,7 @@
 //! Semantic object identity bound to [`ResourceId`].
 
+use core::fmt;
+
 use astrid_resource_types::{CanonicalDecode, CanonicalEncode, ResourceId};
 
 use crate::encoding::{
@@ -12,9 +14,16 @@ use crate::error::ProjectionError;
 /// The object is a view of exactly one [`ResourceId`]. It cannot be constructed
 /// from a string name, schema topic, or [`astrid_resource_types::ResourceKind`].
 /// Knowing the identifier is not a grant.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SemanticObjectId {
     resource: ResourceId,
+}
+
+impl fmt::Debug for SemanticObjectId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let _ = self;
+        formatter.write_str("SemanticObjectId")
+    }
 }
 
 impl SemanticObjectId {

--- a/crates/astrid-projection/src/revision.rs
+++ b/crates/astrid-projection/src/revision.rs
@@ -1,6 +1,6 @@
 //! Checked projection revisions. Never wrap.
 
-use core::num::NonZeroU64;
+use core::{fmt, num::NonZeroU64};
 
 use crate::encoding::{
     DescriptorDecode, DescriptorEncode, ProjectionTypeTag, check_header, write_header,
@@ -10,8 +10,15 @@ use crate::error::ProjectionError;
 /// Generation of a projection snapshot stream.
 ///
 /// Distinct from object, provider, lifecycle, and authority generations.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ProjectionRevision(NonZeroU64);
+
+impl fmt::Debug for ProjectionRevision {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let _ = self;
+        formatter.write_str("ProjectionRevision")
+    }
+}
 
 impl ProjectionRevision {
     /// First valid revision.


### PR DESCRIPTION
## Linked Issue

Closes #1661
Tracking #1564

## Summary

Add a private, non-authoritative `ActionDescriptor` so two structurally different consumers can observe the same scoped, object-bound action eligibility without acquiring a handle, lease, or live invocation.

This branch is a signed no-ff integration onto current `os/universal`. Accepted descriptor content is preserved as the second parent. No content rewrite.

## Changes

- `ActionDescriptor` (projection type tag 7, 164-byte canonical encoding) binds a typed `SemanticObjectId` plus opaque digest, revision, scope, generation, expiry, and principal.
- Snapshot-derived constructors and eligibility require the same `SemanticObjectId`; cross-object replay fails closed as `ActionObjectMismatch`.
- Independent presenter vs facts consumers both consult `snapshot.object()`. Presentation labels/metadata cannot mint, widen, or refresh authority.
- Name-only `Debug` on the descriptor, observation, facts, binding identities, `ProjectionRevision`, and `SemanticObjectId`. Action stale-revision checks return `ActionStaleRevision` without raw revision numbers.
- Changelog fragment `changes/1661.added.md` (add-only).

## Verification

- `cargo fmt --check -p astrid-projection`
- `cargo test --locked -p astrid-projection`
- `cargo test --locked -p astrid-projection --no-default-features`
- `cargo test --locked -p astrid-projection --features alloc`
- `cargo check --locked -p astrid-projection --target wasm32-unknown-unknown`
- `cargo check --locked -p astrid-projection --target x86_64-unknown-none --no-default-features`
- `cargo clippy --locked -p astrid-projection --all-targets --all-features -- -D warnings`
- Independent review accepted content `7d8a98f64b734c91e399b5fc04d5795fdefae931`.
- Integration vehicle `695befb7998f64ca2c47b4b0806f0aab78778be2` (first parent live `os/universal` `3d787cc9ab34e03e9f6b21b9b0768e07d922dea5`, second parent `7d8a98f6`, tree `9b46e42d360377dd3de2e524961d68d939ce23d7`).

## AI / Tool Assistance

Assisted-by: Codex
Affected area: `crates/astrid-projection/**` and `changes/1661.added.md`.
Reviewed against issue #1661, including the two-consumer same-snapshot exit gate and Debug/error redaction. Signed content `7d8a98f64b734c91e399b5fc04d5795fdefae931` is preserved as the second parent.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/{issue}.{kind}.md`
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
