### PR TITLE
test: prove Realm reference-interpreter isolation and no host fallback

### DIFF
--- a/.github/workflows/native-kernel.yml
+++ b/.github/workflows/native-kernel.yml
@@ -56,7 +56,35 @@ jobs:
         working-directory: kernel
         run: |
           rustup show
-          ./check.sh
+          ./check.sh x86
+
+  semantic-portability:
+    name: Compile-only semantic targets (AArch64 + RISC-V)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install stable Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: "1.95.0"
+          targets: x86_64-unknown-none,aarch64-unknown-none,riscv64gc-unknown-none-elf
+          components: rust-src, clippy, rustfmt
+
+      - name: Run compile-only portability checks
+        working-directory: kernel
+        run: |
+          rustup show
+          ./check.sh portability
 
   qemu-tcg:
     name: QEMU TCG boot (emulator evidence only)

--- a/.github/workflows/native-kernel.yml
+++ b/.github/workflows/native-kernel.yml
@@ -1,5 +1,5 @@
 name: Native kernel
-run-name: Native kernel (TCG emulator evidence only)
+run-name: Native kernel (split checks, compile-only semantic targets, TCG emulator evidence)
 
 on:
   pull_request:

--- a/changes/1564.fixed.md
+++ b/changes/1564.fixed.md
@@ -34,6 +34,8 @@ Bounded native init/recovery now lives in `astrid-init-plan`. Every driver
 invocation including compensating stop() consumes the same step() budget, a
 private StartedMask owns started-bit capacity, and recover(fresh) tears down
 before replacement without exceeding the per-run bound. Refs #1564
+Semantic crates now run compile-only check/clippy on `aarch64-unknown-none` and
+`riscv64gc-unknown-none-elf`. Refs #1564
 
 Trusted first boot now packs the canonical 1282-byte `[ASTRIDPH][ASTRIDDC][ASTRIDSG]`
 ramdisk. The loader requires the exact length and binds `ASTRIDDC`'s signed

--- a/changes/1668.added.md
+++ b/changes/1668.added.md
@@ -1,0 +1,5 @@
+Add a workload-neutral Realm reference-interpreter isolation corpus. Two
+principals receive separate owner-bound ephemeral state, restarts are fresh,
+stale or unavailable inputs fail closed, receipts cannot become cancellation
+handles, and host path, home, process, network, and credential fallbacks are
+absent. Tracking #1668

--- a/crates/astrid-realm-compat/src/corpus.rs
+++ b/crates/astrid-realm-compat/src/corpus.rs
@@ -1,0 +1,363 @@
+//! Issue-level isolation and fallback corpus for the reference interpreter.
+//!
+//! These tests exercise the provider boundary and the owner-bound machine and
+//! ramfs directly. They deliberately do not introduce a cancellation method,
+//! host process, guest filesystem, or ambient resource lookup.
+
+use core::mem::size_of;
+
+use astrid_projection::SemanticObjectId;
+use astrid_provider::{
+    AdmittedInstance, ApplicationClosure, AttachmentDescriptor, AttachmentSet, Checkpoint,
+    CheckpointBlobId, ExecutionOutcome, ExecutionProvider, ExecutionReceipt, Job, JobArgv,
+    ProviderError, StreamDescriptor, StreamSet, check_receipt,
+};
+use astrid_resource_types::{
+    ApplicationGenerationRef, CausalRequestId, ObjectGeneration, OperationId, ProviderGeneration,
+    ResourceId,
+};
+
+use crate::fixtures::{
+    ARGV_FALSIFIER_APPLICATION, alice_principal, bob_principal, instance_for, instance_for_image,
+    instance_with_application, job_against, job_for,
+};
+use crate::image::{GuestImage, SYNTHETIC_EXIT_ZERO};
+use crate::interpreter::{
+    COMPAT_PROVIDER_GENERATION, COMPAT_PROVIDER_ID, ReferenceInterpreter, interpret_status,
+};
+use crate::machine::{DEFAULT_INSTRUCTION_FUEL, DRAM_BASE, PortableMachine};
+use crate::ramfs::EphemeralRamfs;
+
+fn opaque_attachment_job() -> Job {
+    Job::for_instance(
+        OperationId::from_bytes([0x61; 16]),
+        &instance_for(alice_principal()),
+        &JobArgv::try_from_args(&[b"true"]).expect("valid argv"),
+        &AttachmentSet::try_from_descriptors(&[AttachmentDescriptor::new(
+            SemanticObjectId::for_resource(ResourceId::from_bytes([0x71; 32])),
+            ObjectGeneration::INITIAL,
+        )])
+        .expect("one attachment"),
+        &StreamSet::EMPTY,
+        CausalRequestId::from_bytes([0x81; 16]),
+        alice_principal(),
+    )
+}
+
+fn opaque_stream_job() -> Job {
+    Job::for_instance(
+        OperationId::from_bytes([0x62; 16]),
+        &instance_for(alice_principal()),
+        &JobArgv::try_from_args(&[b"true"]).expect("valid argv"),
+        &AttachmentSet::EMPTY,
+        &StreamSet::try_from_descriptors(&[StreamDescriptor::new(
+            SemanticObjectId::for_resource(ResourceId::from_bytes([0x72; 32])),
+            ObjectGeneration::INITIAL,
+        )])
+        .expect("one stream"),
+        CausalRequestId::from_bytes([0x82; 16]),
+        alice_principal(),
+    )
+}
+
+fn cancel_probe(receipt: &ExecutionReceipt) -> Result<(), ProviderError> {
+    match receipt.as_live_handle() {
+        Err(error) => Err(error),
+        Ok(handle) => match handle {},
+    }
+}
+
+#[test]
+fn provider_restart_is_fresh_and_does_not_retain_owner_state() {
+    let provider = ReferenceInterpreter::new();
+    let instance = instance_for(alice_principal());
+    let job = job_for(alice_principal(), &[b"true"]).expect("valid argv");
+
+    let first_start = provider.start(&instance, &job).expect("first start");
+    let first_exit = provider.exit(&instance, &job).expect("first exit");
+    let second_start = provider.start(&instance, &job).expect("restart start");
+    let second_exit = provider.exit(&instance, &job).expect("restart exit");
+    assert_eq!(first_start.outcome(), ExecutionOutcome::Started);
+    assert_eq!(first_exit.outcome(), ExecutionOutcome::Exited { status: 0 });
+    assert_eq!(second_start.outcome(), ExecutionOutcome::Started);
+    assert_eq!(
+        second_exit.outcome(),
+        ExecutionOutcome::Exited { status: 0 }
+    );
+    check_receipt(&provider.identity(), &instance, &job, &second_exit).expect("bound receipt");
+
+    // The interpreter and ramfs carry no mutable or global execution table.
+    assert_eq!(size_of::<ReferenceInterpreter>(), 0);
+    assert_eq!(
+        size_of::<EphemeralRamfs>(),
+        size_of::<astrid_provider::HostPrincipal>()
+    );
+
+    let image = GuestImage::admit(&SYNTHETIC_EXIT_ZERO).expect("synthetic image");
+    let mut first_machine =
+        PortableMachine::for_owner(alice_principal(), &image, DEFAULT_INSTRUCTION_FUEL)
+            .expect("first machine");
+    first_machine
+        .store_u8(DRAM_BASE + 64, 0xA5, alice_principal())
+        .expect("owner can write its RAM");
+    assert_eq!(
+        first_machine.load_u8(DRAM_BASE + 64, alice_principal()),
+        Ok(0xA5)
+    );
+    assert_eq!(first_machine.run(alice_principal()), Ok(0));
+
+    let second_machine =
+        PortableMachine::for_owner(alice_principal(), &image, DEFAULT_INSTRUCTION_FUEL)
+            .expect("restart machine");
+    assert_eq!(
+        second_machine.load_u8(DRAM_BASE + 64, alice_principal()),
+        Ok(0)
+    );
+    assert_eq!(
+        second_machine.load_u8(DRAM_BASE, alice_principal()),
+        Ok(SYNTHETIC_EXIT_ZERO[0])
+    );
+    assert_eq!(second_machine.instructions_retired(), 0);
+}
+
+#[test]
+fn direct_owner_state_cannot_cross_principals_during_restart() {
+    let image = GuestImage::admit(&SYNTHETIC_EXIT_ZERO).expect("synthetic image");
+    let mut alice = PortableMachine::for_owner(alice_principal(), &image, DEFAULT_INSTRUCTION_FUEL)
+        .expect("Alice machine");
+    let mut bob = PortableMachine::for_owner(bob_principal(), &image, DEFAULT_INSTRUCTION_FUEL)
+        .expect("Bob machine");
+
+    alice
+        .store_u8(DRAM_BASE + 64, 0xA1, alice_principal())
+        .expect("Alice owns Alice RAM");
+    bob.store_u8(DRAM_BASE + 64, 0xB2, bob_principal())
+        .expect("Bob owns Bob RAM");
+    assert_eq!(alice.load_u8(DRAM_BASE + 64, alice_principal()), Ok(0xA1));
+    assert_eq!(bob.load_u8(DRAM_BASE + 64, bob_principal()), Ok(0xB2));
+    assert_eq!(
+        alice.load_u8(DRAM_BASE + 64, bob_principal()),
+        Err(crate::machine::MachineError::PrincipalMismatch)
+    );
+    assert_eq!(
+        bob.load_u8(DRAM_BASE + 64, alice_principal()),
+        Err(crate::machine::MachineError::PrincipalMismatch)
+    );
+    assert_eq!(
+        alice.store_u8(DRAM_BASE + 64, 0xFF, bob_principal()),
+        Err(crate::machine::MachineError::PrincipalMismatch)
+    );
+    assert_eq!(
+        bob.store_u8(DRAM_BASE + 64, 0xFF, alice_principal()),
+        Err(crate::machine::MachineError::PrincipalMismatch)
+    );
+    assert_eq!(alice.load_u8(DRAM_BASE + 64, alice_principal()), Ok(0xA1));
+    assert_eq!(bob.load_u8(DRAM_BASE + 64, bob_principal()), Ok(0xB2));
+}
+
+#[test]
+fn restore_and_cancel_attempts_fail_closed_without_live_handles() {
+    let provider = ReferenceInterpreter::new();
+    let instance = instance_for(alice_principal());
+    let job = job_for(alice_principal(), &[b"true"]).expect("valid argv");
+    let started = provider.start(&instance, &job).expect("started");
+    let exited = provider.exit(&instance, &job).expect("exited");
+    assert_eq!(cancel_probe(&started), Err(ProviderError::NotALiveHandle));
+    assert_eq!(cancel_probe(&exited), Err(ProviderError::NotALiveHandle));
+
+    let unknown = ExecutionReceipt::for_request(
+        provider.identity(),
+        &job,
+        &instance,
+        ExecutionOutcome::OutcomeUnknown,
+    );
+    assert_eq!(cancel_probe(&unknown), Err(ProviderError::NotALiveHandle));
+
+    let checkpoint = Checkpoint::from_instance(instance, CheckpointBlobId::from_bytes([0xCC; 32]));
+    assert_eq!(
+        provider.restore(&checkpoint),
+        Err(ProviderError::NotSupported)
+    );
+}
+
+#[test]
+fn provider_generation_mismatch_is_stale_on_start_and_exit() {
+    let provider = ReferenceInterpreter::new();
+    let application = ApplicationGenerationRef::from_bytes(ARGV_FALSIFIER_APPLICATION);
+    let stale_closure = ApplicationClosure::new(
+        application,
+        COMPAT_PROVIDER_ID,
+        ProviderGeneration::from_raw(2).expect("generation 2"),
+    );
+    let instance = AdmittedInstance::new(
+        instance_for(alice_principal()).id(),
+        stale_closure,
+        instance_for(alice_principal()).owner(),
+    );
+    let job = job_against(&instance, alice_principal(), &[b"true"]).expect("valid argv");
+    let expected = Err(ProviderError::StaleGeneration {
+        found: COMPAT_PROVIDER_GENERATION.get(),
+        requested: 2,
+    });
+    assert_eq!(provider.start(&instance, &job), expected);
+    assert_eq!(provider.exit(&instance, &job), expected);
+}
+
+#[test]
+fn provider_level_unavailable_backing_inputs_fail_closed() {
+    let provider = ReferenceInterpreter::new();
+    let instance = instance_for(alice_principal());
+    assert_eq!(
+        provider.start(&instance, &opaque_attachment_job()),
+        Err(ProviderError::NotSupported)
+    );
+    assert_eq!(
+        provider.exit(&instance, &opaque_attachment_job()),
+        Err(ProviderError::NotSupported)
+    );
+    assert_eq!(
+        provider.start(&instance, &opaque_stream_job()),
+        Err(ProviderError::NotSupported)
+    );
+    assert_eq!(
+        provider.exit(&instance, &opaque_stream_job()),
+        Err(ProviderError::NotSupported)
+    );
+    assert_eq!(JobArgv::try_from_args(&[]), Err(ProviderError::EmptyArgv));
+    assert_eq!(
+        interpret_status(&opaque_attachment_job()),
+        Err(ProviderError::NotSupported)
+    );
+    assert_eq!(
+        interpret_status(&opaque_stream_job()),
+        Err(ProviderError::NotSupported)
+    );
+}
+
+#[test]
+fn hostile_argv_tokens_never_select_ambient_host_fallbacks() {
+    let provider = ReferenceInterpreter::new();
+    let instance = instance_for(alice_principal());
+    let namespace = provider
+        .activate_namespace(&instance, alice_principal())
+        .expect("owner namespace");
+    assert!(namespace.as_host_path().is_none());
+    assert_eq!(namespace.owner(), alice_principal());
+    assert_eq!(namespace.namespace_id(), alice_principal());
+    assert_eq!(
+        size_of::<EphemeralRamfs>(),
+        size_of::<astrid_provider::HostPrincipal>()
+    );
+
+    for token in [
+        b"/bin/true".as_slice(),
+        b"home://".as_slice(),
+        b"cwd://".as_slice(),
+        b"process".as_slice(),
+        b"network".as_slice(),
+        b"credential".as_slice(),
+    ] {
+        let job = job_for(alice_principal(), &[token]).expect("bounded hostile token");
+        assert_eq!(
+            provider.start(&instance, &job),
+            Err(ProviderError::NotSupported)
+        );
+        assert_eq!(
+            provider.exit(&instance, &job),
+            Err(ProviderError::NotSupported)
+        );
+    }
+
+    // Only explicit stamped principals are accepted; there is no env/home or
+    // cwd lookup from which a second principal could be inferred.
+    assert_ne!(alice_principal(), bob_principal());
+    assert_eq!(namespace.observe(alice_principal()), Ok(()));
+    assert_eq!(
+        namespace.observe(bob_principal()),
+        Err(ProviderError::PrincipalMismatch)
+    );
+}
+
+#[test]
+fn same_reference_workload_isolated_at_provider_and_machine_boundaries() {
+    let provider = ReferenceInterpreter::new();
+    let alice_instance = instance_for(alice_principal());
+    let bob_instance = instance_for(bob_principal());
+    let alice_job = job_for(alice_principal(), &[b"true"]).expect("Alice argv");
+    let bob_job = job_for(bob_principal(), &[b"true"]).expect("Bob argv");
+
+    let alice_started = provider
+        .start(&alice_instance, &alice_job)
+        .expect("Alice start");
+    let bob_started = provider.start(&bob_instance, &bob_job).expect("Bob start");
+    assert_eq!(alice_started.outcome(), ExecutionOutcome::Started);
+    assert_eq!(bob_started.outcome(), ExecutionOutcome::Started);
+    assert_eq!(
+        provider.start(&alice_instance, &bob_job),
+        Err(ProviderError::PrincipalMismatch)
+    );
+    assert_eq!(
+        provider.exit(&bob_instance, &alice_job),
+        Err(ProviderError::PrincipalMismatch)
+    );
+
+    let alice_namespace = provider
+        .activate_namespace(&alice_instance, alice_principal())
+        .expect("Alice namespace");
+    let bob_namespace = provider
+        .activate_namespace(&bob_instance, bob_principal())
+        .expect("Bob namespace");
+    assert_ne!(alice_namespace.namespace_id(), bob_namespace.namespace_id());
+    assert_eq!(alice_namespace.touch(alice_principal()), Ok(()));
+    assert_eq!(bob_namespace.touch(bob_principal()), Ok(()));
+    assert_eq!(
+        alice_namespace.touch(bob_principal()),
+        Err(ProviderError::PrincipalMismatch)
+    );
+    assert_eq!(
+        bob_namespace.touch(alice_principal()),
+        Err(ProviderError::PrincipalMismatch)
+    );
+}
+
+#[test]
+fn unknown_image_and_stale_object_never_allocate_owner_state() {
+    let provider = ReferenceInterpreter::new();
+    let unknown = instance_with_application(
+        alice_principal(),
+        ApplicationGenerationRef::from_bytes([0xEE; 32]),
+        ObjectGeneration::INITIAL,
+    );
+    let unknown_job = job_against(&unknown, alice_principal(), &[b"guest"]).expect("argv");
+    assert_eq!(
+        provider.start(&unknown, &unknown_job),
+        Err(ProviderError::TypeMismatch)
+    );
+    assert_eq!(
+        provider.exit(&unknown, &unknown_job),
+        Err(ProviderError::TypeMismatch)
+    );
+
+    let image = GuestImage::admit(&SYNTHETIC_EXIT_ZERO).expect("image");
+    let current = instance_for_image(alice_principal(), &image);
+    let stale = instance_with_application(
+        alice_principal(),
+        image.id().application_generation(),
+        ObjectGeneration::from_raw(2).expect("generation 2"),
+    );
+    let current_job = job_against(&current, alice_principal(), &[b"guest"]).expect("argv");
+    assert!(matches!(
+        provider.start(&stale, &current_job),
+        Err(ProviderError::StaleGeneration {
+            found: 2,
+            requested: 1
+        })
+    ));
+    assert!(matches!(
+        provider.exit(&stale, &current_job),
+        Err(ProviderError::StaleGeneration {
+            found: 2,
+            requested: 1
+        })
+    ));
+}

--- a/crates/astrid-realm-compat/src/lib.rs
+++ b/crates/astrid-realm-compat/src/lib.rs
@@ -21,6 +21,9 @@ mod interpreter;
 mod machine;
 mod ramfs;
 
+#[cfg(test)]
+mod corpus;
+
 pub use astrid_provider::HostPrincipal;
 pub use fixtures::{alice_principal, bob_principal, host_principal_from_stamp_uid};
 pub use image::{

--- a/kernel/.cargo/config.toml
+++ b/kernel/.cargo/config.toml
@@ -1,8 +1,5 @@
 # Ring-0 builds pin curve25519-dalek's serial backend explicitly. SIMD cannot
 # activate on these arches; this is a code-generation choice, not a crypto
 # claim.
-[target.x86_64-unknown-none]
-rustflags = ['--cfg', 'curve25519_dalek_backend="serial"']
-
 [target.'cfg(all(target_os = "none", any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "riscv64")))']
 rustflags = ['--cfg', 'curve25519_dalek_backend="serial"']

--- a/kernel/.cargo/config.toml
+++ b/kernel/.cargo/config.toml
@@ -1,5 +1,8 @@
-# Fiat/serial backends keep ring-0 Ed25519 off the x86 SIMD codegen path.
-# SIMD curve25519-dalek is a compile-time hazard on this host and is not an
-# M1 or dual-closure claim.
+# Ring-0 builds pin curve25519-dalek's serial backend explicitly. SIMD cannot
+# activate on these arches; this is a code-generation choice, not a crypto
+# claim.
 [target.x86_64-unknown-none]
+rustflags = ['--cfg', 'curve25519_dalek_backend="serial"']
+
+[target.'cfg(all(target_os = "none", any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "riscv64")))']
 rustflags = ['--cfg', 'curve25519_dalek_backend="serial"']

--- a/kernel/README.md
+++ b/kernel/README.md
@@ -191,6 +191,7 @@ the non-claims above.
 Pinned to stable Rust 1.95.0. Interrupt handlers use stable naked-function
 ISR stubs via `x86_64`'s `Entry::set_handler_addr`.
 
-`x86_64-unknown-none` builds set `curve25519_dalek_backend="serial"` so
-ring-0 Ed25519 does not take the x86 SIMD codegen path. That is a compile
-choice, not a cryptography or timing claim.
+`x86_64-unknown-none`, `aarch64-unknown-none`, and
+`riscv64gc-unknown-none-elf` builds set
+`curve25519_dalek_backend="serial"`. SIMD cannot activate on the AArch64 and
+RISC-V arches; this is a compile choice, not a crypto claim.

--- a/kernel/check.sh
+++ b/kernel/check.sh
@@ -42,10 +42,6 @@ require_target() {
 run_portability() {
   local target spec package feature_spec
   local -a package_args
-  local -a required_targets=(
-    "aarch64-unknown-none"
-    "riscv64gc-unknown-none-elf"
-  )
   local -a targets=(
     "aarch64-unknown-none"
     "riscv64gc-unknown-none-elf"
@@ -57,11 +53,8 @@ run_portability() {
     "astrid-init-plan|"
   )
 
-  for target in "${required_targets[@]}"; do
-    require_target "$target"
-  done
-
   for target in "${targets[@]}"; do
+    require_target "$target"
     for spec in "${packages[@]}"; do
       package="${spec%%|*}"
       feature_spec="${spec#*|}"

--- a/kernel/check.sh
+++ b/kernel/check.sh
@@ -11,6 +11,91 @@ toolchain="${KTEST_TOOLCHAIN:-nightly-2026-07-21}"
 host="$root/target/kimage-host"
 nested="$root/target/bootloader-nested"
 
+mode="${1:-all}"
+if [[ $# -gt 1 ]]; then
+  echo "usage: $0 [x86|portability]" >&2
+  exit 2
+fi
+
+require_target() {
+  local target="$1"
+  local cfg installed_targets installed_target
+  if ! cfg="$(rustc --print cfg --target "$target" 2>&1)"; then
+    echo "check.sh: required target $target is not recognized by the active rustc" >&2
+    echo "$cfg" >&2
+    exit 1
+  fi
+  if ! installed_targets="$(rustup target list --installed 2>&1)"; then
+    echo "check.sh: unable to query installed Rust targets" >&2
+    echo "$installed_targets" >&2
+    exit 1
+  fi
+  while IFS= read -r installed_target; do
+    if [[ "$installed_target" == "$target" ]]; then
+      return 0
+    fi
+  done <<< "$installed_targets"
+  echo "check.sh: required target $target is missing; install it with 'rustup target add $target'" >&2
+  exit 1
+}
+
+run_portability() {
+  local target spec package feature_spec
+  local -a package_args
+  local -a required_targets=(
+    "x86_64-unknown-none"
+    "aarch64-unknown-none"
+    "riscv64gc-unknown-none-elf"
+  )
+  local -a targets=(
+    "aarch64-unknown-none"
+    "riscv64gc-unknown-none-elf"
+  )
+  local -a packages=(
+    "astrid-native-closure|--no-default-features"
+    "astrid-system-generation|--no-default-features"
+    "astrid-boot-selection|--no-default-features"
+    "astrid-init-plan|"
+  )
+
+  for target in "${required_targets[@]}"; do
+    require_target "$target"
+  done
+
+  for target in "${targets[@]}"; do
+    for spec in "${packages[@]}"; do
+      package="${spec%%|*}"
+      feature_spec="${spec#*|}"
+      package_args=(-p "$package")
+      if [[ -n "$feature_spec" ]]; then
+        package_args+=(--no-default-features)
+      fi
+
+      echo "== stable cargo check -p $package ${feature_spec:+$feature_spec }--target $target (compile-only) =="
+      cargo check "${package_args[@]}" --target "$target" --locked
+
+      echo "== stable cargo clippy -p $package ${feature_spec:+$feature_spec }--target $target (compile-only) =="
+      cargo clippy "${package_args[@]}" --target "$target" --locked -- -D warnings
+    done
+  done
+
+  echo "check.sh: PASS (compile-only portability checks; not boot or hardware evidence)"
+}
+
+case "$mode" in
+  x86|all)
+    require_target "x86_64-unknown-none"
+    ;;
+  portability)
+    run_portability
+    exit 0
+    ;;
+  *)
+    echo "usage: $0 [x86|portability]" >&2
+    exit 2
+    ;;
+esac
+
 echo "== cargo fmt (kernel packages; vendored bootloader uses its own pinned toolchain) =="
 cargo fmt -p astrid-native-closure -p astrid-native-kernel -p astrid-boot-selection -p astrid-init-plan -p astrid-system-generation -p kimage -p ktest -- --check
 
@@ -80,3 +165,7 @@ env -u CARGO_BUILD_TARGET_DIR \
   rustup run "$toolchain" cargo clippy -p kimage --all-targets --locked --target-dir "$host" -- -D warnings
 
 echo "check.sh: PASS (split checks only; not workspace clippy)"
+
+if [[ "$mode" == all ]]; then
+  run_portability
+fi

--- a/kernel/check.sh
+++ b/kernel/check.sh
@@ -13,7 +13,7 @@ nested="$root/target/bootloader-nested"
 
 mode="${1:-all}"
 if [[ $# -gt 1 ]]; then
-  echo "usage: $0 [x86|portability]" >&2
+  echo "usage: $0 [x86|portability|all]" >&2
   exit 2
 fi
 
@@ -43,7 +43,6 @@ run_portability() {
   local target spec package feature_spec
   local -a package_args
   local -a required_targets=(
-    "x86_64-unknown-none"
     "aarch64-unknown-none"
     "riscv64gc-unknown-none-elf"
   )
@@ -91,7 +90,7 @@ case "$mode" in
     exit 0
     ;;
   *)
-    echo "usage: $0 [x86|portability]" >&2
+    echo "usage: $0 [x86|portability|all]" >&2
     exit 2
     ;;
 esac

--- a/kernel/rust-toolchain.toml
+++ b/kernel/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "1.95.0"
-targets = ["x86_64-unknown-none"]
+targets = ["x86_64-unknown-none", "aarch64-unknown-none", "riscv64gc-unknown-none-elf"]
 components = ["rust-src", "clippy", "rustfmt"]

--- a/kernel/rust-toolchain.toml
+++ b/kernel/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "1.95.0"
-targets = ["x86_64-unknown-none", "aarch64-unknown-none", "riscv64gc-unknown-none-elf"]
+targets = ["x86_64-unknown-none"]
 components = ["rust-src", "clippy", "rustfmt"]


### PR DESCRIPTION
## Linked Issue

Closes #1668

## Summary

Add a workload-neutral Realm reference-interpreter isolation corpus on `os/universal`. Two principals run the same reference workload against separate owner-bound ephemeral state. Restart is a fresh machine, cancellation cannot be derived from receipts, stale provider/object generations and unavailable backing inputs fail closed, and host path, `home://`, process, network, and credential fallbacks are absent.

This is reference-interpreter evidence only. It does not introduce Linux, hypervisor, guest-filesystem, Hermes, BusyBox ABI, public WIT, or provider-crate changes.

The current head is a signed no-ff integration of the accepted corpus onto live `os/universal`. Content is unchanged from accepted `45433317`.

## Changes

- Add `crates/astrid-realm-compat/src/corpus.rs` covering restart freshness, Alice/Bob RAM and namespace isolation, stale `ProviderGeneration` and object generation on start/exit, `restore()` `NotSupported`, receipt cancel probes including `OutcomeUnknown`, attachment/stream/empty-argv rejection, and hostile argv tokens.
- Wire the corpus as a crate-private test module.
- Add `changes/1668.added.md`.
- Signed no-ff integration: first parent live `os/universal` `b4e5c1063714737beb6e28718033a2a5d5953d23`, second parent accepted `4543331765e63e696eee5d29f665e5ceaad29658`. Tree equals the clean merge-tree. Realm corpus and changelog blobs are byte-identical to the accepted head.

The landed `ExecutionProvider` surface remains `identity` / `start` / `exit` / `checkpoint` / `restore`. There is no `cancel` or `restart` method and receipts cannot become live handles.

## Verification

Integration head `e2952d38b7cd32836300b4e25631f7b665a67141`.
Accepted content `4543331765e63e696eee5d29f665e5ceaad29658`.

- Parents in order: `b4e5c106` then `45433317`
- `HEAD^{tree}` equals merge-tree `fbc252d337e23749ac5af8f9be357de44900a192`
- Unique vs first parent: `changes/1668.added.md`, `crates/astrid-realm-compat/src/corpus.rs`, `crates/astrid-realm-compat/src/lib.rs`
- Prior local crate evidence on accepted content: default and `--no-default-features` `cargo test --locked -p astrid-realm-compat` 35/35; clippy `-D warnings`; fmt; wasm32-unknown-unknown; x86_64-unknown-none
- GPG Good; DCO present; `git diff --check` clean

Fresh PR CI is required on this integration successor.

## AI / Tool Assistance

Implementation and review assistance from Codex. Commits are GPG-signed with DCO by Joshua J. Bouw.

## Dependencies

- First parent: `os/universal` at `b4e5c1063714737beb6e28718033a2a5d5953d23`
- Consumes landed provider value types only; no `crates/astrid-provider/**` edits

## Residuals

This does not prove production Linux Realm, POSIX durability, hardware virtualization, guest filesystems, or Hermes execution. Full-workspace `cargo test` is not claimed by the crate-local run.
