### PR TITLE
fix(bootloader): derive deterministic GPT identities

### DIFF
--- a/changes/1663.fixed.md
+++ b/changes/1663.fixed.md
@@ -1,0 +1,4 @@
+Pin deterministic, role-typed GPT disk and ESP identifiers in the native
+emulator image packager so sequential kimage invocations produce byte-identical
+UEFI disks. Random UUID v4 uniqueness fields are replaced, not erased.
+Closes #1663

--- a/kernel/Cargo.lock
+++ b/kernel/Cargo.lock
@@ -119,6 +119,7 @@ dependencies = [
  "llvm-tools",
  "serde_json",
  "tempfile",
+ "uuid",
 ]
 
 [[package]]
@@ -585,6 +586,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -683,6 +690,7 @@ checksum = "f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc"
 dependencies = [
  "getrandom",
  "js-sys",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 

--- a/kernel/README.md
+++ b/kernel/README.md
@@ -140,9 +140,10 @@ the parent target lock.
 
 No KVM, virtio/IOMMU, DMA, bare-metal/no-host, physical ownership, A/B
 persistence, first-owner, services, Wasmtime, filesystem, Linux, or
-Hermes claim. Timing is not evidence. Image determinism is reported
-honestly: `DETERMINISM: FAIL` does not fail boot assertions and is not
-coerced to PASS.
+Hermes claim. Timing is not evidence. Sequential emulator-image
+packaging determinism is reported as an independent result:
+`DETERMINISM: PASS` does not strengthen boot assertions and is not
+coerced into them.
 
 The pre-relocation hook and ring 0 compile only the emulator-fixture **root
 public key** and minimum generation/floors. The loader measures the original
@@ -171,8 +172,8 @@ remain untrusted advertisements.
   with `CARGO_TARGET_DIR=target/bootloader-nested` so nested
   `cargo install -Zbuild-std` cannot deadlock on the parent lock.
 
-`./run.sh` is the QEMU evidence. Image determinism is reported honestly
-and remains FAIL.
+`./run.sh` is the QEMU evidence. Sequential native emulator-image
+packaging determinism reports `PASS`.
 
 ### CI
 
@@ -182,9 +183,9 @@ requests targeting `os/universal`. It installs stable 1.95.0 plus
 invokes `./check.sh` plus `./run.sh`. It does not install rolling
 `nightly`. Root `ci.yml` still targets `main` and does not ingest this
 nested workspace. Do not run `cargo clippy --workspace` here.
-`DETERMINISM: FAIL` is reported by the QEMU job and is not a
-boot-assertion gate. That job is emulator evidence only and preserves
-the non-claims above.
+The QEMU job reports `DETERMINISM: PASS` for sequential native
+emulator-image packaging and does not treat it as a boot-assertion gate.
+That job is emulator evidence only and preserves the non-claims above.
 
 ## Toolchain
 

--- a/kernel/tools/bootloader/Cargo.lock
+++ b/kernel/tools/bootloader/Cargo.lock
@@ -111,6 +111,7 @@ dependencies = [
  "mbrman",
  "serde_json",
  "tempfile",
+ "uuid",
 ]
 
 [[package]]
@@ -831,6 +832,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1032,6 +1039,7 @@ checksum = "f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 

--- a/kernel/tools/bootloader/Cargo.toml
+++ b/kernel/tools/bootloader/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "3"
 [features]
 default = ["bios", "uefi"]
 bios = ["dep:mbrman"]
-uefi = ["dep:gpt"]
+uefi = ["dep:gpt", "dep:uuid"]
 
 [dependencies]
 anyhow = "1.0.32"
@@ -25,6 +25,7 @@ fatfs = { version = "0.3.4", default-features = false, features = [
 tempfile = "3.27.0"
 mbrman = { version = "0.5.1", optional = true }
 gpt = { version = "3.0.0", optional = true }
+uuid = { version = "=1.25.0", default-features = false, features = ["v5"], optional = true }
 bootloader-boot-config = { path = "common/config", version = "0.11.16" }
 serde_json = "1.0.91"
 

--- a/kernel/tools/bootloader/src/gpt.rs
+++ b/kernel/tools/bootloader/src/gpt.rs
@@ -1,9 +1,63 @@
 use anyhow::Context;
 use std::{
+    collections::BTreeMap,
     fs::{self, File},
     io::{self, Seek},
     path::Path,
 };
+use uuid::Uuid;
+
+/// Scheme namespace for emulator GPT identifiers (UUID v5 over DNS).
+const GPT_SCHEME_DNS_NAME: &[u8] = b"astrid.kimage.gpt.v1";
+const DISK_GUID_NAME: &[u8] = b"astrid.kimage.gpt.disk.v1";
+const ESP_GUID_NAME: &[u8] = b"astrid.kimage.gpt.esp.v1";
+
+/// Deterministic GPT disk GUID. Not interchangeable with [`EspPartitionGuid`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct GptDiskGuid(Uuid);
+
+/// Deterministic EFI system-partition GUID. Not interchangeable with [`GptDiskGuid`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct EspPartitionGuid(Uuid);
+
+fn gpt_scheme_namespace() -> Uuid {
+    Uuid::new_v5(&Uuid::NAMESPACE_DNS, GPT_SCHEME_DNS_NAME)
+}
+
+impl GptDiskGuid {
+    fn derive() -> Self {
+        Self(Uuid::new_v5(&gpt_scheme_namespace(), DISK_GUID_NAME))
+    }
+
+    fn as_uuid(self) -> Uuid {
+        self.0
+    }
+}
+
+impl EspPartitionGuid {
+    fn derive() -> Self {
+        Self(Uuid::new_v5(&gpt_scheme_namespace(), ESP_GUID_NAME))
+    }
+
+    fn as_uuid(self) -> Uuid {
+        self.0
+    }
+}
+
+fn assign_esp_guid(
+    gpt: &mut gpt::GptDisk<'_>,
+    partition_id: u32,
+    guid: EspPartitionGuid,
+) -> anyhow::Result<()> {
+    let mut partitions: BTreeMap<_, _> = gpt.partitions().clone();
+    let Some(partition) = partitions.get_mut(&partition_id) else {
+        anyhow::bail!("boot partition {partition_id} missing after creation");
+    };
+    partition.part_guid = guid.as_uuid();
+    gpt.update_partitions(partitions)
+        .context("failed to apply deterministic ESP GUID")?;
+    Ok(())
+}
 
 pub fn create_gpt_disk(fat_image: &Path, out_gpt_path: &Path) -> anyhow::Result<()> {
     // create new file
@@ -31,21 +85,22 @@ pub fn create_gpt_disk(fat_image: &Path, out_gpt_path: &Path) -> anyhow::Result<
     mbr.overwrite_lba0(&mut disk)
         .context("failed to write protective MBR")?;
 
-    // create new GPT structure
+    // create new GPT structure with a role-typed disk GUID (never v4).
     let block_size = gpt::disk::LogicalBlockSize::Lb512;
     let mut gpt = gpt::GptConfig::new()
         .writable(true)
         .initialized(false)
         .logical_block_size(block_size)
-        .create_from_device(Box::new(&mut disk), None)
+        .create_from_device(Box::new(&mut disk), Some(GptDiskGuid::derive().as_uuid()))
         .context("failed to create GPT structure in file")?;
     gpt.update_partitions(Default::default())
         .context("failed to update GPT partitions")?;
 
-    // add new EFI system partition and get its byte offset in the file
+    // add new EFI system partition and replace the crate-generated v4 part GUID
     let partition_id = gpt
         .add_partition("boot", partition_size, gpt::partition_types::EFI, 0, None)
         .context("failed to add boot EFI partition")?;
+    assign_esp_guid(&mut gpt, partition_id, EspPartitionGuid::derive())?;
     let partition = gpt
         .partitions()
         .get(&partition_id)
@@ -67,4 +122,84 @@ pub fn create_gpt_disk(fat_image: &Path, out_gpt_path: &Path) -> anyhow::Result<
     .context("failed to copy FAT image to GPT disk")?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gpt::disk::LogicalBlockSize;
+    use std::io::Write;
+    use uuid::{Variant, Version};
+
+    /// Pins the SHA-1 inputs independently so an accidental domain rename
+    /// cannot silently mint a new, stable identifier.
+    const GPT_SCHEME_NAMESPACE_HEX: &str = "d08462a2-13e1-5f24-8aef-4ade5bc98a45";
+    const DISK_GUID_HEX: &str = "f0fe4d2d-e958-51f8-8ce5-a4c5c468df58";
+    const ESP_GUID_HEX: &str = "f7a06508-bd91-5466-8e4c-b042a0c951c4";
+
+    fn pinned_uuid(hex: &str) -> Uuid {
+        Uuid::try_parse(hex).expect("pinned test UUID parses")
+    }
+
+    fn write_blank_fat(path: &Path, len: u64) -> anyhow::Result<()> {
+        let mut file = fs::OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .open(path)?;
+        file.set_len(len)?;
+        file.write_all(&[0u8; 512])?;
+        Ok(())
+    }
+
+    #[test]
+    fn disk_and_esp_guids_are_distinct_v5_roles() {
+        let disk = GptDiskGuid::derive();
+        let esp = EspPartitionGuid::derive();
+        assert_eq!(
+            gpt_scheme_namespace(),
+            pinned_uuid(GPT_SCHEME_NAMESPACE_HEX)
+        );
+        assert_eq!(disk, GptDiskGuid::derive());
+        assert_eq!(esp, EspPartitionGuid::derive());
+        assert_eq!(disk.as_uuid(), pinned_uuid(DISK_GUID_HEX));
+        assert_eq!(esp.as_uuid(), pinned_uuid(ESP_GUID_HEX));
+        assert_ne!(disk.as_uuid(), esp.as_uuid());
+        assert_ne!(disk.as_uuid(), Uuid::nil());
+        assert_ne!(esp.as_uuid(), Uuid::nil());
+        assert_eq!(disk.as_uuid().get_version(), Some(Version::Sha1));
+        assert_eq!(esp.as_uuid().get_version(), Some(Version::Sha1));
+        assert_eq!(disk.as_uuid().get_variant(), Variant::RFC4122);
+        assert_eq!(esp.as_uuid().get_variant(), Variant::RFC4122);
+    }
+
+    #[test]
+    fn create_gpt_disk_is_byte_identical_and_crc_valid() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let fat = dir.path().join("fat.bin");
+        write_blank_fat(&fat, 1024 * 1024).expect("fat");
+        let image_a = dir.path().join("a.img");
+        let image_b = dir.path().join("b.img");
+        create_gpt_disk(&fat, &image_a).expect("gpt a");
+        create_gpt_disk(&fat, &image_b).expect("gpt b");
+        let bytes_a = fs::read(&image_a).expect("read a");
+        let bytes_b = fs::read(&image_b).expect("read b");
+        assert_eq!(bytes_a, bytes_b, "GPT packaging must be deterministic");
+
+        let mut file = File::open(&image_a).expect("open gpt");
+        let opened = gpt::GptConfig::new()
+            .writable(false)
+            .initialized(true)
+            .logical_block_size(LogicalBlockSize::Lb512)
+            .open_from_device(Box::new(&mut file) as gpt::DiskDeviceObject)
+            .expect("primary/backup GPT CRC must validate");
+        assert_eq!(*opened.guid(), pinned_uuid(DISK_GUID_HEX));
+        let esp = opened
+            .partitions()
+            .values()
+            .find(|part| part.part_guid == pinned_uuid(ESP_GUID_HEX))
+            .expect("ESP unique GUID must be present and readable");
+        assert_eq!(esp.name, "boot");
+        assert!(esp.bytes_start(LogicalBlockSize::Lb512).expect("start") > 0);
+    }
 }


### PR DESCRIPTION
## Linked Issue

Closes #1663
Tracking #1564

## Summary

Sequential native emulator UEFI images from identical inputs were byte-divergent because GPT disk and ESP identifiers were random. This change derives role-typed, domain-separated UUIDv5 identities so two sequential `kimage` builds in the same tree are byte-identical, while QEMU boot assertions stay independent.

## Changes

- Nested bootloader GPT packaging now uses `GptDiskGuid` and `EspPartitionGuid` newtypes over UUIDv5 (`astrid.kimage.gpt.v1` scheme, distinct `disk.v1` / `esp.v1` roles).
- Extractable regressions pin the two identities, reject nil/shared GUIDs, and require byte-identical sequential GPT images with valid primary/backup CRCs.
- Changelog fragment `changes/1663.fixed.md`.
- `kernel/README.md` now reports `DETERMINISM: PASS` for sequential emulator-image packaging and keeps it independent of boot assertions.

## Verification

- `cargo test -p bootloader --locked --lib --no-default-features --features uefi` under `nightly-2026-07-21`: 2/2 pass.
- `kernel/check.sh x86`: PASS.
- `python3 scripts/changelog.py check --base ce05384cae795c41f3086e31f75ee3a35cff425b --head 13ed338c3af08f1d6ccb3c8683ac14a5ae1d2c1b`: pass.
- Sequential `kernel/run.sh`: `DETERMINISM: PASS`, independent QEMU TCG assertions PASS, exit 33.
- Hosted Native kernel workflow on this PR: Native split checks PASS, compile-only semantic targets PASS, QEMU TCG boot PASS (`DETERMINISM: PASS`, blake3 `55961a452ced4af8a465fd91bdafa351bfb8ae7ecd8a919e9a5be57c5599b471`, TCG explicit).

## AI / Tool Assistance

Assisted-by: Codex:GLM-5.3-flash
Implementation of deterministic GPT identities, regressions, changelog, and README honesty. Independent exact-head review, sequential kimage/QEMU counter-run, and hosted Native kernel CI were used to validate the result. No model, task, or coordination metadata is in the commits.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/{issue}.{kind}.md` (docs/CI-only may skip; release PRs roll fragments into the version section instead of adding one)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
