### PR TITLE
ci: publish versioned Astrid toolchain images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,7 +4,14 @@
 !container/amd64/entrypoint.sh
 !container/arm64/
 !container/arm64/Dockerfile
+!container/ci/
+!container/ci/Dockerfile
 !dist/
+!dist/ci/
+!dist/ci/astrid
+!dist/ci/astrid-build
+!dist/ci/astrid-daemon
+!dist/ci/astrid-emit
 !dist/oci-amd64/
 !dist/oci-amd64/astrid-release.tar.gz
 !dist/oci-amd64/release-receipt.json

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -7,25 +7,47 @@ on:
       - '.github/workflows/ci-image.yml'
       - 'container/ci/**'
       - 'scripts/test_ci_image_contract.py'
-  push:
-    branches: [main]
+  workflow_run:
+    workflows: ['Release']
+    types: [completed]
   workflow_dispatch:
+    inputs:
+      version:
+        description: Exact stable Astrid release version, without the v prefix
+        required: true
+        type: string
+      source_commit:
+        description: Exact 40-character commit bound by the stable release
+        required: true
+        type: string
 
 permissions:
   contents: read
 
 concurrency:
-  group: astrid-ci-image-${{ github.ref }}
-  cancel-in-progress: true
+  group: astrid-ci-image-${{ github.event.workflow_run.id || github.run_id }}
+  cancel-in-progress: false
 
 env:
   IMAGE_NAME: ghcr.io/astrid-runtime/astrid-ci
+  RUST_VERSION: 1.95.0
+  IMAGE_VARIANT: bookworm
 
 jobs:
   build:
     name: Build and test exact CI image
+    if: >-
+      github.event_name != 'workflow_run' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'push' &&
+       startsWith(github.event.workflow_run.head_branch, 'v') &&
+       !contains(github.event.workflow_run.head_branch, '-nightly.'))
     runs-on: ubuntu-latest
+    outputs:
+      source_commit: ${{ steps.metadata.outputs.source_commit }}
+      version: ${{ steps.metadata.outputs.version }}
     permissions:
+      actions: read
       contents: read
     steps:
       - name: Harden runner
@@ -33,7 +55,109 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Check out the image definition
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Select exact source and version
+        id: metadata
+        env:
+          DISPATCH_VERSION: ${{ inputs.version }}
+          DISPATCH_SOURCE_COMMIT: ${{ inputs.source_commit }}
+          RELEASE_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          RELEASE_EVENT: ${{ github.event.workflow_run.event }}
+          RELEASE_REF: ${{ github.event.workflow_run.head_branch }}
+          RELEASE_SOURCE_COMMIT: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          case "$GITHUB_EVENT_NAME" in
+            workflow_run)
+              [[ "$RELEASE_CONCLUSION" == success ]]
+              [[ "$RELEASE_EVENT" == push ]]
+              [[ "$RELEASE_REF" == v* ]]
+              VERSION=${RELEASE_REF#v}
+              SOURCE_COMMIT=$RELEASE_SOURCE_COMMIT
+              ;;
+            workflow_dispatch)
+              VERSION=$DISPATCH_VERSION
+              SOURCE_COMMIT=$DISPATCH_SOURCE_COMMIT
+              ;;
+            pull_request)
+              VERSION=$(python3 -c 'import tomllib; print(tomllib.load(open("Cargo.toml", "rb"))["workspace"]["package"]["version"])')
+              SOURCE_COMMIT=$(git rev-parse HEAD)
+              ;;
+            *)
+              echo "unsupported event: $GITHUB_EVENT_NAME" >&2
+              exit 1
+              ;;
+          esac
+          [[ "$VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]
+          [[ "$SOURCE_COMMIT" =~ ^[0-9a-f]{40}$ ]]
+          {
+            echo "VERSION=$VERSION"
+            echo "SOURCE_COMMIT=$SOURCE_COMMIT"
+          } >> "$GITHUB_ENV"
+          {
+            echo "version=$VERSION"
+            echo "source_commit=$SOURCE_COMMIT"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Check out exact Astrid release source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          path: .ci-source
+          persist-credentials: false
+          ref: ${{ steps.metadata.outputs.source_commit }}
+          submodules: recursive
+
+      - name: Verify exact source checkout
+        run: |
+          test "$(git -C .ci-source rev-parse HEAD)" = "$SOURCE_COMMIT"
+          SOURCE_VERSION=$(python3 -c 'import tomllib; print(tomllib.load(open(".ci-source/Cargo.toml", "rb"))["workspace"]["package"]["version"])')
+          test "$SOURCE_VERSION" = "$VERSION"
+
+      - name: Authenticate published stable release
+        if: github.event_name != 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          TAG="v$VERSION"
+          TAG_OBJECT=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$TAG")
+          TAG_TYPE=$(jq -er .object.type <<< "$TAG_OBJECT")
+          TAG_COMMIT=$(jq -er .object.sha <<< "$TAG_OBJECT")
+          for _ in {1..8}; do
+            [[ "$TAG_TYPE" == tag ]] || break
+            TAG_OBJECT=$(gh api "repos/$GITHUB_REPOSITORY/git/tags/$TAG_COMMIT")
+            TAG_TYPE=$(jq -er .object.type <<< "$TAG_OBJECT")
+            TAG_COMMIT=$(jq -er .object.sha <<< "$TAG_OBJECT")
+          done
+          [[ "$TAG_TYPE" == commit ]]
+          [[ "$TAG_COMMIT" == "$SOURCE_COMMIT" ]]
+
+          gh api "repos/$GITHUB_REPOSITORY/releases/tags/$TAG" \
+            | jq -e \
+              'select(.draft == false and .immutable == true and .prerelease == false and .published_at != null) | true' \
+            | grep -Fx true
+
+          if [[ "$GITHUB_EVENT_NAME" == workflow_run ]]; then
+            RUN=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$RELEASE_RUN_ID")
+            jq -e \
+              --arg source "$SOURCE_COMMIT" \
+              --arg tag "$TAG" \
+              'select(.name == "Release" and .event == "push" and .status == "completed" and .conclusion == "success" and .head_sha == $source and .head_branch == $tag) | true' \
+              <<< "$RUN" | grep -Fx true
+          else
+            RUNS="$RUNNER_TEMP/successful-stable-release-runs.json"
+            gh api --paginate --slurp \
+              "repos/$GITHUB_REPOSITORY/actions/workflows/release.yml/runs?event=push&status=success&per_page=100" \
+              > "$RUNS"
+            jq -e \
+              --arg source "$SOURCE_COMMIT" \
+              --arg tag "$TAG" \
+              '[.[] | .workflow_runs[] | select(.head_sha == $source and .head_branch == $tag)] | length >= 1' \
+              "$RUNS" >/dev/null
+          fi
 
       - name: Install pinned Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -45,44 +169,52 @@ jobs:
         uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
           shared-key: ci-image
+          workspaces: .ci-source -> .ci-source/target
 
       - name: Test CI image contracts
         run: python3 scripts/test_ci_image_contract.py
 
       - name: Build exact Astrid binaries
-        run: cargo build --release --locked -p astrid
+        run: |
+          cargo build \
+            --manifest-path .ci-source/Cargo.toml \
+            --target-dir .ci-source/target \
+            --release \
+            --locked \
+            -p astrid
 
       - name: Stage CI image payload
         run: |
           mkdir -p dist/ci
           for binary in astrid astrid-build astrid-daemon astrid-emit; do
-            install -m 0755 "target/release/$binary" "dist/ci/$binary"
+            install -m 0755 ".ci-source/target/release/$binary" "dist/ci/$binary"
           done
 
       - name: Build CI image from staged binaries
         run: |
           docker build \
             --platform linux/amd64 \
-            --build-arg "ASTRID_SOURCE_COMMIT=$GITHUB_SHA" \
+            --build-arg "ASTRID_SOURCE_COMMIT=$SOURCE_COMMIT" \
+            --build-arg "ASTRID_VERSION=$VERSION" \
             --tag astrid-ci:test \
             --file container/ci/Dockerfile \
             .
 
       - name: Test exact CI image
-        run: container/ci/test.sh astrid-ci:test "$GITHUB_SHA"
+        run: container/ci/test.sh astrid-ci:test "$VERSION" "$SOURCE_COMMIT"
 
       - name: Export exact tested image
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
         run: |
           docker image save --output dist/ci/astrid-ci-image.tar astrid-ci:test
           sha256sum dist/ci/astrid-ci-image.tar > dist/ci/astrid-ci-image.tar.sha256
           sha256sum --check dist/ci/astrid-ci-image.tar.sha256
 
       - name: Upload exact tested image
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: astrid-ci-image-${{ github.sha }}
+          name: astrid-ci-image-${{ steps.metadata.outputs.version }}-${{ steps.metadata.outputs.source_commit }}
           path: |
             dist/ci/astrid-ci-image.tar
             dist/ci/astrid-ci-image.tar.sha256
@@ -90,15 +222,18 @@ jobs:
           retention-days: 1
 
   publish:
-    name: Publish exact tested CI image
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    name: Publish versioned CI image
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-latest
+    env:
+      SOURCE_COMMIT: ${{ needs.build.outputs.source_commit }}
+      VERSION: ${{ needs.build.outputs.version }}
     permissions:
-      contents: read
-      packages: write
-      id-token: write
       attestations: write
+      contents: read
+      id-token: write
+      packages: write
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
@@ -108,34 +243,99 @@ jobs:
       - name: Download exact tested image
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: astrid-ci-image-${{ github.sha }}
+          name: astrid-ci-image-${{ needs.build.outputs.version }}-${{ needs.build.outputs.source_commit }}
           path: dist/ci
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Verify and load exact tested image
         run: |
           sha256sum --check dist/ci/astrid-ci-image.tar.sha256
           docker image load --input dist/ci/astrid-ci-image.tar
-          test "$(docker image inspect astrid-ci:test --format '{{index .Config.Labels "org.opencontainers.image.revision"}}')" = "$GITHUB_SHA"
+          test "$(docker image inspect astrid-ci:test --format '{{index .Config.Labels "org.opencontainers.image.revision"}}')" = "$SOURCE_COMMIT"
+          test "$(docker image inspect astrid-ci:test --format '{{index .Config.Labels "org.opencontainers.image.version"}}')" = "$VERSION"
 
       - name: Authenticate to GHCR
         env:
           GHCR_TOKEN: ${{ github.token }}
         run: printf '%s' "$GHCR_TOKEN" | docker login ghcr.io --username "$GITHUB_ACTOR" --password-stdin
 
-      - name: Publish immutable source-commit tag
+      - name: Publish immutable release tags
         id: publish
         run: |
-          IMAGE_TAG="${IMAGE_NAME}:${GITHUB_SHA}"
-          docker image tag astrid-ci:test "$IMAGE_TAG"
-          docker image push "$IMAGE_TAG"
-          docker image pull "$IMAGE_TAG"
-          BOUND_IMAGE=$(docker image inspect "$IMAGE_TAG" --format '{{index .RepoDigests 0}}')
-          DIGEST=${BOUND_IMAGE##*@}
+          remote_digest() {
+            local error_file="$RUNNER_TEMP/manifest-${RANDOM}.err"
+            local inspect_output
+            if inspect_output=$(docker manifest inspect --verbose "$1" 2> "$error_file"); then
+              if ! jq -er '.Descriptor.digest' <<< "$inspect_output"; then
+                echo "registry returned an unrecognized manifest for $1" >&2
+                rm -f "$error_file"
+                return 2
+              fi
+              rm -f "$error_file"
+              return 0
+            fi
+            if grep -Eq 'manifest unknown|no such manifest' "$error_file"; then
+              rm -f "$error_file"
+              return 1
+            fi
+            cat "$error_file" >&2
+            rm -f "$error_file"
+            return 2
+          }
+
+          CANONICAL_TAG="${IMAGE_NAME}:sha-${SOURCE_COMMIT}"
+          set +e
+          DIGEST=$(remote_digest "$CANONICAL_TAG")
+          remote_status=$?
+          set -e
+          case "$remote_status" in
+            0)
+              docker image pull "$CANONICAL_TAG"
+              test "$(docker image inspect "$CANONICAL_TAG" --format '{{index .Config.Labels "org.opencontainers.image.revision"}}')" = "$SOURCE_COMMIT"
+              test "$(docker image inspect "$CANONICAL_TAG" --format '{{index .Config.Labels "org.opencontainers.image.version"}}')" = "$VERSION"
+              ;;
+            1)
+              docker image tag astrid-ci:test "$CANONICAL_TAG"
+              docker image push "$CANONICAL_TAG"
+              DIGEST=$(remote_digest "$CANONICAL_TAG")
+              ;;
+            *)
+              echo "cannot prove whether $CANONICAL_TAG already exists" >&2
+              exit "$remote_status"
+              ;;
+          esac
           [[ "$DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]
-          test "$BOUND_IMAGE" = "${IMAGE_NAME}@${DIGEST}"
+          CANONICAL_IMAGE="${IMAGE_NAME}@${DIGEST}"
+
+          VERSION_TAG="${IMAGE_NAME}:${VERSION}"
+          VARIANT_TAG="${IMAGE_NAME}:${VERSION}-rust${RUST_VERSION}-${IMAGE_VARIANT}"
+          for alias in "$VERSION_TAG" "$VARIANT_TAG"; do
+            set +e
+            ALIAS_DIGEST=$(remote_digest "$alias")
+            remote_status=$?
+            set -e
+            case "$remote_status" in
+              0)
+                test "$ALIAS_DIGEST" = "$DIGEST"
+                ;;
+              1)
+                docker buildx imagetools create --tag "$alias" "$CANONICAL_IMAGE"
+                test "$(remote_digest "$alias")" = "$DIGEST"
+                ;;
+              *)
+                echo "cannot prove whether $alias already exists" >&2
+                exit "$remote_status"
+                ;;
+            esac
+          done
+
           {
-            echo "image=$BOUND_IMAGE"
+            echo "image=$CANONICAL_IMAGE"
             echo "digest=$DIGEST"
+            echo "version-tag=$VERSION_TAG"
+            echo "variant-tag=$VARIANT_TAG"
           } >> "$GITHUB_OUTPUT"
 
       - name: Attest published image provenance
@@ -145,7 +345,14 @@ jobs:
           subject-digest: ${{ steps.publish.outputs.digest }}
           push-to-registry: true
 
-      - name: Record digest for consumers
+      - name: Record digest and release tags for consumers
         env:
           PUBLISHED_IMAGE: ${{ steps.publish.outputs.image }}
-        run: printf '%s\n' "\`$PUBLISHED_IMAGE\`" >> "$GITHUB_STEP_SUMMARY"
+          VARIANT_TAG: ${{ steps.publish.outputs.variant-tag }}
+          VERSION_TAG: ${{ steps.publish.outputs.version-tag }}
+        run: |
+          {
+            printf '%s\n' "Immutable image: \`$PUBLISHED_IMAGE\`"
+            printf '%s\n' "Release tag: \`$VERSION_TAG\`"
+            printf '%s\n' "Toolchain variant: \`$VARIANT_TAG\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -30,6 +30,7 @@ concurrency:
 
 env:
   IMAGE_NAME: ghcr.io/astrid-runtime/astrid-ci
+  BUILD_IMAGE: docker.io/library/rust:1.95.0-bookworm@sha256:4c2fd73ef19c5ef9d54bee03b06b2839a392604fbfcd578ed948b71b37c1d7fb
   RUST_VERSION: 1.95.0
   IMAGE_VARIANT: bookworm
 
@@ -168,7 +169,7 @@ jobs:
       - name: Restore Rust build cache
         uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
-          shared-key: ci-image
+          shared-key: ci-image-bookworm-amd64
           workspaces: .ci-source -> .ci-source/target
 
       - name: Test CI image contracts
@@ -176,12 +177,19 @@ jobs:
 
       - name: Build exact Astrid binaries
         run: |
-          cargo build \
-            --manifest-path .ci-source/Cargo.toml \
-            --target-dir .ci-source/target \
-            --release \
-            --locked \
-            -p astrid
+          docker run --rm \
+            --platform linux/amd64 \
+            --env CARGO_INCREMENTAL=0 \
+            --env CARGO_TERM_COLOR=always \
+            --env HOST_GID="$(id -g)" \
+            --env HOST_UID="$(id -u)" \
+            --volume "$PWD:/workspace" \
+            --workdir /workspace/.ci-source \
+            "$BUILD_IMAGE" \
+            bash -euc '
+              cargo build --target-dir target --release --locked -p astrid
+              chown -R "$HOST_UID:$HOST_GID" target
+            '
 
       - name: Stage CI image payload
         run: |

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -1,0 +1,151 @@
+name: CI toolchain image
+
+on:
+  pull_request:
+    paths:
+      - '.dockerignore'
+      - '.github/workflows/ci-image.yml'
+      - 'container/ci/**'
+      - 'scripts/test_ci_image_contract.py'
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: astrid-ci-image-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  IMAGE_NAME: ghcr.io/astrid-runtime/astrid-ci
+
+jobs:
+  build:
+    name: Build and test exact CI image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install pinned Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: '1.95.0'
+          targets: wasm32-unknown-unknown
+
+      - name: Restore Rust build cache
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+        with:
+          shared-key: ci-image
+
+      - name: Test CI image contracts
+        run: python3 scripts/test_ci_image_contract.py
+
+      - name: Build exact Astrid binaries
+        run: cargo build --release --locked -p astrid
+
+      - name: Stage CI image payload
+        run: |
+          mkdir -p dist/ci
+          for binary in astrid astrid-build astrid-daemon astrid-emit; do
+            install -m 0755 "target/release/$binary" "dist/ci/$binary"
+          done
+
+      - name: Build CI image from staged binaries
+        run: |
+          docker build \
+            --platform linux/amd64 \
+            --build-arg "ASTRID_SOURCE_COMMIT=$GITHUB_SHA" \
+            --tag astrid-ci:test \
+            --file container/ci/Dockerfile \
+            .
+
+      - name: Test exact CI image
+        run: container/ci/test.sh astrid-ci:test "$GITHUB_SHA"
+
+      - name: Export exact tested image
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          docker image save --output dist/ci/astrid-ci-image.tar astrid-ci:test
+          sha256sum dist/ci/astrid-ci-image.tar > dist/ci/astrid-ci-image.tar.sha256
+          sha256sum --check dist/ci/astrid-ci-image.tar.sha256
+
+      - name: Upload exact tested image
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: astrid-ci-image-${{ github.sha }}
+          path: |
+            dist/ci/astrid-ci-image.tar
+            dist/ci/astrid-ci-image.tar.sha256
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    name: Publish exact tested CI image
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - name: Download exact tested image
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: astrid-ci-image-${{ github.sha }}
+          path: dist/ci
+
+      - name: Verify and load exact tested image
+        run: |
+          sha256sum --check dist/ci/astrid-ci-image.tar.sha256
+          docker image load --input dist/ci/astrid-ci-image.tar
+          test "$(docker image inspect astrid-ci:test --format '{{index .Config.Labels "org.opencontainers.image.revision"}}')" = "$GITHUB_SHA"
+
+      - name: Authenticate to GHCR
+        env:
+          GHCR_TOKEN: ${{ github.token }}
+        run: printf '%s' "$GHCR_TOKEN" | docker login ghcr.io --username "$GITHUB_ACTOR" --password-stdin
+
+      - name: Publish immutable source-commit tag
+        id: publish
+        run: |
+          IMAGE_TAG="${IMAGE_NAME}:${GITHUB_SHA}"
+          docker image tag astrid-ci:test "$IMAGE_TAG"
+          docker image push "$IMAGE_TAG"
+          docker image pull "$IMAGE_TAG"
+          BOUND_IMAGE=$(docker image inspect "$IMAGE_TAG" --format '{{index .RepoDigests 0}}')
+          DIGEST=${BOUND_IMAGE##*@}
+          [[ "$DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]
+          test "$BOUND_IMAGE" = "${IMAGE_NAME}@${DIGEST}"
+          {
+            echo "image=$BOUND_IMAGE"
+            echo "digest=$DIGEST"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Attest published image provenance
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-name: ${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.publish.outputs.digest }}
+          push-to-registry: true
+
+      - name: Record digest for consumers
+        env:
+          PUBLISHED_IMAGE: ${{ steps.publish.outputs.image }}
+        run: printf '%s\n' "\`$PUBLISHED_IMAGE\`" >> "$GITHUB_STEP_SUMMARY"

--- a/container/ci/Dockerfile
+++ b/container/ci/Dockerfile
@@ -1,12 +1,16 @@
 FROM rust:1.95.0-bookworm@sha256:4c2fd73ef19c5ef9d54bee03b06b2839a392604fbfcd578ed948b71b37c1d7fb
 
 ARG ASTRID_SOURCE_COMMIT
+ARG ASTRID_VERSION
 
 LABEL org.opencontainers.image.title="Astrid CI toolchain"
 LABEL org.opencontainers.image.description="CI-only Rust toolchain and Astrid binaries for capsule repositories"
 LABEL org.opencontainers.image.source="https://github.com/astrid-runtime/astrid"
 LABEL org.opencontainers.image.revision="${ASTRID_SOURCE_COMMIT}"
+LABEL org.opencontainers.image.version="${ASTRID_VERSION}"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL io.astrid.ci.rust-version="1.95.0"
+LABEL io.astrid.ci.variant="bookworm"
 
 ENV CARGO_TERM_COLOR=always
 ENV RUST_BACKTRACE=1

--- a/container/ci/Dockerfile
+++ b/container/ci/Dockerfile
@@ -1,0 +1,34 @@
+FROM rust:1.95.0-bookworm@sha256:4c2fd73ef19c5ef9d54bee03b06b2839a392604fbfcd578ed948b71b37c1d7fb
+
+ARG ASTRID_SOURCE_COMMIT
+
+LABEL org.opencontainers.image.title="Astrid CI toolchain"
+LABEL org.opencontainers.image.description="CI-only Rust toolchain and Astrid binaries for capsule repositories"
+LABEL org.opencontainers.image.source="https://github.com/astrid-runtime/astrid"
+LABEL org.opencontainers.image.revision="${ASTRID_SOURCE_COMMIT}"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+
+ENV CARGO_TERM_COLOR=always
+ENV RUST_BACKTRACE=1
+
+RUN rustup target add wasm32-unknown-unknown \
+    && apt-get update \
+    && apt-get install --yes --no-install-recommends \
+        gh \
+        jq \
+        python3 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --chmod=0755 dist/ci/astrid /usr/local/bin/astrid
+COPY --chmod=0755 dist/ci/astrid-build /usr/local/bin/astrid-build
+COPY --chmod=0755 dist/ci/astrid-daemon /usr/local/bin/astrid-daemon
+COPY --chmod=0755 dist/ci/astrid-emit /usr/local/bin/astrid-emit
+
+RUN rustc --version | grep -Fq 'rustc 1.95.0 ' \
+    && rustup target list --installed | grep -Fxq wasm32-unknown-unknown \
+    && astrid --version \
+    && astrid-build --version \
+    && astrid-daemon --version \
+    && astrid-emit --version
+
+WORKDIR /github/workspace

--- a/container/ci/README.md
+++ b/container/ci/README.md
@@ -1,0 +1,30 @@
+# Astrid CI toolchain image
+
+This image is a CI-only build environment for Astrid capsule repositories. It
+contains the repository's pinned Rust toolchain, the `wasm32-unknown-unknown`
+target, common GitHub Actions utilities, and the `astrid`, `astrid-build`,
+`astrid-daemon`, and `astrid-emit` binaries built from one exact Astrid commit.
+
+It is not an Astrid runtime release, release channel, product distro, or a
+replacement for the authenticated release OCI images under `container/amd64`
+and `container/arm64`.
+
+The workflow publishes one amd64 image tag per protected `main` commit:
+
+```text
+ghcr.io/astrid-runtime/astrid-ci:<40-character-source-commit>
+```
+
+Consumers must resolve that tag once and pin the resulting manifest digest:
+
+```yaml
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/astrid-runtime/astrid-ci@sha256:<manifest-digest>
+```
+
+Do not consume a moving tag. The OCI revision label, published provenance, and
+the pinned digest together bind the toolchain to the source commit that built
+the Astrid binaries.

--- a/container/ci/README.md
+++ b/container/ci/README.md
@@ -1,30 +1,56 @@
 # Astrid CI toolchain image
 
 This image is a CI-only build environment for Astrid capsule repositories. It
-contains the repository's pinned Rust toolchain, the `wasm32-unknown-unknown`
-target, common GitHub Actions utilities, and the `astrid`, `astrid-build`,
-`astrid-daemon`, and `astrid-emit` binaries built from one exact Astrid commit.
+contains Rust 1.95.0, the `wasm32-unknown-unknown` target, common GitHub Actions
+utilities, and the `astrid`, `astrid-build`, `astrid-daemon`, and `astrid-emit`
+binaries from one authenticated stable Astrid release.
 
-It is not an Astrid runtime release, release channel, product distro, or a
-replacement for the authenticated release OCI images under `container/amd64`
+It is not an Astrid runtime release image, release channel, product distro, or
+a replacement for the authenticated release OCI images under `container/amd64`
 and `container/arm64`.
 
-The workflow publishes one amd64 image tag per protected `main` commit:
+## Publication and tags
+
+Pull requests build and test the image without registry write permission. A
+successful authenticated stable `vX.Y.Z` release causes the image workflow to
+publish the tested amd64 image under three exact tags:
 
 ```text
-ghcr.io/astrid-runtime/astrid-ci:<40-character-source-commit>
+ghcr.io/astrid-runtime/astrid-ci:X.Y.Z
+ghcr.io/astrid-runtime/astrid-ci:X.Y.Z-rust1.95.0-bookworm
+ghcr.io/astrid-runtime/astrid-ci:sha-<40-character-source-commit>
 ```
 
-Consumers must resolve that tag once and pin the resulting manifest digest:
+The workflow does not publish `latest`, major, minor, or other moving aliases.
+It refuses to replace an existing release tag that resolves to different image
+content. A manual dispatch exists only to recover or bootstrap an already
+published immutable stable release; it reauthenticates both the release and its
+source commit before building.
+
+## Consumption
+
+Select the release or toolchain-variant tag, resolve it once, and pin the
+resulting manifest digest:
+
+```bash
+docker manifest inspect --verbose \
+  ghcr.io/astrid-runtime/astrid-ci:0.10.4 \
+  | jq -r '.Descriptor.digest'
+```
 
 ```yaml
 jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/astrid-runtime/astrid-ci@sha256:<manifest-digest>
+      image: ghcr.io/astrid-runtime/astrid-ci:0.10.4@sha256:<manifest-digest>
 ```
 
-Do not consume a moving tag. The OCI revision label, published provenance, and
-the pinned digest together bind the toolchain to the source commit that built
-the Astrid binaries.
+Do not consume a tag without its digest. The OCI version and revision labels,
+published provenance, and pinned digest bind the toolchain to the release and
+source commit that built the Astrid binaries.
+
+GHCR package visibility and downstream repository access are configured by the
+repository owners. This workflow deliberately does not change package
+visibility. A private package requires `read:packages` credentials or explicit
+GitHub Actions access for the consuming repository.

--- a/container/ci/test.sh
+++ b/container/ci/test.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE=${1:?usage: test.sh IMAGE SOURCE_COMMIT}
+SOURCE_COMMIT=${2:?usage: test.sh IMAGE SOURCE_COMMIT}
+
+revision=$(docker image inspect "$IMAGE" --format '{{index .Config.Labels "org.opencontainers.image.revision"}}')
+test "$revision" = "$SOURCE_COMMIT"
+test "$(docker image inspect "$IMAGE" --format '{{json .Config.Entrypoint}}')" = null
+
+docker run --rm "$IMAGE" bash -euc '
+  rustc --version | grep -Fq "rustc 1.95.0 "
+  cargo --version
+  rustup target list --installed | grep -Fxq wasm32-unknown-unknown
+  for command in astrid astrid-build astrid-daemon astrid-emit gh jq python3 git; do
+    command -v "$command" >/dev/null
+  done
+  astrid --version
+  astrid-build --version
+  astrid-daemon --version
+  astrid-emit --version
+'

--- a/container/ci/test.sh
+++ b/container/ci/test.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-IMAGE=${1:?usage: test.sh IMAGE SOURCE_COMMIT}
-SOURCE_COMMIT=${2:?usage: test.sh IMAGE SOURCE_COMMIT}
+IMAGE=${1:?usage: test.sh IMAGE VERSION SOURCE_COMMIT}
+VERSION=${2:?usage: test.sh IMAGE VERSION SOURCE_COMMIT}
+SOURCE_COMMIT=${3:?usage: test.sh IMAGE VERSION SOURCE_COMMIT}
 
 revision=$(docker image inspect "$IMAGE" --format '{{index .Config.Labels "org.opencontainers.image.revision"}}')
 test "$revision" = "$SOURCE_COMMIT"
+version=$(docker image inspect "$IMAGE" --format '{{index .Config.Labels "org.opencontainers.image.version"}}')
+test "$version" = "$VERSION"
 test "$(docker image inspect "$IMAGE" --format '{{json .Config.Entrypoint}}')" = null
 
 docker run --rm "$IMAGE" bash -euc '

--- a/scripts/test_ci_image_contract.py
+++ b/scripts/test_ci_image_contract.py
@@ -14,11 +14,12 @@ WORKFLOW = (ROOT / ".github/workflows/ci-image.yml").read_text(encoding="utf-8")
 
 
 class DockerfileContractTests(unittest.TestCase):
-    def test_base_and_source_are_immutable(self) -> None:
+    def test_base_source_and_version_are_bound(self) -> None:
         first_line = DOCKERFILE.splitlines()[0]
         self.assertRegex(first_line, r"^FROM .+@sha256:[0-9a-f]{64}$")
         self.assertIn('org.opencontainers.image.revision="${ASTRID_SOURCE_COMMIT}"', DOCKERFILE)
-        self.assertNotIn("latest", DOCKERFILE.lower())
+        self.assertIn('org.opencontainers.image.version="${ASTRID_VERSION}"', DOCKERFILE)
+        self.assertIn('io.astrid.ci.rust-version="1.95.0"', DOCKERFILE)
 
     def test_packages_prebuilt_repository_binaries(self) -> None:
         for binary in ("astrid", "astrid-build", "astrid-daemon", "astrid-emit"):
@@ -33,19 +34,47 @@ class DockerfileContractTests(unittest.TestCase):
 
 
 class WorkflowContractTests(unittest.TestCase):
-    def test_pull_requests_cannot_publish(self) -> None:
+    def test_release_completion_and_manual_recovery_are_the_only_publish_events(self) -> None:
+        self.assertIn("workflow_run:", WORKFLOW)
+        self.assertIn("workflows: ['Release']", WORKFLOW)
+        self.assertIn("workflow_dispatch:", WORKFLOW)
+        self.assertNotIn("\n  push:", WORKFLOW)
         publish = WORKFLOW.split("\n  publish:\n", 1)[1]
-        self.assertIn("github.event_name == 'push'", publish)
+        self.assertIn("github.event_name != 'pull_request'", publish)
         self.assertIn("github.ref == 'refs/heads/main'", publish)
+        self.assertIn("!contains(github.event.workflow_run.head_branch, '-nightly.')", WORKFLOW)
         build = WORKFLOW.split("\n  publish:\n", 1)[0]
         self.assertNotIn("packages: write", build)
         self.assertNotIn("id-token: write", build)
 
-    def test_publishes_only_the_full_source_commit_tag(self) -> None:
-        self.assertIn('IMAGE_TAG="${IMAGE_NAME}:${GITHUB_SHA}"', WORKFLOW)
+    def test_authenticates_the_stable_release_and_source(self) -> None:
+        self.assertIn(".immutable == true", WORKFLOW)
+        self.assertIn(".prerelease == false", WORKFLOW)
+        self.assertIn('[[ "$TAG_COMMIT" == "$SOURCE_COMMIT" ]]', WORKFLOW)
+        self.assertIn('.name == "Release"', WORKFLOW)
+        self.assertIn('.conclusion == "success"', WORKFLOW)
+
+    def test_image_definition_is_separate_from_exact_release_source(self) -> None:
+        self.assertIn("Check out the image definition", WORKFLOW)
+        self.assertIn("Check out exact Astrid release source", WORKFLOW)
+        self.assertIn("path: .ci-source", WORKFLOW)
+        self.assertIn("--manifest-path .ci-source/Cargo.toml", WORKFLOW)
+
+    def test_publishes_exact_version_variant_and_source_tags(self) -> None:
+        self.assertIn('CANONICAL_TAG="${IMAGE_NAME}:sha-${SOURCE_COMMIT}"', WORKFLOW)
+        self.assertIn('VERSION_TAG="${IMAGE_NAME}:${VERSION}"', WORKFLOW)
+        self.assertIn(
+            'VARIANT_TAG="${IMAGE_NAME}:${VERSION}-rust${RUST_VERSION}-${IMAGE_VARIANT}"',
+            WORKFLOW,
+        )
         for moving_tag in ("latest", "stable", "nightly", "dev"):
             self.assertNotIn(f'${{IMAGE_NAME}}:{moving_tag}', WORKFLOW)
-        self.assertNotIn("docker manifest", WORKFLOW.lower())
+
+    def test_existing_tags_must_resolve_to_the_canonical_digest(self) -> None:
+        self.assertIn('test "$ALIAS_DIGEST" = "$DIGEST"', WORKFLOW)
+        self.assertIn("docker buildx imagetools create", WORKFLOW)
+        self.assertIn("manifest unknown|no such manifest", WORKFLOW)
+        self.assertIn("cannot prove whether $alias already exists", WORKFLOW)
 
     def test_publishes_the_exact_tested_archive_with_provenance(self) -> None:
         build = WORKFLOW.split("\n  publish:\n", 1)[0]
@@ -58,10 +87,11 @@ class WorkflowContractTests(unittest.TestCase):
 
 
 class DocumentationContractTests(unittest.TestCase):
-    def test_consumers_are_told_to_pin_a_digest(self) -> None:
-        self.assertIn("CI-only", README)
-        self.assertIn("@sha256:<manifest-digest>", README)
-        self.assertIn("Do not consume a moving tag", README)
+    def test_consumers_are_told_to_pin_a_release_digest(self) -> None:
+        self.assertIn("authenticated stable Astrid release", README)
+        self.assertIn(":X.Y.Z-rust1.95.0-bookworm", README)
+        self.assertIn(":0.10.4@sha256:<manifest-digest>", README)
+        self.assertIn("Do not consume a tag without its digest", README)
 
 
 if __name__ == "__main__":

--- a/scripts/test_ci_image_contract.py
+++ b/scripts/test_ci_image_contract.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Static contract tests for the CI-only Astrid toolchain image."""
+
+from __future__ import annotations
+
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+DOCKERFILE = (ROOT / "container/ci/Dockerfile").read_text(encoding="utf-8")
+README = (ROOT / "container/ci/README.md").read_text(encoding="utf-8")
+WORKFLOW = (ROOT / ".github/workflows/ci-image.yml").read_text(encoding="utf-8")
+
+
+class DockerfileContractTests(unittest.TestCase):
+    def test_base_and_source_are_immutable(self) -> None:
+        first_line = DOCKERFILE.splitlines()[0]
+        self.assertRegex(first_line, r"^FROM .+@sha256:[0-9a-f]{64}$")
+        self.assertIn('org.opencontainers.image.revision="${ASTRID_SOURCE_COMMIT}"', DOCKERFILE)
+        self.assertNotIn("latest", DOCKERFILE.lower())
+
+    def test_packages_prebuilt_repository_binaries(self) -> None:
+        for binary in ("astrid", "astrid-build", "astrid-daemon", "astrid-emit"):
+            self.assertIn(f"COPY --chmod=0755 dist/ci/{binary}", DOCKERFILE)
+        self.assertNotIn("cargo build", DOCKERFILE)
+        self.assertNotIn("git clone", DOCKERFILE)
+
+    def test_has_the_capsule_ci_toolchain_without_an_entrypoint(self) -> None:
+        self.assertIn("rust:1.95.0-bookworm@sha256:", DOCKERFILE)
+        self.assertIn("rustup target add wasm32-unknown-unknown", DOCKERFILE)
+        self.assertNotIn("ENTRYPOINT", DOCKERFILE)
+
+
+class WorkflowContractTests(unittest.TestCase):
+    def test_pull_requests_cannot_publish(self) -> None:
+        publish = WORKFLOW.split("\n  publish:\n", 1)[1]
+        self.assertIn("github.event_name == 'push'", publish)
+        self.assertIn("github.ref == 'refs/heads/main'", publish)
+        build = WORKFLOW.split("\n  publish:\n", 1)[0]
+        self.assertNotIn("packages: write", build)
+        self.assertNotIn("id-token: write", build)
+
+    def test_publishes_only_the_full_source_commit_tag(self) -> None:
+        self.assertIn('IMAGE_TAG="${IMAGE_NAME}:${GITHUB_SHA}"', WORKFLOW)
+        for moving_tag in ("latest", "stable", "nightly", "dev"):
+            self.assertNotIn(f'${{IMAGE_NAME}}:{moving_tag}', WORKFLOW)
+        self.assertNotIn("docker manifest", WORKFLOW.lower())
+
+    def test_publishes_the_exact_tested_archive_with_provenance(self) -> None:
+        build = WORKFLOW.split("\n  publish:\n", 1)[0]
+        publish = WORKFLOW.split("\n  publish:\n", 1)[1]
+        self.assertLess(build.index("container/ci/test.sh"), build.index("docker image save"))
+        self.assertIn("sha256sum --check", publish)
+        self.assertIn("docker image load", publish)
+        self.assertIn("actions/attest-build-provenance@", publish)
+        self.assertIn("push-to-registry: true", publish)
+
+
+class DocumentationContractTests(unittest.TestCase):
+    def test_consumers_are_told_to_pin_a_digest(self) -> None:
+        self.assertIn("CI-only", README)
+        self.assertIn("@sha256:<manifest-digest>", README)
+        self.assertIn("Do not consume a moving tag", README)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_ci_image_contract.py
+++ b/scripts/test_ci_image_contract.py
@@ -58,7 +58,15 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertIn("Check out the image definition", WORKFLOW)
         self.assertIn("Check out exact Astrid release source", WORKFLOW)
         self.assertIn("path: .ci-source", WORKFLOW)
-        self.assertIn("--manifest-path .ci-source/Cargo.toml", WORKFLOW)
+        self.assertIn("--workdir /workspace/.ci-source", WORKFLOW)
+
+    def test_binaries_are_built_inside_the_exact_runtime_base(self) -> None:
+        base = DOCKERFILE.splitlines()[0].removeprefix("FROM ")
+        self.assertIn(f"BUILD_IMAGE: docker.io/library/{base}", WORKFLOW)
+        self.assertIn('"$BUILD_IMAGE"', WORKFLOW)
+        self.assertIn("--workdir /workspace/.ci-source", WORKFLOW)
+        self.assertIn("cargo build --target-dir target --release --locked -p astrid", WORKFLOW)
+        self.assertIn("shared-key: ci-image-bookworm-amd64", WORKFLOW)
 
     def test_publishes_exact_version_variant_and_source_tags(self) -> None:
         self.assertIn('CANONICAL_TAG="${IMAGE_NAME}:sha-${SOURCE_COMMIT}"', WORKFLOW)


### PR DESCRIPTION
## Linked Issue

Closes #1675

## Summary

Add a maintained, CI-only Astrid toolchain image that downstream capsule repositories can select by exact Astrid release and Rust/platform variant, then consume by immutable manifest digest.

## Changes

- Build the four Astrid CLI binaries inside the same digest-pinned Rust 1.95.0 Bookworm base used by the final amd64 image, then test that exact staged image with `wasm32-unknown-unknown` and common GitHub Actions utilities.
- Keep pull-request runs read-only; publication occurs only after a successful stable `Release` workflow or an authenticated manual recovery dispatch on `main`.
- Publish exact `X.Y.Z`, `X.Y.Z-rust1.95.0-bookworm`, and `sha-<source-commit>` tags without moving aliases.
- Reauthenticate the immutable GitHub release, tag ancestry, source commit, and successful release run before publication.
- Preserve the exact tested image between build and publish jobs, attest its registry digest, and refuse ambiguous registry failures or conflicting existing tags.
- Keep the image definition separate from the exact release-source checkout so an existing authenticated release such as `v0.10.4` can be bootstrapped after this workflow lands.
- Document digest-pinned GitHub Actions consumption and private-package access requirements.

## Verification

- `python3 scripts/test_ci_image_contract.py` — 11 tests pass.
- `python3 -m py_compile scripts/test_ci_image_contract.py`
- `bash -n container/ci/test.sh`
- `actionlint .github/workflows/ci-image.yml`
- `git diff --check`
- Hosted run `32982118463` exposed a glibc boundary mismatch when Ubuntu 24-built binaries were copied into Bookworm. Successor `db920024` compiles inside the exact pinned Bookworm base and keys the target cache to that ABI boundary.
- Replayed the stable-release authentication contract against published `v0.10.4`: immutable release, exact tag/source binding, and successful release workflow all verified.
- Confirmed the registry digest parser against the pinned Rust base manifest and the fail-closed missing-manifest classification against a nonexistent tag.

The full Rust build and Docker image test are intentionally left to this pull request's hosted workflow.

## AI / Tool Assistance

Assisted-by: Codex: GPT-5.6

Codex assisted with the workflow, container contract tests, and documentation. I reviewed the release boundary, permissions, exact-source binding, tag-conflict behavior, and all generated changes, then ran the validation listed above.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment not required: this is CI-only
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.