### PR TITLE
feat(config): add orcarouter as a first-class LLM provider

### DIFF
--- a/changes/1716.added.md
+++ b/changes/1716.added.md
@@ -1,0 +1,1 @@
+`orcarouter` is now a first-class `[model].provider` value in `astrid-config`, on par with `claude`, `openai`, `openai-compat`, and `zai`. The provider enum in config validation accepts it, `ORCAROUTER_API_KEY` falls back to `model.api_key` like the other provider keys, and the `[model]` docs list it. Closes #1716.

--- a/crates/astrid-config/src/defaults.toml
+++ b/crates/astrid-config/src/defaults.toml
@@ -16,7 +16,8 @@
 # Controls which LLM provider and model to use, along with generation settings.
 
 [model]
-# LLM provider to use. Currently supported: "claude"
+# LLM provider to use. Currently supported: "claude", "openai", "openai-compat",
+# "orcarouter", "zai"
 provider = "unknown"
 
 # Model identifier. Examples:
@@ -27,7 +28,9 @@ model = "unknown"
 
 # API key for the provider. If not set here, will be read from:
 # - ANTHROPIC_API_KEY environment variable (for Claude)
-# - OPENAI_API_KEY environment variable (for OpenAI, future)
+# - OPENAI_API_KEY environment variable (for OpenAI)
+# - ORCAROUTER_API_KEY environment variable (for OrcaRouter)
+# - ZAI_API_KEY environment variable (for Z.AI)
 # api_key = ""
 
 # Custom API endpoint URL. Leave empty to use provider's default.

--- a/crates/astrid-config/src/env.rs
+++ b/crates/astrid-config/src/env.rs
@@ -103,6 +103,11 @@ const ENV_MAPPINGS: &[EnvMapping] = &[
         var_name: "ZAI_API_KEY",
         field_path: "model.api_key",
     },
+    // OrcaRouter env var.
+    EnvMapping {
+        var_name: "ORCAROUTER_API_KEY",
+        field_path: "model.api_key",
+    },
     // OpenAI env var.
     EnvMapping {
         var_name: "OPENAI_API_KEY",
@@ -422,6 +427,21 @@ mod tests {
         apply_env_fallbacks(&mut merged, &mut sources, &env);
 
         assert_eq!(merged["model"]["api_key"].as_str().unwrap(), "sk-ant-test");
+    }
+
+    #[test]
+    fn test_orcarouter_api_key_fallback() {
+        let mut merged: toml::Value = toml::from_str("[model]").unwrap();
+        let mut sources = FieldSources::new();
+        let env = make_env(&[("ORCAROUTER_API_KEY", "orc-test-key")]);
+
+        apply_env_fallbacks(&mut merged, &mut sources, &env);
+
+        assert_eq!(merged["model"]["api_key"].as_str().unwrap(), "orc-test-key");
+        assert_eq!(
+            sources.get("model.api_key"),
+            Some(&ConfigLayer::Environment)
+        );
     }
 
     // ---- Restricted ${VAR} resolution tests ----

--- a/crates/astrid-config/src/validate.rs
+++ b/crates/astrid-config/src/validate.rs
@@ -38,12 +38,12 @@ fn validate_model(config: &Config) -> ConfigResult<()> {
 
     if !matches!(
         m.provider.as_str(),
-        "claude" | "openai" | "openai-compat" | "zai" | "unknown"
+        "claude" | "openai" | "openai-compat" | "orcarouter" | "zai" | "unknown"
     ) {
         return Err(ConfigError::ValidationError {
             field: "model.provider".to_owned(),
             message: format!(
-                "unsupported provider '{}'; expected one of: claude, openai, openai-compat, zai, unknown",
+                "unsupported provider '{}'; expected one of: claude, openai, openai-compat, orcarouter, zai, unknown",
                 m.provider
             ),
         });
@@ -436,6 +436,13 @@ mod tests {
         config.model.provider = "grok".to_owned();
         let err = validate(&config).unwrap_err();
         assert!(matches!(err, ConfigError::ValidationError { .. }));
+    }
+
+    #[test]
+    fn test_orcarouter_provider_is_valid() {
+        let mut config = Config::default();
+        config.model.provider = "orcarouter".to_owned();
+        assert!(validate(&config).is_ok());
     }
 
     #[test]

--- a/docs/config.md
+++ b/docs/config.md
@@ -67,7 +67,7 @@ output_per_million = 15.0
 
 | Field | Type | Description |
 |---|---|---|
-| `provider` | string | The model provider (e.g., `"claude"`). |
+| `provider` | string | The model provider (`"claude"`, `"openai"`, `"openai-compat"`, `"orcarouter"`, `"zai"`). |
 | `model` | string | The model identifier sent to the API. |
 | `max_tokens` | integer | Maximum tokens to generate per response. |
 | `temperature` | float | Sampling temperature (0.0 - 1.0). |


### PR DESCRIPTION
## Linked Issue

Closes #1716

## Summary

Adding `orcarouter` as a first-class value of the `[model].provider` field means Astrid users can select an OrcaRouter gateway the same way they already select `claude`, `openai`, `openai-compat`, or `zai` - validated by `astrid config`, with the credential picked up from the `ORCAROUTER_API_KEY` env fallback - instead of treating it as an anonymous custom `api_url` override.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models - but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a named provider means Astrid's provider namespace can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint - screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Changes

- `crates/astrid-config/src/validate.rs` - accept `orcarouter` in the `[model].provider` allow-list.
- `crates/astrid-config/src/env.rs` - `ORCAROUTER_API_KEY` falls back to `model.api_key`, mirroring `OPENAI_API_KEY` / `ZAI_API_KEY`; unit test added.
- `crates/astrid-config/src/defaults.toml`, `docs/config.md` - document the new provider and env key.
- `changes/1716.added.md` - changelog fragment.

## Verification

- `cargo test -p astrid-config` - 120 tests pass (including the two new ones).
- `cargo fmt -p astrid-config -- --check` and `cargo clippy -p astrid-config --all-targets` - clean.
- Live-tested the endpoint this config targets: `POST https://api.orcarouter.ai/v1/chat/completions` with a real key returns HTTP 200 for both `openai/gpt-5.5` and the `orcarouter/auto` smart router.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.

## AI / Tool Assistance

Assisted-by: Claude Code (Claude Opus). This PR was implemented and validated with tool assistance; the contributor reviewed the complete diff, ran the local test/lint suite, and live-tested the OrcaRouter endpoint before submitting.
