### PR TITLE
fix(cli): replace idle MCP attaches and reap orphaned attach children

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,6 +291,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.20",
  "tokio",
+ "tokio-util",
  "toml",
  "toml_edit",
  "tracing",

--- a/changes/1677.fixed.md
+++ b/changes/1677.fixed.md
@@ -1,0 +1,9 @@
+The persistent MCP gateway now treats Codex `ASTRID_SESSION_ID` as a
+replaceable attach key: a reconnect cancels the previous slot before
+taking a new permit. Silent attach readers idle-EOF after two minutes
+(a protocol DoS ceiling, not an astrid-config knob). At the 16-attach
+cap the gateway LRU-evicts an idle slot and fail-fasts if every slot is
+still active. `mcp gc` reaps orphaned `astrid`/`aos mcp attach`
+processes whose parent is dead, and never signals Python
+`aos-mcp-frame`. `mcp serve` remains the explicit per-session escape
+hatch. Closes #1677

--- a/changes/1677.fixed.md
+++ b/changes/1677.fixed.md
@@ -7,4 +7,6 @@ cap the gateway LRU-evicts an idle slot and fail-fasts if every slot is
 still active. `mcp gc` reaps orphaned `astrid`/`aos mcp attach`
 processes whose parent is dead, and never signals Python
 `aos-mcp-frame`; unrelated wrapper commands are ignored. `mcp serve`
-remains the explicit per-session escape hatch. Closes #1677
+remains the explicit per-session escape hatch. Replacement teardown now
+cancels RMCP initialization and rejects a reconnect when the old slot does
+not finish within its bounded teardown window. Closes #1677

--- a/changes/1677.fixed.md
+++ b/changes/1677.fixed.md
@@ -1,6 +1,7 @@
 The persistent MCP gateway now treats Codex `ASTRID_SESSION_ID` as a
 replaceable attach key: a reconnect cancels the previous slot before
-taking a new permit. Silent attach readers idle-EOF after two minutes
+taking a new permit, with replacement admission serialized and stale
+teardown unable to remove the new slot. Silent attach readers idle-EOF after two minutes
 (a protocol DoS ceiling, not an astrid-config knob). At the 16-attach
 cap the gateway LRU-evicts an idle slot and fail-fasts if every slot is
 still active. `mcp gc` reaps orphaned `astrid`/`aos mcp attach`

--- a/changes/1677.fixed.md
+++ b/changes/1677.fixed.md
@@ -6,5 +6,5 @@ teardown unable to remove the new slot. Silent attach readers idle-EOF after two
 cap the gateway LRU-evicts an idle slot and fail-fasts if every slot is
 still active. `mcp gc` reaps orphaned `astrid`/`aos mcp attach`
 processes whose parent is dead, and never signals Python
-`aos-mcp-frame`. `mcp serve` remains the explicit per-session escape
-hatch. Closes #1677
+`aos-mcp-frame`; unrelated wrapper commands are ignored. `mcp serve`
+remains the explicit per-session escape hatch. Closes #1677

--- a/crates/astrid-cli/Cargo.toml
+++ b/crates/astrid-cli/Cargo.toml
@@ -77,6 +77,7 @@ thiserror = { workspace = true }
 # `net` (socket/TCP clients), `rt-multi-thread` (`#[tokio::main]`): native-only,
 # no longer in the workspace tokio base.
 tokio = { workspace = true, features = ["net", "rt-multi-thread"] }
+tokio-util = { workspace = true }
 toml = { workspace = true }
 toml_edit = "0.25.3"
 tracing = { workspace = true }

--- a/crates/astrid-cli/src/commands/mcp/gateway.rs
+++ b/crates/astrid-cli/src/commands/mcp/gateway.rs
@@ -71,6 +71,48 @@ struct GatewayState {
     initialize: Mutex<()>,
 }
 
+#[cfg(test)]
+thread_local! {
+    static FINISH_SLOT_PROBE: std::cell::RefCell<Option<Arc<StdMutex<Option<bool>>>>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+#[cfg(test)]
+struct FinishSlotProbeGuard;
+
+#[cfg(test)]
+fn register_finish_slot_probe(result: Arc<StdMutex<Option<bool>>>) -> FinishSlotProbeGuard {
+    FINISH_SLOT_PROBE.with(|probe| {
+        assert!(
+            probe.replace(Some(result)).is_none(),
+            "finish-slot probe already set"
+        );
+    });
+    FinishSlotProbeGuard
+}
+
+#[cfg(test)]
+impl Drop for FinishSlotProbeGuard {
+    fn drop(&mut self) {
+        FINISH_SLOT_PROBE.with(|probe| {
+            probe.borrow_mut().take();
+        });
+    }
+}
+
+#[cfg(test)]
+fn probe_finish_slot(semaphore: &Semaphore) {
+    FINISH_SLOT_PROBE.with(|probe| {
+        let Some(result) = probe.borrow().clone() else {
+            return;
+        };
+        let available = semaphore.try_acquire().is_ok();
+        if let Ok(mut observed) = result.lock() {
+            *observed = Some(available);
+        }
+    });
+}
+
 impl GatewayState {
     fn new(daemon_root: PathBuf, principal: astrid_core::PrincipalId, hook_token: String) -> Self {
         Self {
@@ -238,7 +280,11 @@ impl GatewayState {
         done: Arc<Notify>,
     ) {
         self.take_slot_if(host_session_id, id).await;
+        #[cfg(test)]
+        let semaphore = self.semaphore_for(self.principal.as_ref()).await;
         drop(permit);
+        #[cfg(test)]
+        probe_finish_slot(&semaphore);
         done.notify_waiters();
     }
 }
@@ -811,7 +857,7 @@ mod tests {
 
     #[tokio::test]
     async fn finish_slot_releases_cap_before_notifying_waiters() {
-        use std::sync::Arc;
+        use std::sync::{Arc, Mutex as StdMutex};
 
         use tokio::sync::Notify;
         use tokio::time::{Duration, timeout};
@@ -823,6 +869,8 @@ mod tests {
             principal,
             "gateway-token".into(),
         ));
+        let observed = Arc::new(StdMutex::new(None));
+        let _probe = super::register_finish_slot_probe(Arc::clone(&observed));
         let finishing = state.acquire("codex-code").await.expect("permit");
         let mut occupied = Vec::with_capacity(MAX_ATTACHES - 1);
         for _ in 0..MAX_ATTACHES - 1 {
@@ -839,6 +887,11 @@ mod tests {
         state
             .finish_slot("thread-1", Uuid::new_v4(), finishing, done)
             .await;
+        assert_eq!(
+            *observed.lock().expect("finish-slot probe mutex"),
+            Some(true),
+            "permit must be available at the notification boundary"
+        );
         let permit = timeout(Duration::from_secs(1), waiter)
             .await
             .expect("waiter must wake")

--- a/crates/astrid-cli/src/commands/mcp/gateway.rs
+++ b/crates/astrid-cli/src/commands/mcp/gateway.rs
@@ -9,17 +9,21 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex as StdMutex};
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use rmcp::ServiceExt;
 use rmcp::service::{Peer, RoleServer};
 use tokio::io::{AsyncRead, AsyncReadExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
-use tokio::sync::{Mutex, OwnedSemaphorePermit, Semaphore};
-use tokio::time::timeout;
+use tokio::sync::{Mutex, Notify, OwnedSemaphorePermit, Semaphore};
+use tokio::time::{Instant, timeout};
+use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 use uuid::Uuid;
+
+use super::idle::{ATTACH_IDLE_EOF, IdleEof, is_idle};
 
 use super::lifecycle::{
     ATTACH_REGISTRATION_VERSION, AttachRegistration, GatewayReady, prepare_gateway_socket,
@@ -43,6 +47,12 @@ const REGISTRATION_TIMEOUT: std::time::Duration = std::time::Duration::from_mill
 type Client = Arc<Mutex<crate::socket_client::SocketClient>>;
 type Peers = Arc<Mutex<HashMap<String, Peer<RoleServer>>>>;
 
+struct AttachSlot {
+    cancel: CancellationToken,
+    last_activity: Arc<StdMutex<Instant>>,
+    done: Arc<Notify>,
+}
+
 struct GatewayState {
     daemon_root: PathBuf,
     principal: astrid_core::PrincipalId,
@@ -50,6 +60,7 @@ struct GatewayState {
     clients: Mutex<HashMap<String, Client>>,
     peers: Mutex<HashMap<String, Peers>>,
     permits: Mutex<HashMap<String, Arc<Semaphore>>>,
+    slots: Mutex<HashMap<String, AttachSlot>>,
     initialize: Mutex<()>,
 }
 
@@ -62,6 +73,7 @@ impl GatewayState {
             clients: Mutex::new(HashMap::new()),
             peers: Mutex::new(HashMap::new()),
             permits: Mutex::new(HashMap::new()),
+            slots: Mutex::new(HashMap::new()),
             initialize: Mutex::new(()),
         }
     }
@@ -123,19 +135,70 @@ impl GatewayState {
             .ok_or_else(|| anyhow::anyhow!("MCP gateway principal channel was not initialized"))
     }
 
-    async fn acquire(&self, principal: &str) -> Result<OwnedSemaphorePermit> {
-        let semaphore = self
-            .permits
+    async fn semaphore_for(&self, principal: &str) -> Arc<Semaphore> {
+        self.permits
             .lock()
             .await
             .entry(principal.to_owned())
             .or_insert_with(|| Arc::new(Semaphore::new(MAX_ATTACHES)))
-            .clone();
-        semaphore.try_acquire_owned().map_err(|_| {
-            anyhow::anyhow!(
-                "MCP gateway attach limit reached for principal '{principal}' ({MAX_ATTACHES})"
-            )
-        })
+            .clone()
+    }
+
+    async fn acquire(&self, principal: &str) -> Result<OwnedSemaphorePermit> {
+        let semaphore = self.semaphore_for(principal).await;
+        if let Ok(permit) = semaphore.clone().try_acquire_owned() {
+            return Ok(permit);
+        }
+        if self.evict_lru_idle().await
+            && let Ok(permit) = semaphore.try_acquire_owned()
+        {
+            return Ok(permit);
+        }
+        anyhow::bail!(
+            "MCP gateway attach limit reached for principal '{principal}' ({MAX_ATTACHES})"
+        )
+    }
+
+    async fn replace_session(&self, host_session_id: &str) {
+        let slot = self.slots.lock().await.remove(host_session_id);
+        if let Some(slot) = slot {
+            let notified = slot.done.notified();
+            tokio::pin!(notified);
+            slot.cancel.cancel();
+            let _ = timeout(Duration::from_secs(1), notified).await;
+        }
+    }
+
+    async fn evict_lru_idle(&self) -> bool {
+        let mut slots = self.slots.lock().await;
+        let idle_key = slots
+            .iter()
+            .filter(|(_, slot)| is_idle(&slot.last_activity, ATTACH_IDLE_EOF))
+            .min_by_key(|(_, slot)| {
+                slot.last_activity
+                    .lock()
+                    .map_or_else(|_| Instant::now(), |instant| *instant)
+            })
+            .map(|(key, _)| key.clone());
+        let Some(key) = idle_key else {
+            return false;
+        };
+        let Some(slot) = slots.remove(&key) else {
+            return false;
+        };
+        drop(slots);
+        let notified = slot.done.notified();
+        tokio::pin!(notified);
+        slot.cancel.cancel();
+        timeout(Duration::from_secs(1), notified).await.is_ok()
+    }
+
+    async fn install_slot(&self, host_session_id: String, slot: AttachSlot) {
+        self.slots.lock().await.insert(host_session_id, slot);
+    }
+
+    async fn take_slot(&self, host_session_id: &str) -> Option<AttachSlot> {
+        self.slots.lock().await.remove(host_session_id)
     }
 }
 
@@ -208,9 +271,24 @@ async fn serve_attach(stream: UnixStream, state: Arc<GatewayState>) -> Result<()
     let workspace = validate_workspace(&registration.workspace_abs)?;
     let principal_key = principal.to_string();
     let host_session_id = registration.host_session_id.clone();
+    state.replace_session(&host_session_id).await;
     let permit = state.acquire(&principal_key).await?;
     let client = state.client_for(&principal).await?;
     let peers = state.peers_for(&principal_key).await?;
+    let last_activity = Arc::new(StdMutex::new(Instant::now()));
+    let cancel = CancellationToken::new();
+    let done = Arc::new(Notify::new());
+    state
+        .install_slot(
+            host_session_id.clone(),
+            AttachSlot {
+                cancel: cancel.clone(),
+                last_activity: Arc::clone(&last_activity),
+                done: Arc::clone(&done),
+            },
+        )
+        .await;
+    let reader = IdleEof::new(reader, ATTACH_IDLE_EOF, last_activity);
 
     info!(
         principal = %principal_key,
@@ -218,7 +296,32 @@ async fn serve_attach(stream: UnixStream, state: Arc<GatewayState>) -> Result<()
         host_session_id = %registration.host_session_id,
         "MCP gateway accepted attach"
     );
-    let server = AstridMcpServer::new(client, principal, state.daemon_root.clone(), workspace);
+    let result = run_attached_session(
+        AstridMcpServer::new(client, principal, state.daemon_root.clone(), workspace),
+        reader,
+        write_half,
+        peers,
+        host_session_id.clone(),
+        cancel,
+    )
+    .await;
+    let _ = state.take_slot(&host_session_id).await;
+    done.notify_waiters();
+    drop(permit);
+    result
+}
+
+async fn run_attached_session<R>(
+    server: AstridMcpServer,
+    reader: R,
+    write_half: tokio::io::WriteHalf<UnixStream>,
+    peers: Peers,
+    host_session_id: String,
+    cancel: CancellationToken,
+) -> Result<()>
+where
+    R: tokio::io::AsyncRead + Unpin + Send + 'static,
+{
     let running = server
         .serve((reader, write_half))
         .await
@@ -227,12 +330,11 @@ async fn serve_attach(stream: UnixStream, state: Arc<GatewayState>) -> Result<()
         .lock()
         .await
         .insert(host_session_id.clone(), running.peer().clone());
-    let result = running
-        .waiting()
-        .await
-        .context("MCP gateway attach transport terminated abnormally");
+    let result = tokio::select! {
+        result = running.waiting() => result.context("MCP gateway attach transport terminated abnormally"),
+        () = cancel.cancelled() => Err(anyhow::anyhow!("MCP attach replaced or idle-evicted")),
+    };
     peers.lock().await.remove(&host_session_id);
-    drop(permit);
     result.map(|_| ())
 }
 
@@ -470,5 +572,135 @@ mod tests {
         let second = mint_hook_token();
         assert_eq!(first.len(), 64);
         assert_ne!(first, second);
+    }
+
+    #[tokio::test]
+    async fn same_session_replaces_the_previous_attach() {
+        use std::sync::{Arc, Mutex as StdMutex};
+
+        use tokio::sync::Notify;
+        use tokio::time::Instant;
+        use tokio_util::sync::CancellationToken;
+
+        use super::AttachSlot;
+
+        let principal = astrid_core::PrincipalId::new("codex-code").expect("principal");
+        let state = GatewayState::new(
+            PathBuf::from("/runtime-home"),
+            principal,
+            "gateway-token".into(),
+        );
+        let permit = state.acquire("codex-code").await.expect("permit");
+        let cancel = CancellationToken::new();
+        let done = Arc::new(Notify::new());
+        state
+            .install_slot(
+                "thread-1".into(),
+                AttachSlot {
+                    cancel: cancel.clone(),
+                    last_activity: Arc::new(StdMutex::new(Instant::now())),
+                    done: Arc::clone(&done),
+                },
+            )
+            .await;
+        tokio::spawn(async move {
+            cancel.cancelled().await;
+            drop(permit);
+            done.notify_waiters();
+        });
+        state.replace_session("thread-1").await;
+        let _permit = state
+            .acquire("codex-code")
+            .await
+            .expect("replaced session must free the attach cap");
+    }
+
+    #[tokio::test]
+    async fn acquire_evicts_idle_lru_then_admits() {
+        use std::sync::{Arc, Mutex as StdMutex};
+
+        use tokio::sync::Notify;
+        use tokio::time::Instant;
+        use tokio_util::sync::CancellationToken;
+
+        use super::{ATTACH_IDLE_EOF, AttachSlot};
+
+        let principal = astrid_core::PrincipalId::new("codex-code").expect("principal");
+        let state = GatewayState::new(
+            PathBuf::from("/runtime-home"),
+            principal,
+            "gateway-token".into(),
+        );
+        for index in 0..MAX_ATTACHES {
+            let permit = state.acquire("codex-code").await.expect("permit");
+            let cancel = CancellationToken::new();
+            let done = Arc::new(Notify::new());
+            let last = Instant::now()
+                .checked_sub(ATTACH_IDLE_EOF + std::time::Duration::from_millis(5))
+                .expect("idle timestamp");
+            state
+                .install_slot(
+                    format!("idle-{index}"),
+                    AttachSlot {
+                        cancel: cancel.clone(),
+                        last_activity: Arc::new(StdMutex::new(last)),
+                        done: Arc::clone(&done),
+                    },
+                )
+                .await;
+            tokio::spawn(async move {
+                cancel.cancelled().await;
+                drop(permit);
+                done.notify_waiters();
+            });
+        }
+        let _permit = state
+            .acquire("codex-code")
+            .await
+            .expect("idle LRU eviction must admit a new attach");
+    }
+
+    #[tokio::test]
+    async fn acquire_does_not_evict_active_slots() {
+        use std::sync::{Arc, Mutex as StdMutex};
+
+        use tokio::sync::Notify;
+        use tokio::time::Instant;
+        use tokio_util::sync::CancellationToken;
+
+        use super::AttachSlot;
+
+        let principal = astrid_core::PrincipalId::new("codex-code").expect("principal");
+        let state = GatewayState::new(
+            PathBuf::from("/runtime-home"),
+            principal,
+            "gateway-token".into(),
+        );
+        let mut cancels = Vec::new();
+        for index in 0..MAX_ATTACHES {
+            let permit = state.acquire("codex-code").await.expect("permit");
+            let cancel = CancellationToken::new();
+            let done = Arc::new(Notify::new());
+            state
+                .install_slot(
+                    format!("live-{index}"),
+                    AttachSlot {
+                        cancel: cancel.clone(),
+                        last_activity: Arc::new(StdMutex::new(Instant::now())),
+                        done: Arc::clone(&done),
+                    },
+                )
+                .await;
+            cancels.push(cancel.clone());
+            tokio::spawn(async move {
+                cancel.cancelled().await;
+                drop(permit);
+                done.notify_waiters();
+            });
+        }
+        assert!(state.acquire("codex-code").await.is_err());
+        for cancel in cancels {
+            cancel.cancel();
+        }
     }
 }

--- a/crates/astrid-cli/src/commands/mcp/gateway.rs
+++ b/crates/astrid-cli/src/commands/mcp/gateway.rs
@@ -59,6 +59,11 @@ struct AttachReservation {
     permit: OwnedSemaphorePermit,
 }
 
+/// Bound cooperative teardown before a replacement may be admitted. This is
+/// a protocol safety ceiling: a predecessor that does not release its slot
+/// promptly must never let a reconnect consume a second permit.
+const REPLACEMENT_TIMEOUT: Duration = Duration::from_secs(1);
+
 struct GatewayState {
     daemon_root: PathBuf,
     principal: astrid_core::PrincipalId,
@@ -69,48 +74,6 @@ struct GatewayState {
     slots: Mutex<HashMap<String, AttachSlot>>,
     admission: Arc<Mutex<()>>,
     initialize: Mutex<()>,
-}
-
-#[cfg(test)]
-thread_local! {
-    static FINISH_SLOT_PROBE: std::cell::RefCell<Option<Arc<StdMutex<Option<bool>>>>> =
-        const { std::cell::RefCell::new(None) };
-}
-
-#[cfg(test)]
-struct FinishSlotProbeGuard;
-
-#[cfg(test)]
-fn register_finish_slot_probe(result: Arc<StdMutex<Option<bool>>>) -> FinishSlotProbeGuard {
-    FINISH_SLOT_PROBE.with(|probe| {
-        assert!(
-            probe.replace(Some(result)).is_none(),
-            "finish-slot probe already set"
-        );
-    });
-    FinishSlotProbeGuard
-}
-
-#[cfg(test)]
-impl Drop for FinishSlotProbeGuard {
-    fn drop(&mut self) {
-        FINISH_SLOT_PROBE.with(|probe| {
-            probe.borrow_mut().take();
-        });
-    }
-}
-
-#[cfg(test)]
-fn probe_finish_slot(semaphore: &Semaphore) {
-    FINISH_SLOT_PROBE.with(|probe| {
-        let Some(result) = probe.borrow().clone() else {
-            return;
-        };
-        let available = semaphore.try_acquire().is_ok();
-        if let Ok(mut observed) = result.lock() {
-            *observed = Some(available);
-        }
-    });
 }
 
 impl GatewayState {
@@ -218,19 +181,26 @@ impl GatewayState {
         principal: &str,
     ) -> Result<AttachReservation> {
         let admission = Arc::clone(&self.admission).lock_owned().await;
-        self.replace_session(host_session_id).await;
+        self.replace_session(host_session_id).await?;
         let permit = self.acquire(principal).await?;
         Ok(AttachReservation { admission, permit })
     }
 
-    async fn replace_session(&self, host_session_id: &str) {
+    async fn replace_session(&self, host_session_id: &str) -> Result<()> {
         let slot = self.slots.lock().await.remove(host_session_id);
         if let Some(slot) = slot {
             let notified = slot.done.notified();
             tokio::pin!(notified);
             slot.cancel.cancel();
-            let _ = timeout(Duration::from_secs(1), notified).await;
+            timeout(REPLACEMENT_TIMEOUT, notified)
+                .await
+                .with_context(|| {
+                    format!(
+                        "MCP gateway attach replacement teardown timed out for host session '{host_session_id}'"
+                    )
+                })?;
         }
+        Ok(())
     }
 
     async fn evict_lru_idle(&self) -> bool {
@@ -284,7 +254,7 @@ impl GatewayState {
         let semaphore = self.semaphore_for(self.principal.as_ref()).await;
         drop(permit);
         #[cfg(test)]
-        probe_finish_slot(&semaphore);
+        tests::probe_finish_slot(&semaphore);
         done.notify_waiters();
     }
 }
@@ -416,8 +386,8 @@ async fn serve_attach(stream: UnixStream, state: Arc<GatewayState>) -> Result<()
     result
 }
 
-async fn run_attached_session<R>(
-    server: AstridMcpServer,
+async fn run_attached_session<S, R>(
+    server: S,
     reader: R,
     write_half: tokio::io::WriteHalf<UnixStream>,
     peers: Peers,
@@ -425,10 +395,11 @@ async fn run_attached_session<R>(
     cancel: CancellationToken,
 ) -> Result<()>
 where
+    S: rmcp::Service<RoleServer>,
     R: tokio::io::AsyncRead + Unpin + Send + 'static,
 {
     let running = server
-        .serve((reader, write_half))
+        .serve_with_ct((reader, write_half), cancel.clone())
         .await
         .context("MCP gateway failed to initialize attach session")?;
     // Use the slot generation rather than the host session id so a delayed
@@ -545,451 +516,5 @@ fn set_socket_mode(path: &Path) -> Result<()> {
 }
 
 #[cfg(test)]
-mod tests {
-    use std::path::PathBuf;
-
-    use tokio::io::{AsyncWriteExt, BufReader};
-
-    use super::{
-        AttachSlot, GatewayState, MAX_ATTACHES, MAX_REGISTRATION_BYTES, authenticate_registration,
-        mint_hook_token, read_registration, read_registration_inner, validate_workspace,
-    };
-    use crate::commands::mcp::lifecycle::AttachRegistration;
-
-    #[test]
-    fn attach_cap_is_bounded_per_principal_channel() {
-        assert_eq!(MAX_ATTACHES, 16);
-    }
-
-    #[tokio::test]
-    async fn attach_cap_rejects_the_seventeenth_live_session() {
-        let principal = astrid_core::PrincipalId::new("codex-code").expect("principal");
-        let state = GatewayState::new(
-            PathBuf::from("/runtime-home"),
-            principal,
-            "gateway-token".into(),
-        );
-        let mut permits = Vec::with_capacity(MAX_ATTACHES);
-        for _ in 0..MAX_ATTACHES {
-            permits.push(state.acquire("codex-code").await.expect("attach permit"));
-        }
-        assert!(state.acquire("codex-code").await.is_err());
-        drop(permits);
-        assert!(state.acquire("codex-code").await.is_ok());
-    }
-
-    #[tokio::test]
-    async fn registration_preface_times_out_without_a_newline() {
-        let (_peer, stream) = tokio::io::duplex(1);
-        let mut reader = BufReader::new(stream);
-        let result = tokio::time::timeout(
-            std::time::Duration::from_secs(2),
-            read_registration(&mut reader),
-        )
-        .await
-        .expect("registration timeout test must complete");
-        let error = result.expect_err("a preface without a newline must time out");
-        assert!(
-            error
-                .to_string()
-                .contains("timed out reading MCP attach registration"),
-            "unexpected error: {error}"
-        );
-    }
-
-    #[tokio::test]
-    async fn oversized_registration_preface_fails_without_waiting_for_a_newline() {
-        let (mut peer, stream) = tokio::io::duplex(MAX_REGISTRATION_BYTES + 1);
-        peer.write_all(&vec![b'x'; MAX_REGISTRATION_BYTES + 1])
-            .await
-            .expect("oversized preface must fit in the test peer");
-        let mut reader = BufReader::new(stream);
-        let result = tokio::time::timeout(
-            std::time::Duration::from_secs(2),
-            read_registration_inner(&mut reader),
-        )
-        .await
-        .expect("registration size test must complete");
-        let error = result.expect_err("an oversized preface must be rejected");
-        assert!(
-            error
-                .to_string()
-                .contains("registration is missing or too large"),
-            "unexpected error: {error}"
-        );
-    }
-
-    #[test]
-    fn registration_workspace_must_be_absolute() {
-        let workspace = tempfile::tempdir().expect("workspace tempdir");
-        assert!(validate_workspace(&workspace.path().to_string_lossy()).is_ok());
-        assert!(validate_workspace("project").is_err());
-        assert!(validate_workspace("").is_err());
-    }
-
-    #[test]
-    fn forged_principal_cannot_select_another_gateway_uplink() {
-        let principal = astrid_core::PrincipalId::new("codex-code").expect("principal");
-        let forged = astrid_core::PrincipalId::new("other-agent").expect("principal");
-        let state = GatewayState::new(
-            PathBuf::from("/runtime-home"),
-            principal,
-            "gateway-token".into(),
-        );
-        let registration = AttachRegistration {
-            version: super::ATTACH_REGISTRATION_VERSION,
-            principal: forged.to_string(),
-            host: "codex".into(),
-            workspace_abs: "/tmp".into(),
-            host_session_id: "thread-1".into(),
-            hook_token: "gateway-token".into(),
-        };
-        let error = authenticate_registration(&registration, &state)
-            .expect_err("forged principal must be rejected");
-        assert!(
-            error
-                .to_string()
-                .contains("authenticated gateway principal")
-        );
-    }
-
-    #[test]
-    fn missing_hook_token_is_rejected_before_uplink_selection() {
-        let principal = astrid_core::PrincipalId::new("codex-code").expect("principal");
-        let state = GatewayState::new(
-            PathBuf::from("/runtime-home"),
-            principal.clone(),
-            "gateway-token".into(),
-        );
-        let registration = AttachRegistration {
-            version: super::ATTACH_REGISTRATION_VERSION,
-            principal: principal.to_string(),
-            host: "codex".into(),
-            workspace_abs: "/tmp".into(),
-            host_session_id: "thread-1".into(),
-            hook_token: String::new(),
-        };
-        let error = authenticate_registration(&registration, &state)
-            .expect_err("missing token must be rejected");
-        assert!(error.to_string().contains("hook_token is invalid"));
-    }
-
-    #[test]
-    fn hook_token_is_minted_with_each_gateway_start() {
-        let first = mint_hook_token();
-        let second = mint_hook_token();
-        assert_eq!(first.len(), 64);
-        assert_ne!(first, second);
-    }
-
-    #[tokio::test]
-    async fn same_session_replaces_the_previous_attach() {
-        use std::sync::{Arc, Mutex as StdMutex};
-
-        use tokio::sync::Notify;
-        use tokio::time::Instant;
-        use tokio_util::sync::CancellationToken;
-
-        use uuid::Uuid;
-
-        let principal = astrid_core::PrincipalId::new("codex-code").expect("principal");
-        let state = GatewayState::new(
-            PathBuf::from("/runtime-home"),
-            principal,
-            "gateway-token".into(),
-        );
-        let permit = state.acquire("codex-code").await.expect("permit");
-        let cancel = CancellationToken::new();
-        let done = Arc::new(Notify::new());
-        state
-            .install_slot(
-                "thread-1".into(),
-                AttachSlot {
-                    id: Uuid::new_v4(),
-                    cancel: cancel.clone(),
-                    last_activity: Arc::new(StdMutex::new(Instant::now())),
-                    done: Arc::clone(&done),
-                },
-            )
-            .await;
-        tokio::spawn(async move {
-            cancel.cancelled().await;
-            drop(permit);
-            done.notify_waiters();
-        });
-        state.replace_session("thread-1").await;
-        let _permit = state
-            .acquire("codex-code")
-            .await
-            .expect("replaced session must free the attach cap");
-    }
-
-    #[tokio::test]
-    async fn same_session_admission_serializes_reserve_acquire_install() {
-        use std::sync::{Arc, Mutex as StdMutex};
-
-        use tokio::sync::Notify;
-        use tokio::time::{Duration, Instant, timeout};
-        use tokio_util::sync::CancellationToken;
-        use uuid::Uuid;
-
-        let principal = astrid_core::PrincipalId::new("codex-code").expect("principal");
-        let state = Arc::new(GatewayState::new(
-            PathBuf::from("/runtime-home"),
-            principal,
-            "gateway-token".into(),
-        ));
-        let first = state
-            .reserve_session("thread-1", "codex-code")
-            .await
-            .expect("first reservation");
-        let second_state = Arc::clone(&state);
-        let mut second =
-            tokio::spawn(
-                async move { second_state.reserve_session("thread-1", "codex-code").await },
-            );
-        tokio::task::yield_now().await;
-        assert!(
-            timeout(Duration::from_millis(20), &mut second)
-                .await
-                .is_err()
-        );
-
-        let first_id = Uuid::new_v4();
-        let first_cancel = CancellationToken::new();
-        let first_done = Arc::new(Notify::new());
-        let first_permit = first
-            .install(
-                &state,
-                "thread-1".into(),
-                AttachSlot {
-                    id: first_id,
-                    cancel: first_cancel.clone(),
-                    last_activity: Arc::new(StdMutex::new(Instant::now())),
-                    done: Arc::clone(&first_done),
-                },
-            )
-            .await;
-        let cleanup_state = Arc::clone(&state);
-        tokio::spawn(async move {
-            first_cancel.cancelled().await;
-            cleanup_state.take_slot_if("thread-1", first_id).await;
-            drop(first_permit);
-            first_done.notify_waiters();
-        });
-
-        let second = timeout(Duration::from_secs(1), &mut second)
-            .await
-            .expect("second reservation must complete")
-            .expect("second reservation task")
-            .expect("second reservation");
-        let second_id = Uuid::new_v4();
-        let second_done = Arc::new(Notify::new());
-        let second_permit = second
-            .install(
-                &state,
-                "thread-1".into(),
-                AttachSlot {
-                    id: second_id,
-                    cancel: CancellationToken::new(),
-                    last_activity: Arc::new(StdMutex::new(Instant::now())),
-                    done: Arc::clone(&second_done),
-                },
-            )
-            .await;
-        assert_eq!(
-            state.slots.lock().await.get("thread-1").map(|slot| slot.id),
-            Some(second_id)
-        );
-        state
-            .finish_slot("thread-1", second_id, second_permit, second_done)
-            .await;
-    }
-
-    #[tokio::test]
-    async fn stale_session_cleanup_cannot_remove_a_replacement() {
-        use std::sync::{Arc, Mutex as StdMutex};
-
-        use tokio::sync::Notify;
-        use tokio::time::Instant;
-        use tokio_util::sync::CancellationToken;
-        use uuid::Uuid;
-
-        let principal = astrid_core::PrincipalId::new("codex-code").expect("principal");
-        let state = GatewayState::new(
-            PathBuf::from("/runtime-home"),
-            principal,
-            "gateway-token".into(),
-        );
-        let old_id = Uuid::new_v4();
-        let old_cancel = CancellationToken::new();
-        state
-            .install_slot(
-                "thread-1".into(),
-                AttachSlot {
-                    id: old_id,
-                    cancel: old_cancel,
-                    last_activity: Arc::new(StdMutex::new(Instant::now())),
-                    done: Arc::new(Notify::new()),
-                },
-            )
-            .await;
-        assert!(state.take_slot_if("thread-1", old_id).await);
-
-        let replacement_id = Uuid::new_v4();
-        state
-            .install_slot(
-                "thread-1".into(),
-                AttachSlot {
-                    id: replacement_id,
-                    cancel: CancellationToken::new(),
-                    last_activity: Arc::new(StdMutex::new(Instant::now())),
-                    done: Arc::new(Notify::new()),
-                },
-            )
-            .await;
-        assert!(!state.take_slot_if("thread-1", old_id).await);
-        assert_eq!(
-            state.slots.lock().await.get("thread-1").map(|slot| slot.id),
-            Some(replacement_id)
-        );
-    }
-
-    #[tokio::test]
-    async fn finish_slot_releases_cap_before_notifying_waiters() {
-        use std::sync::{Arc, Mutex as StdMutex};
-
-        use tokio::sync::Notify;
-        use tokio::time::{Duration, timeout};
-        use uuid::Uuid;
-
-        let principal = astrid_core::PrincipalId::new("codex-code").expect("principal");
-        let state = Arc::new(GatewayState::new(
-            PathBuf::from("/runtime-home"),
-            principal,
-            "gateway-token".into(),
-        ));
-        let observed = Arc::new(StdMutex::new(None));
-        let _probe = super::register_finish_slot_probe(Arc::clone(&observed));
-        let finishing = state.acquire("codex-code").await.expect("permit");
-        let mut occupied = Vec::with_capacity(MAX_ATTACHES - 1);
-        for _ in 0..MAX_ATTACHES - 1 {
-            occupied.push(state.acquire("codex-code").await.expect("permit"));
-        }
-        let done = Arc::new(Notify::new());
-        let notified = Arc::clone(&done).notified_owned();
-        let waiter_state = Arc::clone(&state);
-        let waiter = tokio::spawn(async move {
-            notified.await;
-            waiter_state.acquire("codex-code").await
-        });
-        tokio::task::yield_now().await;
-        state
-            .finish_slot("thread-1", Uuid::new_v4(), finishing, done)
-            .await;
-        assert_eq!(
-            *observed.lock().expect("finish-slot probe mutex"),
-            Some(true),
-            "permit must be available at the notification boundary"
-        );
-        let permit = timeout(Duration::from_secs(1), waiter)
-            .await
-            .expect("waiter must wake")
-            .expect("waiter task")
-            .expect("released permit must be available before notification");
-        drop(permit);
-        drop(occupied);
-    }
-
-    #[tokio::test]
-    async fn acquire_evicts_idle_lru_then_admits() {
-        use std::sync::{Arc, Mutex as StdMutex};
-
-        use tokio::sync::Notify;
-        use tokio::time::Instant;
-        use tokio_util::sync::CancellationToken;
-
-        use super::{ATTACH_IDLE_EOF, AttachSlot};
-        use uuid::Uuid;
-
-        let principal = astrid_core::PrincipalId::new("codex-code").expect("principal");
-        let state = GatewayState::new(
-            PathBuf::from("/runtime-home"),
-            principal,
-            "gateway-token".into(),
-        );
-        for index in 0..MAX_ATTACHES {
-            let permit = state.acquire("codex-code").await.expect("permit");
-            let cancel = CancellationToken::new();
-            let done = Arc::new(Notify::new());
-            let last = Instant::now()
-                .checked_sub(ATTACH_IDLE_EOF + std::time::Duration::from_millis(5))
-                .expect("idle timestamp");
-            state
-                .install_slot(
-                    format!("idle-{index}"),
-                    AttachSlot {
-                        id: Uuid::new_v4(),
-                        cancel: cancel.clone(),
-                        last_activity: Arc::new(StdMutex::new(last)),
-                        done: Arc::clone(&done),
-                    },
-                )
-                .await;
-            tokio::spawn(async move {
-                cancel.cancelled().await;
-                drop(permit);
-                done.notify_waiters();
-            });
-        }
-        let _permit = state
-            .acquire("codex-code")
-            .await
-            .expect("idle LRU eviction must admit a new attach");
-    }
-
-    #[tokio::test]
-    async fn acquire_does_not_evict_active_slots() {
-        use std::sync::{Arc, Mutex as StdMutex};
-
-        use tokio::sync::Notify;
-        use tokio::time::Instant;
-        use tokio_util::sync::CancellationToken;
-
-        use uuid::Uuid;
-
-        let principal = astrid_core::PrincipalId::new("codex-code").expect("principal");
-        let state = GatewayState::new(
-            PathBuf::from("/runtime-home"),
-            principal,
-            "gateway-token".into(),
-        );
-        let mut cancels = Vec::new();
-        for index in 0..MAX_ATTACHES {
-            let permit = state.acquire("codex-code").await.expect("permit");
-            let cancel = CancellationToken::new();
-            let done = Arc::new(Notify::new());
-            state
-                .install_slot(
-                    format!("live-{index}"),
-                    AttachSlot {
-                        id: Uuid::new_v4(),
-                        cancel: cancel.clone(),
-                        last_activity: Arc::new(StdMutex::new(Instant::now())),
-                        done: Arc::clone(&done),
-                    },
-                )
-                .await;
-            cancels.push(cancel.clone());
-            tokio::spawn(async move {
-                cancel.cancelled().await;
-                drop(permit);
-                done.notify_waiters();
-            });
-        }
-        assert!(state.acquire("codex-code").await.is_err());
-        for cancel in cancels {
-            cancel.cancel();
-        }
-    }
-}
+#[path = "gateway_tests.rs"]
+mod tests;

--- a/crates/astrid-cli/src/commands/mcp/gateway.rs
+++ b/crates/astrid-cli/src/commands/mcp/gateway.rs
@@ -17,7 +17,7 @@ use rmcp::ServiceExt;
 use rmcp::service::{Peer, RoleServer};
 use tokio::io::{AsyncRead, AsyncReadExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
-use tokio::sync::{Mutex, Notify, OwnedSemaphorePermit, Semaphore};
+use tokio::sync::{Mutex, Notify, OwnedMutexGuard, OwnedSemaphorePermit, Semaphore};
 use tokio::time::{Instant, timeout};
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
@@ -48,9 +48,15 @@ type Client = Arc<Mutex<crate::socket_client::SocketClient>>;
 type Peers = Arc<Mutex<HashMap<String, Peer<RoleServer>>>>;
 
 struct AttachSlot {
+    id: Uuid,
     cancel: CancellationToken,
     last_activity: Arc<StdMutex<Instant>>,
     done: Arc<Notify>,
+}
+
+struct AttachReservation {
+    admission: OwnedMutexGuard<()>,
+    permit: OwnedSemaphorePermit,
 }
 
 struct GatewayState {
@@ -61,6 +67,7 @@ struct GatewayState {
     peers: Mutex<HashMap<String, Peers>>,
     permits: Mutex<HashMap<String, Arc<Semaphore>>>,
     slots: Mutex<HashMap<String, AttachSlot>>,
+    admission: Arc<Mutex<()>>,
     initialize: Mutex<()>,
 }
 
@@ -74,6 +81,7 @@ impl GatewayState {
             peers: Mutex::new(HashMap::new()),
             permits: Mutex::new(HashMap::new()),
             slots: Mutex::new(HashMap::new()),
+            admission: Arc::new(Mutex::new(())),
             initialize: Mutex::new(()),
         }
     }
@@ -159,6 +167,20 @@ impl GatewayState {
         )
     }
 
+    /// Reserve a host session through replacement, cap admission, and slot
+    /// installation as one linearizable operation. The reservation owns the
+    /// admission guard until `install` publishes the new slot.
+    async fn reserve_session(
+        &self,
+        host_session_id: &str,
+        principal: &str,
+    ) -> Result<AttachReservation> {
+        let admission = Arc::clone(&self.admission).lock_owned().await;
+        self.replace_session(host_session_id).await;
+        let permit = self.acquire(principal).await?;
+        Ok(AttachReservation { admission, permit })
+    }
+
     async fn replace_session(&self, host_session_id: &str) {
         let slot = self.slots.lock().await.remove(host_session_id);
         if let Some(slot) = slot {
@@ -197,8 +219,41 @@ impl GatewayState {
         self.slots.lock().await.insert(host_session_id, slot);
     }
 
-    async fn take_slot(&self, host_session_id: &str) -> Option<AttachSlot> {
-        self.slots.lock().await.remove(host_session_id)
+    async fn take_slot_if(&self, host_session_id: &str, id: Uuid) -> bool {
+        let mut slots = self.slots.lock().await;
+        if slots.get(host_session_id).is_some_and(|slot| slot.id == id) {
+            slots.remove(host_session_id);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Remove a slot, release its cap, then wake replacement/eviction waiters.
+    async fn finish_slot(
+        &self,
+        host_session_id: &str,
+        id: Uuid,
+        permit: OwnedSemaphorePermit,
+        done: Arc<Notify>,
+    ) {
+        self.take_slot_if(host_session_id, id).await;
+        drop(permit);
+        done.notify_waiters();
+    }
+}
+
+impl AttachReservation {
+    async fn install(
+        self,
+        state: &GatewayState,
+        host_session_id: String,
+        slot: AttachSlot,
+    ) -> OwnedSemaphorePermit {
+        let Self { admission, permit } = self;
+        state.install_slot(host_session_id, slot).await;
+        drop(admission);
+        permit
     }
 }
 
@@ -271,17 +326,21 @@ async fn serve_attach(stream: UnixStream, state: Arc<GatewayState>) -> Result<()
     let workspace = validate_workspace(&registration.workspace_abs)?;
     let principal_key = principal.to_string();
     let host_session_id = registration.host_session_id.clone();
-    state.replace_session(&host_session_id).await;
-    let permit = state.acquire(&principal_key).await?;
     let client = state.client_for(&principal).await?;
     let peers = state.peers_for(&principal_key).await?;
+    let reservation = state
+        .reserve_session(&host_session_id, &principal_key)
+        .await?;
     let last_activity = Arc::new(StdMutex::new(Instant::now()));
     let cancel = CancellationToken::new();
     let done = Arc::new(Notify::new());
-    state
-        .install_slot(
+    let slot_id = Uuid::new_v4();
+    let permit = reservation
+        .install(
+            &state,
             host_session_id.clone(),
             AttachSlot {
+                id: slot_id,
                 cancel: cancel.clone(),
                 last_activity: Arc::clone(&last_activity),
                 done: Arc::clone(&done),
@@ -301,13 +360,13 @@ async fn serve_attach(stream: UnixStream, state: Arc<GatewayState>) -> Result<()
         reader,
         write_half,
         peers,
-        host_session_id.clone(),
+        slot_id,
         cancel,
     )
     .await;
-    let _ = state.take_slot(&host_session_id).await;
-    done.notify_waiters();
-    drop(permit);
+    state
+        .finish_slot(&host_session_id, slot_id, permit, done)
+        .await;
     result
 }
 
@@ -316,7 +375,7 @@ async fn run_attached_session<R>(
     reader: R,
     write_half: tokio::io::WriteHalf<UnixStream>,
     peers: Peers,
-    host_session_id: String,
+    slot_id: Uuid,
     cancel: CancellationToken,
 ) -> Result<()>
 where
@@ -326,15 +385,18 @@ where
         .serve((reader, write_half))
         .await
         .context("MCP gateway failed to initialize attach session")?;
+    // Use the slot generation rather than the host session id so a delayed
+    // predecessor cannot remove a replacement's peer from the shared watcher.
+    let peer_key = slot_id.to_string();
     peers
         .lock()
         .await
-        .insert(host_session_id.clone(), running.peer().clone());
+        .insert(peer_key.clone(), running.peer().clone());
     let result = tokio::select! {
         result = running.waiting() => result.context("MCP gateway attach transport terminated abnormally"),
         () = cancel.cancelled() => Err(anyhow::anyhow!("MCP attach replaced or idle-evicted")),
     };
-    peers.lock().await.remove(&host_session_id);
+    peers.lock().await.remove(&peer_key);
     result.map(|_| ())
 }
 
@@ -443,7 +505,7 @@ mod tests {
     use tokio::io::{AsyncWriteExt, BufReader};
 
     use super::{
-        GatewayState, MAX_ATTACHES, MAX_REGISTRATION_BYTES, authenticate_registration,
+        AttachSlot, GatewayState, MAX_ATTACHES, MAX_REGISTRATION_BYTES, authenticate_registration,
         mint_hook_token, read_registration, read_registration_inner, validate_workspace,
     };
     use crate::commands::mcp::lifecycle::AttachRegistration;
@@ -582,7 +644,7 @@ mod tests {
         use tokio::time::Instant;
         use tokio_util::sync::CancellationToken;
 
-        use super::AttachSlot;
+        use uuid::Uuid;
 
         let principal = astrid_core::PrincipalId::new("codex-code").expect("principal");
         let state = GatewayState::new(
@@ -597,6 +659,7 @@ mod tests {
             .install_slot(
                 "thread-1".into(),
                 AttachSlot {
+                    id: Uuid::new_v4(),
                     cancel: cancel.clone(),
                     last_activity: Arc::new(StdMutex::new(Instant::now())),
                     done: Arc::clone(&done),
@@ -616,6 +679,176 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn same_session_admission_serializes_reserve_acquire_install() {
+        use std::sync::{Arc, Mutex as StdMutex};
+
+        use tokio::sync::Notify;
+        use tokio::time::{Duration, Instant, timeout};
+        use tokio_util::sync::CancellationToken;
+        use uuid::Uuid;
+
+        let principal = astrid_core::PrincipalId::new("codex-code").expect("principal");
+        let state = Arc::new(GatewayState::new(
+            PathBuf::from("/runtime-home"),
+            principal,
+            "gateway-token".into(),
+        ));
+        let first = state
+            .reserve_session("thread-1", "codex-code")
+            .await
+            .expect("first reservation");
+        let second_state = Arc::clone(&state);
+        let mut second =
+            tokio::spawn(
+                async move { second_state.reserve_session("thread-1", "codex-code").await },
+            );
+        tokio::task::yield_now().await;
+        assert!(
+            timeout(Duration::from_millis(20), &mut second)
+                .await
+                .is_err()
+        );
+
+        let first_id = Uuid::new_v4();
+        let first_cancel = CancellationToken::new();
+        let first_done = Arc::new(Notify::new());
+        let first_permit = first
+            .install(
+                &state,
+                "thread-1".into(),
+                AttachSlot {
+                    id: first_id,
+                    cancel: first_cancel.clone(),
+                    last_activity: Arc::new(StdMutex::new(Instant::now())),
+                    done: Arc::clone(&first_done),
+                },
+            )
+            .await;
+        let cleanup_state = Arc::clone(&state);
+        tokio::spawn(async move {
+            first_cancel.cancelled().await;
+            cleanup_state.take_slot_if("thread-1", first_id).await;
+            drop(first_permit);
+            first_done.notify_waiters();
+        });
+
+        let second = timeout(Duration::from_secs(1), &mut second)
+            .await
+            .expect("second reservation must complete")
+            .expect("second reservation task")
+            .expect("second reservation");
+        let second_id = Uuid::new_v4();
+        let second_done = Arc::new(Notify::new());
+        let second_permit = second
+            .install(
+                &state,
+                "thread-1".into(),
+                AttachSlot {
+                    id: second_id,
+                    cancel: CancellationToken::new(),
+                    last_activity: Arc::new(StdMutex::new(Instant::now())),
+                    done: Arc::clone(&second_done),
+                },
+            )
+            .await;
+        assert_eq!(
+            state.slots.lock().await.get("thread-1").map(|slot| slot.id),
+            Some(second_id)
+        );
+        state
+            .finish_slot("thread-1", second_id, second_permit, second_done)
+            .await;
+    }
+
+    #[tokio::test]
+    async fn stale_session_cleanup_cannot_remove_a_replacement() {
+        use std::sync::{Arc, Mutex as StdMutex};
+
+        use tokio::sync::Notify;
+        use tokio::time::Instant;
+        use tokio_util::sync::CancellationToken;
+        use uuid::Uuid;
+
+        let principal = astrid_core::PrincipalId::new("codex-code").expect("principal");
+        let state = GatewayState::new(
+            PathBuf::from("/runtime-home"),
+            principal,
+            "gateway-token".into(),
+        );
+        let old_id = Uuid::new_v4();
+        let old_cancel = CancellationToken::new();
+        state
+            .install_slot(
+                "thread-1".into(),
+                AttachSlot {
+                    id: old_id,
+                    cancel: old_cancel,
+                    last_activity: Arc::new(StdMutex::new(Instant::now())),
+                    done: Arc::new(Notify::new()),
+                },
+            )
+            .await;
+        assert!(state.take_slot_if("thread-1", old_id).await);
+
+        let replacement_id = Uuid::new_v4();
+        state
+            .install_slot(
+                "thread-1".into(),
+                AttachSlot {
+                    id: replacement_id,
+                    cancel: CancellationToken::new(),
+                    last_activity: Arc::new(StdMutex::new(Instant::now())),
+                    done: Arc::new(Notify::new()),
+                },
+            )
+            .await;
+        assert!(!state.take_slot_if("thread-1", old_id).await);
+        assert_eq!(
+            state.slots.lock().await.get("thread-1").map(|slot| slot.id),
+            Some(replacement_id)
+        );
+    }
+
+    #[tokio::test]
+    async fn finish_slot_releases_cap_before_notifying_waiters() {
+        use std::sync::Arc;
+
+        use tokio::sync::Notify;
+        use tokio::time::{Duration, timeout};
+        use uuid::Uuid;
+
+        let principal = astrid_core::PrincipalId::new("codex-code").expect("principal");
+        let state = Arc::new(GatewayState::new(
+            PathBuf::from("/runtime-home"),
+            principal,
+            "gateway-token".into(),
+        ));
+        let finishing = state.acquire("codex-code").await.expect("permit");
+        let mut occupied = Vec::with_capacity(MAX_ATTACHES - 1);
+        for _ in 0..MAX_ATTACHES - 1 {
+            occupied.push(state.acquire("codex-code").await.expect("permit"));
+        }
+        let done = Arc::new(Notify::new());
+        let notified = Arc::clone(&done).notified_owned();
+        let waiter_state = Arc::clone(&state);
+        let waiter = tokio::spawn(async move {
+            notified.await;
+            waiter_state.acquire("codex-code").await
+        });
+        tokio::task::yield_now().await;
+        state
+            .finish_slot("thread-1", Uuid::new_v4(), finishing, done)
+            .await;
+        let permit = timeout(Duration::from_secs(1), waiter)
+            .await
+            .expect("waiter must wake")
+            .expect("waiter task")
+            .expect("released permit must be available before notification");
+        drop(permit);
+        drop(occupied);
+    }
+
+    #[tokio::test]
     async fn acquire_evicts_idle_lru_then_admits() {
         use std::sync::{Arc, Mutex as StdMutex};
 
@@ -624,6 +857,7 @@ mod tests {
         use tokio_util::sync::CancellationToken;
 
         use super::{ATTACH_IDLE_EOF, AttachSlot};
+        use uuid::Uuid;
 
         let principal = astrid_core::PrincipalId::new("codex-code").expect("principal");
         let state = GatewayState::new(
@@ -642,6 +876,7 @@ mod tests {
                 .install_slot(
                     format!("idle-{index}"),
                     AttachSlot {
+                        id: Uuid::new_v4(),
                         cancel: cancel.clone(),
                         last_activity: Arc::new(StdMutex::new(last)),
                         done: Arc::clone(&done),
@@ -668,7 +903,7 @@ mod tests {
         use tokio::time::Instant;
         use tokio_util::sync::CancellationToken;
 
-        use super::AttachSlot;
+        use uuid::Uuid;
 
         let principal = astrid_core::PrincipalId::new("codex-code").expect("principal");
         let state = GatewayState::new(
@@ -685,6 +920,7 @@ mod tests {
                 .install_slot(
                     format!("live-{index}"),
                     AttachSlot {
+                        id: Uuid::new_v4(),
                         cancel: cancel.clone(),
                         last_activity: Arc::new(StdMutex::new(Instant::now())),
                         done: Arc::clone(&done),

--- a/crates/astrid-cli/src/commands/mcp/gateway_tests.rs
+++ b/crates/astrid-cli/src/commands/mcp/gateway_tests.rs
@@ -1,0 +1,633 @@
+use std::sync::{Arc, Mutex as StdMutex};
+
+use tokio::sync::{Notify, Semaphore};
+use tokio::time::Instant;
+
+use super::*;
+
+thread_local! {
+    static FINISH_SLOT_PROBE: std::cell::RefCell<Option<Arc<StdMutex<Option<bool>>>>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+struct FinishSlotProbeGuard;
+
+fn register_finish_slot_probe(result: Arc<StdMutex<Option<bool>>>) -> FinishSlotProbeGuard {
+    FINISH_SLOT_PROBE.with(|probe| {
+        assert!(
+            probe.replace(Some(result)).is_none(),
+            "finish-slot probe already set"
+        );
+    });
+    FinishSlotProbeGuard
+}
+
+impl Drop for FinishSlotProbeGuard {
+    fn drop(&mut self) {
+        FINISH_SLOT_PROBE.with(|probe| {
+            probe.borrow_mut().take();
+        });
+    }
+}
+
+pub(super) fn probe_finish_slot(semaphore: &Semaphore) {
+    FINISH_SLOT_PROBE.with(|probe| {
+        let Some(result) = probe.borrow().clone() else {
+            return;
+        };
+        let available = semaphore.try_acquire().is_ok();
+        if let Ok(mut observed) = result.lock() {
+            *observed = Some(available);
+        }
+    });
+}
+use std::path::PathBuf;
+
+use tokio::io::{AsyncWriteExt, BufReader};
+
+use super::{
+    AttachSlot, GatewayState, MAX_ATTACHES, MAX_REGISTRATION_BYTES, authenticate_registration,
+    mint_hook_token, read_registration, read_registration_inner, validate_workspace,
+};
+use crate::commands::mcp::lifecycle::AttachRegistration;
+
+#[test]
+fn attach_cap_is_bounded_per_principal_channel() {
+    assert_eq!(MAX_ATTACHES, 16);
+}
+
+#[tokio::test]
+async fn attach_cap_rejects_the_seventeenth_live_session() {
+    let principal = astrid_core::PrincipalId::new("codex-code").expect("principal");
+    let state = GatewayState::new(
+        PathBuf::from("/runtime-home"),
+        principal,
+        "gateway-token".into(),
+    );
+    let mut permits = Vec::with_capacity(MAX_ATTACHES);
+    for _ in 0..MAX_ATTACHES {
+        permits.push(state.acquire("codex-code").await.expect("attach permit"));
+    }
+    assert!(state.acquire("codex-code").await.is_err());
+    drop(permits);
+    assert!(state.acquire("codex-code").await.is_ok());
+}
+
+#[tokio::test]
+async fn registration_preface_times_out_without_a_newline() {
+    let (_peer, stream) = tokio::io::duplex(1);
+    let mut reader = BufReader::new(stream);
+    let result = tokio::time::timeout(
+        std::time::Duration::from_secs(2),
+        read_registration(&mut reader),
+    )
+    .await
+    .expect("registration timeout test must complete");
+    let error = result.expect_err("a preface without a newline must time out");
+    assert!(
+        error
+            .to_string()
+            .contains("timed out reading MCP attach registration"),
+        "unexpected error: {error}"
+    );
+}
+
+#[tokio::test]
+async fn oversized_registration_preface_fails_without_waiting_for_a_newline() {
+    let (mut peer, stream) = tokio::io::duplex(MAX_REGISTRATION_BYTES + 1);
+    peer.write_all(&vec![b'x'; MAX_REGISTRATION_BYTES + 1])
+        .await
+        .expect("oversized preface must fit in the test peer");
+    let mut reader = BufReader::new(stream);
+    let result = tokio::time::timeout(
+        std::time::Duration::from_secs(2),
+        read_registration_inner(&mut reader),
+    )
+    .await
+    .expect("registration size test must complete");
+    let error = result.expect_err("an oversized preface must be rejected");
+    assert!(
+        error
+            .to_string()
+            .contains("registration is missing or too large"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn registration_workspace_must_be_absolute() {
+    let workspace = tempfile::tempdir().expect("workspace tempdir");
+    assert!(validate_workspace(&workspace.path().to_string_lossy()).is_ok());
+    assert!(validate_workspace("project").is_err());
+    assert!(validate_workspace("").is_err());
+}
+
+#[test]
+fn forged_principal_cannot_select_another_gateway_uplink() {
+    let principal = astrid_core::PrincipalId::new("codex-code").expect("principal");
+    let forged = astrid_core::PrincipalId::new("other-agent").expect("principal");
+    let state = GatewayState::new(
+        PathBuf::from("/runtime-home"),
+        principal,
+        "gateway-token".into(),
+    );
+    let registration = AttachRegistration {
+        version: super::ATTACH_REGISTRATION_VERSION,
+        principal: forged.to_string(),
+        host: "codex".into(),
+        workspace_abs: "/tmp".into(),
+        host_session_id: "thread-1".into(),
+        hook_token: "gateway-token".into(),
+    };
+    let error = authenticate_registration(&registration, &state)
+        .expect_err("forged principal must be rejected");
+    assert!(
+        error
+            .to_string()
+            .contains("authenticated gateway principal")
+    );
+}
+
+#[test]
+fn missing_hook_token_is_rejected_before_uplink_selection() {
+    let principal = astrid_core::PrincipalId::new("codex-code").expect("principal");
+    let state = GatewayState::new(
+        PathBuf::from("/runtime-home"),
+        principal.clone(),
+        "gateway-token".into(),
+    );
+    let registration = AttachRegistration {
+        version: super::ATTACH_REGISTRATION_VERSION,
+        principal: principal.to_string(),
+        host: "codex".into(),
+        workspace_abs: "/tmp".into(),
+        host_session_id: "thread-1".into(),
+        hook_token: String::new(),
+    };
+    let error = authenticate_registration(&registration, &state)
+        .expect_err("missing token must be rejected");
+    assert!(error.to_string().contains("hook_token is invalid"));
+}
+
+#[test]
+fn hook_token_is_minted_with_each_gateway_start() {
+    let first = mint_hook_token();
+    let second = mint_hook_token();
+    assert_eq!(first.len(), 64);
+    assert_ne!(first, second);
+}
+
+#[tokio::test]
+async fn same_session_replaces_the_previous_attach() {
+    use std::sync::{Arc, Mutex as StdMutex};
+
+    use tokio::sync::Notify;
+    use tokio::time::Instant;
+    use tokio_util::sync::CancellationToken;
+
+    use uuid::Uuid;
+
+    let principal = astrid_core::PrincipalId::new("codex-code").expect("principal");
+    let state = GatewayState::new(
+        PathBuf::from("/runtime-home"),
+        principal,
+        "gateway-token".into(),
+    );
+    let permit = state.acquire("codex-code").await.expect("permit");
+    let cancel = CancellationToken::new();
+    let done = Arc::new(Notify::new());
+    state
+        .install_slot(
+            "thread-1".into(),
+            AttachSlot {
+                id: Uuid::new_v4(),
+                cancel: cancel.clone(),
+                last_activity: Arc::new(StdMutex::new(Instant::now())),
+                done: Arc::clone(&done),
+            },
+        )
+        .await;
+    tokio::spawn(async move {
+        cancel.cancelled().await;
+        drop(permit);
+        done.notify_waiters();
+    });
+    state
+        .replace_session("thread-1")
+        .await
+        .expect("replacement teardown must complete");
+    let _permit = state
+        .acquire("codex-code")
+        .await
+        .expect("replaced session must free the attach cap");
+}
+
+#[tokio::test]
+async fn same_session_admission_serializes_reserve_acquire_install() {
+    use std::sync::{Arc, Mutex as StdMutex};
+
+    use tokio::sync::Notify;
+    use tokio::time::{Duration, Instant, timeout};
+    use tokio_util::sync::CancellationToken;
+    use uuid::Uuid;
+
+    let principal = astrid_core::PrincipalId::new("codex-code").expect("principal");
+    let state = Arc::new(GatewayState::new(
+        PathBuf::from("/runtime-home"),
+        principal,
+        "gateway-token".into(),
+    ));
+    let first = state
+        .reserve_session("thread-1", "codex-code")
+        .await
+        .expect("first reservation");
+    let second_state = Arc::clone(&state);
+    let mut second =
+        tokio::spawn(async move { second_state.reserve_session("thread-1", "codex-code").await });
+    tokio::task::yield_now().await;
+    assert!(
+        timeout(Duration::from_millis(20), &mut second)
+            .await
+            .is_err()
+    );
+
+    let first_id = Uuid::new_v4();
+    let first_cancel = CancellationToken::new();
+    let first_done = Arc::new(Notify::new());
+    let first_permit = first
+        .install(
+            &state,
+            "thread-1".into(),
+            AttachSlot {
+                id: first_id,
+                cancel: first_cancel.clone(),
+                last_activity: Arc::new(StdMutex::new(Instant::now())),
+                done: Arc::clone(&first_done),
+            },
+        )
+        .await;
+    let cleanup_state = Arc::clone(&state);
+    tokio::spawn(async move {
+        first_cancel.cancelled().await;
+        cleanup_state.take_slot_if("thread-1", first_id).await;
+        drop(first_permit);
+        first_done.notify_waiters();
+    });
+
+    let second = timeout(Duration::from_secs(1), &mut second)
+        .await
+        .expect("second reservation must complete")
+        .expect("second reservation task")
+        .expect("second reservation");
+    let second_id = Uuid::new_v4();
+    let second_done = Arc::new(Notify::new());
+    let second_permit = second
+        .install(
+            &state,
+            "thread-1".into(),
+            AttachSlot {
+                id: second_id,
+                cancel: CancellationToken::new(),
+                last_activity: Arc::new(StdMutex::new(Instant::now())),
+                done: Arc::clone(&second_done),
+            },
+        )
+        .await;
+    assert_eq!(
+        state.slots.lock().await.get("thread-1").map(|slot| slot.id),
+        Some(second_id)
+    );
+    state
+        .finish_slot("thread-1", second_id, second_permit, second_done)
+        .await;
+}
+
+struct SilentServer;
+
+impl rmcp::ServerHandler for SilentServer {}
+
+#[tokio::test]
+async fn replacement_waits_for_pending_rmcp_initialization() {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use tokio::net::UnixStream;
+    use tokio::time::{Duration, timeout};
+    use tokio_util::sync::CancellationToken;
+    use uuid::Uuid;
+
+    let principal = astrid_core::PrincipalId::new("codex-code").expect("principal");
+    let state = Arc::new(GatewayState::new(
+        PathBuf::from("/runtime-home"),
+        principal,
+        "gateway-token".into(),
+    ));
+    let (peer, stream) = UnixStream::pair().expect("Unix stream pair");
+    let (reader, write_half) = tokio::io::split(stream);
+    let host_session_id = "thread-1";
+    let slot_id = Uuid::new_v4();
+    let cancel = CancellationToken::new();
+    let done = Arc::new(Notify::new());
+    let permit = state.acquire("codex-code").await.expect("old permit");
+    state
+        .install_slot(
+            host_session_id.into(),
+            AttachSlot {
+                id: slot_id,
+                cancel: cancel.clone(),
+                last_activity: Arc::new(StdMutex::new(Instant::now())),
+                done: Arc::clone(&done),
+            },
+        )
+        .await;
+
+    let peers = Arc::new(Mutex::new(HashMap::new()));
+    let finished = Arc::new(AtomicBool::new(false));
+    let cleanup_state = Arc::clone(&state);
+    let cleanup_finished = Arc::clone(&finished);
+    let cleanup_done = Arc::clone(&done);
+    let cleanup_cancel = cancel.clone();
+    let mut old_task = tokio::spawn(async move {
+        let result = run_attached_session(
+            SilentServer,
+            reader,
+            write_half,
+            peers,
+            slot_id,
+            cleanup_cancel,
+        )
+        .await;
+        cleanup_finished.store(true, Ordering::Release);
+        cleanup_state
+            .finish_slot(host_session_id, slot_id, permit, cleanup_done)
+            .await;
+        result
+    });
+
+    // Keep the transport open and silent: serve_with_ct must be cancellable
+    // while waiting for the initialize request itself.
+    let _peer = peer;
+    let reservation = timeout(
+        Duration::from_secs(2),
+        state.reserve_session(host_session_id, "codex-code"),
+    )
+    .await
+    .expect("replacement admission must be bounded")
+    .expect("replacement must wait for the old RMCP session to finish");
+    assert!(
+        finished.load(Ordering::Acquire),
+        "new admission must not proceed while the old attach is pending"
+    );
+    assert!(
+        state.slots.lock().await.get(host_session_id).is_none(),
+        "old slot must be removed before replacement admission"
+    );
+    let mut available = Vec::with_capacity(MAX_ATTACHES - 1);
+    for _ in 0..MAX_ATTACHES - 1 {
+        available.push(
+            state
+                .acquire("codex-code")
+                .await
+                .expect("old permit must be released before replacement admission"),
+        );
+    }
+    drop(available);
+    drop(reservation);
+
+    let old_result = timeout(Duration::from_secs(1), &mut old_task)
+        .await
+        .expect("old attach cleanup must finish")
+        .expect("old attach task");
+    assert!(
+        old_result.is_err(),
+        "cancelled initialization must fail closed"
+    );
+    cancel.cancel();
+}
+
+#[tokio::test]
+async fn replacement_timeout_rejects_new_admission() {
+    use tokio::time::{Duration, timeout};
+    use tokio_util::sync::CancellationToken;
+    use uuid::Uuid;
+
+    let principal = astrid_core::PrincipalId::new("codex-code").expect("principal");
+    let state = GatewayState::new(
+        PathBuf::from("/runtime-home"),
+        principal,
+        "gateway-token".into(),
+    );
+    let permit = state.acquire("codex-code").await.expect("old permit");
+    state
+        .install_slot(
+            "thread-1".into(),
+            AttachSlot {
+                id: Uuid::new_v4(),
+                cancel: CancellationToken::new(),
+                last_activity: Arc::new(StdMutex::new(Instant::now())),
+                done: Arc::new(Notify::new()),
+            },
+        )
+        .await;
+
+    let result = timeout(
+        Duration::from_secs(2),
+        state.reserve_session("thread-1", "codex-code"),
+    )
+    .await
+    .expect("replacement timeout must be bounded");
+    let Err(error) = result else {
+        panic!("new admission must fail when teardown does not finish");
+    };
+    assert!(
+        error.to_string().contains("replacement teardown timed out"),
+        "unexpected replacement error: {error}"
+    );
+    drop(permit);
+}
+
+#[tokio::test]
+async fn stale_session_cleanup_cannot_remove_a_replacement() {
+    use std::sync::{Arc, Mutex as StdMutex};
+
+    use tokio::sync::Notify;
+    use tokio::time::Instant;
+    use tokio_util::sync::CancellationToken;
+    use uuid::Uuid;
+
+    let principal = astrid_core::PrincipalId::new("codex-code").expect("principal");
+    let state = GatewayState::new(
+        PathBuf::from("/runtime-home"),
+        principal,
+        "gateway-token".into(),
+    );
+    let old_id = Uuid::new_v4();
+    let old_cancel = CancellationToken::new();
+    state
+        .install_slot(
+            "thread-1".into(),
+            AttachSlot {
+                id: old_id,
+                cancel: old_cancel,
+                last_activity: Arc::new(StdMutex::new(Instant::now())),
+                done: Arc::new(Notify::new()),
+            },
+        )
+        .await;
+    assert!(state.take_slot_if("thread-1", old_id).await);
+
+    let replacement_id = Uuid::new_v4();
+    state
+        .install_slot(
+            "thread-1".into(),
+            AttachSlot {
+                id: replacement_id,
+                cancel: CancellationToken::new(),
+                last_activity: Arc::new(StdMutex::new(Instant::now())),
+                done: Arc::new(Notify::new()),
+            },
+        )
+        .await;
+    assert!(!state.take_slot_if("thread-1", old_id).await);
+    assert_eq!(
+        state.slots.lock().await.get("thread-1").map(|slot| slot.id),
+        Some(replacement_id)
+    );
+}
+
+#[tokio::test]
+async fn finish_slot_releases_cap_before_notifying_waiters() {
+    use std::sync::{Arc, Mutex as StdMutex};
+
+    use tokio::sync::Notify;
+    use tokio::time::{Duration, timeout};
+    use uuid::Uuid;
+
+    let principal = astrid_core::PrincipalId::new("codex-code").expect("principal");
+    let state = Arc::new(GatewayState::new(
+        PathBuf::from("/runtime-home"),
+        principal,
+        "gateway-token".into(),
+    ));
+    let observed = Arc::new(StdMutex::new(None));
+    let _probe = register_finish_slot_probe(Arc::clone(&observed));
+    let finishing = state.acquire("codex-code").await.expect("permit");
+    let mut occupied = Vec::with_capacity(MAX_ATTACHES - 1);
+    for _ in 0..MAX_ATTACHES - 1 {
+        occupied.push(state.acquire("codex-code").await.expect("permit"));
+    }
+    let done = Arc::new(Notify::new());
+    let notified = Arc::clone(&done).notified_owned();
+    let waiter_state = Arc::clone(&state);
+    let waiter = tokio::spawn(async move {
+        notified.await;
+        waiter_state.acquire("codex-code").await
+    });
+    tokio::task::yield_now().await;
+    state
+        .finish_slot("thread-1", Uuid::new_v4(), finishing, done)
+        .await;
+    assert_eq!(
+        *observed.lock().expect("finish-slot probe mutex"),
+        Some(true),
+        "permit must be available at the notification boundary"
+    );
+    let permit = timeout(Duration::from_secs(1), waiter)
+        .await
+        .expect("waiter must wake")
+        .expect("waiter task")
+        .expect("released permit must be available before notification");
+    drop(permit);
+    drop(occupied);
+}
+
+#[tokio::test]
+async fn acquire_evicts_idle_lru_then_admits() {
+    use std::sync::{Arc, Mutex as StdMutex};
+
+    use tokio::sync::Notify;
+    use tokio::time::Instant;
+    use tokio_util::sync::CancellationToken;
+
+    use super::{ATTACH_IDLE_EOF, AttachSlot};
+    use uuid::Uuid;
+
+    let principal = astrid_core::PrincipalId::new("codex-code").expect("principal");
+    let state = GatewayState::new(
+        PathBuf::from("/runtime-home"),
+        principal,
+        "gateway-token".into(),
+    );
+    for index in 0..MAX_ATTACHES {
+        let permit = state.acquire("codex-code").await.expect("permit");
+        let cancel = CancellationToken::new();
+        let done = Arc::new(Notify::new());
+        let last = Instant::now()
+            .checked_sub(ATTACH_IDLE_EOF + std::time::Duration::from_millis(5))
+            .expect("idle timestamp");
+        state
+            .install_slot(
+                format!("idle-{index}"),
+                AttachSlot {
+                    id: Uuid::new_v4(),
+                    cancel: cancel.clone(),
+                    last_activity: Arc::new(StdMutex::new(last)),
+                    done: Arc::clone(&done),
+                },
+            )
+            .await;
+        tokio::spawn(async move {
+            cancel.cancelled().await;
+            drop(permit);
+            done.notify_waiters();
+        });
+    }
+    let _permit = state
+        .acquire("codex-code")
+        .await
+        .expect("idle LRU eviction must admit a new attach");
+}
+
+#[tokio::test]
+async fn acquire_does_not_evict_active_slots() {
+    use std::sync::{Arc, Mutex as StdMutex};
+
+    use tokio::sync::Notify;
+    use tokio::time::Instant;
+    use tokio_util::sync::CancellationToken;
+
+    use uuid::Uuid;
+
+    let principal = astrid_core::PrincipalId::new("codex-code").expect("principal");
+    let state = GatewayState::new(
+        PathBuf::from("/runtime-home"),
+        principal,
+        "gateway-token".into(),
+    );
+    let mut cancels = Vec::new();
+    for index in 0..MAX_ATTACHES {
+        let permit = state.acquire("codex-code").await.expect("permit");
+        let cancel = CancellationToken::new();
+        let done = Arc::new(Notify::new());
+        state
+            .install_slot(
+                format!("live-{index}"),
+                AttachSlot {
+                    id: Uuid::new_v4(),
+                    cancel: cancel.clone(),
+                    last_activity: Arc::new(StdMutex::new(Instant::now())),
+                    done: Arc::clone(&done),
+                },
+            )
+            .await;
+        cancels.push(cancel.clone());
+        tokio::spawn(async move {
+            cancel.cancelled().await;
+            drop(permit);
+            done.notify_waiters();
+        });
+    }
+    assert!(state.acquire("codex-code").await.is_err());
+    for cancel in cancels {
+        cancel.cancel();
+    }
+}

--- a/crates/astrid-cli/src/commands/mcp/idle.rs
+++ b/crates/astrid-cli/src/commands/mcp/idle.rs
@@ -1,0 +1,123 @@
+//! Idle-EOF ceiling for gateway attach readers.
+//!
+//! This is a protocol leak guard, not an operator config knob. Codex keeps a
+//! stdio child per conversation and does not always drop it when the thread
+//! ends; a reader without a deadline would pin a broker slot forever. Same
+//! class as `MAX_ATTACHES` and `REGISTRATION_TIMEOUT`.
+
+use std::io;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use tokio::io::{AsyncRead, ReadBuf};
+use tokio::time::{Instant, Sleep};
+
+/// Production attach sockets that go silent are reaped after two minutes.
+#[cfg(not(test))]
+pub(crate) const ATTACH_IDLE_EOF: Duration = Duration::from_mins(2);
+/// Tests use a tight bound so idle-EOF is deterministic in milliseconds.
+#[cfg(test)]
+pub(crate) const ATTACH_IDLE_EOF: Duration = Duration::from_millis(80);
+
+pub(crate) struct IdleEof<R> {
+    inner: R,
+    idle: Duration,
+    sleep: Pin<Box<Sleep>>,
+    last_activity: Arc<Mutex<Instant>>,
+}
+
+impl<R> IdleEof<R> {
+    pub(crate) fn new(inner: R, idle: Duration, last_activity: Arc<Mutex<Instant>>) -> Self {
+        Self {
+            inner,
+            idle,
+            sleep: Box::pin(tokio::time::sleep(idle)),
+            last_activity,
+        }
+    }
+
+    fn bump(&mut self) {
+        let now = Instant::now();
+        if let Ok(mut guard) = self.last_activity.lock() {
+            *guard = now;
+        }
+        self.sleep
+            .as_mut()
+            .reset(now.checked_add(self.idle).unwrap_or(now));
+    }
+}
+
+impl<R: AsyncRead + Unpin> AsyncRead for IdleEof<R> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        let filled_before = buf.filled().len();
+        match Pin::new(&mut this.inner).poll_read(cx, buf) {
+            Poll::Ready(Ok(())) => {
+                if buf.filled().len() > filled_before {
+                    this.bump();
+                }
+                Poll::Ready(Ok(()))
+            },
+            Poll::Ready(Err(error)) => Poll::Ready(Err(error)),
+            Poll::Pending => match this.sleep.as_mut().poll(cx) {
+                Poll::Ready(()) => Poll::Ready(Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "MCP attach idle-EOF",
+                ))),
+                Poll::Pending => Poll::Pending,
+            },
+        }
+    }
+}
+
+pub(crate) fn is_idle(last_activity: &Mutex<Instant>, idle: Duration) -> bool {
+    last_activity
+        .lock()
+        .is_ok_and(|instant| instant.elapsed() >= idle)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+
+    use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
+    use tokio::time::Instant;
+
+    use super::{ATTACH_IDLE_EOF, IdleEof, is_idle};
+
+    #[tokio::test]
+    async fn idle_reader_times_out_without_bytes() {
+        let (_peer, stream) = tokio::io::duplex(32);
+        let last = Arc::new(Mutex::new(Instant::now()));
+        let mut reader = IdleEof::new(BufReader::new(stream), ATTACH_IDLE_EOF, last);
+        let started = Instant::now();
+        let error = reader
+            .read_u8()
+            .await
+            .expect_err("silent attach must idle-EOF");
+        assert_eq!(error.kind(), std::io::ErrorKind::TimedOut);
+        assert!(error.to_string().contains("idle-EOF"), "{error}");
+        assert!(started.elapsed() >= ATTACH_IDLE_EOF);
+        assert!(started.elapsed() < Duration::from_secs(2));
+    }
+
+    #[tokio::test]
+    async fn idle_reader_survives_traffic_inside_the_window() {
+        let (mut peer, stream) = tokio::io::duplex(32);
+        let last = Arc::new(Mutex::new(Instant::now()));
+        let mut reader = IdleEof::new(BufReader::new(stream), ATTACH_IDLE_EOF, Arc::clone(&last));
+        tokio::spawn(async move {
+            tokio::time::sleep(ATTACH_IDLE_EOF / 2).await;
+            peer.write_u8(b'x').await.expect("traffic");
+        });
+        assert_eq!(reader.read_u8().await.expect("byte"), b'x');
+        assert!(!is_idle(&last, ATTACH_IDLE_EOF));
+    }
+}

--- a/crates/astrid-cli/src/commands/mcp/idle.rs
+++ b/crates/astrid-cli/src/commands/mcp/idle.rs
@@ -109,15 +109,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn idle_reader_survives_traffic_inside_the_window() {
+    async fn idle_reader_resets_after_traffic_and_survives_the_original_deadline() {
         let (mut peer, stream) = tokio::io::duplex(32);
         let last = Arc::new(Mutex::new(Instant::now()));
         let mut reader = IdleEof::new(BufReader::new(stream), ATTACH_IDLE_EOF, Arc::clone(&last));
         tokio::spawn(async move {
             tokio::time::sleep(ATTACH_IDLE_EOF / 2).await;
             peer.write_u8(b'x').await.expect("traffic");
+            tokio::time::sleep(ATTACH_IDLE_EOF * 7 / 8).await;
+            let _ = peer.write_u8(b'y').await;
         });
         assert_eq!(reader.read_u8().await.expect("byte"), b'x');
         assert!(!is_idle(&last, ATTACH_IDLE_EOF));
+        assert_eq!(reader.read_u8().await.expect("reset byte"), b'y');
     }
 }

--- a/crates/astrid-cli/src/commands/mcp/lifecycle.rs
+++ b/crates/astrid-cli/src/commands/mcp/lifecycle.rs
@@ -284,6 +284,18 @@ fn command_file_name(token: &str) -> &str {
         .unwrap_or(token)
 }
 
+fn is_env_assignment(token: &str) -> bool {
+    let Some((name, _value)) = token.split_once('=') else {
+        return false;
+    };
+    let mut characters = name.bytes();
+    let Some(first) = characters.next() else {
+        return false;
+    };
+    (first == b'_' || first.is_ascii_alphabetic())
+        && characters.all(|byte| byte == b'_' || byte.is_ascii_alphanumeric())
+}
+
 fn is_python_frame(command: &str) -> bool {
     command.contains("aos-mcp-frame")
         || command.contains("Python.framework")
@@ -314,12 +326,29 @@ fn is_mcp_attach(command: &str) -> bool {
     let Some(attach_index) = tokens.windows(2).position(|pair| pair == ["mcp", "attach"]) else {
         return false;
     };
-    // Only the executable/wrapper prefix can establish Astrid identity. A
-    // basename after `mcp attach` is commonly a workspace or script argument
-    // and must not make an unrelated process reapable.
-    tokens[..attach_index]
-        .iter()
-        .any(|token| matches!(command_file_name(token), "astrid" | "aos"))
+    // Only argv[0] (or an explicit `env VAR=value ...` wrapper) can establish
+    // Astrid identity. A basename later in the command is commonly a script,
+    // workspace, or argument and must not make an unrelated process reapable.
+    let prefix = &tokens[..attach_index];
+    let Some(executable) = prefix.first() else {
+        return false;
+    };
+    if matches!(command_file_name(executable), "astrid" | "aos") {
+        return true;
+    }
+    if command_file_name(executable) != "env" {
+        return false;
+    }
+    let mut index = 1;
+    while prefix
+        .get(index)
+        .is_some_and(|token| is_env_assignment(token))
+    {
+        index = index.saturating_add(1);
+    }
+    prefix
+        .get(index)
+        .is_some_and(|token| matches!(command_file_name(token), "astrid" | "aos"))
 }
 
 fn is_reapable_mcp(command: &str) -> bool {
@@ -415,6 +444,10 @@ mod tests {
         ));
         assert!(!is_mcp_attach(
             "node worker.js mcp attach --workspace /tmp/astrid"
+        ));
+        assert!(!is_mcp_attach("node /tmp/astrid worker.js mcp attach"));
+        assert!(is_mcp_attach(
+            "env ASTRID_SESSION_ID=thread-1 /opt/aos mcp attach --workspace /tmp/proj"
         ));
         assert!(!is_mcp_attach("astrid --principal codex-code mcp gateway"));
         assert!(!is_mcp_attach("aos mcp serve --request-timeout 1d5m"));

--- a/crates/astrid-cli/src/commands/mcp/lifecycle.rs
+++ b/crates/astrid-cli/src/commands/mcp/lifecycle.rs
@@ -311,11 +311,15 @@ fn is_mcp_attach(command: &str) -> bool {
         return false;
     }
     let tokens = command.split_whitespace().collect::<Vec<_>>();
-    let has_attach = tokens.windows(2).any(|pair| pair == ["mcp", "attach"]);
-    has_attach
-        && tokens
-            .iter()
-            .any(|token| matches!(command_file_name(token), "astrid" | "aos"))
+    let Some(attach_index) = tokens.windows(2).position(|pair| pair == ["mcp", "attach"]) else {
+        return false;
+    };
+    // Only the executable/wrapper prefix can establish Astrid identity. A
+    // basename after `mcp attach` is commonly a workspace or script argument
+    // and must not make an unrelated process reapable.
+    tokens[..attach_index]
+        .iter()
+        .any(|token| matches!(command_file_name(token), "astrid" | "aos"))
 }
 
 fn is_reapable_mcp(command: &str) -> bool {
@@ -408,6 +412,9 @@ mod tests {
         ));
         assert!(is_python_frame(
             "Python -u /cache/bin/aos-mcp-frame astrid --principal codex-code mcp attach"
+        ));
+        assert!(!is_mcp_attach(
+            "node worker.js mcp attach --workspace /tmp/astrid"
         ));
         assert!(!is_mcp_attach("astrid --principal codex-code mcp gateway"));
         assert!(!is_mcp_attach("aos mcp serve --request-timeout 1d5m"));

--- a/crates/astrid-cli/src/commands/mcp/lifecycle.rs
+++ b/crates/astrid-cli/src/commands/mcp/lifecycle.rs
@@ -277,6 +277,24 @@ fn parse_process_row(line: &str) -> Option<ProcessRow> {
     })
 }
 
+fn command_file_name(token: &str) -> &str {
+    Path::new(token)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(token)
+}
+
+fn is_python_frame(command: &str) -> bool {
+    command.contains("aos-mcp-frame")
+        || command.contains("Python.framework")
+        || command.split_whitespace().any(|token| {
+            matches!(
+                command_file_name(token),
+                "python3" | "Python" | "aos-mcp-frame"
+            )
+        })
+}
+
 fn is_long_mcp_serve(command: &str) -> bool {
     let tokens = command.split_whitespace().collect::<Vec<_>>();
     let has_mcp_serve = tokens.windows(2).any(|pair| pair == ["mcp", "serve"]);
@@ -288,7 +306,26 @@ fn is_long_mcp_serve(command: &str) -> bool {
     has_mcp_serve && has_timeout
 }
 
-/// Remove orphaned long-timeout `mcp serve` processes.
+fn is_mcp_attach(command: &str) -> bool {
+    if is_python_frame(command) {
+        return false;
+    }
+    let tokens = command.split_whitespace().collect::<Vec<_>>();
+    let has_attach = tokens.windows(2).any(|pair| pair == ["mcp", "attach"]);
+    has_attach
+        && tokens
+            .iter()
+            .any(|token| matches!(command_file_name(token), "astrid" | "aos"))
+}
+
+fn is_reapable_mcp(command: &str) -> bool {
+    is_long_mcp_serve(command) || is_mcp_attach(command)
+}
+
+/// Remove orphaned long-timeout `mcp serve` and `mcp attach` processes.
+///
+/// Never signals Python `aos-mcp-frame` processes. Those abort on 3.14 if a
+/// SIGKILL races `Buffered_close`; attach children are the reap target.
 pub(crate) fn gc() -> Result<ExitCode> {
     let output = Command::new("ps")
         .args(["-axo", "pid=,ppid=,command="])
@@ -300,7 +337,7 @@ pub(crate) fn gc() -> Result<ExitCode> {
     let listing = String::from_utf8_lossy(&output.stdout);
     let mut reaped = 0_u32;
     for row in listing.lines().filter_map(parse_process_row) {
-        if row.pid == std::process::id() || !is_long_mcp_serve(&row.command) {
+        if row.pid == std::process::id() || !is_reapable_mcp(&row.command) {
             continue;
         }
         let parent_dead =
@@ -309,8 +346,8 @@ pub(crate) fn gc() -> Result<ExitCode> {
             continue;
         }
         // Re-read the command immediately before signalling to avoid killing a
-        // recycled PID that no longer belongs to the long-timeout MCP shim.
-        if !process_command(row.pid).is_some_and(|command| is_long_mcp_serve(&command)) {
+        // recycled PID that no longer belongs to a reapable MCP shim.
+        if !process_command(row.pid).is_some_and(|command| is_reapable_mcp(&command)) {
             continue;
         }
         #[cfg(unix)]
@@ -338,7 +375,10 @@ fn process_command(pid: u32) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{GatewayReady, ReadyFormat, is_long_mcp_serve, parse_process_row};
+    use super::{
+        GatewayReady, ReadyFormat, is_long_mcp_serve, is_mcp_attach, is_python_frame,
+        parse_process_row,
+    };
 
     #[test]
     fn process_parser_preserves_command_after_pid_fields() {
@@ -355,6 +395,22 @@ mod tests {
         assert!(is_long_mcp_serve("aos mcp serve --request-timeout=1d5m"));
         assert!(!is_long_mcp_serve("aos mcp serve --request-timeout 30s"));
         assert!(!is_long_mcp_serve("aos mcp gateway --request-timeout 1d5m"));
+    }
+
+    #[test]
+    fn gc_reaps_orphaned_attach_but_never_python_frames() {
+        assert!(is_mcp_attach(
+            "/Users/me/.aos/runtime/bin/astrid --principal codex-code mcp attach --workspace /tmp/proj"
+        ));
+        assert!(is_mcp_attach("aos --principal codex-code mcp attach"));
+        assert!(!is_mcp_attach(
+            "/opt/homebrew/Cellar/python@3.14/3.14.6/Frameworks/Python.framework/Versions/3.14/Resources/Python.app/Contents/MacOS/Python -u /cache/unicity-aos/bin/aos-mcp-frame /runtime/bin/astrid --principal codex-code mcp attach --workspace /plugin"
+        ));
+        assert!(is_python_frame(
+            "Python -u /cache/bin/aos-mcp-frame astrid --principal codex-code mcp attach"
+        ));
+        assert!(!is_mcp_attach("astrid --principal codex-code mcp gateway"));
+        assert!(!is_mcp_attach("aos mcp serve --request-timeout 1d5m"));
     }
 
     #[test]

--- a/crates/astrid-cli/src/commands/mcp/mod.rs
+++ b/crates/astrid-cli/src/commands/mcp/mod.rs
@@ -56,6 +56,8 @@ mod elicit;
 mod form_elicitation;
 #[cfg(unix)]
 mod gateway;
+#[cfg(unix)]
+mod idle;
 #[cfg(not(unix))]
 mod gateway {
     use std::process::ExitCode;


### PR DESCRIPTION
## Linked Issue

Closes #1677

## Summary

Codex was pinning a new gateway attach per conversation until the 16-slot cap, then MCP startup hit the 20s timeout. The gateway now uses one persistent principal uplink, replaces a reconnecting host session atomically, idle-EOFs silent readers, and provides bounded orphan cleanup without signalling the Python `aos-mcp-frame` shim.

## Changes

- Gateway attach keyed by host session: replacement, cap admission, and slot publication are serialized; slot generations prevent delayed predecessors from removing replacements; teardown releases permits before waking waiters.
- Silent MCP initialization is cancellable: `run_attached_session` passes the slot token into RMCP `serve_with_ct`, and `replace_session` fails closed if predecessor teardown exceeds `REPLACEMENT_TIMEOUT` before `acquire`.
- Idle-EOF reader (`Duration::from_mins(2)` production, 80ms in tests). Protocol DoS ceiling, not `astrid-config`.
- At `MAX_ATTACHES`, LRU-evict an idle slot; fail fast if every slot is still active.
- `mcp gc` matches only Astrid `mcp attach` command prefixes (`argv0` `astrid`/`aos`, or explicit `env VAR=value*` wrappers), skips false positives and `aos-mcp-frame` / Python, and retains the pre-signal command recheck.
- `mcp serve` remains the explicit per-session escape hatch.

## Verification

- `cargo test -p astrid --locked --bin astrid mcp -- --test-threads=1` (89 passed, throwaway `HOME`/`ASTRID_HOME`)
- `cargo clippy -p astrid --locked --all-targets -- -D warnings` (clean)
- Named regressions cover serialized same-session admission, stale cleanup, cap release before notification, idle reset across the original deadline, idle LRU admission, active-slot fail-fast, silent-initialization cancellation before replacement, replacement-timeout fail-closed, and the non-Astrid GC false positive.

## Test Plan

- Reconnect with the same host session must leave exactly one slot and free the previous permit.
- A delayed predecessor must not remove the replacement slot or peer.
- A silent attach waiting on initialize must cancel before replacement admission; traffic inside the idle window must survive past the original deadline.
- The 17th attach against 16 idle slots must succeed; against 16 active slots it must fail.
- `mcp gc` must not select Python `aos-mcp-frame` or `node /tmp/astrid worker.js mcp attach`.
- Do not raise Codex `startup_timeout_sec`; attach after a ready gateway is milliseconds.

## AI / Tool Assistance

Assisted-by: OpenAI Codex: Grok 4.6
Assisted-by: OpenAI Codex: GPT-5.6 Luna
Assisted-by: OpenAI Codex: GLM-5.3

Codex authored the gateway attach replacement, idle-EOF, RMCP cancellation wiring, and named regressions. Independent exact-head review attacked replacement linearizability, idle-timer reset, GC identity, and silent-initialization cancellation. I reviewed the resulting production paths and retained the named tests above.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/1677.fixed.md`
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.

## Follow-up validation

- Replacement timeout is a documented protocol safety ceiling, not `astrid-config`.
- Plugin remains off until this PR and the companion oracles attach path are CI-green and explicitly authorized live.
