### PR TITLE
feat: wire HostState ResourceAuthority lifecycle

### DIFF
--- a/changes/1683.added.md
+++ b/changes/1683.added.md
@@ -2,4 +2,5 @@ Bind HostState to invocation-scoped ResourceAuthority cleanup for private
 SemanticObject fixtures. Live wrappers retain their admission stamps, drain
 delegation children first before attribution changes or publisher replacement,
 provide Store-return and Drop backstops, and release reclaimed reservations
-through bounded live-slot and revocation-tombstone tables. Tracking #1564
+through bounded live-slot and revocation-tombstone tables. Live-slot occupancy
+includes attenuation children. Tracking #1564

--- a/changes/1683.added.md
+++ b/changes/1683.added.md
@@ -1,0 +1,5 @@
+Bind HostState to invocation-scoped ResourceAuthority cleanup for private
+SemanticObject fixtures. Live wrappers retain their admission stamps, drain
+delegation children first before attribution changes or publisher replacement,
+provide Store-return and Drop backstops, and release reclaimed reservations
+through bounded live-slot and revocation-tombstone tables. Tracking #1564

--- a/crates/astrid-capsule/src/engine/wasm/host_state.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host_state.rs
@@ -16,6 +16,8 @@ use astrid_core::uplink::{InboundMessage, MAX_UPLINKS_PER_CAPSULE, UplinkDescrip
 use astrid_storage::ScopedKvStore;
 use astrid_storage::secret::SecretStore;
 
+pub use crate::engine::wasm::host_state_types::LifecyclePhase;
+
 /// An active network stream owned by a capsule.
 ///
 /// Holds either an inbound host-local connection (accepted from the
@@ -63,19 +65,6 @@ pub struct TcpStreamSlot {
 pub struct SharedTcpListener {
     pub listener: Arc<tokio::net::TcpListener>,
     pub holders: std::sync::atomic::AtomicUsize,
-}
-
-/// The lifecycle phase a capsule is currently executing in.
-///
-/// Set on [`HostState`] during `#[install]` or `#[upgrade]` dispatch.
-/// The `astrid_elicit` host function checks this field and rejects calls
-/// outside of a lifecycle phase.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum LifecyclePhase {
-    /// First-time installation.
-    Install,
-    /// Upgrading from a previous version.
-    Upgrade,
 }
 
 /// Metadata for an interceptor binding declared in `Capsule.toml`.
@@ -263,6 +252,11 @@ pub struct HostState {
     /// Attribution only; not a live authority grant. Crate-private so a
     /// downstream crate cannot install or replay a cloned stamp.
     pub(crate) stamped_invocation: Option<crate::stamp::StampedInvocation>,
+    /// Invocation-scoped authorities for the crate-private SemanticObject fixture.
+    ///
+    /// This is deliberately independent of WASI files, streams, HTTP, sockets,
+    /// processes, and every guest-visible resource-table entry.
+    pub(crate) semantic_authorities: super::host_state_authority::HostStateSemanticAuthorities,
     /// Explicit kernel-service scope. When false, every long-lived IPC route
     /// is restricted to `principal`; default-principal is still a principal.
     pub system_runtime: bool,

--- a/crates/astrid-capsule/src/engine/wasm/host_state_authority.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host_state_authority.rs
@@ -1,0 +1,186 @@
+//! Lifecycle bookkeeping for invocation-scoped semantic-object authorities.
+
+use crate::resource_authority::{ResourceAuthorityTable, ResourceHandle};
+use crate::stamp::StampedInvocation;
+
+/// One live authority paired with the exact host stamp that admitted it.
+#[derive(Debug)]
+struct TrackedAuthority {
+    stamp: StampedInvocation,
+    handle: ResourceHandle,
+}
+
+/// [`crate::engine::wasm::host_state::HostState`]-owned authority cleanup.
+///
+/// A repeating principal alias is not proof of a continuing invocation, so
+/// cleanup keeps the admission-time stamp instead of borrowing the current one.
+#[derive(Debug, Default)]
+pub(crate) struct HostStateSemanticAuthorities {
+    table: ResourceAuthorityTable,
+    tracked: Vec<TrackedAuthority>,
+    released_units: u128,
+}
+
+impl HostStateSemanticAuthorities {
+    /// Drain child-first, then replace the bounded table unconditionally.
+    pub(crate) fn prepare_for_replacement(&mut self) {
+        // Children are appended after parents, so reverse consumption follows
+        // delegation lineage and lets each refund land on its live parent.
+        while let Some(tracked) = self.tracked.pop() {
+            let releases_before = self.table.released_reserved_units();
+            let result = self.table.drop_handle(&tracked.stamp, tracked.handle);
+            self.record_release(releases_before);
+            debug_assert!(
+                result.is_ok(),
+                "exact-stamp reverse drain must reclaim a tracked entry"
+            );
+        }
+        self.table = ResourceAuthorityTable::default();
+    }
+
+    fn record_release(&mut self, previous_released_units: u128) {
+        let latest_released_units = self.table.released_reserved_units();
+        if let Some(delta_released_units) =
+            latest_released_units.checked_sub(previous_released_units)
+            && let Some(total_released_units) =
+                self.released_units.checked_add(delta_released_units)
+        {
+            self.released_units = total_released_units;
+        } else {
+            // Overflow would mean inconsistent table accounting; saturating
+            // prevents corruption from looking like available release capacity.
+            self.released_units = u128::MAX;
+        }
+    }
+}
+
+#[cfg(test)]
+impl HostStateSemanticAuthorities {
+    /// Admit one fixture SemanticObject and retain its cleanup pair.
+    pub(crate) fn admit(
+        &mut self,
+        stamp: &StampedInvocation,
+        kind: astrid_resource_types::ResourceKind,
+        identity: astrid_resource_types::ResourceId,
+        scope: crate::resource_authority::ResourceScope,
+        reservation: crate::resource_authority::Reservation,
+        options: crate::resource_authority::AdmissionOptions,
+    ) -> Result<ResourceHandle, astrid_resource_types::ResourceErrorCode> {
+        let handle = self
+            .table
+            .admit(stamp, kind, identity, scope, reservation, options)?;
+        self.tracked.push(TrackedAuthority {
+            stamp: stamp.clone(),
+            handle,
+        });
+        Ok(handle)
+    }
+
+    /// Preflight against the admission-time stamp, not an equivalent alias.
+    pub(crate) fn preflight(
+        &self,
+        stamp: &StampedInvocation,
+        handle: ResourceHandle,
+        requested_right: astrid_resource_types::Rights,
+        requested_scope: &crate::resource_authority::ResourceScope,
+        requested_budget: u64,
+    ) -> Result<(), astrid_resource_types::ResourceErrorCode> {
+        self.table.preflight(
+            stamp,
+            handle,
+            requested_right,
+            requested_scope,
+            requested_budget,
+        )
+    }
+
+    /// Create a child authority and retain it behind its parent in cleanup.
+    pub(crate) fn attenuate(
+        &mut self,
+        stamp: &StampedInvocation,
+        parent: ResourceHandle,
+        rights: astrid_resource_types::Rights,
+        scope: crate::resource_authority::ResourceScope,
+        budget: u64,
+    ) -> Result<ResourceHandle, astrid_resource_types::ResourceErrorCode> {
+        let handle = self.table.attenuate(stamp, parent, rights, scope, budget)?;
+        self.tracked.push(TrackedAuthority {
+            stamp: stamp.clone(),
+            handle,
+        });
+        Ok(handle)
+    }
+
+    /// Reclaim a live or invalidated entry through its admission stamp.
+    pub(crate) fn reclaim(
+        &mut self,
+        stamp: &StampedInvocation,
+        handle: ResourceHandle,
+    ) -> Result<(), astrid_resource_types::ResourceErrorCode> {
+        let releases_before = self.table.released_reserved_units();
+        self.table.reclaim(stamp, handle)?;
+        self.tracked.retain(|tracked| tracked.handle != handle);
+        self.record_release(releases_before);
+        Ok(())
+    }
+
+    /// Mark an entry invalid while retaining its cleanup reservation.
+    pub(crate) fn revoke(
+        &mut self,
+        handle: ResourceHandle,
+    ) -> Result<(), astrid_resource_types::ResourceErrorCode> {
+        self.table.revoke(handle)
+    }
+
+    /// Invalidate entries carrying a selector; replacement clears tombstones.
+    pub(crate) fn revoke_selector(
+        &mut self,
+        selector: crate::resource_authority::RevocationSelector,
+    ) -> Result<(), astrid_resource_types::ResourceErrorCode> {
+        self.table.revoke_selector(selector)
+    }
+
+    /// Invalidate reservations from an older authority epoch.
+    pub(crate) fn advance_authority_epoch(
+        &mut self,
+    ) -> Result<astrid_resource_types::AuthorityEpoch, astrid_resource_types::ResourceErrorCode>
+    {
+        self.table.advance_authority_epoch()
+    }
+
+    pub(crate) const fn tracked_count(&self) -> usize {
+        self.tracked.len()
+    }
+
+    pub(crate) fn tracks_handle(&self, handle: ResourceHandle) -> bool {
+        self.tracked.iter().any(|tracked| tracked.handle == handle)
+    }
+
+    pub(crate) const fn active_reserved_units(&self) -> u128 {
+        self.table.active_reserved_units()
+    }
+
+    pub(crate) const fn released_reserved_units(&self) -> u128 {
+        self.released_units
+    }
+
+    pub(crate) fn revoked_selector_count(&self) -> usize {
+        self.table.revoked_selector_count()
+    }
+
+    pub(crate) const fn allocated_slot_count(&self) -> usize {
+        self.table.slot_count()
+    }
+}
+
+impl Drop for HostStateSemanticAuthorities {
+    fn drop(&mut self) {
+        while let Some(tracked) = self.tracked.pop() {
+            // Store teardown must never panic on a backstop race. Dropping the
+            // finite table frees an entry whose stale-generation reclaim fails.
+            let releases_before = self.table.released_reserved_units();
+            let _unused = self.table.drop_handle(&tracked.stamp, tracked.handle);
+            self.record_release(releases_before);
+        }
+    }
+}

--- a/crates/astrid-capsule/src/engine/wasm/host_state_authority_tests.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host_state_authority_tests.rs
@@ -1,0 +1,357 @@
+//! Regressions for HostState-owned semantic-object authority lifecycle.
+
+use std::time::Instant;
+
+use astrid_core::{PrincipalId, PrincipalUid};
+use astrid_resource_types::{AuthorityEpoch, ResourceErrorCode, ResourceId, ResourceKind, Rights};
+
+use super::pool::clear_on_return;
+use super::test_fixtures::minimal_host_state;
+use crate::resource_authority::{AdmissionOptions, Reservation, ResourceScope, RevocationSelector};
+use crate::stamp::StampedInvocation;
+
+fn identity(seed: u8) -> ResourceId {
+    ResourceId::from_bytes([seed; 32])
+}
+
+fn root_rights() -> Rights {
+    Rights::from_bits(Rights::READ.bits() | Rights::USE.bits() | Rights::DELEGATE.bits())
+        .expect("read, use, and delegate are closed-vocabulary rights")
+}
+
+fn scope(identity: ResourceId) -> ResourceScope {
+    ResourceScope::singleton(identity)
+}
+
+fn reservation(units: u64) -> Reservation {
+    Reservation::new(
+        astrid_resource_types::AccountId::from_bytes([7u8; 16]),
+        astrid_resource_types::BudgetId::from_bytes([11u8; 16]),
+        units,
+    )
+}
+
+fn options(
+    rights: Rights,
+    expiry: Option<Instant>,
+    revocation: Option<RevocationSelector>,
+) -> AdmissionOptions {
+    AdmissionOptions::new(rights, AuthorityEpoch::INITIAL, expiry, revocation)
+}
+
+fn stamp(seed: u8) -> StampedInvocation {
+    StampedInvocation::from_trusted_uid(PrincipalUid::from_bytes([seed; 32]))
+}
+
+fn event_message(principal: Option<&str>) -> astrid_events::ipc::IpcMessage {
+    let message = astrid_events::ipc::IpcMessage::new(
+        astrid_events::ipc::Topic::from_raw("some.v1.event"),
+        astrid_events::ipc::IpcPayload::RawJson(serde_json::json!({})),
+        uuid::Uuid::new_v4(),
+    );
+    match principal {
+        Some(name) => message.with_principal(name.to_string()),
+        None => message,
+    }
+}
+
+fn owner_state(alias: &str) -> (super::HostState, StampedInvocation) {
+    let mut state = minimal_host_state(tokio::runtime::Handle::current());
+    let principal = PrincipalId::new(alias).expect("fixture principal");
+    let uid = state
+        .principal_directory
+        .uid_for(&principal)
+        .expect("registered fixture identity");
+    let admission_stamp = StampedInvocation::from_trusted_uid(uid);
+    state.principal = principal;
+    state.stamped_invocation = Some(admission_stamp.clone());
+    (state, admission_stamp)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn recv_drains_before_same_principal_stamp_retention() {
+    let (mut state, admission_stamp) = owner_state("alice");
+    let object = identity(9);
+    let handle = state
+        .semantic_authorities
+        .admit(
+            &admission_stamp,
+            ResourceKind::SemanticObject,
+            object,
+            scope(object),
+            reservation(8),
+            options(root_rights(), None, None),
+        )
+        .expect("one fixture SemanticObject admits");
+    assert_eq!(state.semantic_authorities.tracked_count(), 1);
+    assert_eq!(state.semantic_authorities.active_reserved_units(), 8);
+
+    // The repeated alias must not turn into a retention fast path: install a
+    // live context only after the previous invocation's table is empty.
+    state.install_recv_invocation_context(&event_message(Some("alice")));
+
+    assert!(!state.semantic_authorities.tracks_handle(handle));
+    assert_eq!(state.semantic_authorities.tracked_count(), 0);
+    assert_eq!(state.semantic_authorities.active_reserved_units(), 0);
+    assert_eq!(state.semantic_authorities.released_reserved_units(), 8);
+    assert_eq!(state.semantic_authorities.allocated_slot_count(), 0);
+    assert_eq!(
+        state
+            .stamped_invocation
+            .as_ref()
+            .map(|stamp| stamp.principal()),
+        Some(admission_stamp.principal())
+    );
+}
+
+#[tokio::test]
+async fn selector_invalidation_releases_delegated_counter_after_child_first_drain() {
+    let mut state = minimal_host_state(tokio::runtime::Handle::current());
+    let admission_stamp = stamp(1);
+    let object = identity(10);
+    let selector = RevocationSelector::new(42);
+    let parent = state
+        .semantic_authorities
+        .admit(
+            &admission_stamp,
+            ResourceKind::SemanticObject,
+            object,
+            scope(object),
+            reservation(10),
+            options(root_rights(), None, Some(selector)),
+        )
+        .expect("parent fixture admits");
+    let child = state
+        .semantic_authorities
+        .attenuate(&admission_stamp, parent, Rights::READ, scope(object), 4)
+        .expect("child fixture attenuates the selected parent");
+    state
+        .semantic_authorities
+        .revoke_selector(selector)
+        .expect("selector tombstone retains its bounded domain");
+    assert_eq!(state.semantic_authorities.tracked_count(), 2);
+    assert_eq!(state.semantic_authorities.active_reserved_units(), 10);
+    assert_eq!(state.semantic_authorities.released_reserved_units(), 0);
+
+    state.semantic_authorities.prepare_for_replacement();
+
+    assert_eq!(state.semantic_authorities.tracked_count(), 0);
+    assert_eq!(state.semantic_authorities.active_reserved_units(), 0);
+    assert_eq!(state.semantic_authorities.released_reserved_units(), 10);
+    assert_eq!(state.semantic_authorities.allocated_slot_count(), 0);
+    assert!(!state.semantic_authorities.tracks_handle(parent));
+    assert!(!state.semantic_authorities.tracks_handle(child));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn epoch_invalidation_has_a_dedicated_counter_release_regression() {
+    let mut state = minimal_host_state(tokio::runtime::Handle::current());
+    let admission_stamp = stamp(2);
+    let object = identity(11);
+    let handle = state
+        .semantic_authorities
+        .admit(
+            &admission_stamp,
+            ResourceKind::SemanticObject,
+            object,
+            scope(object),
+            reservation(3),
+            options(Rights::READ, None, None),
+        )
+        .expect("epoch fixture admits");
+    let next_epoch = state
+        .semantic_authorities
+        .advance_authority_epoch()
+        .expect("checked epoch advance succeeds");
+    assert_ne!(next_epoch, AuthorityEpoch::INITIAL);
+    assert_eq!(
+        state.semantic_authorities.preflight(
+            &admission_stamp,
+            handle,
+            Rights::READ,
+            &scope(object),
+            1,
+        ),
+        Err(ResourceErrorCode::Revoked)
+    );
+
+    state.semantic_authorities.prepare_for_replacement();
+
+    assert_eq!(state.semantic_authorities.tracked_count(), 0);
+    assert_eq!(state.semantic_authorities.active_reserved_units(), 0);
+    assert_eq!(state.semantic_authorities.released_reserved_units(), 3);
+    assert_eq!(state.semantic_authorities.allocated_slot_count(), 0);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pool_return_drains_and_resets_in_both_resource_modes() {
+    for reset_resources in [false, true] {
+        let (mut state, admission_stamp) = owner_state("alice");
+        let object = identity(u8::from(reset_resources));
+        let _unused_handle = state
+            .semantic_authorities
+            .admit(
+                &admission_stamp,
+                ResourceKind::SemanticObject,
+                object,
+                scope(object),
+                reservation(5),
+                options(Rights::READ, None, None),
+            )
+            .expect("pool-state fixture admits");
+
+        clear_on_return(&mut state, reset_resources);
+
+        assert!(state.stamped_invocation.is_none());
+        assert_eq!(state.semantic_authorities.tracked_count(), 0);
+        assert_eq!(state.semantic_authorities.active_reserved_units(), 0);
+        assert_eq!(state.semantic_authorities.released_reserved_units(), 5);
+        assert_eq!(state.semantic_authorities.allocated_slot_count(), 0);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn invalidated_entries_remain_reclaimable_exactly_once() {
+    let mut state = minimal_host_state(tokio::runtime::Handle::current());
+    let admission_stamp = stamp(3);
+    let object = identity(12);
+    let handle = state
+        .semantic_authorities
+        .admit(
+            &admission_stamp,
+            ResourceKind::SemanticObject,
+            object,
+            scope(object),
+            reservation(6),
+            options(Rights::READ, None, None),
+        )
+        .expect("invalidated-reclaim fixture admits");
+
+    state
+        .semantic_authorities
+        .revoke(handle)
+        .expect("in-place invalidation marks without releasing");
+    assert_eq!(
+        state.semantic_authorities.preflight(
+            &admission_stamp,
+            handle,
+            Rights::READ,
+            &scope(object),
+            1,
+        ),
+        Err(ResourceErrorCode::Revoked)
+    );
+    assert_eq!(state.semantic_authorities.tracked_count(), 1);
+    assert_eq!(state.semantic_authorities.active_reserved_units(), 6);
+    assert_eq!(state.semantic_authorities.released_reserved_units(), 0);
+
+    state
+        .semantic_authorities
+        .reclaim(&admission_stamp, handle)
+        .expect("an invalidated entry remains reclaimable by its original stamp");
+    assert_eq!(state.semantic_authorities.tracked_count(), 0);
+    assert_eq!(state.semantic_authorities.active_reserved_units(), 0);
+    assert_eq!(state.semantic_authorities.released_reserved_units(), 6);
+    assert_eq!(
+        state.semantic_authorities.reclaim(&admission_stamp, handle),
+        Err(ResourceErrorCode::StaleGeneration)
+    );
+    assert_eq!(state.semantic_authorities.released_reserved_units(), 6);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn live_slot_pressure_fails_closed_and_reuses_reclaimed_slots() {
+    let mut state = minimal_host_state(tokio::runtime::Handle::current());
+    let admission_stamp = stamp(4);
+    let mut handles = Vec::new();
+    for index in 0..64usize {
+        let object = identity(index.try_into().expect("bounded index"));
+        let outcome = state.semantic_authorities.admit(
+            &admission_stamp,
+            ResourceKind::SemanticObject,
+            object,
+            scope(object),
+            reservation(1),
+            options(Rights::READ, None, None),
+        );
+        let Ok(handle) = outcome else {
+            panic!(
+                "live authority {index} must admit below the bound: {:?}",
+                outcome.as_ref().err()
+            );
+        };
+        handles.push(handle);
+    }
+    assert_eq!(handles.len(), 64);
+    assert_eq!(state.semantic_authorities.active_reserved_units(), 64);
+
+    let overflow_identity = identity(64);
+    assert_eq!(
+        state.semantic_authorities.admit(
+            &admission_stamp,
+            ResourceKind::SemanticObject,
+            overflow_identity,
+            scope(overflow_identity),
+            reservation(1),
+            options(Rights::READ, None, None),
+        ),
+        Err(ResourceErrorCode::Exhausted)
+    );
+
+    for handle in handles.drain(..).rev() {
+        state
+            .semantic_authorities
+            .reclaim(&admission_stamp, handle)
+            .expect("each root entry reclaims through its original stamp");
+    }
+    assert_eq!(state.semantic_authorities.active_reserved_units(), 0);
+    assert_eq!(state.semantic_authorities.released_reserved_units(), 64);
+    assert_eq!(state.semantic_authorities.allocated_slot_count(), 64);
+
+    let object = identity(u8::MAX - 191);
+    let replacement = state
+        .semantic_authorities
+        .admit(
+            &admission_stamp,
+            ResourceKind::SemanticObject,
+            object,
+            scope(object),
+            reservation(2),
+            options(Rights::READ, None, None),
+        )
+        .expect("a reclaimed slot becomes reusable within the fixed bound");
+    assert_eq!(state.semantic_authorities.allocated_slot_count(), 64);
+    assert_eq!(state.semantic_authorities.tracked_count(), 1);
+    assert_eq!(state.semantic_authorities.active_reserved_units(), 2);
+    assert!(state.semantic_authorities.tracks_handle(replacement));
+}
+
+#[tokio::test]
+async fn selector_tombstones_are_bounded_and_cleared_on_table_replacement() {
+    let mut state = minimal_host_state(tokio::runtime::Handle::current());
+    for index in 0..64u64 {
+        state
+            .semantic_authorities
+            .revoke_selector(RevocationSelector::new(index))
+            .expect("distinct selector admits below tombstone bound");
+    }
+    assert_eq!(state.semantic_authorities.revoked_selector_count(), 64);
+    assert_eq!(
+        state
+            .semantic_authorities
+            .revoke_selector(RevocationSelector::new(64)),
+        Err(ResourceErrorCode::Exhausted)
+    );
+    state
+        .semantic_authorities
+        .revoke_selector(RevocationSelector::new(0))
+        .expect("an existing tombstone can remain present at capacity");
+    assert_eq!(state.semantic_authorities.revoked_selector_count(), 64);
+
+    state.semantic_authorities.prepare_for_replacement();
+
+    assert_eq!(state.semantic_authorities.revoked_selector_count(), 0);
+    assert_eq!(state.semantic_authorities.tracked_count(), 0);
+    assert_eq!(state.semantic_authorities.active_reserved_units(), 0);
+    assert_eq!(state.semantic_authorities.allocated_slot_count(), 0);
+}

--- a/crates/astrid-capsule/src/engine/wasm/host_state_authority_tests.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host_state_authority_tests.rs
@@ -355,3 +355,42 @@ async fn selector_tombstones_are_bounded_and_cleared_on_table_replacement() {
     assert_eq!(state.semantic_authorities.active_reserved_units(), 0);
     assert_eq!(state.semantic_authorities.allocated_slot_count(), 0);
 }
+
+#[tokio::test]
+async fn attenuation_child_respects_live_authority_ceiling() {
+    let mut state = minimal_host_state(tokio::runtime::Handle::current());
+    let admission_stamp = stamp(5);
+    let mut roots = Vec::with_capacity(64);
+    for index in 0..64usize {
+        let object = identity(index.try_into().expect("bounded index"));
+        let outcome = state.semantic_authorities.admit(
+            &admission_stamp,
+            ResourceKind::SemanticObject,
+            object,
+            scope(object),
+            reservation(10),
+            options(root_rights(), None, None),
+        );
+        let Ok(root) = outcome else {
+            panic!(
+                "live authority {index} must admit below the bound: {:?}",
+                outcome.as_ref().err()
+            );
+        };
+        roots.push(root);
+    }
+
+    assert_eq!(
+        state.semantic_authorities.attenuate(
+            &admission_stamp,
+            roots[0],
+            Rights::READ,
+            scope(identity(0)),
+            1,
+        ),
+        Err(ResourceErrorCode::Exhausted)
+    );
+    assert_eq!(state.semantic_authorities.tracked_count(), 64);
+    assert_eq!(state.semantic_authorities.allocated_slot_count(), 64);
+    assert_eq!(state.semantic_authorities.active_reserved_units(), 640);
+}

--- a/crates/astrid-capsule/src/engine/wasm/host_state_hook.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host_state_hook.rs
@@ -49,6 +49,7 @@ impl HostState {
             store_meter,
             principal: astrid_core::PrincipalId::default(),
             stamped_invocation: None,
+            semantic_authorities: Default::default(),
             system_runtime: false,
             capsule_uuid: uuid::Uuid::new_v4(),
             caller_context: None,

--- a/crates/astrid-capsule/src/engine/wasm/host_state_invocation.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host_state_invocation.rs
@@ -65,6 +65,7 @@ impl HostState {
                 self.capsule_id
             )));
         };
+        self.semantic_authorities.prepare_for_replacement();
         self.stamped_invocation =
             Some(crate::stamp::StampedInvocation::from_trusted_uid(owner_uid));
         self.invocation_kv = Some(self.kv.clone());
@@ -236,6 +237,7 @@ impl HostState {
             return;
         }
 
+        self.semantic_authorities.prepare_for_replacement();
         let publisher: Option<astrid_core::PrincipalId> = msg
             .principal
             .as_deref()

--- a/crates/astrid-capsule/src/engine/wasm/host_state_types.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host_state_types.rs
@@ -1,0 +1,14 @@
+//! Support types split out of the large [`HostState`] module.
+
+/// The lifecycle phase a capsule is currently executing in.
+///
+/// Set on [`HostState`](super::host_state::HostState) during `#[install]`
+/// or `#[upgrade]` dispatch. The `astrid_elicit` host function checks this
+/// field and rejects calls outside of a lifecycle phase.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LifecyclePhase {
+    /// First-time installation.
+    Install,
+    /// Upgrading from a previous version.
+    Upgrade,
+}

--- a/crates/astrid-capsule/src/engine/wasm/mod.rs
+++ b/crates/astrid-capsule/src/engine/wasm/mod.rs
@@ -48,6 +48,11 @@ mod bind_workers;
 pub(crate) mod bindings;
 pub mod host;
 pub mod host_state;
+mod host_state_authority;
+#[cfg(test)]
+#[path = "host_state_authority_tests.rs"]
+mod host_state_authority_tests;
+mod host_state_types;
 pub mod limits;
 mod pool;
 mod storage_vfs;
@@ -2604,6 +2609,7 @@ impl ExecutionEngine for WasmEngine {
                 ),
                 principal: st_principal.clone(),
                 stamped_invocation: None,
+                semantic_authorities: Default::default(),
                 system_runtime: st_system_runtime,
                 capsule_uuid,
                 caller_context: None,
@@ -3941,6 +3947,7 @@ async fn build_lifecycle_host_state(
         resource_table: wasmtime::component::ResourceTable::new(),
         principal: principal.clone(),
         stamped_invocation: None,
+        semantic_authorities: Default::default(),
         system_runtime: false,
         capsule_uuid: uuid::Uuid::new_v4(),
         caller_context: None,

--- a/crates/astrid-capsule/src/engine/wasm/pool.rs
+++ b/crates/astrid-capsule/src/engine/wasm/pool.rs
@@ -454,7 +454,10 @@ impl Drop for PoolCheckout {
 /// capsules import zero `wasi:*` functions, so the only WASI-created handles
 /// (streams/pollables) live in the `resource_table` cleared above, not in the
 /// ctx, whose sole content is the inherited-stderr stdio config.
-fn clear_on_return(state: &mut HostState, reset_resources: bool) {
+pub(super) fn clear_on_return(state: &mut HostState, reset_resources: bool) {
+    // Reverse-drain authorities while their admission stamps are still in
+    // place, then replace the bounded table so neither lease sees prior slots.
+    state.semantic_authorities.prepare_for_replacement();
     state.caller_context = None;
     state.stamped_invocation = None;
     state.interceptor_active = false;

--- a/crates/astrid-capsule/src/engine/wasm/test_fixtures.rs
+++ b/crates/astrid-capsule/src/engine/wasm/test_fixtures.rs
@@ -104,6 +104,7 @@ pub(crate) fn minimal_host_state(rt: tokio::runtime::Handle) -> HostState {
         ),
         principal: astrid_core::PrincipalId::default(),
         stamped_invocation: None,
+        semantic_authorities: Default::default(),
         system_runtime: false,
         capsule_uuid: uuid::Uuid::new_v4(),
         caller_context: None,

--- a/crates/astrid-capsule/src/resource_authority/mod.rs
+++ b/crates/astrid-capsule/src/resource_authority/mod.rs
@@ -3,15 +3,11 @@
 //! The table is deliberately independent from the Wasmtime resource table. A
 //! [`ResourceHandle`] only names a slot in this table; it is not useful as a
 //! bearer value without the current host stamp and matching live entry.
-
-// This vertical slice is intentionally not wired into a host-state field yet;
-// its crate-private API is exercised by the sibling regressions until an
-// admission caller is selected.
 #![cfg_attr(
     not(test),
     expect(
         dead_code,
-        reason = "this staged host-only API is exercised by sibling tests before wiring"
+        reason = "cleanup lifecycle is wired; fixture-specific lookup and delegation controls await the first admission caller"
     )
 )]
 
@@ -21,21 +17,7 @@ mod table;
 #[cfg(test)]
 mod tests;
 
-#[cfg_attr(
-    not(test),
-    expect(
-        unused_imports,
-        reason = "crate-private re-exports reserve the staged table API for its future caller"
-    )
-)]
-pub(crate) use scope::{
-    AdmissionOptions, Reservation, ResourceHandle, ResourceScope, RevocationSelector,
-};
-#[cfg_attr(
-    not(test),
-    expect(
-        unused_imports,
-        reason = "crate-private re-export reserves the staged table API for its future caller"
-    )
-)]
+pub(crate) use scope::ResourceHandle;
+#[cfg(test)]
+pub(crate) use scope::{AdmissionOptions, Reservation, ResourceScope, RevocationSelector};
 pub(crate) use table::ResourceAuthorityTable;

--- a/crates/astrid-capsule/src/resource_authority/table.rs
+++ b/crates/astrid-capsule/src/resource_authority/table.rs
@@ -10,12 +10,18 @@ use astrid_resource_types::{
 use crate::stamp::StampedInvocation;
 
 use super::scope::{
-    AdmissionOptions, Reservation, ResourceAuthority, ResourceHandle, ResourceScope,
-    RevocationSelector, SemanticObject,
+    AdmissionOptions, MAX_SCOPE_OBJECTS, Reservation, ResourceAuthority, ResourceHandle,
+    ResourceScope, RevocationSelector, SemanticObject,
 };
 
 /// Maximum delegation depth checked while resolving a live child.
 const MAX_LINEAGE_DEPTH: usize = 64;
+/// Reuse the existing per-scope object ceiling as the per-table live ceiling.
+///
+/// This is a host-side containment bound, not an operator policy knob.
+const MAX_LIVE_AUTHORITY_SLOTS: usize = MAX_SCOPE_OBJECTS;
+/// A distinct invalidator may address every bounded live authority once.
+const MAX_REVOCATION_SELECTORS: usize = MAX_SCOPE_OBJECTS;
 
 #[derive(Debug)]
 struct Slot {
@@ -82,6 +88,18 @@ impl ResourceAuthorityTable {
     #[must_use]
     pub(crate) const fn released_reserved_units(&self) -> u128 {
         self.released_reserved_units
+    }
+
+    /// Number of table-local slot records allocated by this instance.
+    #[must_use]
+    pub(crate) const fn slot_count(&self) -> usize {
+        self.slots.len()
+    }
+
+    /// Number of retained selector tombstones in this instance.
+    #[must_use]
+    pub(crate) fn revoked_selector_count(&self) -> usize {
+        self.revoked_selectors.len()
     }
 
     /// Admit one invocation-scoped [`ResourceKind::SemanticObject`].
@@ -267,6 +285,12 @@ impl ResourceAuthorityTable {
         &mut self,
         selector: RevocationSelector,
     ) -> Result<(), ResourceErrorCode> {
+        if self.revoked_selectors.contains(&selector) {
+            return Ok(());
+        }
+        if self.revoked_selectors.len() >= MAX_REVOCATION_SELECTORS {
+            return Err(ResourceErrorCode::Exhausted);
+        }
         self.revoked_selectors.insert(selector);
         Ok(())
     }
@@ -314,7 +338,17 @@ impl ResourceAuthorityTable {
         {
             return Err(ResourceErrorCode::Exhausted);
         }
+        if self.live_authority_count() >= MAX_LIVE_AUTHORITY_SLOTS {
+            return Err(ResourceErrorCode::Exhausted);
+        }
         Ok(())
+    }
+
+    fn live_authority_count(&self) -> usize {
+        self.slots
+            .iter()
+            .filter(|slot| !slot.retired && slot.authority.is_some())
+            .count()
     }
 
     fn reserve_units(&mut self, units: u64) -> Result<(), ResourceErrorCode> {

--- a/crates/astrid-capsule/src/resource_authority/table.rs
+++ b/crates/astrid-capsule/src/resource_authority/table.rs
@@ -113,8 +113,8 @@ impl ResourceAuthorityTable {
         options: AdmissionOptions,
     ) -> Result<ResourceHandle, ResourceErrorCode> {
         self.validate_admission(kind, identity, &scope, &options, reservation.remaining)?;
+        let handle = self.allocate_slot()?;
         self.reserve_units(reservation.remaining)?;
-        let handle = self.allocate_slot();
         let authority = ResourceAuthority {
             kind,
             identity,
@@ -205,7 +205,7 @@ impl ResourceAuthorityTable {
         let requested_scope = scope.borrow().clone();
         let snapshot = self.delegation_snapshot(stamp, parent)?;
         self.validate_delegation(&snapshot, rights, &requested_scope, budget, expiry)?;
-        let handle = self.allocate_slot();
+        let handle = self.allocate_slot()?;
         self.debit_parent(parent, budget)?;
         let authority = ResourceAuthority {
             kind: snapshot.kind,
@@ -338,9 +338,6 @@ impl ResourceAuthorityTable {
         {
             return Err(ResourceErrorCode::Exhausted);
         }
-        if self.live_authority_count() >= MAX_LIVE_AUTHORITY_SLOTS {
-            return Err(ResourceErrorCode::Exhausted);
-        }
         Ok(())
     }
 
@@ -359,24 +356,27 @@ impl ResourceAuthorityTable {
         Ok(())
     }
 
-    fn allocate_slot(&mut self) -> ResourceHandle {
+    fn allocate_slot(&mut self) -> Result<ResourceHandle, ResourceErrorCode> {
+        if self.live_authority_count() >= MAX_LIVE_AUTHORITY_SLOTS {
+            return Err(ResourceErrorCode::Exhausted);
+        }
         if let Some((slot, entry)) = self
             .slots
             .iter()
             .enumerate()
             .find(|(_, entry)| !entry.retired && entry.authority.is_none())
         {
-            return ResourceHandle {
+            return Ok(ResourceHandle {
                 slot,
                 generation: entry.generation,
-            };
+            });
         }
         let slot = self.slots.len();
         self.slots.push(Slot::new());
-        ResourceHandle {
+        Ok(ResourceHandle {
             slot,
             generation: ObjectGeneration::INITIAL,
-        }
+        })
     }
 
     fn slot_authority(

--- a/crates/astrid-capsule/src/resource_authority/tests.rs
+++ b/crates/astrid-capsule/src/resource_authority/tests.rs
@@ -412,3 +412,47 @@ fn live_authority_surface_has_no_serialization_or_descriptor_constructor() {
     assert!(!source.contains("impl From<BudgetId> for Reservation"));
     assert!(!source.contains("impl From<AccountId> for Reservation"));
 }
+
+#[test]
+fn attenuation_child_respects_live_authority_ceiling() {
+    let owner = stamp(7);
+    let mut table = ResourceAuthorityTable::new();
+    let mut roots = Vec::with_capacity(64);
+    for index in 0..64u8 {
+        let object = identity(index);
+        let outcome = table.admit(
+            &owner,
+            ResourceKind::SemanticObject,
+            object,
+            ResourceScope::singleton(object),
+            reservation(10),
+            options(
+                rights(Rights::READ.bits() | Rights::DELEGATE.bits()),
+                None,
+                None,
+            ),
+        );
+        let Ok(root) = outcome else {
+            panic!(
+                "live authority {index} must admit below the bound: {:?}",
+                outcome.as_ref().err()
+            );
+        };
+        roots.push(root);
+    }
+
+    let parent = roots[0];
+    assert_eq!(
+        table.attenuate(
+            &owner,
+            parent,
+            Rights::READ,
+            ResourceScope::singleton(identity(0)),
+            1,
+        ),
+        Err(ResourceErrorCode::Exhausted)
+    );
+    assert_eq!(table.slot_count(), 64);
+    assert_eq!(table.active_reserved_units(), 640);
+    assert!(roots.iter().all(|root| table.lookup(&owner, *root).is_ok()));
+}


### PR DESCRIPTION
Closes #1683
Tracking #1564

## Linked Issue

Closes #1683
Tracking #1564

## Summary

Private HostState ResourceAuthority lifecycle for one invocation-scoped SemanticObject fixture. Live wrappers retain their admission stamps, drain children first on attribution or publisher replacement, and reclaim occupancy through bounded live-slot and selector-tombstone tables.

The branch head is a signed no-fast-forward merge with live `os/universal` `695befb7998f64ca2c47b4b0806f0aab78778be2` as first parent and accepted content `b958ee199a3c34e74a8b5746365a14597c438d98` as second parent. Resulting tree is `e94a69cf51844342410a2d9b5e78a20c8ca865f4`.

## Changes

- Adds a crate-private HostState authority wrapper that tracks admitted handles with their stamps and drains children before parents.
- Enforces the 64 live-authority occupancy bound on every allocation path, including attenuation children; a 65th live allocation returns Exhausted without growing slots or tracked handles.
- Bounds distinct selector tombstones at 64; a new selector at capacity returns Exhausted, while repeated revocation of an already-present selector remains Ok and neither grows state nor restores authority.
- Reclaims occupancy on pool return, run-loop drain, and Drop. HostState admission/preflight/attenuation remain fixture-only in this change.

## Verification

- GPG-signed merge and content commits with matching DCO
- Unique ancestry versus live `os/universal`: merge `ec9688d49baffd4fe7085af936c876ea44ee8b88` and content `b958ee199a3c34e74a8b5746365a14597c438d98`
- Unique files versus first parent: 13 HostState/ResourceAuthority files plus `changes/1683.added.md`; content blobs match the accepted second parent
- `cargo +1.95.0 test --locked -p astrid-capsule --lib -- resource_authority::tests host_state_authority_tests`
- `cargo +1.95.0 test --locked -p astrid-capsule --lib`
- `cargo +1.95.0 clippy --locked -p astrid-capsule --all-targets --all-features -- -D warnings`
- `cargo +1.95.0 fmt --all -- --check`
- Independent exact-head integration-preservation review ACCEPT on `ec9688d4`

## Residuals

- HostState admission remains fixture-only; this change does not claim live FileHandle, ServiceLease, provider, projection, Realm, or public WIT authority.
- Landing must stay a trunk-first no-fast-forward merge from then-live `os/universal`. If trunk moves before merge, rebuild the vehicle rather than fast-forwarding this head.
- Direct `remaining_budget()` assertion on the table test is not present; occupancy, slot, tracked-handle, and reservation unchanged-state regressions cover the occupancy gate.

## AI / Tool Assistance

Assisted-by: Codex

The HostState wrapper, occupancy bound, landing merge, and changelog fragment were produced with coding-agent assistance. Parent, tree identity, GPG/DCO, and focused tests were independently inspected.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/{issue}.{kind}.md` (docs/CI-only may skip; release PRs roll fragments into the version section instead of adding one)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
