### PR TITLE
feat: add host-internal ResourceAuthority table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -394,6 +394,7 @@ dependencies = [
  "astrid-crypto",
  "astrid-events",
  "astrid-mcp",
+ "astrid-resource-types",
  "astrid-runtime",
  "astrid-storage",
  "astrid-uplink",

--- a/changes/1660.added.md
+++ b/changes/1660.added.md
@@ -2,5 +2,6 @@ Add a host-owned, invocation-scoped ResourceAuthority table for in-memory
 SemanticObject fixtures. Live handles bind the host stamp, object generation,
 bounded object scope, rights, authority epoch, and a non-serializable reserved
 budget; attenuation, expiry, revocation, cross-principal use, stale handles,
-and reservation reclamation fail closed. Tracking #1660
+and reservation reclamation fail closed. Scope construction counts raw identity
+cardinality against a hard 64-object DoS bound. Tracking #1660
 Tracking #1564

--- a/changes/1660.added.md
+++ b/changes/1660.added.md
@@ -1,0 +1,6 @@
+Add a host-owned, invocation-scoped ResourceAuthority table for in-memory
+SemanticObject fixtures. Live handles bind the host stamp, object generation,
+bounded object scope, rights, authority epoch, and a non-serializable reserved
+budget; attenuation, expiry, revocation, cross-principal use, stale handles,
+and reservation reclamation fail closed. Tracking #1660
+Tracking #1564

--- a/crates/astrid-capsule/Cargo.toml
+++ b/crates/astrid-capsule/Cargo.toml
@@ -26,6 +26,7 @@ astrid-core = { workspace = true }
 astrid-crypto = { workspace = true }
 astrid-events = { workspace = true }
 astrid-runtime = { workspace = true }
+astrid-resource-types = { workspace = true }
 astrid-storage = { workspace = true }
 anyhow = { workspace = true }
 arc-swap = { workspace = true }

--- a/crates/astrid-capsule/src/lib.rs
+++ b/crates/astrid-capsule/src/lib.rs
@@ -33,6 +33,7 @@ pub mod principal_class;
 pub mod profile_cache;
 pub mod readiness;
 pub mod registry;
+pub(crate) mod resource_authority;
 pub mod schema_catalog;
 pub mod security;
 pub mod stamp;

--- a/crates/astrid-capsule/src/resource_authority/mod.rs
+++ b/crates/astrid-capsule/src/resource_authority/mod.rs
@@ -1,0 +1,41 @@
+//! Host-owned authority for invocation-scoped semantic-object fixtures.
+//!
+//! The table is deliberately independent from the Wasmtime resource table. A
+//! [`ResourceHandle`] only names a slot in this table; it is not useful as a
+//! bearer value without the current host stamp and matching live entry.
+
+// This vertical slice is intentionally not wired into a host-state field yet;
+// its crate-private API is exercised by the sibling regressions until an
+// admission caller is selected.
+#![cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "this staged host-only API is exercised by sibling tests before wiring"
+    )
+)]
+
+mod scope;
+mod table;
+
+#[cfg(test)]
+mod tests;
+
+#[cfg_attr(
+    not(test),
+    expect(
+        unused_imports,
+        reason = "crate-private re-exports reserve the staged table API for its future caller"
+    )
+)]
+pub(crate) use scope::{
+    AdmissionOptions, Reservation, ResourceHandle, ResourceScope, RevocationSelector,
+};
+#[cfg_attr(
+    not(test),
+    expect(
+        unused_imports,
+        reason = "crate-private re-export reserves the staged table API for its future caller"
+    )
+)]
+pub(crate) use table::ResourceAuthorityTable;

--- a/crates/astrid-capsule/src/resource_authority/scope.rs
+++ b/crates/astrid-capsule/src/resource_authority/scope.rs
@@ -33,16 +33,24 @@ impl ResourceScope {
     }
 
     /// Build a bounded host selector from already typed identities.
+    ///
+    /// The ceiling is raw input cardinality, not unique-set size.
     pub(crate) fn from_identities<I>(identities: I) -> Result<Self, ResourceErrorCode>
     where
         I: IntoIterator<Item = ResourceId>,
     {
         let mut admitted = BTreeSet::new();
+        // Bound raw input cardinality, not unique-set size, so a repeating or
+        // unbounded iterator still trips the DoS ceiling.
+        let mut raw_count = 0usize;
         for identity in identities {
-            admitted.insert(identity);
-            if admitted.len() > MAX_SCOPE_OBJECTS {
+            raw_count = raw_count
+                .checked_add(1)
+                .ok_or(ResourceErrorCode::InvalidDescriptor)?;
+            if raw_count > MAX_SCOPE_OBJECTS {
                 return Err(ResourceErrorCode::InvalidDescriptor);
             }
+            admitted.insert(identity);
         }
         Ok(Self {
             identities: admitted,

--- a/crates/astrid-capsule/src/resource_authority/scope.rs
+++ b/crates/astrid-capsule/src/resource_authority/scope.rs
@@ -1,0 +1,233 @@
+//! Host-only scope, reservation, and authority values for the table.
+
+use std::{collections::BTreeSet, time::Instant};
+
+use astrid_core::PrincipalUid;
+use astrid_resource_types::{
+    AccountId, AuthorityEpoch, BudgetId, ObjectGeneration, OwnerId, ResourceErrorCode, ResourceId,
+    ResourceKind, Rights, TransferClass,
+};
+
+/// Hard DoS bound for a host-admitted object subset. This is a table invariant,
+/// not an operator policy knob: scope admission must remain bounded even when
+/// an untrusted request is converted into a host-side selector.
+pub(super) const MAX_SCOPE_OBJECTS: usize = 64;
+
+/// A bounded, host-only set of semantic-object identities.
+///
+/// This type intentionally has no path, string, byte-decoding, or serde
+/// constructor. A scope describes an already admitted object subset; it never
+/// grants access by itself.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ResourceScope {
+    pub(super) identities: BTreeSet<ResourceId>,
+}
+
+impl ResourceScope {
+    /// Build the smallest scope that contains one admitted object identity.
+    #[must_use]
+    pub(crate) fn singleton(identity: ResourceId) -> Self {
+        Self {
+            identities: BTreeSet::from([identity]),
+        }
+    }
+
+    /// Build a bounded host selector from already typed identities.
+    pub(crate) fn from_identities<I>(identities: I) -> Result<Self, ResourceErrorCode>
+    where
+        I: IntoIterator<Item = ResourceId>,
+    {
+        let mut admitted = BTreeSet::new();
+        for identity in identities {
+            admitted.insert(identity);
+            if admitted.len() > MAX_SCOPE_OBJECTS {
+                return Err(ResourceErrorCode::InvalidDescriptor);
+            }
+        }
+        Ok(Self {
+            identities: admitted,
+        })
+    }
+
+    pub(super) fn contains(&self, identity: ResourceId) -> bool {
+        self.identities.contains(&identity)
+    }
+
+    pub(super) fn is_subset_of(&self, admitted: &Self) -> bool {
+        self.identities.is_subset(&admitted.identities)
+    }
+}
+
+/// A host reservation linked to a descriptor identity and a remaining unit
+/// envelope. The descriptor IDs are labels only; this wrapper is the live
+/// reservation held by the authority table.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct Reservation {
+    pub(super) account: AccountId,
+    pub(super) budget: BudgetId,
+    pub(super) remaining: u64,
+}
+
+impl Reservation {
+    /// Reserve units under an already admitted accounting and budget domain.
+    ///
+    /// The constructor is crate-private so a guest cannot deserialize or mint
+    /// a live envelope from an [`AccountId`] or [`BudgetId`].
+    #[must_use]
+    pub(crate) const fn new(account: AccountId, budget: BudgetId, units: u64) -> Self {
+        Self {
+            account,
+            budget,
+            remaining: units,
+        }
+    }
+}
+
+/// A selector for a host revocation domain. It is not a bearer token.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct RevocationSelector(pub(super) u64);
+
+impl RevocationSelector {
+    /// Construct a selector at a trusted host boundary.
+    #[must_use]
+    pub(crate) const fn new(value: u64) -> Self {
+        Self(value)
+    }
+}
+
+/// Host-side admission options that carry authority-bearing checks.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct AdmissionOptions {
+    pub(super) rights: Rights,
+    pub(super) authority_epoch: AuthorityEpoch,
+    pub(super) expiry: Option<Instant>,
+    pub(super) revocation: Option<RevocationSelector>,
+}
+
+impl AdmissionOptions {
+    /// Construct options from a current host epoch and optional invalidators.
+    #[must_use]
+    pub(crate) const fn new(
+        rights: Rights,
+        authority_epoch: AuthorityEpoch,
+        expiry: Option<Instant>,
+        revocation: Option<RevocationSelector>,
+    ) -> Self {
+        Self {
+            rights,
+            authority_epoch,
+            expiry,
+            revocation,
+        }
+    }
+}
+
+/// Opaque table-local handle bound to an object generation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub(crate) struct ResourceHandle {
+    pub(super) slot: usize,
+    pub(super) generation: ObjectGeneration,
+}
+
+impl ResourceHandle {
+    #[cfg(test)]
+    pub(super) fn generation(self) -> ObjectGeneration {
+        self.generation
+    }
+}
+
+/// Live authority resolved by [`ResourceAuthorityTable::lookup`].
+///
+/// This type has no serialization or public constructor. Its reservation,
+/// scope, principal, and revocation state are all table-owned.
+#[derive(Debug)]
+pub(crate) struct ResourceAuthority {
+    pub(super) kind: ResourceKind,
+    pub(super) identity: ResourceId,
+    pub(super) scope: ResourceScope,
+    pub(super) reservation: Reservation,
+    pub(super) rights: Rights,
+    pub(super) owner: OwnerId,
+    pub(super) principal: PrincipalUid,
+    pub(super) initiator: PrincipalUid,
+    pub(super) authority_epoch: AuthorityEpoch,
+    pub(super) transfer_class: TransferClass,
+    pub(super) expiry: Option<Instant>,
+    pub(super) revocation: Option<RevocationSelector>,
+    pub(super) revoked: bool,
+    pub(super) parent: Option<ResourceHandle>,
+    pub(super) resource: SemanticObject,
+}
+
+impl ResourceAuthority {
+    #[must_use]
+    pub(crate) const fn kind(&self) -> ResourceKind {
+        self.kind
+    }
+
+    #[must_use]
+    pub(crate) const fn identity(&self) -> ResourceId {
+        self.identity
+    }
+
+    #[must_use]
+    pub(crate) const fn rights(&self) -> Rights {
+        self.rights
+    }
+
+    #[must_use]
+    pub(crate) const fn owner(&self) -> OwnerId {
+        self.owner
+    }
+
+    #[must_use]
+    pub(crate) const fn authority_epoch(&self) -> AuthorityEpoch {
+        self.authority_epoch
+    }
+
+    #[must_use]
+    pub(crate) const fn transfer_class(&self) -> TransferClass {
+        self.transfer_class
+    }
+
+    #[must_use]
+    pub(crate) const fn remaining_budget(&self) -> u64 {
+        self.reservation.remaining
+    }
+
+    #[must_use]
+    pub(crate) const fn budget_id(&self) -> BudgetId {
+        self.reservation.budget
+    }
+
+    #[must_use]
+    pub(crate) const fn account_id(&self) -> AccountId {
+        self.reservation.account
+    }
+
+    #[must_use]
+    pub(crate) const fn scope(&self) -> &ResourceScope {
+        &self.scope
+    }
+
+    #[must_use]
+    pub(crate) const fn principal(&self) -> PrincipalUid {
+        self.principal
+    }
+
+    #[must_use]
+    pub(crate) const fn initiator(&self) -> PrincipalUid {
+        self.initiator
+    }
+
+    #[must_use]
+    pub(crate) const fn parent(&self) -> Option<ResourceHandle> {
+        self.parent
+    }
+}
+
+/// Private in-memory fixture payload for the one admitted kind.
+#[derive(Debug)]
+pub(super) struct SemanticObject {
+    pub(super) identity: ResourceId,
+}

--- a/crates/astrid-capsule/src/resource_authority/table.rs
+++ b/crates/astrid-capsule/src/resource_authority/table.rs
@@ -1,0 +1,637 @@
+//! Slot table and live preflight enforcement.
+
+use std::{borrow::Borrow, collections::BTreeSet, time::Instant};
+
+use astrid_resource_types::{
+    AccountId, AuthorityEpoch, BudgetId, ObjectGeneration, OwnerId, ResourceErrorCode, ResourceId,
+    ResourceKind, Rights, TransferClass,
+};
+
+use crate::stamp::StampedInvocation;
+
+use super::scope::{
+    AdmissionOptions, Reservation, ResourceAuthority, ResourceHandle, ResourceScope,
+    RevocationSelector, SemanticObject,
+};
+
+/// Maximum delegation depth checked while resolving a live child.
+const MAX_LINEAGE_DEPTH: usize = 64;
+
+#[derive(Debug)]
+struct Slot {
+    generation: ObjectGeneration,
+    authority: Option<ResourceAuthority>,
+    retired: bool,
+}
+
+impl Slot {
+    const fn new() -> Self {
+        Self {
+            generation: ObjectGeneration::INITIAL,
+            authority: None,
+            retired: false,
+        }
+    }
+}
+
+/// Host-owned live authority table for invocation-scoped semantic objects.
+#[derive(Debug)]
+pub(crate) struct ResourceAuthorityTable {
+    slots: Vec<Slot>,
+    authority_epoch: AuthorityEpoch,
+    active_reserved_units: u128,
+    released_reserved_units: u128,
+    revoked_selectors: BTreeSet<RevocationSelector>,
+}
+
+impl Default for ResourceAuthorityTable {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ResourceAuthorityTable {
+    /// Start an empty table at the initial authority epoch.
+    #[must_use]
+    pub(crate) fn new() -> Self {
+        Self::new_at_epoch(AuthorityEpoch::INITIAL)
+    }
+
+    /// Start an empty table at a trusted current authority epoch.
+    #[must_use]
+    pub(crate) fn new_at_epoch(authority_epoch: AuthorityEpoch) -> Self {
+        Self {
+            slots: Vec::new(),
+            authority_epoch,
+            active_reserved_units: 0,
+            released_reserved_units: 0,
+            revoked_selectors: BTreeSet::new(),
+        }
+    }
+
+    #[must_use]
+    pub(crate) const fn authority_epoch(&self) -> AuthorityEpoch {
+        self.authority_epoch
+    }
+
+    #[must_use]
+    pub(crate) const fn active_reserved_units(&self) -> u128 {
+        self.active_reserved_units
+    }
+
+    #[must_use]
+    pub(crate) const fn released_reserved_units(&self) -> u128 {
+        self.released_reserved_units
+    }
+
+    /// Admit one invocation-scoped [`ResourceKind::SemanticObject`].
+    pub(crate) fn admit(
+        &mut self,
+        stamp: &StampedInvocation,
+        kind: ResourceKind,
+        identity: ResourceId,
+        scope: ResourceScope,
+        reservation: Reservation,
+        options: AdmissionOptions,
+    ) -> Result<ResourceHandle, ResourceErrorCode> {
+        self.validate_admission(kind, identity, &scope, &options, reservation.remaining)?;
+        self.reserve_units(reservation.remaining)?;
+        let handle = self.allocate_slot();
+        let authority = ResourceAuthority {
+            kind,
+            identity,
+            scope,
+            reservation,
+            rights: options.rights,
+            owner: OwnerId::from(stamp.principal()),
+            principal: stamp.principal(),
+            initiator: stamp.principal(),
+            authority_epoch: options.authority_epoch,
+            transfer_class: TransferClass::None,
+            expiry: options.expiry,
+            revocation: options.revocation,
+            revoked: false,
+            parent: None,
+            resource: SemanticObject { identity },
+        };
+        self.slot_mut(handle)?.authority = Some(authority);
+        Ok(handle)
+    }
+
+    /// Resolve a live authority for the stamped acting principal.
+    pub(crate) fn lookup(
+        &self,
+        stamp: &StampedInvocation,
+        handle: ResourceHandle,
+    ) -> Result<&ResourceAuthority, ResourceErrorCode> {
+        let authority = self.slot_authority(handle)?;
+        self.validate_live(stamp, authority)?;
+        Ok(authority)
+    }
+
+    /// Check one operation against the live authority without consuming it.
+    pub(crate) fn preflight<S>(
+        &self,
+        stamp: &StampedInvocation,
+        handle: ResourceHandle,
+        requested_right: Rights,
+        requested_scope: S,
+        requested_budget: u64,
+    ) -> Result<(), ResourceErrorCode>
+    where
+        S: Borrow<ResourceScope>,
+    {
+        let authority = self.lookup(stamp, handle)?;
+        let requested_scope = requested_scope.borrow();
+        if !authority.rights.contains(requested_right) {
+            return Err(ResourceErrorCode::MissingRight);
+        }
+        if !requested_scope.is_subset_of(&authority.scope) {
+            return Err(ResourceErrorCode::InvalidDescriptor);
+        }
+        if requested_budget > authority.reservation.remaining {
+            return Err(ResourceErrorCode::Exhausted);
+        }
+        Ok(())
+    }
+
+    /// Create a child authority with an inherited expiry.
+    pub(crate) fn attenuate<S>(
+        &mut self,
+        stamp: &StampedInvocation,
+        parent: ResourceHandle,
+        rights: Rights,
+        scope: S,
+        budget: u64,
+    ) -> Result<ResourceHandle, ResourceErrorCode>
+    where
+        S: Borrow<ResourceScope>,
+    {
+        let expiry = self.lookup(stamp, parent)?.expiry;
+        self.attenuate_with_expiry(stamp, parent, rights, scope, budget, expiry)
+    }
+
+    /// Create a child authority while enforcing the parent's expiry bound.
+    pub(crate) fn attenuate_with_expiry<S>(
+        &mut self,
+        stamp: &StampedInvocation,
+        parent: ResourceHandle,
+        rights: Rights,
+        scope: S,
+        budget: u64,
+        expiry: Option<Instant>,
+    ) -> Result<ResourceHandle, ResourceErrorCode>
+    where
+        S: Borrow<ResourceScope>,
+    {
+        let requested_scope = scope.borrow().clone();
+        let snapshot = self.delegation_snapshot(stamp, parent)?;
+        self.validate_delegation(&snapshot, rights, &requested_scope, budget, expiry)?;
+        let handle = self.allocate_slot();
+        self.debit_parent(parent, budget)?;
+        let authority = ResourceAuthority {
+            kind: snapshot.kind,
+            identity: snapshot.identity,
+            scope: requested_scope,
+            reservation: Reservation::new(snapshot.account, snapshot.budget, budget),
+            rights,
+            owner: OwnerId::from(stamp.principal()),
+            principal: stamp.principal(),
+            initiator: stamp.principal(),
+            authority_epoch: snapshot.authority_epoch,
+            transfer_class: snapshot.transfer_class,
+            expiry,
+            revocation: snapshot.revocation,
+            revoked: false,
+            parent: Some(parent),
+            resource: SemanticObject {
+                identity: snapshot.identity,
+            },
+        };
+        self.slot_mut(handle)?.authority = Some(authority);
+        Ok(handle)
+    }
+
+    /// Reclaim one live handle and advance its table generation.
+    pub(crate) fn reclaim(
+        &mut self,
+        stamp: &StampedInvocation,
+        handle: ResourceHandle,
+    ) -> Result<(), ResourceErrorCode> {
+        let (parent, reservation) = self.reclaim_snapshot(stamp, handle)?;
+        let refund_parent = self.can_refund_parent(parent, &reservation);
+        if !refund_parent {
+            self.ensure_external_release(reservation.remaining)?;
+        }
+        let authority = self.slot_mut(handle)?.authority.take();
+        if authority.is_none() {
+            return Err(ResourceErrorCode::StaleGeneration);
+        }
+        self.advance_slot(handle)?;
+        if refund_parent {
+            self.refund_parent(parent, &reservation)?;
+        } else {
+            self.release_external(reservation.remaining)?;
+        }
+        Ok(())
+    }
+
+    /// Alias used by host drop paths; it retains the stamp boundary.
+    pub(crate) fn drop_handle(
+        &mut self,
+        stamp: &StampedInvocation,
+        handle: ResourceHandle,
+    ) -> Result<(), ResourceErrorCode> {
+        self.reclaim(stamp, handle)
+    }
+
+    /// Revoke one live handle without changing its slot generation.
+    pub(crate) fn revoke(&mut self, handle: ResourceHandle) -> Result<(), ResourceErrorCode> {
+        let authority = self.slot_authority_mut(handle)?;
+        authority.revoked = true;
+        Ok(())
+    }
+
+    /// Revoke one handle after checking the stamped owner.
+    pub(crate) fn revoke_for(
+        &mut self,
+        stamp: &StampedInvocation,
+        handle: ResourceHandle,
+    ) -> Result<(), ResourceErrorCode> {
+        self.reclaim_owner(stamp, handle)?;
+        self.revoke(handle)
+    }
+
+    /// Revoke every authority carrying a selector from this table.
+    pub(crate) fn revoke_selector(
+        &mut self,
+        selector: RevocationSelector,
+    ) -> Result<(), ResourceErrorCode> {
+        self.revoked_selectors.insert(selector);
+        Ok(())
+    }
+
+    /// Advance the current epoch; entries from older epochs fail closed.
+    pub(crate) fn advance_authority_epoch(&mut self) -> Result<AuthorityEpoch, ResourceErrorCode> {
+        let next = self
+            .authority_epoch
+            .checked_next()
+            .map_err(|_| ResourceErrorCode::Internal)?;
+        self.authority_epoch = next;
+        Ok(next)
+    }
+
+    fn validate_admission(
+        &self,
+        kind: ResourceKind,
+        identity: ResourceId,
+        scope: &ResourceScope,
+        options: &AdmissionOptions,
+        units: u64,
+    ) -> Result<(), ResourceErrorCode> {
+        if kind != ResourceKind::SemanticObject || !scope.contains(identity) {
+            return Err(ResourceErrorCode::InvalidDescriptor);
+        }
+        if options.authority_epoch != self.authority_epoch {
+            return Err(ResourceErrorCode::Revoked);
+        }
+        if options
+            .expiry
+            .is_some_and(|deadline| deadline <= Instant::now())
+        {
+            return Err(ResourceErrorCode::Revoked);
+        }
+        if options
+            .revocation
+            .is_some_and(|selector| self.revoked_selectors.contains(&selector))
+        {
+            return Err(ResourceErrorCode::Revoked);
+        }
+        if self
+            .active_reserved_units
+            .checked_add(u128::from(units))
+            .is_none()
+        {
+            return Err(ResourceErrorCode::Exhausted);
+        }
+        Ok(())
+    }
+
+    fn reserve_units(&mut self, units: u64) -> Result<(), ResourceErrorCode> {
+        self.active_reserved_units = self
+            .active_reserved_units
+            .checked_add(u128::from(units))
+            .ok_or(ResourceErrorCode::Exhausted)?;
+        Ok(())
+    }
+
+    fn allocate_slot(&mut self) -> ResourceHandle {
+        if let Some((slot, entry)) = self
+            .slots
+            .iter()
+            .enumerate()
+            .find(|(_, entry)| !entry.retired && entry.authority.is_none())
+        {
+            return ResourceHandle {
+                slot,
+                generation: entry.generation,
+            };
+        }
+        let slot = self.slots.len();
+        self.slots.push(Slot::new());
+        ResourceHandle {
+            slot,
+            generation: ObjectGeneration::INITIAL,
+        }
+    }
+
+    fn slot_authority(
+        &self,
+        handle: ResourceHandle,
+    ) -> Result<&ResourceAuthority, ResourceErrorCode> {
+        let slot = self
+            .slots
+            .get(handle.slot)
+            .ok_or(ResourceErrorCode::StaleGeneration)?;
+        if slot.retired || slot.generation != handle.generation {
+            return Err(ResourceErrorCode::StaleGeneration);
+        }
+        slot.authority
+            .as_ref()
+            .ok_or(ResourceErrorCode::StaleGeneration)
+    }
+
+    fn slot_authority_mut(
+        &mut self,
+        handle: ResourceHandle,
+    ) -> Result<&mut ResourceAuthority, ResourceErrorCode> {
+        let slot = self
+            .slots
+            .get_mut(handle.slot)
+            .ok_or(ResourceErrorCode::StaleGeneration)?;
+        if slot.retired || slot.generation != handle.generation {
+            return Err(ResourceErrorCode::StaleGeneration);
+        }
+        slot.authority
+            .as_mut()
+            .ok_or(ResourceErrorCode::StaleGeneration)
+    }
+
+    fn slot_mut(&mut self, handle: ResourceHandle) -> Result<&mut Slot, ResourceErrorCode> {
+        self.slots
+            .get_mut(handle.slot)
+            .ok_or(ResourceErrorCode::StaleGeneration)
+    }
+
+    fn validate_live(
+        &self,
+        stamp: &StampedInvocation,
+        authority: &ResourceAuthority,
+    ) -> Result<(), ResourceErrorCode> {
+        if authority.resource.identity != authority.identity {
+            return Err(ResourceErrorCode::Internal);
+        }
+        if authority.principal != stamp.principal() || authority.initiator != stamp.principal() {
+            return Err(ResourceErrorCode::WrongOwner);
+        }
+        if authority.authority_epoch != self.authority_epoch {
+            return Err(ResourceErrorCode::Revoked);
+        }
+        if authority.revoked
+            || authority
+                .revocation
+                .is_some_and(|selector| self.revoked_selectors.contains(&selector))
+        {
+            return Err(ResourceErrorCode::Revoked);
+        }
+        if authority
+            .expiry
+            .is_some_and(|deadline| deadline <= Instant::now())
+        {
+            return Err(ResourceErrorCode::Revoked);
+        }
+        if !self.lineage_is_live(authority.parent) {
+            return Err(ResourceErrorCode::Revoked);
+        }
+        Ok(())
+    }
+
+    fn lineage_is_live(&self, mut parent: Option<ResourceHandle>) -> bool {
+        for _ in 0..=MAX_LINEAGE_DEPTH {
+            let Some(handle) = parent else {
+                return true;
+            };
+            let Ok(authority) = self.slot_authority(handle) else {
+                return false;
+            };
+            if authority.authority_epoch != self.authority_epoch
+                || authority.revoked
+                || authority
+                    .revocation
+                    .is_some_and(|selector| self.revoked_selectors.contains(&selector))
+                || authority
+                    .expiry
+                    .is_some_and(|deadline| deadline <= Instant::now())
+            {
+                return false;
+            }
+            parent = authority.parent;
+        }
+        false
+    }
+
+    fn delegation_snapshot(
+        &self,
+        stamp: &StampedInvocation,
+        parent: ResourceHandle,
+    ) -> Result<DelegationSnapshot, ResourceErrorCode> {
+        let authority = self.lookup(stamp, parent)?;
+        Ok(DelegationSnapshot {
+            kind: authority.kind,
+            identity: authority.identity,
+            parent_rights: authority.rights,
+            parent_scope: authority.scope.clone(),
+            account: authority.reservation.account,
+            budget: authority.reservation.budget,
+            remaining: authority.reservation.remaining,
+            authority_epoch: authority.authority_epoch,
+            transfer_class: authority.transfer_class,
+            expiry: authority.expiry,
+            revocation: authority.revocation,
+        })
+    }
+
+    fn validate_delegation(
+        &self,
+        snapshot: &DelegationSnapshot,
+        rights: Rights,
+        scope: &ResourceScope,
+        budget: u64,
+        expiry: Option<Instant>,
+    ) -> Result<(), ResourceErrorCode> {
+        if snapshot.kind != ResourceKind::SemanticObject {
+            return Err(ResourceErrorCode::Unsupported);
+        }
+        if !snapshot.parent_rights.contains(Rights::DELEGATE)
+            || !rights.is_subset(snapshot.parent_rights)
+        {
+            return Err(ResourceErrorCode::MissingRight);
+        }
+        if !scope.is_subset_of(&snapshot.parent_scope) {
+            return Err(ResourceErrorCode::InvalidDescriptor);
+        }
+        if budget > snapshot.remaining {
+            return Err(ResourceErrorCode::Exhausted);
+        }
+        if (snapshot.expiry.is_some() && expiry.is_none())
+            || matches!((snapshot.expiry, expiry), (Some(parent), Some(child)) if child > parent)
+        {
+            return Err(ResourceErrorCode::InvalidDescriptor);
+        }
+        if expiry.is_some_and(|deadline| deadline <= Instant::now()) {
+            return Err(ResourceErrorCode::Revoked);
+        }
+        if snapshot
+            .revocation
+            .is_some_and(|selector| self.revoked_selectors.contains(&selector))
+        {
+            return Err(ResourceErrorCode::Revoked);
+        }
+        Ok(())
+    }
+
+    fn debit_parent(
+        &mut self,
+        parent: ResourceHandle,
+        budget: u64,
+    ) -> Result<(), ResourceErrorCode> {
+        let authority = self.slot_authority_mut(parent)?;
+        authority.reservation.remaining = authority
+            .reservation
+            .remaining
+            .checked_sub(budget)
+            .ok_or(ResourceErrorCode::Exhausted)?;
+        Ok(())
+    }
+
+    fn reclaim_snapshot(
+        &self,
+        stamp: &StampedInvocation,
+        handle: ResourceHandle,
+    ) -> Result<(Option<ResourceHandle>, ReservationSnapshot), ResourceErrorCode> {
+        let authority = self.slot_authority(handle)?;
+        if authority.principal != stamp.principal() {
+            return Err(ResourceErrorCode::WrongOwner);
+        }
+        Ok((
+            authority.parent,
+            ReservationSnapshot {
+                account: authority.reservation.account,
+                budget: authority.reservation.budget,
+                remaining: authority.reservation.remaining,
+            },
+        ))
+    }
+
+    fn reclaim_owner(
+        &self,
+        stamp: &StampedInvocation,
+        handle: ResourceHandle,
+    ) -> Result<(), ResourceErrorCode> {
+        let authority = self.slot_authority(handle)?;
+        if authority.principal != stamp.principal() {
+            return Err(ResourceErrorCode::WrongOwner);
+        }
+        Ok(())
+    }
+
+    fn can_refund_parent(
+        &self,
+        parent: Option<ResourceHandle>,
+        reservation: &ReservationSnapshot,
+    ) -> bool {
+        let Some(parent) = parent else {
+            return false;
+        };
+        let Ok(authority) = self.slot_authority(parent) else {
+            return false;
+        };
+        authority.reservation.account == reservation.account
+            && authority.reservation.budget == reservation.budget
+            && authority
+                .reservation
+                .remaining
+                .checked_add(reservation.remaining)
+                .is_some()
+    }
+
+    fn refund_parent(
+        &mut self,
+        parent: Option<ResourceHandle>,
+        reservation: &ReservationSnapshot,
+    ) -> Result<(), ResourceErrorCode> {
+        let Some(parent) = parent else {
+            return Err(ResourceErrorCode::Internal);
+        };
+        let authority = self.slot_authority_mut(parent)?;
+        if authority.reservation.account != reservation.account
+            || authority.reservation.budget != reservation.budget
+        {
+            return Err(ResourceErrorCode::Internal);
+        }
+        authority.reservation.remaining = authority
+            .reservation
+            .remaining
+            .checked_add(reservation.remaining)
+            .ok_or(ResourceErrorCode::Internal)?;
+        Ok(())
+    }
+
+    fn ensure_external_release(&self, units: u64) -> Result<(), ResourceErrorCode> {
+        if self.active_reserved_units < u128::from(units)
+            || self
+                .released_reserved_units
+                .checked_add(u128::from(units))
+                .is_none()
+        {
+            return Err(ResourceErrorCode::Internal);
+        }
+        Ok(())
+    }
+
+    fn release_external(&mut self, units: u64) -> Result<(), ResourceErrorCode> {
+        self.ensure_external_release(units)?;
+        self.active_reserved_units -= u128::from(units);
+        self.released_reserved_units += u128::from(units);
+        Ok(())
+    }
+
+    fn advance_slot(&mut self, handle: ResourceHandle) -> Result<(), ResourceErrorCode> {
+        let slot = self.slot_mut(handle)?;
+        match slot.generation.checked_next() {
+            Ok(next) => slot.generation = next,
+            Err(_) => slot.retired = true,
+        }
+        Ok(())
+    }
+}
+
+struct DelegationSnapshot {
+    kind: ResourceKind,
+    identity: ResourceId,
+    parent_rights: Rights,
+    parent_scope: ResourceScope,
+    account: AccountId,
+    budget: BudgetId,
+    remaining: u64,
+    authority_epoch: AuthorityEpoch,
+    transfer_class: TransferClass,
+    expiry: Option<Instant>,
+    revocation: Option<RevocationSelector>,
+}
+
+struct ReservationSnapshot {
+    account: AccountId,
+    budget: BudgetId,
+    remaining: u64,
+}

--- a/crates/astrid-capsule/src/resource_authority/tests.rs
+++ b/crates/astrid-capsule/src/resource_authority/tests.rs
@@ -366,6 +366,16 @@ fn scope_is_bounded_and_wrong_kind_is_rejected() {
         ResourceScope::from_identities(ids),
         Err(ResourceErrorCode::InvalidDescriptor)
     );
+    let repeated = std::iter::repeat_n(identity(1), 65);
+    assert_eq!(
+        ResourceScope::from_identities(repeated),
+        Err(ResourceErrorCode::InvalidDescriptor)
+    );
+    assert_eq!(
+        ResourceScope::from_identities(std::iter::repeat_n(identity(1), 64))
+            .expect("64 raw identities remain within the bound"),
+        ResourceScope::singleton(identity(1))
+    );
     let object = identity(9);
     assert_eq!(
         table.admit(

--- a/crates/astrid-capsule/src/resource_authority/tests.rs
+++ b/crates/astrid-capsule/src/resource_authority/tests.rs
@@ -1,0 +1,404 @@
+use std::time::{Duration, Instant};
+
+use astrid_core::PrincipalUid;
+use astrid_resource_types::{
+    AccountId, AuthorityEpoch, BudgetId, OwnerId, ResourceErrorCode, ResourceId, ResourceKind,
+    Rights,
+};
+
+use super::{
+    AdmissionOptions, Reservation, ResourceAuthorityTable, ResourceHandle, ResourceScope,
+    RevocationSelector,
+};
+use crate::stamp::StampedInvocation;
+
+fn stamp(byte: u8) -> StampedInvocation {
+    StampedInvocation::from_trusted_uid(PrincipalUid::from_bytes([byte; 32]))
+}
+
+fn identity(byte: u8) -> ResourceId {
+    ResourceId::from_bytes([byte; 32])
+}
+
+fn account(byte: u8) -> AccountId {
+    AccountId::from_bytes([byte; 16])
+}
+
+fn budget(byte: u8) -> BudgetId {
+    BudgetId::from_bytes([byte; 16])
+}
+
+fn rights(bits: u64) -> Rights {
+    Rights::from_bits(bits).expect("test rights must be from the closed vocabulary")
+}
+
+fn reservation(units: u64) -> Reservation {
+    Reservation::new(account(1), budget(2), units)
+}
+
+fn options(
+    rights: Rights,
+    expiry: Option<Instant>,
+    revocation: Option<RevocationSelector>,
+) -> AdmissionOptions {
+    AdmissionOptions::new(rights, AuthorityEpoch::INITIAL, expiry, revocation)
+}
+
+fn options_at(
+    rights: Rights,
+    authority_epoch: AuthorityEpoch,
+    expiry: Option<Instant>,
+    revocation: Option<RevocationSelector>,
+) -> AdmissionOptions {
+    AdmissionOptions::new(rights, authority_epoch, expiry, revocation)
+}
+
+fn admit(table: &mut ResourceAuthorityTable, owner: &StampedInvocation) -> ResourceHandle {
+    let object = identity(9);
+    table
+        .admit(
+            owner,
+            ResourceKind::SemanticObject,
+            object,
+            ResourceScope::singleton(object),
+            reservation(10),
+            options(
+                rights(Rights::READ.bits() | Rights::USE.bits() | Rights::DELEGATE.bits()),
+                None,
+                None,
+            ),
+        )
+        .expect("fixture admission should succeed")
+}
+
+#[test]
+fn admission_and_preflight_bind_stamp_scope_rights_and_budget() {
+    let owner = stamp(1);
+    let mut table = ResourceAuthorityTable::new();
+    let handle = admit(&mut table, &owner);
+    let object = identity(9);
+    let scope = ResourceScope::singleton(object);
+
+    let authority = table
+        .lookup(&owner, handle)
+        .expect("owner should resolve its live handle");
+    assert_eq!(authority.kind(), ResourceKind::SemanticObject);
+    assert_eq!(authority.identity(), object);
+    assert_eq!(authority.principal(), owner.principal());
+    assert_eq!(authority.initiator(), owner.principal());
+    assert_eq!(authority.owner(), OwnerId::from(owner.principal()));
+    assert_eq!(authority.authority_epoch(), AuthorityEpoch::INITIAL);
+    assert_eq!(
+        authority.transfer_class(),
+        astrid_resource_types::TransferClass::None
+    );
+    assert_eq!(
+        authority.rights(),
+        rights(Rights::READ.bits() | Rights::USE.bits() | Rights::DELEGATE.bits())
+    );
+    assert_eq!(authority.remaining_budget(), 10);
+    assert_eq!(authority.account_id(), account(1));
+    assert_eq!(authority.budget_id(), budget(2));
+    assert_eq!(authority.scope(), &scope);
+    assert_eq!(table.authority_epoch(), AuthorityEpoch::INITIAL);
+
+    assert!(
+        table
+            .preflight(&owner, handle, Rights::READ, &scope, 10)
+            .is_ok()
+    );
+    assert_eq!(
+        table.preflight(&owner, handle, Rights::WRITE, &scope, 1),
+        Err(ResourceErrorCode::MissingRight)
+    );
+    assert_eq!(
+        table.preflight(
+            &owner,
+            handle,
+            Rights::READ,
+            ResourceScope::from_identities([object, identity(10)]).unwrap(),
+            1,
+        ),
+        Err(ResourceErrorCode::InvalidDescriptor)
+    );
+    assert_eq!(
+        table.preflight(&owner, handle, Rights::READ, &scope, 11),
+        Err(ResourceErrorCode::Exhausted)
+    );
+}
+
+#[test]
+fn lookup_rejects_cross_principal_and_replayed_generation() {
+    let owner = stamp(1);
+    let other = stamp(2);
+    let mut table = ResourceAuthorityTable::new();
+    let handle = admit(&mut table, &owner);
+
+    assert_eq!(
+        table.lookup(&other, handle).err(),
+        Some(ResourceErrorCode::WrongOwner)
+    );
+    assert_eq!(
+        table.reclaim(&other, handle),
+        Err(ResourceErrorCode::WrongOwner)
+    );
+    assert_eq!(table.active_reserved_units(), 10);
+
+    let generation = handle.generation();
+    table
+        .reclaim(&owner, handle)
+        .expect("owner reclaim should retire the slot");
+    assert_eq!(table.active_reserved_units(), 0);
+    assert_eq!(table.released_reserved_units(), 10);
+    assert_eq!(
+        table.lookup(&owner, handle).err(),
+        Some(ResourceErrorCode::StaleGeneration)
+    );
+
+    let replacement = admit(&mut table, &owner);
+    assert_ne!(replacement.generation(), generation);
+    assert_eq!(
+        table.lookup(&owner, handle).err(),
+        Some(ResourceErrorCode::StaleGeneration)
+    );
+
+    table
+        .drop_handle(&owner, replacement)
+        .expect("drop alias should reclaim through the same stamp boundary");
+    assert_eq!(table.active_reserved_units(), 0);
+}
+
+#[test]
+fn attenuation_cannot_widen_rights_scope_or_budget() {
+    let owner = stamp(3);
+    let object = identity(9);
+    let other_object = identity(10);
+    let mut table = ResourceAuthorityTable::new();
+    let parent = table
+        .admit(
+            &owner,
+            ResourceKind::SemanticObject,
+            object,
+            ResourceScope::from_identities([object, other_object]).unwrap(),
+            reservation(10),
+            options(
+                rights(Rights::READ.bits() | Rights::USE.bits() | Rights::DELEGATE.bits()),
+                None,
+                None,
+            ),
+        )
+        .expect("parent admission should succeed");
+
+    let child = table
+        .attenuate(
+            &owner,
+            parent,
+            Rights::READ,
+            ResourceScope::singleton(object),
+            4,
+        )
+        .expect("attenuated child should succeed");
+    assert_eq!(table.lookup(&owner, parent).unwrap().remaining_budget(), 6);
+    assert_eq!(table.lookup(&owner, child).unwrap().remaining_budget(), 4);
+    assert_eq!(table.lookup(&owner, child).unwrap().parent(), Some(parent));
+
+    assert_eq!(
+        table.attenuate(
+            &owner,
+            parent,
+            Rights::WRITE,
+            ResourceScope::singleton(object),
+            1,
+        ),
+        Err(ResourceErrorCode::MissingRight)
+    );
+    assert_eq!(
+        table.attenuate(
+            &owner,
+            parent,
+            Rights::READ,
+            ResourceScope::from_identities([object, identity(11)]).unwrap(),
+            1,
+        ),
+        Err(ResourceErrorCode::InvalidDescriptor)
+    );
+    assert_eq!(
+        table.attenuate(
+            &owner,
+            parent,
+            Rights::READ,
+            ResourceScope::singleton(object),
+            7,
+        ),
+        Err(ResourceErrorCode::Exhausted)
+    );
+}
+
+#[test]
+fn child_reclaim_refunds_parent_and_parent_reclaim_invalidates_child() {
+    let owner = stamp(4);
+    let mut table = ResourceAuthorityTable::new();
+    let parent = admit(&mut table, &owner);
+    let object = identity(9);
+    let child = table
+        .attenuate(
+            &owner,
+            parent,
+            Rights::READ,
+            ResourceScope::singleton(object),
+            4,
+        )
+        .expect("child should be admitted");
+    assert_eq!(table.lookup(&owner, parent).unwrap().remaining_budget(), 6);
+
+    table
+        .reclaim(&owner, child)
+        .expect("child reclaim should return its unspent envelope");
+    assert_eq!(table.lookup(&owner, parent).unwrap().remaining_budget(), 10);
+    assert_eq!(
+        table.lookup(&owner, child).err(),
+        Some(ResourceErrorCode::StaleGeneration)
+    );
+
+    let child = table
+        .attenuate(
+            &owner,
+            parent,
+            Rights::READ,
+            ResourceScope::singleton(object),
+            3,
+        )
+        .expect("second child should be admitted");
+    table
+        .reclaim(&owner, parent)
+        .expect("parent reclaim should release its own reservation");
+    assert_eq!(
+        table.lookup(&owner, child).err(),
+        Some(ResourceErrorCode::Revoked)
+    );
+}
+
+#[test]
+fn expiry_revocation_and_epoch_changes_fail_closed() {
+    let owner = stamp(5);
+    let other = stamp(6);
+    let object = identity(9);
+    let mut table = ResourceAuthorityTable::new();
+    let expired = Instant::now() - Duration::from_secs(1);
+    assert_eq!(
+        table.admit(
+            &owner,
+            ResourceKind::SemanticObject,
+            object,
+            ResourceScope::singleton(object),
+            reservation(1),
+            options(Rights::READ, Some(expired), None),
+        ),
+        Err(ResourceErrorCode::Revoked)
+    );
+
+    let selector = RevocationSelector::new(7);
+    let handle = table
+        .admit(
+            &owner,
+            ResourceKind::SemanticObject,
+            object,
+            ResourceScope::singleton(object),
+            reservation(2),
+            options(
+                Rights::READ,
+                Some(Instant::now() + Duration::from_mins(1)),
+                Some(selector),
+            ),
+        )
+        .expect("future authority should be admitted");
+    assert_eq!(
+        table.revoke_for(&other, handle),
+        Err(ResourceErrorCode::WrongOwner)
+    );
+    table
+        .revoke_for(&owner, handle)
+        .expect("host revocation should find the live slot");
+    assert_eq!(
+        table.lookup(&owner, handle).err(),
+        Some(ResourceErrorCode::Revoked)
+    );
+
+    let next_epoch = table
+        .advance_authority_epoch()
+        .expect("epoch should advance");
+    assert_ne!(next_epoch, AuthorityEpoch::INITIAL);
+    assert_eq!(
+        table.lookup(&owner, handle).err(),
+        Some(ResourceErrorCode::Revoked)
+    );
+    assert_eq!(
+        table.admit(
+            &owner,
+            ResourceKind::SemanticObject,
+            object,
+            ResourceScope::singleton(object),
+            reservation(1),
+            options(Rights::READ, None, None),
+        ),
+        Err(ResourceErrorCode::Revoked)
+    );
+    table.revoke_selector(selector).unwrap();
+    assert_eq!(
+        table.admit(
+            &owner,
+            ResourceKind::SemanticObject,
+            object,
+            ResourceScope::singleton(object),
+            reservation(1),
+            options_at(Rights::READ, next_epoch, None, Some(selector)),
+        ),
+        Err(ResourceErrorCode::Revoked)
+    );
+}
+
+#[test]
+fn scope_is_bounded_and_wrong_kind_is_rejected() {
+    let owner = stamp(6);
+    let mut table = ResourceAuthorityTable::new();
+    let ids = (0..65).map(identity);
+    assert_eq!(
+        ResourceScope::from_identities(ids),
+        Err(ResourceErrorCode::InvalidDescriptor)
+    );
+    let object = identity(9);
+    assert_eq!(
+        table.admit(
+            &owner,
+            ResourceKind::Storage,
+            object,
+            ResourceScope::singleton(object),
+            reservation(1),
+            options(Rights::READ, None, None),
+        ),
+        Err(ResourceErrorCode::InvalidDescriptor)
+    );
+}
+
+#[test]
+fn live_authority_surface_has_no_serialization_or_descriptor_constructor() {
+    let source = [
+        include_str!("mod.rs"),
+        include_str!("scope.rs"),
+        include_str!("table.rs"),
+    ]
+    .concat();
+    assert!(!source.contains("Serialize"));
+    assert!(!source.contains("serde::"));
+    assert!(source.contains("stamp: &StampedInvocation"));
+    assert!(!source.contains("IngressIdentity"));
+    assert!(source.contains("pub(crate) struct ResourceAuthority"));
+    assert!(source.contains("pub(crate) struct ResourceHandle"));
+    assert!(source.contains("pub(crate) struct Reservation"));
+    assert!(source.contains("pub(crate) const fn new("));
+    assert!(source.contains("pub(crate) fn singleton("));
+    assert!(!source.contains("pub fn new("));
+    assert!(!source.contains("pub fn singleton("));
+    assert!(!source.contains("impl From<BudgetId> for Reservation"));
+    assert!(!source.contains("impl From<AccountId> for Reservation"));
+}


### PR DESCRIPTION
Tracking #1660
Tracking #1564

## Linked Issue

Tracking #1660
Tracking #1564

## Summary

Host-internal ResourceAuthority table for one invocation-scoped SemanticObject kind. Live handles bind stamp, generation, bounded raw-cardinality scope, rights, epoch, and a non-serializable reservation. Attenuation, reclaim, revoke, and cross-principal use fail closed. This change does not wire HostState or introduce ServiceLease.

## Changes

Signed no-ff integration of the accepted host-internal ResourceAuthority table onto live `os/universal`. First parent is `e2952d38b7cd32836300b4e25631f7b665a67141`. Second parent is accepted content `7b6c8e90e0c76331f60f57274dba2372525f1d55`, preserving `de5fae8688c3649481338988b3b7280956b8c946`. Adds a crate-private table module with fail-closed preflight, reservation, lookup, attenuation, and reclamation.

## Verification

- GPG-signed merge; DCO present
- Merge tree `2d0cb288fdb5361f3fe85b6b395e6dedd40316d4` matches `git merge-tree` of the two parents
- `cargo test --locked -p astrid-capsule resource_authority`: 7 passed
- `cargo fmt --all --check`
- `cargo clippy --locked -p astrid-capsule --all-targets -- -D warnings`
- Frozen stamp, resource-types, provider, projection, WIT, IpcMessage, host_state, and engine surfaces are empty versus the first parent

## Residuals

- The table remains intentionally unwired from HostState; this change proves the private table contract, not live admission.
- ServiceLease remains frozen.
- This draft is signed integration evidence. A later trunk-first successor may replace it if another accepted PR lands on `os/universal` first.

## AI / Tool Assistance

Assisted-by: Codex:grok-4.6

The ResourceAuthority table, raw-cardinality bound, signed no-ff vehicle, and changelog fragment were produced with coding-agent assistance. Merge parents, tree identity, GPG/DCO, and focused tests were independently inspected.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/{issue}.{kind}.md` (docs/CI-only may skip; release PRs roll fragments into the version section instead of adding one)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.