### PR TITLE
feat(realm-compat): add owner-scoped durable volume portal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -812,7 +812,9 @@ dependencies = [
  "astrid-projection",
  "astrid-provider",
  "astrid-resource-types",
+ "astrid-storage",
  "blake3",
+ "tempfile",
 ]
 
 [[package]]

--- a/changes/1676.added.md
+++ b/changes/1676.added.md
@@ -1,0 +1,5 @@
+# Added
+
+- Added an owner-scoped durable Realm compatibility volume portal over
+  `AstridVolume`, with persisted generations, principal isolation, and a
+  path-free native volume boundary. Tracking #1676.

--- a/changes/1676.fixed.md
+++ b/changes/1676.fixed.md
@@ -1,0 +1,6 @@
+# Fixed
+
+Realm compatibility volume portals now serialize staged writes across every
+handle that shares a volume. A pending write cannot be flushed by another
+principal or portal, and a successful owner sync publishes one generation and
+releases the volume for subsequent operations. Refs #1676

--- a/crates/astrid-realm-compat/Cargo.toml
+++ b/crates/astrid-realm-compat/Cargo.toml
@@ -10,14 +10,17 @@ description = "Workload-neutral compatibility portable-machine fixture for Astri
 
 [features]
 default = []
+volume = ["dep:astrid-storage"]
 
 [dependencies]
 astrid-provider = { workspace = true }
 astrid-resource-types = { workspace = true }
+astrid-storage = { workspace = true, optional = true }
 blake3 = { version = "1.5", default-features = false, features = ["pure"] }
 
 [dev-dependencies]
 astrid-projection = { workspace = true }
+tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/astrid-realm-compat/src/lib.rs
+++ b/crates/astrid-realm-compat/src/lib.rs
@@ -10,9 +10,13 @@
 //! fallback. Guest argv cannot select a namespace. Two-principal isolation uses
 //! the [`HostPrincipal`] stamp seam; this crate does not mint stamps or leases.
 //!
+//! The optional `volume` feature adds a native, owner-scoped durable portal
+//! over an injected `AstridVolume`; the default and wasm builds remain this
+//! ephemeral compatibility fixture.
+//!
 //! Live authority stays on the host. Receipts cannot become live handles.
 
-#![no_std]
+#![cfg_attr(any(not(feature = "volume"), target_family = "wasm"), no_std)]
 #![forbid(unsafe_code)]
 
 mod fixtures;
@@ -20,6 +24,9 @@ mod image;
 mod interpreter;
 mod machine;
 mod ramfs;
+
+#[cfg(all(feature = "volume", not(target_family = "wasm")))]
+mod volume_portal;
 
 #[cfg(test)]
 mod corpus;
@@ -38,3 +45,6 @@ pub use machine::{
     RAM_BYTES,
 };
 pub use ramfs::EphemeralRamfs;
+
+#[cfg(all(feature = "volume", not(target_family = "wasm")))]
+pub use volume_portal::{MAX_OWNER_VOLUME_BYTES, OwnerVolumePortal};

--- a/crates/astrid-realm-compat/src/volume_portal.rs
+++ b/crates/astrid-realm-compat/src/volume_portal.rs
@@ -6,11 +6,12 @@
 //! namespace selection. The volume remains the only byte store and the only
 //! durability boundary.
 
+use std::collections::HashMap;
 use std::fmt;
 use std::io::Read;
 use std::sync::{
-    Arc, Mutex, MutexGuard,
-    atomic::{AtomicBool, Ordering},
+    Arc, Mutex, MutexGuard, OnceLock, Weak,
+    atomic::{AtomicBool, AtomicU64, Ordering},
 };
 
 use astrid_provider::{HostPrincipal, ProviderError};
@@ -32,6 +33,42 @@ const METADATA_LEN: usize = METADATA_MAGIC.len() + 32 + GENERATION_ENCODED_LEN;
 const OWNER_OFFSET: usize = 8;
 const GENERATION_OFFSET: usize = 40;
 
+static NEXT_PORTAL_ID: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Debug)]
+struct VolumeCoordinator {
+    state: Mutex<CoordinatorState>,
+}
+
+// A staged mutation is released only by the staging portal's successful
+// commit. Drop must not clear it: that would let another portal flush the
+// unsynced volume tail through AstridVolume::sync.
+
+#[derive(Debug, Default)]
+struct CoordinatorState {
+    active: Option<ActiveMutation>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct ActiveMutation {
+    owner: HostPrincipal,
+    portal_id: u64,
+}
+
+#[derive(Debug)]
+struct VolumeCoordinatorEntry {
+    volume: Weak<dyn AstridVolume>,
+    coordinator: Arc<VolumeCoordinator>,
+}
+
+static VOLUME_COORDINATORS: OnceLock<Mutex<HashMap<usize, VolumeCoordinatorEntry>>> =
+    OnceLock::new();
+
+struct OperationGuard<'a> {
+    _operation: MutexGuard<'a, ()>,
+    coordinator: MutexGuard<'a, CoordinatorState>,
+}
+
 /// Durable owner-bound byte portal.
 ///
 /// The owner is immutable for the lifetime of this value. Every byte and
@@ -44,8 +81,9 @@ pub struct OwnerVolumePortal {
     metadata_region: VolumeRegion,
     payload_region: VolumeRegion,
     operation_lock: Arc<Mutex<()>>,
+    coordinator: Arc<VolumeCoordinator>,
+    portal_id: u64,
     poisoned: Arc<AtomicBool>,
-    dirty: Arc<AtomicBool>,
 }
 
 impl Clone for OwnerVolumePortal {
@@ -56,8 +94,9 @@ impl Clone for OwnerVolumePortal {
             metadata_region: self.metadata_region.clone(),
             payload_region: self.payload_region.clone(),
             operation_lock: Arc::clone(&self.operation_lock),
+            coordinator: Arc::clone(&self.coordinator),
+            portal_id: self.portal_id,
             poisoned: Arc::clone(&self.poisoned),
-            dirty: Arc::clone(&self.dirty),
         }
     }
 }
@@ -88,11 +127,17 @@ impl OwnerVolumePortal {
         owner: HostPrincipal,
     ) -> Result<Self, ProviderError> {
         let (metadata_region, payload_region) = regions_for(owner)?;
-        let metadata_exists = volume
-            .region_exists(&metadata_region)
+        let coordinator = coordinator_for(&volume)?;
+        let portal =
+            Self::new_unchecked(volume, owner, metadata_region, payload_region, coordinator);
+        let mut guard = portal.lock_operation()?;
+        let metadata_exists = portal
+            .volume
+            .region_exists(&portal.metadata_region)
             .map_err(|_| ProviderError::NotSupported)?;
-        let payload_exists = volume
-            .region_exists(&payload_region)
+        let payload_exists = portal
+            .volume
+            .region_exists(&portal.payload_region)
             .map_err(|_| ProviderError::NotSupported)?;
 
         if metadata_exists != payload_exists {
@@ -100,19 +145,26 @@ impl OwnerVolumePortal {
         }
 
         if !metadata_exists {
-            volume
-                .create_region(&metadata_region, true)
+            guard
+                .coordinator
+                .reserve_mutation(portal.owner, portal.portal_id)?;
+            portal
+                .volume
+                .create_region(&portal.metadata_region, true)
                 .map_err(|_| ProviderError::NotSupported)?;
-            volume
-                .create_region(&payload_region, true)
+            portal
+                .volume
+                .create_region(&portal.payload_region, true)
                 .map_err(|_| ProviderError::NotSupported)?;
-            let portal = Self::new_unchecked(volume, owner, metadata_region, payload_region);
             portal.write_generation(ObjectGeneration::INITIAL)?;
             portal.sync_unchecked()?;
+            guard
+                .coordinator
+                .clear_mutation(portal.owner, portal.portal_id)?;
+            drop(guard);
             return Ok(portal);
         }
 
-        let portal = Self::new_unchecked(volume, owner, metadata_region, payload_region);
         let _ = portal.read_generation()?;
         let payload_len = portal
             .volume
@@ -122,6 +174,7 @@ impl OwnerVolumePortal {
             portal.poison();
             return Err(ProviderError::NotSupported);
         }
+        drop(guard);
         Ok(portal)
     }
 
@@ -153,6 +206,7 @@ impl OwnerVolumePortal {
         owner: HostPrincipal,
         metadata_region: VolumeRegion,
         payload_region: VolumeRegion,
+        coordinator: Arc<VolumeCoordinator>,
     ) -> Self {
         Self {
             volume,
@@ -160,8 +214,9 @@ impl OwnerVolumePortal {
             metadata_region,
             payload_region,
             operation_lock: Arc::new(Mutex::new(())),
+            coordinator,
+            portal_id: NEXT_PORTAL_ID.fetch_add(1, Ordering::Relaxed),
             poisoned: Arc::new(AtomicBool::new(false)),
-            dirty: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -351,11 +406,17 @@ impl OwnerVolumePortal {
         payload: &mut dyn Read,
     ) -> Result<(), ProviderError> {
         self.require_owner(caller)?;
-        let _guard = self.lock_operation()?;
+        let mut guard = self.lock_operation()?;
+        let owns_active_mutation = guard.coordinator.active_for(self.owner, self.portal_id)?;
         self.check_generation(generation)?;
         Self::check_range_u64(offset, payload_len)?;
         if payload_len == 0 {
             return Ok(());
+        }
+        if !owns_active_mutation {
+            guard
+                .coordinator
+                .reserve_mutation(self.owner, self.portal_id)?;
         }
         self.write_payload_unchecked(offset, payload_len, payload)
     }
@@ -411,16 +472,19 @@ impl OwnerVolumePortal {
         generation: ObjectGeneration,
     ) -> Result<ObjectGeneration, ProviderError> {
         self.require_owner(caller)?;
-        let _guard = self.lock_operation()?;
+        let mut guard = self.lock_operation()?;
+        let owns_active_mutation = guard.coordinator.active_for(self.owner, self.portal_id)?;
         self.check_generation(generation)?;
-        if self.dirty.load(Ordering::Acquire) {
+        if owns_active_mutation {
             let next = generation.checked_next().map_err(|_| {
                 self.poison();
                 ProviderError::NotSupported
             })?;
             self.write_generation(next)?;
             self.sync_unchecked()?;
-            self.dirty.store(false, Ordering::Release);
+            guard
+                .coordinator
+                .clear_mutation(self.owner, self.portal_id)?;
             Ok(next)
         } else {
             self.sync_unchecked()?;
@@ -446,7 +510,8 @@ impl OwnerVolumePortal {
         bytes: &[u8],
     ) -> Result<ObjectGeneration, ProviderError> {
         self.require_owner(caller)?;
-        let _guard = self.lock_operation()?;
+        let mut guard = self.lock_operation()?;
+        let owns_active_mutation = guard.coordinator.active_for(self.owner, self.portal_id)?;
         self.check_generation(generation)?;
         let payload_len = u64::try_from(bytes.len()).map_err(|_| ProviderError::NotSupported)?;
         Self::check_range_u64(offset, payload_len)?;
@@ -454,10 +519,17 @@ impl OwnerVolumePortal {
             self.poison();
             ProviderError::NotSupported
         })?;
+        if !owns_active_mutation {
+            guard
+                .coordinator
+                .reserve_mutation(self.owner, self.portal_id)?;
+        }
         self.write_payload_unchecked(offset, payload_len, &mut &bytes[..])?;
         self.write_generation(next)?;
         self.sync_unchecked()?;
-        self.dirty.store(false, Ordering::Release);
+        guard
+            .coordinator
+            .clear_mutation(self.owner, self.portal_id)?;
         Ok(next)
     }
 
@@ -493,15 +565,23 @@ impl OwnerVolumePortal {
         generation: ObjectGeneration,
     ) -> Result<ObjectGeneration, ProviderError> {
         self.require_owner(caller)?;
-        let _guard = self.lock_operation()?;
+        let mut guard = self.lock_operation()?;
+        let owns_active_mutation = guard.coordinator.active_for(self.owner, self.portal_id)?;
         self.check_generation(generation)?;
         let next = generation.checked_next().map_err(|_| {
             self.poison();
             ProviderError::NotSupported
         })?;
+        if !owns_active_mutation {
+            guard
+                .coordinator
+                .reserve_mutation(self.owner, self.portal_id)?;
+        }
         self.write_generation(next)?;
         self.sync_unchecked()?;
-        self.dirty.store(false, Ordering::Release);
+        guard
+            .coordinator
+            .clear_mutation(self.owner, self.portal_id)?;
         Ok(next)
     }
 
@@ -518,13 +598,21 @@ impl OwnerVolumePortal {
         self.advance_generation(caller, generation)
     }
 
-    fn lock_operation(&self) -> Result<MutexGuard<'_, ()>, ProviderError> {
+    fn lock_operation(&self) -> Result<OperationGuard<'_>, ProviderError> {
         if self.poisoned.load(Ordering::Acquire) {
             return Err(ProviderError::NotSupported);
         }
-        self.operation_lock.lock().map_err(|_| {
+        let Ok(operation) = self.operation_lock.lock() else {
             self.poison();
-            ProviderError::NotSupported
+            return Err(ProviderError::NotSupported);
+        };
+        let Ok(coordinator) = self.coordinator.state.lock() else {
+            self.poison();
+            return Err(ProviderError::NotSupported);
+        };
+        Ok(OperationGuard {
+            _operation: operation,
+            coordinator,
         })
     }
 
@@ -607,7 +695,6 @@ impl OwnerVolumePortal {
                 self.poison();
                 ProviderError::NotSupported
             })?;
-        self.dirty.store(true, Ordering::Release);
         Ok(())
     }
 
@@ -638,6 +725,71 @@ impl OwnerVolumePortal {
     }
 }
 
+impl CoordinatorState {
+    fn active_for(&self, owner: HostPrincipal, portal_id: u64) -> Result<bool, ProviderError> {
+        match self.active {
+            None => Ok(false),
+            Some(active) if active.owner == owner && active.portal_id == portal_id => Ok(true),
+            Some(_) => Err(ProviderError::NotSupported),
+        }
+    }
+
+    fn reserve_mutation(
+        &mut self,
+        owner: HostPrincipal,
+        portal_id: u64,
+    ) -> Result<(), ProviderError> {
+        match self.active {
+            None => {
+                self.active = Some(ActiveMutation { owner, portal_id });
+                Ok(())
+            },
+            Some(active) if active.owner == owner && active.portal_id == portal_id => Ok(()),
+            Some(_) => Err(ProviderError::NotSupported),
+        }
+    }
+
+    fn clear_mutation(
+        &mut self,
+        owner: HostPrincipal,
+        portal_id: u64,
+    ) -> Result<(), ProviderError> {
+        match self.active {
+            Some(active) if active.owner == owner && active.portal_id == portal_id => {
+                self.active = None;
+                Ok(())
+            },
+            _ => Err(ProviderError::NotSupported),
+        }
+    }
+}
+
+fn coordinator_for(
+    volume: &Arc<dyn AstridVolume>,
+) -> Result<Arc<VolumeCoordinator>, ProviderError> {
+    let key = Arc::as_ptr(volume).cast::<()>() as usize;
+    let registry = VOLUME_COORDINATORS.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut entries = registry.lock().map_err(|_| ProviderError::NotSupported)?;
+    entries.retain(|_, entry| entry.volume.upgrade().is_some());
+    if let Some(entry) = entries.get(&key)
+        && let Some(existing_volume) = entry.volume.upgrade()
+        && Arc::ptr_eq(&existing_volume, volume)
+    {
+        return Ok(Arc::clone(&entry.coordinator));
+    }
+    let coordinator = Arc::new(VolumeCoordinator {
+        state: Mutex::new(CoordinatorState::default()),
+    });
+    entries.insert(
+        key,
+        VolumeCoordinatorEntry {
+            volume: Arc::downgrade(volume),
+            coordinator: Arc::clone(&coordinator),
+        },
+    );
+    Ok(coordinator)
+}
+
 fn regions_for(owner: HostPrincipal) -> Result<(VolumeRegion, VolumeRegion), ProviderError> {
     let encoded = owner.as_bytes();
     let mut base = String::new();
@@ -655,162 +807,5 @@ fn regions_for(owner: HostPrincipal) -> Result<(VolumeRegion, VolumeRegion), Pro
 }
 
 #[cfg(test)]
-mod tests {
-    use super::{MAX_OWNER_VOLUME_BYTES, OwnerVolumePortal};
-    use crate::fixtures::{alice_principal, bob_principal};
-    use astrid_provider::ProviderError;
-    use astrid_resource_types::ObjectGeneration;
-    use astrid_storage::volume::HostedFileVolume;
-    use std::sync::Arc;
-
-    fn volume() -> (tempfile::TempDir, Arc<HostedFileVolume>) {
-        let temporary = tempfile::tempdir().expect("temporary volume directory");
-        let path = temporary.path().join("astrid.volume");
-        let volume = HostedFileVolume::open(path).expect("hosted volume");
-        (temporary, volume)
-    }
-
-    #[test]
-    fn two_principals_are_isolated_in_one_reopened_volume() {
-        let (temporary, volume) = volume();
-        let path = temporary.path().join("astrid.volume");
-        let alice = OwnerVolumePortal::open(volume.clone(), alice_principal()).unwrap();
-        let bob = OwnerVolumePortal::open(volume.clone(), bob_principal()).unwrap();
-        let generation = ObjectGeneration::INITIAL;
-        alice
-            .write_at(alice_principal(), generation, 0, b"alice")
-            .unwrap();
-        let alice_generation = alice.sync(alice_principal(), generation).unwrap();
-        bob.write_at(bob_principal(), generation, 0, b"bob")
-            .unwrap();
-        let bob_generation = bob.sync(bob_principal(), generation).unwrap();
-
-        let mut alice_bytes = [0_u8; 5];
-        let mut bob_bytes = [0_u8; 3];
-        assert_eq!(
-            alice.read_at(alice_principal(), alice_generation, 0, &mut alice_bytes),
-            Ok(5)
-        );
-        assert_eq!(
-            bob.read_at(bob_principal(), bob_generation, 0, &mut bob_bytes),
-            Ok(3)
-        );
-        assert_eq!(&alice_bytes, b"alice");
-        assert_eq!(&bob_bytes, b"bob");
-        assert_eq!(
-            alice.read_at(bob_principal(), alice_generation, 0, &mut alice_bytes),
-            Err(ProviderError::PrincipalMismatch)
-        );
-        assert_eq!(
-            bob.write_at(alice_principal(), bob_generation, 0, b"nope"),
-            Err(ProviderError::PrincipalMismatch)
-        );
-
-        drop(alice);
-        drop(bob);
-        drop(volume);
-        let reopened_volume = HostedFileVolume::open(path).unwrap();
-        let reopened_alice =
-            OwnerVolumePortal::open(reopened_volume.clone(), alice_principal()).unwrap();
-        let reopened_bob = OwnerVolumePortal::open(reopened_volume, bob_principal()).unwrap();
-        let mut alice_after = [0_u8; 5];
-        let mut bob_after = [0_u8; 3];
-        reopened_alice
-            .read_at(alice_principal(), alice_generation, 0, &mut alice_after)
-            .unwrap();
-        reopened_bob
-            .read_at(bob_principal(), bob_generation, 0, &mut bob_after)
-            .unwrap();
-        assert_eq!(&alice_after, b"alice");
-        assert_eq!(&bob_after, b"bob");
-    }
-
-    #[test]
-    fn stale_generation_and_host_path_fail_closed() {
-        let (_temporary, volume) = volume();
-        let portal = OwnerVolumePortal::open(volume, alice_principal()).unwrap();
-        assert!(portal.as_host_path().is_none());
-        assert_eq!(
-            portal.require_owner(bob_principal()),
-            Err(ProviderError::PrincipalMismatch)
-        );
-        assert_eq!(
-            portal.require_generation(alice_principal(), ObjectGeneration::from_raw(2).unwrap(),),
-            Err(ProviderError::StaleGeneration {
-                found: 1,
-                requested: 2,
-            })
-        );
-        assert_eq!(portal.owner(), alice_principal());
-        assert_eq!(portal.namespace_id(), alice_principal());
-    }
-
-    #[test]
-    fn generation_advance_is_durable_and_denies_old_generation() {
-        let (_temporary, volume) = volume();
-        let portal = OwnerVolumePortal::open(volume, alice_principal()).unwrap();
-        let next = portal
-            .advance_generation(alice_principal(), ObjectGeneration::INITIAL)
-            .unwrap();
-        assert_eq!(next.get(), 2);
-        assert_eq!(
-            portal.write_at(alice_principal(), ObjectGeneration::INITIAL, 0, b"stale"),
-            Err(ProviderError::StaleGeneration {
-                found: 2,
-                requested: 1,
-            })
-        );
-        portal
-            .write_at(alice_principal(), next, 0, b"current")
-            .unwrap();
-        portal.sync(alice_principal(), next).unwrap();
-    }
-
-    #[test]
-    fn unsynced_tail_is_discarded_on_reopen_without_mixed_owner_bytes() {
-        let (temporary, volume) = volume();
-        let path = temporary.path().join("astrid.volume");
-        let portal = OwnerVolumePortal::open(volume.clone(), alice_principal()).unwrap();
-        let generation = ObjectGeneration::INITIAL;
-        portal
-            .write_at(alice_principal(), generation, 0, b"committed")
-            .unwrap();
-        let generation = portal.sync(alice_principal(), generation).unwrap();
-        portal
-            .write_at(alice_principal(), generation, 0, b"unsynced")
-            .unwrap();
-        let crash_copy = temporary.path().join("crash.volume");
-        std::fs::copy(&path, &crash_copy).unwrap();
-        drop(portal);
-        drop(volume);
-
-        let reopened_volume = HostedFileVolume::open(crash_copy).unwrap();
-        let reopened_alice =
-            OwnerVolumePortal::open(reopened_volume.clone(), alice_principal()).unwrap();
-        let reopened_bob = OwnerVolumePortal::open(reopened_volume, bob_principal()).unwrap();
-        let mut bytes = [0_u8; 9];
-        reopened_alice
-            .read_at(alice_principal(), generation, 0, &mut bytes)
-            .unwrap();
-        assert_eq!(&bytes, b"committed");
-        assert_eq!(
-            reopened_bob.read_at(bob_principal(), ObjectGeneration::INITIAL, 0, &mut bytes,),
-            Ok(0)
-        );
-    }
-
-    #[test]
-    fn bounded_extent_rejects_over_capacity_before_volume_write() {
-        let (_temporary, volume) = volume();
-        let portal = OwnerVolumePortal::open(volume, alice_principal()).unwrap();
-        assert_eq!(
-            portal.write_at(
-                alice_principal(),
-                ObjectGeneration::INITIAL,
-                MAX_OWNER_VOLUME_BYTES,
-                b"x",
-            ),
-            Err(ProviderError::NotSupported)
-        );
-    }
-}
+#[path = "volume_portal_tests.rs"]
+mod tests;

--- a/crates/astrid-realm-compat/src/volume_portal.rs
+++ b/crates/astrid-realm-compat/src/volume_portal.rs
@@ -1,0 +1,816 @@
+//! Owner-scoped durable byte portal over an injected [`AstridVolume`].
+//!
+//! The portal deliberately does not accept a host path. Region names are
+//! derived from the trusted [`HostPrincipal`] bytes and the fixed domain
+//! separator below; guest paths, argv, and payloads never participate in
+//! namespace selection. The volume remains the only byte store and the only
+//! durability boundary.
+
+use std::fmt;
+use std::io::Read;
+use std::sync::{
+    Arc, Mutex, MutexGuard,
+    atomic::{AtomicBool, Ordering},
+};
+
+use astrid_provider::{HostPrincipal, ProviderError};
+use astrid_resource_types::{CanonicalDecode, CanonicalEncode, ObjectGeneration};
+use astrid_storage::volume::{AstridVolume, VolumeRegion};
+
+/// Maximum logical payload extent in one owner portal.
+///
+/// The bound keeps malformed or hostile callers from turning a portal into an
+/// unbounded namespace. It is a format policy, not a host filesystem quota.
+pub const MAX_OWNER_VOLUME_BYTES: u64 = 64 * 1024 * 1024;
+
+const REGION_PREFIX: &str = "astrid-realm-compat/v1/owner";
+const METADATA_SUFFIX: &str = "metadata";
+const PAYLOAD_SUFFIX: &str = "payload";
+const METADATA_MAGIC: [u8; 8] = *b"ARCPORT1";
+const GENERATION_ENCODED_LEN: usize = 11;
+const METADATA_LEN: usize = METADATA_MAGIC.len() + 32 + GENERATION_ENCODED_LEN;
+const OWNER_OFFSET: usize = 8;
+const GENERATION_OFFSET: usize = 40;
+
+/// Durable owner-bound byte portal.
+///
+/// The owner is immutable for the lifetime of this value. Every byte and
+/// durability operation checks both the caller principal and the persisted
+/// [`ObjectGeneration`]. This type stores an injected volume handle, never a
+/// host path or a second byte store.
+pub struct OwnerVolumePortal {
+    volume: Arc<dyn AstridVolume>,
+    owner: HostPrincipal,
+    metadata_region: VolumeRegion,
+    payload_region: VolumeRegion,
+    operation_lock: Arc<Mutex<()>>,
+    poisoned: Arc<AtomicBool>,
+    dirty: Arc<AtomicBool>,
+}
+
+impl Clone for OwnerVolumePortal {
+    fn clone(&self) -> Self {
+        Self {
+            volume: Arc::clone(&self.volume),
+            owner: self.owner,
+            metadata_region: self.metadata_region.clone(),
+            payload_region: self.payload_region.clone(),
+            operation_lock: Arc::clone(&self.operation_lock),
+            poisoned: Arc::clone(&self.poisoned),
+            dirty: Arc::clone(&self.dirty),
+        }
+    }
+}
+
+impl fmt::Debug for OwnerVolumePortal {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("OwnerVolumePortal")
+            .field("owner", &self.owner)
+            .finish_non_exhaustive()
+    }
+}
+
+impl OwnerVolumePortal {
+    /// Open an owner portal on an injected volume.
+    ///
+    /// A new owner receives one metadata region and one payload region. Both
+    /// are created and the initial generation is synchronized before this
+    /// method reports success. Existing regions must contain a valid,
+    /// owner-matching metadata record and a bounded payload extent.
+    ///
+    /// # Errors
+    ///
+    /// Storage errors, malformed metadata, mixed initialization state, and
+    /// capacity violations fail closed as [`ProviderError::NotSupported`].
+    pub fn open(
+        volume: Arc<dyn AstridVolume>,
+        owner: HostPrincipal,
+    ) -> Result<Self, ProviderError> {
+        let (metadata_region, payload_region) = regions_for(owner)?;
+        let metadata_exists = volume
+            .region_exists(&metadata_region)
+            .map_err(|_| ProviderError::NotSupported)?;
+        let payload_exists = volume
+            .region_exists(&payload_region)
+            .map_err(|_| ProviderError::NotSupported)?;
+
+        if metadata_exists != payload_exists {
+            return Err(ProviderError::NotSupported);
+        }
+
+        if !metadata_exists {
+            volume
+                .create_region(&metadata_region, true)
+                .map_err(|_| ProviderError::NotSupported)?;
+            volume
+                .create_region(&payload_region, true)
+                .map_err(|_| ProviderError::NotSupported)?;
+            let portal = Self::new_unchecked(volume, owner, metadata_region, payload_region);
+            portal.write_generation(ObjectGeneration::INITIAL)?;
+            portal.sync_unchecked()?;
+            return Ok(portal);
+        }
+
+        let portal = Self::new_unchecked(volume, owner, metadata_region, payload_region);
+        let _ = portal.read_generation()?;
+        let payload_len = portal
+            .volume
+            .region_len(&portal.payload_region)
+            .map_err(|_| ProviderError::NotSupported)?;
+        if payload_len > MAX_OWNER_VOLUME_BYTES {
+            portal.poison();
+            return Err(ProviderError::NotSupported);
+        }
+        Ok(portal)
+    }
+
+    /// Alias for [`Self::open`] that emphasizes construction from a volume.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProviderError::NotSupported`] when the volume cannot be
+    /// opened or its owner metadata is invalid.
+    pub fn new(volume: Arc<dyn AstridVolume>, owner: HostPrincipal) -> Result<Self, ProviderError> {
+        Self::open(volume, owner)
+    }
+
+    /// Alias for [`Self::open`] using the owner-bound naming used by ramfs.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProviderError::NotSupported`] when the volume cannot be
+    /// opened or its owner metadata is invalid.
+    pub fn for_owner(
+        volume: Arc<dyn AstridVolume>,
+        owner: HostPrincipal,
+    ) -> Result<Self, ProviderError> {
+        Self::open(volume, owner)
+    }
+
+    fn new_unchecked(
+        volume: Arc<dyn AstridVolume>,
+        owner: HostPrincipal,
+        metadata_region: VolumeRegion,
+        payload_region: VolumeRegion,
+    ) -> Self {
+        Self {
+            volume,
+            owner,
+            metadata_region,
+            payload_region,
+            operation_lock: Arc::new(Mutex::new(())),
+            poisoned: Arc::new(AtomicBool::new(false)),
+            dirty: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// Immutable trusted owner encoded by this portal.
+    #[must_use]
+    pub const fn owner(&self) -> HostPrincipal {
+        self.owner
+    }
+
+    /// Stable owner identity for this portal. This is not a host path.
+    #[must_use]
+    pub const fn namespace_id(&self) -> HostPrincipal {
+        self.owner
+    }
+
+    /// Host path probe. A durable portal never exposes a host path.
+    #[must_use]
+    pub const fn as_host_path(&self) -> Option<&'static str> {
+        let _ = self;
+        None
+    }
+
+    /// Require the caller to match this portal's immutable owner.
+    ///
+    /// This check is independent of provider/interpreter preflight.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProviderError::PrincipalMismatch`] for a different owner.
+    pub fn require_owner(&self, caller: HostPrincipal) -> Result<(), ProviderError> {
+        if caller.as_bytes() == self.owner.as_bytes() {
+            Ok(())
+        } else {
+            Err(ProviderError::PrincipalMismatch)
+        }
+    }
+
+    /// Return the currently persisted generation for `caller`.
+    ///
+    /// Callers that are about to perform an operation should pass the returned
+    /// value back to that operation; the operation checks it again.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProviderError::PrincipalMismatch`] for a different owner,
+    /// or [`ProviderError::NotSupported`] when metadata cannot be read or is
+    /// malformed.
+    pub fn generation(&self, caller: HostPrincipal) -> Result<ObjectGeneration, ProviderError> {
+        self.require_owner(caller)?;
+        let _guard = self.lock_operation()?;
+        self.read_generation()
+    }
+
+    /// Return the persisted generation after checking the caller owner.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProviderError::PrincipalMismatch`] for a different owner,
+    /// or [`ProviderError::NotSupported`] for invalid metadata.
+    pub fn generation_for(&self, caller: HostPrincipal) -> Result<ObjectGeneration, ProviderError> {
+        self.generation(caller)
+    }
+
+    /// Require a caller-supplied generation to match the persisted value.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProviderError::PrincipalMismatch`] for a different owner,
+    /// [`ProviderError::StaleGeneration`] when `requested` is stale, or
+    /// [`ProviderError::NotSupported`] for invalid metadata.
+    pub fn require_generation(
+        &self,
+        caller: HostPrincipal,
+        requested: ObjectGeneration,
+    ) -> Result<(), ProviderError> {
+        self.require_owner(caller)?;
+        let _guard = self.lock_operation()?;
+        self.check_generation(requested)
+    }
+
+    /// Require both owner and generation for one operation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProviderError::PrincipalMismatch`] for a different owner,
+    /// [`ProviderError::StaleGeneration`] for a stale generation, or
+    /// [`ProviderError::NotSupported`] when metadata cannot be read.
+    pub fn require_owner_generation(
+        &self,
+        caller: HostPrincipal,
+        requested: ObjectGeneration,
+    ) -> Result<(), ProviderError> {
+        self.require_owner(caller)?;
+        let _guard = self.lock_operation()?;
+        self.check_generation(requested)
+    }
+
+    /// Read bytes at an exact payload offset.
+    ///
+    /// A successful read is an observation of the live volume state. Call
+    /// [`Self::sync`] separately when a preceding write must cross the durable
+    /// barrier and advance the owner generation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProviderError::PrincipalMismatch`],
+    /// [`ProviderError::StaleGeneration`], or [`ProviderError::NotSupported`]
+    /// when the read fails or the request exceeds the extent bound.
+    pub fn read_at(
+        &self,
+        caller: HostPrincipal,
+        generation: ObjectGeneration,
+        offset: u64,
+        buffer: &mut [u8],
+    ) -> Result<usize, ProviderError> {
+        self.require_owner(caller)?;
+        let _guard = self.lock_operation()?;
+        self.check_generation(generation)?;
+        Self::check_range(offset, buffer.len())?;
+        self.volume
+            .read_region_at(&self.payload_region, offset, buffer)
+            .map_err(|_| {
+                self.poison();
+                ProviderError::NotSupported
+            })
+    }
+
+    /// Read bytes using the portal's owner and generation checks.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same authority, generation, storage, and capacity errors
+    /// as [`Self::read_at`].
+    pub fn read(
+        &self,
+        caller: HostPrincipal,
+        generation: ObjectGeneration,
+        offset: u64,
+        buffer: &mut [u8],
+    ) -> Result<usize, ProviderError> {
+        self.read_at(caller, generation, offset, buffer)
+    }
+
+    /// Return the current payload extent after owner and generation checks.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProviderError::PrincipalMismatch`],
+    /// [`ProviderError::StaleGeneration`], or [`ProviderError::NotSupported`]
+    /// when payload metadata is unavailable or out of bounds.
+    pub fn len(
+        &self,
+        caller: HostPrincipal,
+        generation: ObjectGeneration,
+    ) -> Result<u64, ProviderError> {
+        self.require_owner(caller)?;
+        let _guard = self.lock_operation()?;
+        self.check_generation(generation)?;
+        let length = self.volume.region_len(&self.payload_region).map_err(|_| {
+            self.poison();
+            ProviderError::NotSupported
+        })?;
+        if length > MAX_OWNER_VOLUME_BYTES {
+            self.poison();
+            return Err(ProviderError::NotSupported);
+        }
+        Ok(length)
+    }
+
+    /// Stream bytes into the payload region at an exact offset.
+    ///
+    /// This method stages one volume payload record and does not claim that
+    /// the bytes are durable. Call [`Self::sync`] to append the next owner
+    /// generation and cross the durability barrier in one volume commit.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProviderError::PrincipalMismatch`],
+    /// [`ProviderError::StaleGeneration`], or [`ProviderError::NotSupported`]
+    /// for a malformed volume, short source, or out-of-range write.
+    pub fn write_from(
+        &self,
+        caller: HostPrincipal,
+        generation: ObjectGeneration,
+        offset: u64,
+        payload_len: u64,
+        payload: &mut dyn Read,
+    ) -> Result<(), ProviderError> {
+        self.require_owner(caller)?;
+        let _guard = self.lock_operation()?;
+        self.check_generation(generation)?;
+        Self::check_range_u64(offset, payload_len)?;
+        if payload_len == 0 {
+            return Ok(());
+        }
+        self.write_payload_unchecked(offset, payload_len, payload)
+    }
+
+    /// Write a byte slice into the payload region without claiming durability.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same authority, generation, storage, and capacity errors
+    /// as [`Self::write_from`].
+    pub fn write_at(
+        &self,
+        caller: HostPrincipal,
+        generation: ObjectGeneration,
+        offset: u64,
+        bytes: &[u8],
+    ) -> Result<(), ProviderError> {
+        let payload_len = u64::try_from(bytes.len()).map_err(|_| ProviderError::NotSupported)?;
+        self.write_from(caller, generation, offset, payload_len, &mut &bytes[..])
+    }
+
+    /// Write a byte slice into the payload region without claiming durability.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same authority, generation, storage, and capacity errors
+    /// as [`Self::write_at`].
+    pub fn write(
+        &self,
+        caller: HostPrincipal,
+        generation: ObjectGeneration,
+        offset: u64,
+        bytes: &[u8],
+    ) -> Result<(), ProviderError> {
+        self.write_at(caller, generation, offset, bytes)
+    }
+
+    /// Flush all preceding portal writes through [`AstridVolume::sync`].
+    ///
+    /// When a write is staged, this appends the next owner-generation record
+    /// before issuing exactly one volume sync. The returned generation is the
+    /// token for subsequent operations. With no staged write, the current
+    /// generation is returned after a plain durability flush.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProviderError::PrincipalMismatch`],
+    /// [`ProviderError::StaleGeneration`], or [`ProviderError::NotSupported`]
+    /// when metadata or the volume durability barrier fails.
+    pub fn sync(
+        &self,
+        caller: HostPrincipal,
+        generation: ObjectGeneration,
+    ) -> Result<ObjectGeneration, ProviderError> {
+        self.require_owner(caller)?;
+        let _guard = self.lock_operation()?;
+        self.check_generation(generation)?;
+        if self.dirty.load(Ordering::Acquire) {
+            let next = generation.checked_next().map_err(|_| {
+                self.poison();
+                ProviderError::NotSupported
+            })?;
+            self.write_generation(next)?;
+            self.sync_unchecked()?;
+            self.dirty.store(false, Ordering::Release);
+            Ok(next)
+        } else {
+            self.sync_unchecked()?;
+            Ok(generation)
+        }
+    }
+
+    /// Stage a payload and commit it with the next owner generation.
+    ///
+    /// The payload record, generation metadata record, and one
+    /// [`AstridVolume::sync`] call form the durable operation. On success the
+    /// returned generation is required for later reads, writes, and syncs.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same authority, generation, storage, and capacity errors
+    /// as [`Self::write_at`] or [`Self::sync`].
+    pub fn write_durable_at(
+        &self,
+        caller: HostPrincipal,
+        generation: ObjectGeneration,
+        offset: u64,
+        bytes: &[u8],
+    ) -> Result<ObjectGeneration, ProviderError> {
+        self.require_owner(caller)?;
+        let _guard = self.lock_operation()?;
+        self.check_generation(generation)?;
+        let payload_len = u64::try_from(bytes.len()).map_err(|_| ProviderError::NotSupported)?;
+        Self::check_range_u64(offset, payload_len)?;
+        let next = generation.checked_next().map_err(|_| {
+            self.poison();
+            ProviderError::NotSupported
+        })?;
+        self.write_payload_unchecked(offset, payload_len, &mut &bytes[..])?;
+        self.write_generation(next)?;
+        self.sync_unchecked()?;
+        self.dirty.store(false, Ordering::Release);
+        Ok(next)
+    }
+
+    /// Alias for [`Self::write_durable_at`].
+    ///
+    /// # Errors
+    ///
+    /// Returns the same errors as [`Self::write_durable_at`].
+    pub fn write_durable(
+        &self,
+        caller: HostPrincipal,
+        generation: ObjectGeneration,
+        offset: u64,
+        bytes: &[u8],
+    ) -> Result<ObjectGeneration, ProviderError> {
+        self.write_durable_at(caller, generation, offset, bytes)
+    }
+
+    /// Advance the owner generation and synchronize the new metadata.
+    ///
+    /// The returned generation is durable only when this method returns
+    /// success. A failed synchronization poisons this portal; callers must
+    /// reopen the volume before attempting another operation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProviderError::PrincipalMismatch`],
+    /// [`ProviderError::StaleGeneration`], or [`ProviderError::NotSupported`]
+    /// when the volume cannot persist the next generation.
+    pub fn advance_generation(
+        &self,
+        caller: HostPrincipal,
+        generation: ObjectGeneration,
+    ) -> Result<ObjectGeneration, ProviderError> {
+        self.require_owner(caller)?;
+        let _guard = self.lock_operation()?;
+        self.check_generation(generation)?;
+        let next = generation.checked_next().map_err(|_| {
+            self.poison();
+            ProviderError::NotSupported
+        })?;
+        self.write_generation(next)?;
+        self.sync_unchecked()?;
+        self.dirty.store(false, Ordering::Release);
+        Ok(next)
+    }
+
+    /// Alias for [`Self::advance_generation`].
+    ///
+    /// # Errors
+    ///
+    /// Returns the same errors as [`Self::advance_generation`].
+    pub fn bump_generation(
+        &self,
+        caller: HostPrincipal,
+        generation: ObjectGeneration,
+    ) -> Result<ObjectGeneration, ProviderError> {
+        self.advance_generation(caller, generation)
+    }
+
+    fn lock_operation(&self) -> Result<MutexGuard<'_, ()>, ProviderError> {
+        if self.poisoned.load(Ordering::Acquire) {
+            return Err(ProviderError::NotSupported);
+        }
+        self.operation_lock.lock().map_err(|_| {
+            self.poison();
+            ProviderError::NotSupported
+        })
+    }
+
+    fn check_generation(&self, requested: ObjectGeneration) -> Result<(), ProviderError> {
+        let found = self.read_generation()?;
+        if found != requested {
+            return Err(ProviderError::StaleGeneration {
+                found: found.get(),
+                requested: requested.get(),
+            });
+        }
+        Ok(())
+    }
+
+    fn read_generation(&self) -> Result<ObjectGeneration, ProviderError> {
+        let length = self.volume.region_len(&self.metadata_region).map_err(|_| {
+            self.poison();
+            ProviderError::NotSupported
+        })?;
+        if length != METADATA_LEN as u64 {
+            self.poison();
+            return Err(ProviderError::NotSupported);
+        }
+        let mut bytes = [0_u8; METADATA_LEN];
+        let read = self
+            .volume
+            .read_region_at(&self.metadata_region, 0, &mut bytes)
+            .map_err(|_| {
+                self.poison();
+                ProviderError::NotSupported
+            })?;
+        if read != bytes.len()
+            || bytes[..OWNER_OFFSET] != METADATA_MAGIC
+            || bytes[OWNER_OFFSET..GENERATION_OFFSET] != self.owner.as_bytes()[..]
+        {
+            self.poison();
+            return Err(ProviderError::NotSupported);
+        }
+        ObjectGeneration::decode_canonical(&bytes[GENERATION_OFFSET..]).map_err(|_| {
+            self.poison();
+            ProviderError::NotSupported
+        })
+    }
+
+    fn write_generation(&self, generation: ObjectGeneration) -> Result<(), ProviderError> {
+        let mut bytes = [0_u8; METADATA_LEN];
+        bytes[..OWNER_OFFSET].copy_from_slice(&METADATA_MAGIC);
+        bytes[OWNER_OFFSET..GENERATION_OFFSET].copy_from_slice(self.owner.as_bytes());
+        generation
+            .encode_canonical(&mut bytes[GENERATION_OFFSET..])
+            .map_err(|_| {
+                self.poison();
+                ProviderError::NotSupported
+            })?;
+        self.volume
+            .write_region_from(
+                &self.metadata_region,
+                0,
+                METADATA_LEN as u64,
+                &mut &bytes[..],
+            )
+            .map_err(|_| {
+                self.poison();
+                ProviderError::NotSupported
+            })
+    }
+
+    fn write_payload_unchecked(
+        &self,
+        offset: u64,
+        payload_len: u64,
+        payload: &mut dyn Read,
+    ) -> Result<(), ProviderError> {
+        if payload_len == 0 {
+            return Ok(());
+        }
+        self.volume
+            .write_region_from(&self.payload_region, offset, payload_len, payload)
+            .map_err(|_| {
+                self.poison();
+                ProviderError::NotSupported
+            })?;
+        self.dirty.store(true, Ordering::Release);
+        Ok(())
+    }
+
+    fn sync_unchecked(&self) -> Result<(), ProviderError> {
+        self.volume.sync().map_err(|_| {
+            self.poison();
+            ProviderError::NotSupported
+        })
+    }
+
+    fn check_range(offset: u64, length: usize) -> Result<(), ProviderError> {
+        let length = u64::try_from(length).map_err(|_| ProviderError::NotSupported)?;
+        Self::check_range_u64(offset, length)
+    }
+
+    fn check_range_u64(offset: u64, length: u64) -> Result<(), ProviderError> {
+        let end = offset
+            .checked_add(length)
+            .ok_or(ProviderError::NotSupported)?;
+        if end > MAX_OWNER_VOLUME_BYTES {
+            return Err(ProviderError::NotSupported);
+        }
+        Ok(())
+    }
+
+    fn poison(&self) {
+        self.poisoned.store(true, Ordering::Release);
+    }
+}
+
+fn regions_for(owner: HostPrincipal) -> Result<(VolumeRegion, VolumeRegion), ProviderError> {
+    let encoded = owner.as_bytes();
+    let mut base = String::new();
+    base.push_str(REGION_PREFIX);
+    base.push('/');
+    for byte in encoded {
+        use fmt::Write as _;
+        write!(base, "{byte:02x}").map_err(|_| ProviderError::NotSupported)?;
+    }
+    let metadata = VolumeRegion::new(format!("{base}/{METADATA_SUFFIX}"))
+        .map_err(|_| ProviderError::NotSupported)?;
+    let payload = VolumeRegion::new(format!("{base}/{PAYLOAD_SUFFIX}"))
+        .map_err(|_| ProviderError::NotSupported)?;
+    Ok((metadata, payload))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MAX_OWNER_VOLUME_BYTES, OwnerVolumePortal};
+    use crate::fixtures::{alice_principal, bob_principal};
+    use astrid_provider::ProviderError;
+    use astrid_resource_types::ObjectGeneration;
+    use astrid_storage::volume::HostedFileVolume;
+    use std::sync::Arc;
+
+    fn volume() -> (tempfile::TempDir, Arc<HostedFileVolume>) {
+        let temporary = tempfile::tempdir().expect("temporary volume directory");
+        let path = temporary.path().join("astrid.volume");
+        let volume = HostedFileVolume::open(path).expect("hosted volume");
+        (temporary, volume)
+    }
+
+    #[test]
+    fn two_principals_are_isolated_in_one_reopened_volume() {
+        let (temporary, volume) = volume();
+        let path = temporary.path().join("astrid.volume");
+        let alice = OwnerVolumePortal::open(volume.clone(), alice_principal()).unwrap();
+        let bob = OwnerVolumePortal::open(volume.clone(), bob_principal()).unwrap();
+        let generation = ObjectGeneration::INITIAL;
+        alice
+            .write_at(alice_principal(), generation, 0, b"alice")
+            .unwrap();
+        let alice_generation = alice.sync(alice_principal(), generation).unwrap();
+        bob.write_at(bob_principal(), generation, 0, b"bob")
+            .unwrap();
+        let bob_generation = bob.sync(bob_principal(), generation).unwrap();
+
+        let mut alice_bytes = [0_u8; 5];
+        let mut bob_bytes = [0_u8; 3];
+        assert_eq!(
+            alice.read_at(alice_principal(), alice_generation, 0, &mut alice_bytes),
+            Ok(5)
+        );
+        assert_eq!(
+            bob.read_at(bob_principal(), bob_generation, 0, &mut bob_bytes),
+            Ok(3)
+        );
+        assert_eq!(&alice_bytes, b"alice");
+        assert_eq!(&bob_bytes, b"bob");
+        assert_eq!(
+            alice.read_at(bob_principal(), alice_generation, 0, &mut alice_bytes),
+            Err(ProviderError::PrincipalMismatch)
+        );
+        assert_eq!(
+            bob.write_at(alice_principal(), bob_generation, 0, b"nope"),
+            Err(ProviderError::PrincipalMismatch)
+        );
+
+        drop(alice);
+        drop(bob);
+        drop(volume);
+        let reopened_volume = HostedFileVolume::open(path).unwrap();
+        let reopened_alice =
+            OwnerVolumePortal::open(reopened_volume.clone(), alice_principal()).unwrap();
+        let reopened_bob = OwnerVolumePortal::open(reopened_volume, bob_principal()).unwrap();
+        let mut alice_after = [0_u8; 5];
+        let mut bob_after = [0_u8; 3];
+        reopened_alice
+            .read_at(alice_principal(), alice_generation, 0, &mut alice_after)
+            .unwrap();
+        reopened_bob
+            .read_at(bob_principal(), bob_generation, 0, &mut bob_after)
+            .unwrap();
+        assert_eq!(&alice_after, b"alice");
+        assert_eq!(&bob_after, b"bob");
+    }
+
+    #[test]
+    fn stale_generation_and_host_path_fail_closed() {
+        let (_temporary, volume) = volume();
+        let portal = OwnerVolumePortal::open(volume, alice_principal()).unwrap();
+        assert!(portal.as_host_path().is_none());
+        assert_eq!(
+            portal.require_owner(bob_principal()),
+            Err(ProviderError::PrincipalMismatch)
+        );
+        assert_eq!(
+            portal.require_generation(alice_principal(), ObjectGeneration::from_raw(2).unwrap(),),
+            Err(ProviderError::StaleGeneration {
+                found: 1,
+                requested: 2,
+            })
+        );
+        assert_eq!(portal.owner(), alice_principal());
+        assert_eq!(portal.namespace_id(), alice_principal());
+    }
+
+    #[test]
+    fn generation_advance_is_durable_and_denies_old_generation() {
+        let (_temporary, volume) = volume();
+        let portal = OwnerVolumePortal::open(volume, alice_principal()).unwrap();
+        let next = portal
+            .advance_generation(alice_principal(), ObjectGeneration::INITIAL)
+            .unwrap();
+        assert_eq!(next.get(), 2);
+        assert_eq!(
+            portal.write_at(alice_principal(), ObjectGeneration::INITIAL, 0, b"stale"),
+            Err(ProviderError::StaleGeneration {
+                found: 2,
+                requested: 1,
+            })
+        );
+        portal
+            .write_at(alice_principal(), next, 0, b"current")
+            .unwrap();
+        portal.sync(alice_principal(), next).unwrap();
+    }
+
+    #[test]
+    fn unsynced_tail_is_discarded_on_reopen_without_mixed_owner_bytes() {
+        let (temporary, volume) = volume();
+        let path = temporary.path().join("astrid.volume");
+        let portal = OwnerVolumePortal::open(volume.clone(), alice_principal()).unwrap();
+        let generation = ObjectGeneration::INITIAL;
+        portal
+            .write_at(alice_principal(), generation, 0, b"committed")
+            .unwrap();
+        let generation = portal.sync(alice_principal(), generation).unwrap();
+        portal
+            .write_at(alice_principal(), generation, 0, b"unsynced")
+            .unwrap();
+        let crash_copy = temporary.path().join("crash.volume");
+        std::fs::copy(&path, &crash_copy).unwrap();
+        drop(portal);
+        drop(volume);
+
+        let reopened_volume = HostedFileVolume::open(crash_copy).unwrap();
+        let reopened_alice =
+            OwnerVolumePortal::open(reopened_volume.clone(), alice_principal()).unwrap();
+        let reopened_bob = OwnerVolumePortal::open(reopened_volume, bob_principal()).unwrap();
+        let mut bytes = [0_u8; 9];
+        reopened_alice
+            .read_at(alice_principal(), generation, 0, &mut bytes)
+            .unwrap();
+        assert_eq!(&bytes, b"committed");
+        assert_eq!(
+            reopened_bob.read_at(bob_principal(), ObjectGeneration::INITIAL, 0, &mut bytes,),
+            Ok(0)
+        );
+    }
+
+    #[test]
+    fn bounded_extent_rejects_over_capacity_before_volume_write() {
+        let (_temporary, volume) = volume();
+        let portal = OwnerVolumePortal::open(volume, alice_principal()).unwrap();
+        assert_eq!(
+            portal.write_at(
+                alice_principal(),
+                ObjectGeneration::INITIAL,
+                MAX_OWNER_VOLUME_BYTES,
+                b"x",
+            ),
+            Err(ProviderError::NotSupported)
+        );
+    }
+}

--- a/crates/astrid-realm-compat/src/volume_portal_tests.rs
+++ b/crates/astrid-realm-compat/src/volume_portal_tests.rs
@@ -1,0 +1,286 @@
+use super::{MAX_OWNER_VOLUME_BYTES, OwnerVolumePortal};
+use crate::fixtures::{alice_principal, bob_principal};
+use astrid_provider::ProviderError;
+use astrid_resource_types::ObjectGeneration;
+use astrid_storage::volume::HostedFileVolume;
+use std::sync::Arc;
+
+fn volume() -> (tempfile::TempDir, Arc<HostedFileVolume>) {
+    let temporary = tempfile::tempdir().expect("temporary volume directory");
+    let path = temporary.path().join("astrid.volume");
+    let volume = HostedFileVolume::open(path).expect("hosted volume");
+    (temporary, volume)
+}
+
+#[test]
+fn two_principals_are_isolated_in_one_reopened_volume() {
+    let (temporary, volume) = volume();
+    let path = temporary.path().join("astrid.volume");
+    let alice = OwnerVolumePortal::open(volume.clone(), alice_principal()).unwrap();
+    let bob = OwnerVolumePortal::open(volume.clone(), bob_principal()).unwrap();
+    let generation = ObjectGeneration::INITIAL;
+    alice
+        .write_at(alice_principal(), generation, 0, b"alice")
+        .unwrap();
+    let alice_generation = alice.sync(alice_principal(), generation).unwrap();
+    bob.write_at(bob_principal(), generation, 0, b"bob")
+        .unwrap();
+    let bob_generation = bob.sync(bob_principal(), generation).unwrap();
+
+    let mut alice_bytes = [0_u8; 5];
+    let mut bob_bytes = [0_u8; 3];
+    assert_eq!(
+        alice.read_at(alice_principal(), alice_generation, 0, &mut alice_bytes),
+        Ok(5)
+    );
+    assert_eq!(
+        bob.read_at(bob_principal(), bob_generation, 0, &mut bob_bytes),
+        Ok(3)
+    );
+    assert_eq!(&alice_bytes, b"alice");
+    assert_eq!(&bob_bytes, b"bob");
+    assert_eq!(
+        alice.read_at(bob_principal(), alice_generation, 0, &mut alice_bytes),
+        Err(ProviderError::PrincipalMismatch)
+    );
+    assert_eq!(
+        bob.write_at(alice_principal(), bob_generation, 0, b"nope"),
+        Err(ProviderError::PrincipalMismatch)
+    );
+
+    drop(alice);
+    drop(bob);
+    drop(volume);
+    let reopened_volume = HostedFileVolume::open(path).unwrap();
+    let reopened_alice =
+        OwnerVolumePortal::open(reopened_volume.clone(), alice_principal()).unwrap();
+    let reopened_bob = OwnerVolumePortal::open(reopened_volume, bob_principal()).unwrap();
+    let mut alice_after = [0_u8; 5];
+    let mut bob_after = [0_u8; 3];
+    reopened_alice
+        .read_at(alice_principal(), alice_generation, 0, &mut alice_after)
+        .unwrap();
+    reopened_bob
+        .read_at(bob_principal(), bob_generation, 0, &mut bob_after)
+        .unwrap();
+    assert_eq!(&alice_after, b"alice");
+    assert_eq!(&bob_after, b"bob");
+}
+
+#[test]
+fn foreign_sync_cannot_flush_an_unsynced_owner_tail() {
+    let (temporary, volume) = volume();
+    let path = temporary.path().join("astrid.volume");
+    let alice = OwnerVolumePortal::open(volume.clone(), alice_principal()).unwrap();
+    let bob = OwnerVolumePortal::open(volume.clone(), bob_principal()).unwrap();
+    let initial = ObjectGeneration::INITIAL;
+    alice
+        .write_at(alice_principal(), initial, 0, b"committed")
+        .unwrap();
+    let generation = alice.sync(alice_principal(), initial).unwrap();
+    alice
+        .write_at(alice_principal(), generation, 0, b"unsynced")
+        .unwrap();
+
+    assert_eq!(
+        bob.write_at(bob_principal(), initial, 0, b"blocked"),
+        Err(ProviderError::NotSupported)
+    );
+    assert_eq!(
+        bob.sync(bob_principal(), initial),
+        Err(ProviderError::NotSupported)
+    );
+    let crash_copy = temporary.path().join("crash.volume");
+    std::fs::copy(&path, &crash_copy).unwrap();
+    let committed_generation = alice.sync(alice_principal(), generation).unwrap();
+    assert_eq!(committed_generation.get(), generation.get() + 1);
+    assert_eq!(bob.sync(bob_principal(), initial), Ok(initial));
+    drop(bob);
+    drop(alice);
+    drop(volume);
+
+    let reopened_volume = HostedFileVolume::open(crash_copy).unwrap();
+    let reopened_alice = OwnerVolumePortal::open(reopened_volume, alice_principal()).unwrap();
+    assert_eq!(
+        reopened_alice.generation(alice_principal()).unwrap(),
+        generation
+    );
+    let mut bytes = [0_u8; 9];
+    reopened_alice
+        .read_at(alice_principal(), generation, 0, &mut bytes)
+        .unwrap();
+    assert_eq!(&bytes, b"committed");
+}
+
+#[test]
+fn same_owner_open_handles_serialize_staging_and_release_after_sync() {
+    let (_temporary, volume) = volume();
+    let first = OwnerVolumePortal::open(volume.clone(), alice_principal()).unwrap();
+    let second = OwnerVolumePortal::open(volume, alice_principal()).unwrap();
+    let initial = ObjectGeneration::INITIAL;
+    first
+        .write_at(alice_principal(), initial, 0, b"first")
+        .unwrap();
+    assert_eq!(
+        second.write_at(alice_principal(), initial, 0, b"blocked"),
+        Err(ProviderError::NotSupported)
+    );
+    assert_eq!(
+        second.sync(alice_principal(), initial),
+        Err(ProviderError::NotSupported)
+    );
+
+    let generation = first.sync(alice_principal(), initial).unwrap();
+    assert_eq!(second.generation(alice_principal()), Ok(generation));
+    second
+        .write_at(alice_principal(), generation, 0, b"second")
+        .unwrap();
+    let next = second.sync(alice_principal(), generation).unwrap();
+    assert_eq!(next.get(), generation.get() + 1);
+}
+
+#[test]
+fn stale_generation_and_host_path_fail_closed() {
+    let (_temporary, volume) = volume();
+    let portal = OwnerVolumePortal::open(volume, alice_principal()).unwrap();
+    assert!(portal.as_host_path().is_none());
+    assert_eq!(
+        portal.require_owner(bob_principal()),
+        Err(ProviderError::PrincipalMismatch)
+    );
+    assert_eq!(
+        portal.require_generation(alice_principal(), ObjectGeneration::from_raw(2).unwrap(),),
+        Err(ProviderError::StaleGeneration {
+            found: 1,
+            requested: 2,
+        })
+    );
+    assert_eq!(portal.owner(), alice_principal());
+    assert_eq!(portal.namespace_id(), alice_principal());
+}
+
+#[test]
+fn generation_advance_is_durable_and_denies_old_generation() {
+    let (_temporary, volume) = volume();
+    let portal = OwnerVolumePortal::open(volume, alice_principal()).unwrap();
+    let next = portal
+        .advance_generation(alice_principal(), ObjectGeneration::INITIAL)
+        .unwrap();
+    assert_eq!(next.get(), 2);
+    assert_eq!(
+        portal.write_at(alice_principal(), ObjectGeneration::INITIAL, 0, b"stale"),
+        Err(ProviderError::StaleGeneration {
+            found: 2,
+            requested: 1,
+        })
+    );
+    portal
+        .write_at(alice_principal(), next, 0, b"current")
+        .unwrap();
+    portal.sync(alice_principal(), next).unwrap();
+}
+
+#[test]
+fn unsynced_tail_is_discarded_on_reopen_without_mixed_owner_bytes() {
+    let (temporary, volume) = volume();
+    let path = temporary.path().join("astrid.volume");
+    let portal = OwnerVolumePortal::open(volume.clone(), alice_principal()).unwrap();
+    let generation = ObjectGeneration::INITIAL;
+    portal
+        .write_at(alice_principal(), generation, 0, b"committed")
+        .unwrap();
+    let generation = portal.sync(alice_principal(), generation).unwrap();
+    portal
+        .write_at(alice_principal(), generation, 0, b"unsynced")
+        .unwrap();
+    let crash_copy = temporary.path().join("crash.volume");
+    std::fs::copy(&path, &crash_copy).unwrap();
+    drop(portal);
+    drop(volume);
+
+    let reopened_volume = HostedFileVolume::open(crash_copy).unwrap();
+    let reopened_alice =
+        OwnerVolumePortal::open(reopened_volume.clone(), alice_principal()).unwrap();
+    let reopened_bob = OwnerVolumePortal::open(reopened_volume, bob_principal()).unwrap();
+    let mut bytes = [0_u8; 9];
+    reopened_alice
+        .read_at(alice_principal(), generation, 0, &mut bytes)
+        .unwrap();
+    assert_eq!(&bytes, b"committed");
+    assert_eq!(
+        reopened_bob.read_at(bob_principal(), ObjectGeneration::INITIAL, 0, &mut bytes,),
+        Ok(0)
+    );
+}
+
+#[test]
+fn bounded_extent_rejects_over_capacity_before_volume_write() {
+    let (_temporary, volume) = volume();
+    let portal = OwnerVolumePortal::open(volume, alice_principal()).unwrap();
+    assert_eq!(
+        portal.write_at(
+            alice_principal(),
+            ObjectGeneration::INITIAL,
+            MAX_OWNER_VOLUME_BYTES,
+            b"x",
+        ),
+        Err(ProviderError::NotSupported)
+    );
+}
+
+#[test]
+fn cloned_portal_shares_staging_identity() {
+    let (_temporary, volume) = volume();
+    let first = OwnerVolumePortal::open(volume.clone(), alice_principal()).unwrap();
+    let cloned = first.clone();
+    let second = OwnerVolumePortal::open(volume, alice_principal()).unwrap();
+    let initial = ObjectGeneration::INITIAL;
+    first
+        .write_at(alice_principal(), initial, 0, b"clone")
+        .unwrap();
+    assert_eq!(
+        second.write_at(alice_principal(), initial, 0, b"blocked"),
+        Err(ProviderError::NotSupported)
+    );
+    let generation = cloned.sync(alice_principal(), initial).unwrap();
+    assert_eq!(generation.get(), 2);
+    let mut bytes = [0_u8; 5];
+    assert_eq!(
+        first.read_at(alice_principal(), generation, 0, &mut bytes),
+        Ok(5)
+    );
+    assert_eq!(&bytes, b"clone");
+}
+
+#[test]
+fn dropping_a_stager_does_not_release_foreign_sync() {
+    let (temporary, volume) = volume();
+    let path = temporary.path().join("astrid.volume");
+    let alice = OwnerVolumePortal::open(volume.clone(), alice_principal()).unwrap();
+    let bob = OwnerVolumePortal::open(volume.clone(), bob_principal()).unwrap();
+    let initial = ObjectGeneration::INITIAL;
+    alice
+        .write_at(alice_principal(), initial, 0, b"committed")
+        .unwrap();
+    let generation = alice.sync(alice_principal(), initial).unwrap();
+    alice
+        .write_at(alice_principal(), generation, 0, b"unsynced")
+        .unwrap();
+    drop(alice);
+    assert_eq!(
+        bob.sync(bob_principal(), initial),
+        Err(ProviderError::NotSupported)
+    );
+    let crash_copy = temporary.path().join("crash.volume");
+    std::fs::copy(&path, &crash_copy).unwrap();
+    drop(bob);
+    drop(volume);
+
+    let reopened_volume = HostedFileVolume::open(crash_copy).unwrap();
+    let reopened_alice = OwnerVolumePortal::open(reopened_volume, alice_principal()).unwrap();
+    let mut bytes = [0_u8; 9];
+    reopened_alice
+        .read_at(alice_principal(), generation, 0, &mut bytes)
+        .unwrap();
+    assert_eq!(&bytes, b"committed");
+}


### PR DESCRIPTION
## Linked Issue

Closes #1676

## Summary

Add a native, feature-gated owner-scoped durable portal over injected `AstridVolume` media. Two principals persist isolated bytes across reopen, owner and generation are checked on every operation, and the portal never exposes a host path. Default, no_std, and wasm builds keep the landed ephemeral isolation corpus.

This head is a signed no-ff integration of accepted content `0ff459d8e26b9cf429996cac0b9e7efdaa12fd6d` onto live `os/universal` `2a5e2f026d63077284d5748345157b88be5afa61`. No content rewrite.

## Changes

- `OwnerVolumePortal` consumes `Arc<dyn AstridVolume>` with owner-derived slash-terminated region names and persisted `ObjectGeneration` metadata.
- Payload plus generation then one `AstridVolume::sync` is the durability boundary; unsynced tails reopen as the last commit.
- Staged writes serialize through one per-volume coordinator, so a pending write cannot be flushed by another principal or handle.
- Feature `volume` is native-only. `StorageMountLeaseV1`, DurableEngine ingest, WAL-on, host/home fallbacks, and ramfs dual-write are not introduced.
- Changelog fragments `changes/1676.added.md` and `changes/1676.fixed.md`. Workspace lock records the optional crate edges.

## Verification

- Isolated `cargo test --locked -p astrid-realm-compat`: 35/35
- `--no-default-features`: 35/35
- `--features volume`: 44/44
- `cargo clippy --locked --all-targets -p astrid-realm-compat -- -D warnings` (default and `--features volume`)
- `cargo fmt --check -p astrid-realm-compat`
- `cargo check --locked --target wasm32-unknown-unknown -p astrid-realm-compat`
- `cargo check --locked --target x86_64-unknown-none -p astrid-realm-compat --no-default-features`
- Unique commits GPG-signed with matching DCO
- `HEAD^{tree}` equals `git merge-tree --write-tree` of the two parents (`f0f6acdaa32ff73213e7f05e2bf892fcf7b4dfaf`)
- Portal, tests, and `changes/1676.*.md` blobs are byte-identical to accepted `0ff459d8`

## Dependencies

- Live `os/universal` `2a5e2f026d63077284d5748345157b88be5afa61` (first parent)
- Accepted content `0ff459d8e26b9cf429996cac0b9e7efdaa12fd6d` (second parent)
- WP2 media contract: volume regions and `sync` only; no kernel lease consume

## Residuals

- Remote PR CI not yet terminal in this description
- Exhaustive HostedFileVolume interior-corruption cases remain storage-owned
- 64 MiB portal extent is a fixture DoS ceiling, not a reserved principal quota
- Interpreter start/exit remains ephemeral ramfs; this PR does not dual-write it
- HostedFileVolume Drop remains best-effort durable; crash tests copy container bytes first

## AI / Tool Assistance

Assisted-by: Codex.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/{issue}.{kind}.md` (docs/CI-only may skip; release PRs roll fragments into the version section instead of adding one)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.