### PR TITLE
Tracking #1708: landable hosted-profile ancestry

### DIFF
--- a/.github/workflows/oci-amd64.yml
+++ b/.github/workflows/oci-amd64.yml
@@ -96,7 +96,17 @@ jobs:
             --output dist/oci-amd64
           ARCHIVE_SHA256=$(python3 -c \
             'import json; print(json.load(open("dist/oci-amd64/release-receipt.json"))["archive-sha256"])')
-          echo "ARCHIVE_SHA256=$ARCHIVE_SHA256" >> "$GITHUB_ENV"
+          ARCHIVE_BLAKE3=$(python3 -c \
+            'import json; print(json.load(open("dist/oci-amd64/release-receipt.json"))["archive-blake3"])')
+          RELEASE_MANIFEST_SHA256=$(python3 -c \
+            'import json; print(json.load(open("dist/oci-amd64/release-receipt.json"))["release-manifest-sha256"])')
+          RELEASE_RECEIPT_SHA256=$(sha256sum dist/oci-amd64/release-receipt.json | cut -d ' ' -f 1)
+          {
+            echo "ARCHIVE_SHA256=$ARCHIVE_SHA256"
+            echo "ARCHIVE_BLAKE3=$ARCHIVE_BLAKE3"
+            echo "RELEASE_MANIFEST_SHA256=$RELEASE_MANIFEST_SHA256"
+            echo "RELEASE_RECEIPT_SHA256=$RELEASE_RECEIPT_SHA256"
+          } >> "$GITHUB_ENV"
 
       - name: Check out pinned compatible uplink fixture
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -153,6 +163,9 @@ jobs:
             --build-arg "ASTRID_VERSION=$VERSION" \
             --build-arg "ASTRID_SOURCE_COMMIT=$SOURCE_COMMIT" \
             --build-arg "ASTRID_ARCHIVE_SHA256=$ARCHIVE_SHA256" \
+            --build-arg "ASTRID_ARCHIVE_BLAKE3=$ARCHIVE_BLAKE3" \
+            --build-arg "ASTRID_RELEASE_MANIFEST_SHA256=$RELEASE_MANIFEST_SHA256" \
+            --build-arg "ASTRID_RELEASE_RECEIPT_SHA256=$RELEASE_RECEIPT_SHA256" \
             --tag "$IMAGE" \
             --file container/amd64/Dockerfile \
             --output "type=oci,dest=dist/astrid-${VERSION}-amd64.oci.tar" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,19 +9,6 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ## [Unreleased]
 
-### Changed
-
-- **The Linux amd64 OCI qualification now fails closed at its exact release
-  baseline instead of inventing unsupported evidence.** The hosted harness
-  rejects inherited sandbox/local-IP policy overrides, proves the daemon is
-  PID 1 as UID/GID `65532`, replaces same-container restart with a fresh
-  container opening the same state/workspace mounts, verifies distinct
-  principal owner state and exact self-scoped agent listings across that
-  reopen, and uses a real restricted principal for denial coverage. It
-  documents shared UID/state-mount key custody and stops with a precise
-  blocker because pinned Astrid v0.10.4 exposes no supported audit
-  chain/head/principal query. Tracking #1708.
-
 ### Fixed
 
 - **`astrid status` and `astrid mcp serve` no longer treat an unlinked

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ## [Unreleased]
 
+### Changed
+
+- **The Linux amd64 OCI qualification now fails closed at its exact release
+  baseline instead of inventing unsupported evidence.** The hosted harness
+  rejects inherited sandbox/local-IP policy overrides, proves the daemon is
+  PID 1 as UID/GID `65532`, replaces same-container restart with a fresh
+  container opening the same state/workspace mounts, verifies distinct
+  principal owner state and exact self-scoped agent listings across that
+  reopen, and uses a real restricted principal for denial coverage. It
+  documents shared UID/state-mount key custody and stops with a precise
+  blocker because pinned Astrid v0.10.4 exposes no supported audit
+  chain/head/principal query. Tracking #1708.
+
 ### Fixed
 
 - **`astrid status` and `astrid mcp serve` no longer treat an unlinked

--- a/changes/1708.added.md
+++ b/changes/1708.added.md
@@ -1,7 +1,12 @@
-Add a bounded signed Linux amd64 hosted-profile qualification. The OCI
+Add a bounded signed Linux amd64 hosted-profile evidence harness. The OCI
 profile verifies release/source/archive provenance, starts a real non-root
-daemon under restricted container privileges, and exercises restart persistence
-with two isolated principals, workspaces, capability groups, and audit state.
-Tampered, missing, mismatched, or path-swapped shuttles fail before daemon
-startup; Linux UID and path identity cannot mint Astrid authority. Tracking
-#1708, #1706, and #1564
+PID 1 daemon under restricted container privileges, and proves persistence in
+a fresh container on shared state/workspace mounts with two principals,
+distinct direct owner-state artifacts, and one durable workspace. Tampered,
+missing, mismatched, or path-swapped shuttles fail before daemon startup.
+Host UID/path alone cannot mint a new Astrid principal or grant, but a
+state-mount reader can wield existing principal keys.
+The pinned v0.10.4 audit surface is a deferred stub without a supported
+chain/head or principal-scoped query, so its status is recorded as a
+non-gating blocked audit probe and the harness does not claim audit continuity
+or hosted-profile qualification. Tracking #1708, #1706, and #1564

--- a/changes/1708.added.md
+++ b/changes/1708.added.md
@@ -7,8 +7,10 @@ missing, mismatched, or path-swapped shuttles fail before daemon startup.
 Host UID/path alone cannot mint a new Astrid principal or grant, but a
 state-mount reader can wield existing principal keys.
 The pinned v0.10.4 audit surface is a deferred stub without a supported
-chain/head or principal-scoped query, so its status is recorded as a
-non-gating blocked audit probe and the harness does not claim audit continuity
-or hosted-profile qualification. Release identity binds use receipt object
-fields rather than final-comma line matches. PID1 identity parses tab-delimited
-proc-status fields. Tracking #1708, #1706, and #1564
+chain/head or principal-scoped query. The harness registers its pinned
+TEST_SOURCE_COMMIT=b6bf5d1d579915eb5d3c944857d84e62a4fcc878 two-line status-2
+stderr byte-for-byte as a non-gating blocked audit probe; any status or byte
+drift fails closed and requires exact-release re-evaluation. It does not claim
+audit continuity or hosted-profile qualification. Release identity binds use
+receipt object fields rather than final-comma line matches. PID1 identity
+parses tab-delimited proc-status fields. Tracking #1708, #1706, and #1564

--- a/changes/1708.added.md
+++ b/changes/1708.added.md
@@ -1,0 +1,7 @@
+Add a bounded signed Linux amd64 hosted-profile qualification. The OCI
+profile verifies release/source/archive provenance, starts a real non-root
+daemon under restricted container privileges, and exercises restart persistence
+with two isolated principals, workspaces, capability groups, and audit state.
+Tampered, missing, mismatched, or path-swapped shuttles fail before daemon
+startup; Linux UID and path identity cannot mint Astrid authority. Tracking
+#1708, #1706, and #1564

--- a/changes/1708.added.md
+++ b/changes/1708.added.md
@@ -10,4 +10,5 @@ The pinned v0.10.4 audit surface is a deferred stub without a supported
 chain/head or principal-scoped query, so its status is recorded as a
 non-gating blocked audit probe and the harness does not claim audit continuity
 or hosted-profile qualification. Release identity binds use receipt object
-fields rather than final-comma line matches. Tracking #1708, #1706, and #1564
+fields rather than final-comma line matches. PID1 identity parses tab-delimited
+proc-status fields. Tracking #1708, #1706, and #1564

--- a/changes/1708.added.md
+++ b/changes/1708.added.md
@@ -9,4 +9,5 @@ state-mount reader can wield existing principal keys.
 The pinned v0.10.4 audit surface is a deferred stub without a supported
 chain/head or principal-scoped query, so its status is recorded as a
 non-gating blocked audit probe and the harness does not claim audit continuity
-or hosted-profile qualification. Tracking #1708, #1706, and #1564
+or hosted-profile qualification. Release identity binds use receipt object
+fields rather than final-comma line matches. Tracking #1708, #1706, and #1564

--- a/changes/1708.added.md
+++ b/changes/1708.added.md
@@ -1,8 +1,8 @@
 Add a bounded signed Linux amd64 hosted-profile evidence harness. The OCI
 profile verifies release/source/archive provenance, starts a real non-root
 PID 1 daemon under restricted container privileges, and proves persistence in
-a fresh container on shared state/workspace mounts with two principals,
-distinct direct owner-state artifacts, and one durable workspace. Tampered,
+a fresh container on shared state/workspace mounts with three principals, two
+with distinct direct owner-state artifacts, and one durable workspace. Tampered,
 missing, mismatched, or path-swapped shuttles fail before daemon startup.
 Host UID/path alone cannot mint a new Astrid principal or grant, but a
 state-mount reader can wield existing principal keys.

--- a/container/amd64/Dockerfile
+++ b/container/amd64/Dockerfile
@@ -38,17 +38,32 @@ RUN set -eu; \
     test "${#ASTRID_RELEASE_MANIFEST_SHA256}" -eq 64; \
     echo "$ASTRID_ARCHIVE_SHA256  /tmp/astrid-release.tar.gz" | sha256sum --check --strict -; \
     echo "$ASTRID_RELEASE_RECEIPT_SHA256  /opt/astrid/release-receipt.json" | sha256sum --check --strict -; \
-    grep -Fqx "  \"repository\": \"astrid-runtime/astrid\"," /opt/astrid/release-receipt.json; \
-    grep -Fqx "  \"version\": \"$ASTRID_VERSION\"," /opt/astrid/release-receipt.json; \
-    grep -Fqx "  \"tag\": \"v$ASTRID_VERSION\"," /opt/astrid/release-receipt.json; \
-    grep -Fqx "  \"source-commit\": \"$ASTRID_SOURCE_COMMIT\"," /opt/astrid/release-receipt.json; \
-    grep -Fqx '  \"target\": \"x86_64-unknown-linux-gnu\",' /opt/astrid/release-receipt.json; \
-    grep -Fqx "  \"archive\": \"astrid-$ASTRID_VERSION-x86_64-unknown-linux-gnu.tar.gz\"," /opt/astrid/release-receipt.json; \
-    grep -Fqx "  \"archive-sha256\": \"$ASTRID_ARCHIVE_SHA256\"," /opt/astrid/release-receipt.json; \
-    grep -Fqx "  \"archive-blake3\": \"$ASTRID_ARCHIVE_BLAKE3\"," /opt/astrid/release-receipt.json; \
-    grep -Fqx "  \"release-manifest\": \"astrid-$ASTRID_VERSION-release.toml\"," /opt/astrid/release-receipt.json; \
-    grep -Fqx "  \"release-manifest-sha256\": \"$ASTRID_RELEASE_MANIFEST_SHA256\"," /opt/astrid/release-receipt.json; \
-    grep -Fqx "  \"release-workflow-identity\": \"https://github.com/astrid-runtime/astrid/.github/workflows/release.yml@refs/tags/v$ASTRID_VERSION\"," /opt/astrid/release-receipt.json; \
+    bind_receipt_field() { \
+      actual=$(sed -nE "s/^[[:space:]]*\"$2\"[[:space:]]*:[[:space:]]*\"([^\"]*)\",?$/\1/p" "$1"); \
+      [ "$actual" = "$3" ]; \
+    }; \
+    bind_receipt_field /opt/astrid/release-receipt.json \
+      "repository" "astrid-runtime/astrid"; \
+    bind_receipt_field /opt/astrid/release-receipt.json \
+      "version" "$ASTRID_VERSION"; \
+    bind_receipt_field /opt/astrid/release-receipt.json \
+      "tag" "v$ASTRID_VERSION"; \
+    bind_receipt_field /opt/astrid/release-receipt.json \
+      "source-commit" "$ASTRID_SOURCE_COMMIT"; \
+    bind_receipt_field /opt/astrid/release-receipt.json \
+      "target" "x86_64-unknown-linux-gnu"; \
+    bind_receipt_field /opt/astrid/release-receipt.json \
+      "archive" "astrid-$ASTRID_VERSION-x86_64-unknown-linux-gnu.tar.gz"; \
+    bind_receipt_field /opt/astrid/release-receipt.json \
+      "archive-sha256" "$ASTRID_ARCHIVE_SHA256"; \
+    bind_receipt_field /opt/astrid/release-receipt.json \
+      "archive-blake3" "$ASTRID_ARCHIVE_BLAKE3"; \
+    bind_receipt_field /opt/astrid/release-receipt.json \
+      "release-manifest" "astrid-$ASTRID_VERSION-release.toml"; \
+    bind_receipt_field /opt/astrid/release-receipt.json \
+      "release-manifest-sha256" "$ASTRID_RELEASE_MANIFEST_SHA256"; \
+    bind_receipt_field /opt/astrid/release-receipt.json \
+      "release-workflow-identity" "https://github.com/astrid-runtime/astrid/.github/workflows/release.yml@refs/tags/v$ASTRID_VERSION"; \
     mkdir -p /opt/astrid/release /var/lib/astrid /workspace /run/astrid; \
     tar -xzf /tmp/astrid-release.tar.gz \
       --strip-components=1 \

--- a/container/amd64/Dockerfile
+++ b/container/amd64/Dockerfile
@@ -3,6 +3,9 @@ FROM docker.io/library/ubuntu@sha256:52df9b1ee71626e0088f7d400d5c6b5f7bb916f8f0c
 ARG ASTRID_VERSION
 ARG ASTRID_SOURCE_COMMIT
 ARG ASTRID_ARCHIVE_SHA256
+ARG ASTRID_ARCHIVE_BLAKE3
+ARG ASTRID_RELEASE_RECEIPT_SHA256
+ARG ASTRID_RELEASE_MANIFEST_SHA256
 
 LABEL org.opencontainers.image.title="Astrid Runtime" \
       org.opencontainers.image.description="Distro-neutral Astrid Runtime for Linux amd64" \
@@ -10,7 +13,11 @@ LABEL org.opencontainers.image.title="Astrid Runtime" \
       org.opencontainers.image.version="${ASTRID_VERSION}" \
       org.opencontainers.image.revision="${ASTRID_SOURCE_COMMIT}" \
       org.opencontainers.image.licenses="Apache-2.0 OR MIT" \
-      io.astrid.release.target="x86_64-unknown-linux-gnu"
+      io.astrid.release.target="x86_64-unknown-linux-gnu" \
+      io.astrid.release.archive-sha256="${ASTRID_ARCHIVE_SHA256}" \
+      io.astrid.release.archive-blake3="${ASTRID_ARCHIVE_BLAKE3}" \
+      io.astrid.release.receipt-sha256="${ASTRID_RELEASE_RECEIPT_SHA256}" \
+      io.astrid.release.manifest-sha256="${ASTRID_RELEASE_MANIFEST_SHA256}"
 
 COPY dist/oci-amd64/astrid-release.tar.gz /tmp/astrid-release.tar.gz
 COPY dist/oci-amd64/release-receipt.json /opt/astrid/release-receipt.json
@@ -23,7 +30,25 @@ RUN set -eu; \
     test "${#ASTRID_SOURCE_COMMIT}" -eq 40; \
     case "$ASTRID_ARCHIVE_SHA256" in *[!0-9a-f]*|'') exit 1 ;; esac; \
     test "${#ASTRID_ARCHIVE_SHA256}" -eq 64; \
+    case "$ASTRID_ARCHIVE_BLAKE3" in *[!0-9a-f]*|'') exit 1 ;; esac; \
+    test "${#ASTRID_ARCHIVE_BLAKE3}" -eq 64; \
+    case "$ASTRID_RELEASE_RECEIPT_SHA256" in *[!0-9a-f]*|'') exit 1 ;; esac; \
+    test "${#ASTRID_RELEASE_RECEIPT_SHA256}" -eq 64; \
+    case "$ASTRID_RELEASE_MANIFEST_SHA256" in *[!0-9a-f]*|'') exit 1 ;; esac; \
+    test "${#ASTRID_RELEASE_MANIFEST_SHA256}" -eq 64; \
     echo "$ASTRID_ARCHIVE_SHA256  /tmp/astrid-release.tar.gz" | sha256sum --check --strict -; \
+    echo "$ASTRID_RELEASE_RECEIPT_SHA256  /opt/astrid/release-receipt.json" | sha256sum --check --strict -; \
+    grep -Fqx "  \"repository\": \"astrid-runtime/astrid\"," /opt/astrid/release-receipt.json; \
+    grep -Fqx "  \"version\": \"$ASTRID_VERSION\"," /opt/astrid/release-receipt.json; \
+    grep -Fqx "  \"tag\": \"v$ASTRID_VERSION\"," /opt/astrid/release-receipt.json; \
+    grep -Fqx "  \"source-commit\": \"$ASTRID_SOURCE_COMMIT\"," /opt/astrid/release-receipt.json; \
+    grep -Fqx '  \"target\": \"x86_64-unknown-linux-gnu\",' /opt/astrid/release-receipt.json; \
+    grep -Fqx "  \"archive\": \"astrid-$ASTRID_VERSION-x86_64-unknown-linux-gnu.tar.gz\"," /opt/astrid/release-receipt.json; \
+    grep -Fqx "  \"archive-sha256\": \"$ASTRID_ARCHIVE_SHA256\"," /opt/astrid/release-receipt.json; \
+    grep -Fqx "  \"archive-blake3\": \"$ASTRID_ARCHIVE_BLAKE3\"," /opt/astrid/release-receipt.json; \
+    grep -Fqx "  \"release-manifest\": \"astrid-$ASTRID_VERSION-release.toml\"," /opt/astrid/release-receipt.json; \
+    grep -Fqx "  \"release-manifest-sha256\": \"$ASTRID_RELEASE_MANIFEST_SHA256\"," /opt/astrid/release-receipt.json; \
+    grep -Fqx "  \"release-workflow-identity\": \"https://github.com/astrid-runtime/astrid/.github/workflows/release.yml@refs/tags/v$ASTRID_VERSION\"," /opt/astrid/release-receipt.json; \
     mkdir -p /opt/astrid/release /var/lib/astrid /workspace /run/astrid; \
     tar -xzf /tmp/astrid-release.tar.gz \
       --strip-components=1 \

--- a/container/amd64/README.md
+++ b/container/amd64/README.md
@@ -96,6 +96,9 @@ owner-only permissions to its state root. Container arguments are restricted
 to verbosity and the three bounded daemon concurrency controls. In particular,
 callers cannot enable ephemeral mode or replace the image-owned
 workspace/session identity.
+The entrypoint also rejects inherited `ASTRID_SANDBOX_POLICY` and
+`ASTRID_ALLOW_LOCAL_IPS` overrides before initialization; the neutral hosted
+profile does not inherit an operator's security-policy bypasses.
 
 The neutral target does not install `bwrap` or a product shell/tool stack.
 Distros that request native subprocess hosting therefore fail closed at
@@ -120,14 +123,30 @@ host or container-engine socket, and a writable state/workspace mount owned by
 UID/GID `65532`.
 
 The OCI harness starts the real daemon, waits for its readiness sentinel, and
-uses an authenticated `astrid status` round trip. It then provisions two
-non-admin principals, records separate owner state and audit counters, stops
-and reopens the same state mount, and verifies that both principals and the
-audit chain survive restart without crossing workspaces or capability grants.
-The harness also rejects absent, externally mismatched, signed-but-tampered,
-and path-swapped shuttles before the daemon is reached. A root or host Linux
-UID/path is only a container runtime identity; it cannot mint an Astrid
-principal, grant, or authority without Astrid's authenticated control path.
+directly checks that the daemon executable is PID 1 as UID/GID `65532` in
+`/workspace`. It provisions agent and genuinely restricted principals, asserts
+exact self-scoped agent-list responses, writes distinct principal owner state,
+and removes the first container before opening the same state/workspace mounts
+in a fresh container. It then verifies the owner state, workspace mount,
+principal identities, and authenticated control path across that fresh reopen
+and rejects cross-principal modification. The harness also rejects absent,
+externally mismatched, signed-but-tampered, and path-swapped shuttles before
+the daemon is reached. A root or host Linux UID/path is only a container
+runtime identity; it cannot mint an Astrid principal, grant, or authority
+through Astrid's authenticated control path.
+
+The pinned v0.10.4 baseline has two explicit custody and evidence limits. The
+runtime signing key and all principal-owned files live under the same
+UID/GID `65532` state mount: the OS does not give each Astrid principal a
+separate UID, and a caller with root access, the container runtime's host
+access, or write access to that state mount can read or alter those bytes.
+Astrid's authenticated IPC remains the authority boundary for principal
+actions; this profile does not claim OS-level per-principal key custody or
+protection from state-mount custody. In addition, v0.10.4's `astrid audit`
+surface is a deferred stub and exposes no supported chain/head or
+principal-scoped query. The harness therefore fails its final audit gate with
+that exact baseline blocker rather than substituting a global count or mutating
+the pinned release.
 
 This is not a Linux application Realm, a graphics or driver Realm, arm64
 parity, a hostless OS, or a claim that the Linux kernel is untrusted. It is

--- a/container/amd64/README.md
+++ b/container/amd64/README.md
@@ -16,12 +16,20 @@ python3 scripts/oci_release.py fetch \
 
 archive_sha256=$(python3 -c \
   'import json; print(json.load(open("dist/oci-amd64/release-receipt.json"))["archive-sha256"])')
+archive_blake3=$(python3 -c \
+  'import json; print(json.load(open("dist/oci-amd64/release-receipt.json"))["archive-blake3"])')
+release_manifest_sha256=$(python3 -c \
+  'import json; print(json.load(open("dist/oci-amd64/release-receipt.json"))["release-manifest-sha256"])')
+release_receipt_sha256=$(sha256sum dist/oci-amd64/release-receipt.json | cut -d ' ' -f 1)
 
 docker build \
   --platform linux/amd64 \
   --build-arg ASTRID_VERSION=0.10.4 \
   --build-arg ASTRID_SOURCE_COMMIT=b6bf5d1d579915eb5d3c944857d84e62a4fcc878 \
   --build-arg ASTRID_ARCHIVE_SHA256="$archive_sha256" \
+  --build-arg ASTRID_ARCHIVE_BLAKE3="$archive_blake3" \
+  --build-arg ASTRID_RELEASE_MANIFEST_SHA256="$release_manifest_sha256" \
+  --build-arg ASTRID_RELEASE_RECEIPT_SHA256="$release_receipt_sha256" \
   --tag astrid-runtime:0.10.4-amd64 \
   --file container/amd64/Dockerfile .
 ```
@@ -35,6 +43,13 @@ bytes into a package-free, digest-pinned Ubuntu 24.04 amd64 base. Ubuntu 24.04
 is the compatibility floor for the currently published `v0.10.4` archive
 (glibc 2.39); releases produced after Astrid's glibc-baseline gate also run
 there.
+
+The image embeds the release receipt derived from the verified signed release
+manifest and archive. It checks the receipt SHA-256 and every identity field
+(repository, tag, source commit, target, archive name, archive SHA-256, archive
+BLAKE3, manifest SHA-256, and release-workflow identity) during the build.
+Those values are repeated as immutable OCI labels, so an image digest cannot be
+detached from the exact signed release/source provenance that was tested.
 
 ## Run
 
@@ -93,6 +108,30 @@ itself never selects that artifact.
 This target does not publish `latest`, channel, or canonical multi-architecture
 tags. ARM64 is a separate target and must be validated independently before a
 multi-architecture index can be assembled.
+
+## Hosted profile qualification
+
+The amd64 target is one bounded hosted profile: a signed Astrid release runs as
+the non-root PID 1 daemon on a Linux container runtime. The profile owns fixed
+`/var/lib/astrid` state and `/workspace` paths; callers cannot replace those
+identities with environment variables or daemon arguments. The qualification
+requires a read-only root, all capabilities dropped, `no-new-privileges`, no
+host or container-engine socket, and a writable state/workspace mount owned by
+UID/GID `65532`.
+
+The OCI harness starts the real daemon, waits for its readiness sentinel, and
+uses an authenticated `astrid status` round trip. It then provisions two
+non-admin principals, records separate owner state and audit counters, stops
+and reopens the same state mount, and verifies that both principals and the
+audit chain survive restart without crossing workspaces or capability grants.
+The harness also rejects absent, externally mismatched, signed-but-tampered,
+and path-swapped shuttles before the daemon is reached. A root or host Linux
+UID/path is only a container runtime identity; it cannot mint an Astrid
+principal, grant, or authority without Astrid's authenticated control path.
+
+This is not a Linux application Realm, a graphics or driver Realm, arm64
+parity, a hostless OS, or a claim that the Linux kernel is untrusted. It is
+only the signed amd64 hosted profile described above.
 
 ## Build evidence and signatures
 

--- a/container/amd64/README.md
+++ b/container/amd64/README.md
@@ -112,41 +112,46 @@ This target does not publish `latest`, channel, or canonical multi-architecture
 tags. ARM64 is a separate target and must be validated independently before a
 multi-architecture index can be assembled.
 
-## Hosted profile qualification
+## Hosted profile evidence
 
 The amd64 target is one bounded hosted profile: a signed Astrid release runs as
 the non-root PID 1 daemon on a Linux container runtime. The profile owns fixed
 `/var/lib/astrid` state and `/workspace` paths; callers cannot replace those
-identities with environment variables or daemon arguments. The qualification
-requires a read-only root, all capabilities dropped, `no-new-privileges`, no
+identities with environment variables or daemon arguments. The checks require a
+read-only root, all capabilities dropped, `no-new-privileges`, no
 host or container-engine socket, and a writable state/workspace mount owned by
 UID/GID `65532`.
 
 The OCI harness starts the real daemon, waits for its readiness sentinel, and
 directly checks that the daemon executable is PID 1 as UID/GID `65532` in
 `/workspace`. It provisions agent and genuinely restricted principals, asserts
-exact self-scoped agent-list responses, writes distinct principal owner state,
-and removes the first container before opening the same state/workspace mounts
-in a fresh container. It then verifies the owner state, workspace mount,
-principal identities, and authenticated control path across that fresh reopen
-and rejects cross-principal modification. The harness also rejects absent,
-externally mismatched, signed-but-tampered, and path-swapped shuttles before
-the daemon is reached. A root or host Linux UID/path is only a container
-runtime identity; it cannot mint an Astrid principal, grant, or authority
-through Astrid's authenticated control path.
+exact self-scoped agent-list responses, uses the release CLI to write distinct
+direct owner-state artifacts, and removes the first container before opening
+the same state/workspace mounts in a fresh container. It then verifies those
+state artifacts, the workspace marker, principal identities, and authenticated
+control path across that fresh reopen and rejects cross-principal
+modification. This is persistence evidence on deliberately shared mounts; it
+does not execute or claim cross-principal workspace, mount, or secret-read
+isolation. The harness also rejects absent, externally mismatched,
+signed-but-tampered, and path-swapped shuttles before the daemon is reached. A
+host Linux UID/path alone cannot mint a new Astrid principal or grant, but a
+reader of the state mount can wield existing principal keys.
 
 The pinned v0.10.4 baseline has two explicit custody and evidence limits. The
 runtime signing key and all principal-owned files live under the same
 UID/GID `65532` state mount: the OS does not give each Astrid principal a
 separate UID, and a caller with root access, the container runtime's host
-access, or write access to that state mount can read or alter those bytes.
-Astrid's authenticated IPC remains the authority boundary for principal
-actions; this profile does not claim OS-level per-principal key custody or
-protection from state-mount custody. In addition, v0.10.4's `astrid audit`
-surface is a deferred stub and exposes no supported chain/head or
-principal-scoped query. The harness therefore fails its final audit gate with
-that exact baseline blocker rather than substituting a global count or mutating
-the pinned release.
+access, or read/write access to that state mount can wield or alter existing
+principal-owned bytes. Minting a new Astrid principal or grant still requires
+an existing credential or authorized control path; this profile does not claim
+OS-level per-principal key custody or protection from state-mount custody. In
+addition, v0.10.4's `astrid audit` surface is a deferred stub and exposes no
+supported chain/head or principal-scoped query. The harness records that
+surface as an explicit
+non-gating blocked audit probe rather than substituting a global count or
+mutating the pinned release. It therefore does not claim audit continuity or
+hosted-profile qualification; issue #1708 remains open until a supported
+immutable release supplies that evidence.
 
 This is not a Linux application Realm, a graphics or driver Realm, arm64
 parity, a hostless OS, or a claim that the Linux kernel is untrusted. It is

--- a/container/amd64/entrypoint.sh
+++ b/container/amd64/entrypoint.sh
@@ -47,6 +47,22 @@ done
 [ -z "$expect_daemon_value" ] ||
     fail "$expect_daemon_value requires an integer greater than zero"
 
+# The hosted profile has one image-owned state/workspace identity.  A caller
+# may choose the bind mounts at these fixed locations, but cannot redirect the
+# daemon to a host path or alias and thereby mint a different authority root.
+if [ "${ASTRID_HOME:-/var/lib/astrid}" != /var/lib/astrid ]; then
+    fail "ASTRID_HOME is fixed to /var/lib/astrid in the hosted profile"
+fi
+if [ "${ASTRID_WORKSPACE:-/workspace}" != /workspace ]; then
+    fail "ASTRID_WORKSPACE is fixed to /workspace in the hosted profile"
+fi
+if [ "${ASTRID_WORKSPACE_STATE_DIR:-.astrid}" != .astrid ]; then
+    fail "ASTRID_WORKSPACE_STATE_DIR is fixed to .astrid in the hosted profile"
+fi
+if [ "${HOME:-/var/lib/astrid}" != /var/lib/astrid ]; then
+    fail "HOME is fixed to /var/lib/astrid in the hosted profile"
+fi
+
 distro_path=${ASTRID_DISTRO_PATH:-/run/astrid/distro.shuttle}
 expected_sha256=${ASTRID_DISTRO_SHA256:-}
 
@@ -65,8 +81,8 @@ esac
 [ ! -L "$distro_path" ] ||
     fail "signed distro must be a regular file, not a symbolic link: $distro_path"
 
-: "${ASTRID_HOME:=/var/lib/astrid}"
-: "${ASTRID_WORKSPACE:=/workspace}"
+ASTRID_HOME=/var/lib/astrid
+ASTRID_WORKSPACE=/workspace
 export ASTRID_HOME ASTRID_WORKSPACE
 export HOME="$ASTRID_HOME"
 export ASTRID_DAEMON_LOG_TARGET=stderr

--- a/container/amd64/entrypoint.sh
+++ b/container/amd64/entrypoint.sh
@@ -6,6 +6,16 @@ fail() {
     exit 1
 }
 
+# These inherited variables disable security gates in the pinned release.
+# Rejecting them here keeps the fail-closed hosted profile independent of the
+# caller's shell, CI matrix, or orchestrator environment.
+if [ "${ASTRID_SANDBOX_POLICY+set}" = set ]; then
+    fail "inherited ASTRID_SANDBOX_POLICY override is not permitted"
+fi
+if [ "${ASTRID_ALLOW_LOCAL_IPS+set}" = set ]; then
+    fail "inherited ASTRID_ALLOW_LOCAL_IPS override is not permitted"
+fi
+
 # The image owns daemon lifecycle. Callers may tune bounded runtime ceilings
 # and verbosity, but may not replace the workspace/session identity, request
 # ephemeral shutdown, or pass newly-added daemon flags without an explicit

--- a/container/amd64/test.sh
+++ b/container/amd64/test.sh
@@ -6,6 +6,7 @@ CLI_UPLINK_CAPSULE=${2:?usage: container/amd64/test.sh IMAGE CLI_UPLINK_CAPSULE}
 OCI_PLATFORM=${ASTRID_OCI_TEST_PLATFORM:-linux/amd64}
 OCI_ARCHITECTURE=${ASTRID_OCI_TEST_ARCHITECTURE:-amd64}
 OCI_TEST_LABEL=${ASTRID_OCI_TEST_LABEL:-amd64}
+PYTHON=${PYTHON:-python3}
 TEST_ROOT=$(mktemp -d)
 TEST_BASE_IMAGE="astrid-oci-bound-base:${RANDOM}-${RANDOM}"
 TEST_IMAGE="astrid-oci-entrypoint-test:${RANDOM}-${RANDOM}"
@@ -70,6 +71,90 @@ runtime_path_is_symlink() {
     sh "$relative"
 }
 
+start_real_runtime() {
+  local state_dir=$1
+  local workspace_dir=$2
+  REAL_CONTAINER=$(docker run --detach \
+    --platform "$OCI_PLATFORM" \
+    --read-only \
+    --cap-drop=ALL \
+    --security-opt=no-new-privileges \
+    --tmpfs /tmp:rw,noexec,nosuid,nodev,size=64m,uid=65532,gid=65532 \
+    --mount "type=bind,src=$TEST_ROOT/fixtures/distro.shuttle,dst=/run/astrid/distro.shuttle,readonly" \
+    --mount "type=bind,src=$state_dir,dst=/var/lib/astrid" \
+    --mount "type=bind,src=$workspace_dir,dst=/workspace" \
+    --env "ASTRID_DISTRO_SHA256=$distro_sha256" \
+    "$IMAGE")
+
+}
+
+wait_real_runtime() {
+  local label=${1:-real}
+  local release_ready=false
+  for _ in $(seq 1 120); do
+    if [[ "$(docker inspect "$REAL_CONTAINER" --format '{{.State.Running}}')" != true ]]; then
+      break
+    fi
+    if docker exec "$REAL_CONTAINER" test -f /var/lib/astrid/run/system.ready &&
+      docker exec "$REAL_CONTAINER" /usr/local/bin/astrid status \
+        >"$TEST_ROOT/$label-status.out" 2>"$TEST_ROOT/$label-status.err"; then
+      release_ready=true
+      break
+    fi
+    sleep 0.5
+  done
+  if [[ "$release_ready" != true ]]; then
+    docker logs "$REAL_CONTAINER" >&2 || true
+    cat "$TEST_ROOT/$label-status.out" >&2 2>/dev/null || true
+    cat "$TEST_ROOT/$label-status.err" >&2 2>/dev/null || true
+    fail "authenticated release daemon did not become ready ($label)"
+  fi
+  grep -q "Astrid daemon" "$TEST_ROOT/$label-status.out" ||
+    fail "authenticated release daemon did not answer status ($label)"
+}
+
+run_real_cli() {
+  docker exec "$REAL_CONTAINER" /usr/local/bin/astrid "$@"
+}
+
+assert_real_json_has_principals() {
+  local path=$1
+  "$PYTHON" - "$path" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+with open(path, encoding="utf-8") as handle:
+    items = json.load(handle)
+if not isinstance(items, list):
+    raise SystemExit("agent list response is not an array")
+names = {item.get("principal") for item in items if isinstance(item, dict)}
+for expected in ("hosted-alpha", "hosted-beta"):
+    if expected not in names:
+        raise SystemExit(f"restart lost principal {expected!r}: {sorted(names)!r}")
+PY
+}
+
+assert_real_principal_isolation() {
+  local alpha=$1
+  local beta=$2
+  "$PYTHON" - "$alpha" "$beta" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    alpha = json.load(handle)
+with open(sys.argv[2], encoding="utf-8") as handle:
+    beta = json.load(handle)
+if alpha.get("principal") != "hosted-alpha" or beta.get("principal") != "hosted-beta":
+    raise SystemExit("principal identity changed during restart")
+if "restricted" not in alpha.get("groups", []):
+    raise SystemExit("hosted-alpha lost its restricted capability group")
+if "restricted" in beta.get("groups", []):
+    raise SystemExit("hosted-beta inherited hosted-alpha's capability group")
+PY
+}
+
 ARCH=$(docker image inspect "$IMAGE" --format '{{.Architecture}}')
 USER=$(docker image inspect "$IMAGE" --format '{{.Config.User}}')
 ENTRYPOINT=$(docker image inspect "$IMAGE" --format '{{json .Config.Entrypoint}}')
@@ -107,39 +192,86 @@ distro_sha256=${distro_sha256%% *}
 # Exercise the authenticated release daemon itself. The readiness sentinel and
 # an authenticated CLI status round trip must both succeed while the daemon is
 # PID 1 under the deployment restrictions claimed by this image.
-REAL_CONTAINER=$(docker run --detach \
-  --platform "$OCI_PLATFORM" \
-  --read-only \
-  --cap-drop=ALL \
-  --security-opt=no-new-privileges \
-  --tmpfs /tmp:rw,noexec,nosuid,nodev,size=64m,uid=65532,gid=65532 \
-  --mount "type=bind,src=$TEST_ROOT/fixtures/distro.shuttle,dst=/run/astrid/distro.shuttle,readonly" \
-  --mount "type=bind,src=$run_dir/real-state,dst=/var/lib/astrid" \
-  --mount "type=bind,src=$run_dir/real-workspace,dst=/workspace" \
-  --env "ASTRID_DISTRO_SHA256=$distro_sha256" \
-  "$IMAGE")
+start_real_runtime "$run_dir/real-state" "$run_dir/real-workspace"
 
-release_ready=false
-for _ in $(seq 1 120); do
-  if [[ "$(docker inspect "$REAL_CONTAINER" --format '{{.State.Running}}')" != true ]]; then
-    break
+# Persist two independent owner records and a capability-group change through
+# the authenticated admin path.  This is deliberately done by the real
+# release binary, not by writing files from the container's Linux UID.
+run_real_cli agent create hosted-alpha --group agent --yes \
+  >"$TEST_ROOT/alpha-create.out" 2>"$TEST_ROOT/alpha-create.err" || {
+  cat "$TEST_ROOT/alpha-create.out" >&2 || true
+  cat "$TEST_ROOT/alpha-create.err" >&2 || true
+  fail "could not create hosted-alpha through the daemon"
+}
+run_real_cli agent create hosted-beta --group agent --yes \
+  >"$TEST_ROOT/beta-create.out" 2>"$TEST_ROOT/beta-create.err" || {
+  cat "$TEST_ROOT/beta-create.out" >&2 || true
+  cat "$TEST_ROOT/beta-create.err" >&2 || true
+  fail "could not create hosted-beta through the daemon"
+}
+run_real_cli agent modify hosted-alpha --add-group restricted \
+  >"$TEST_ROOT/alpha-modify.out" 2>"$TEST_ROOT/alpha-modify.err" || {
+  cat "$TEST_ROOT/alpha-modify.out" >&2 || true
+  cat "$TEST_ROOT/alpha-modify.err" >&2 || true
+  fail "could not update hosted-alpha capability group"
+}
+run_real_cli agent show hosted-alpha --format json >"$TEST_ROOT/alpha-before.json" \
+  || fail "could not inspect hosted-alpha before restart"
+run_real_cli agent show hosted-beta --format json >"$TEST_ROOT/beta-before.json" \
+  || fail "could not inspect hosted-beta before restart"
+assert_real_principal_isolation "$TEST_ROOT/alpha-before.json" "$TEST_ROOT/beta-before.json"
+run_real_cli agent list --format json >"$TEST_ROOT/agents-before.json" \
+  || fail "could not list hosted principals before restart"
+assert_real_json_has_principals "$TEST_ROOT/agents-before.json"
+run_real_cli audit stats --format json >"$TEST_ROOT/audit-before.json" \
+  || fail "could not read audit stats before restart"
+
+# Restart/reopen the same owner state/workspace mounts. The image's init
+# path must not turn a restart into a fresh identity or silently reset audit
+# heads. Docker keeps the same container, PID 1, and bind mounts for this gate.
+docker restart --time 10 "$REAL_CONTAINER" >/dev/null
+wait_real_runtime restart
+run_real_cli agent list --format json >"$TEST_ROOT/agents-after.json" \
+  || fail "could not list hosted principals after restart"
+assert_real_json_has_principals "$TEST_ROOT/agents-after.json"
+run_real_cli agent show hosted-alpha --format json >"$TEST_ROOT/alpha-after.json" \
+  || fail "could not inspect hosted-alpha after restart"
+run_real_cli agent show hosted-beta --format json >"$TEST_ROOT/beta-after.json" \
+  || fail "could not inspect hosted-beta after restart"
+assert_real_principal_isolation "$TEST_ROOT/alpha-after.json" "$TEST_ROOT/beta-after.json"
+run_real_cli audit stats --format json >"$TEST_ROOT/audit-after.json" \
+  || fail "could not read audit stats after restart"
+"$PYTHON" - "$TEST_ROOT/audit-before.json" "$TEST_ROOT/audit-after.json" <<'PY'
+import json
+import sys
+
+before = json.load(open(sys.argv[1], encoding="utf-8"))
+after = json.load(open(sys.argv[2], encoding="utf-8"))
+before_stats = before.get("stats", {})
+after_stats = after.get("stats", {})
+before_count = before_stats.get("total_count")
+after_count = after_stats.get("total_count")
+if not isinstance(before_count, int) or not isinstance(after_count, int):
+    raise SystemExit("audit stats omitted total_count across restart")
+if after_count < before_count:
+    raise SystemExit(f"audit count regressed across restart: {before_count} -> {after_count}")
+if after_stats.get("degraded"):
+    raise SystemExit("audit became degraded after restart")
+PY
+
+# A principal's stamped client cannot use its Linux UID or an environment
+# label to gain operator authority.  The kernel must reject admin enumeration
+# for both owner principals even though they share the container UID.
+for principal in hosted-alpha hosted-beta; do
+  if docker exec "$REAL_CONTAINER" env ASTRID_PRINCIPAL="$principal" \
+    /usr/local/bin/astrid agent list >"$TEST_ROOT/$principal-list.out" \
+    2>"$TEST_ROOT/$principal-list.err"; then
+    fail "$principal unexpectedly gained operator agent-list authority"
   fi
-  if docker exec "$REAL_CONTAINER" test -f /var/lib/astrid/run/system.ready &&
-    docker exec "$REAL_CONTAINER" /usr/local/bin/astrid status \
-      >"$TEST_ROOT/real-status.out" 2>"$TEST_ROOT/real-status.err"; then
-    release_ready=true
-    break
-  fi
-  sleep 0.5
+  grep -Eqi "denied|permission|admin" "$TEST_ROOT/$principal-list.err" ||
+    fail "$principal denial did not identify an authority boundary"
 done
-if [[ "$release_ready" != true ]]; then
-  docker logs "$REAL_CONTAINER" >&2 || true
-  cat "$TEST_ROOT/real-status.out" >&2 2>/dev/null || true
-  cat "$TEST_ROOT/real-status.err" >&2 2>/dev/null || true
-  fail "authenticated release daemon did not become ready"
-fi
-grep -q "Astrid daemon" "$TEST_ROOT/real-status.out" ||
-  fail "authenticated release daemon did not answer status"
+
 docker stop --time 10 "$REAL_CONTAINER" >/dev/null
 docker rm "$REAL_CONTAINER" >/dev/null
 REAL_CONTAINER=
@@ -164,6 +296,23 @@ if docker run --rm --platform "$OCI_PLATFORM" "$IMAGE" --host-io-concurrency 0 \
 fi
 grep -q "requires an integer greater than zero" "$TEST_ROOT/zero.err" ||
   fail "zero daemon concurrency did not fail at the allowlist"
+
+# Environment aliases are authority inputs too: a Linux caller cannot move
+# the state/workspace roots (or HOME) to a path it controls and thereby mint a
+# fresh Astrid identity.  These checks run before any distro is mounted.
+for override in \
+  "ASTRID_HOME=/attacker" \
+  "ASTRID_WORKSPACE=/attacker" \
+  "ASTRID_WORKSPACE_STATE_DIR=attacker" \
+  "HOME=/attacker"; do
+  override_name=${override%%=*}
+  if docker run --rm --platform "$OCI_PLATFORM" --env "$override" "$IMAGE" \
+    >"$TEST_ROOT/$override_name.out" 2>"$TEST_ROOT/$override_name.err"; then
+    fail "hosted profile accepted authority-root override $override"
+  fi
+  grep -q "fixed to" "$TEST_ROOT/$override_name.err" ||
+    fail "authority-root override $override did not fail closed"
+done
 
 cat > "$TEST_ROOT/fake-daemon" <<'EOF'
 #!/bin/sh
@@ -270,6 +419,27 @@ if docker run --rm \
 fi
 grep -q "signed distro is absent" "$TEST_ROOT/missing.err" ||
   fail "absent distro did not fail at the entrypoint trust gate"
+
+prepare_runtime_dir "$TEST_ROOT/mismatched-state"
+prepare_runtime_dir "$TEST_ROOT/mismatched-workspace" 0755
+if docker run --rm \
+  --platform "$OCI_PLATFORM" \
+  --read-only \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --tmpfs /tmp:rw,noexec,nosuid,nodev,size=64m,uid=65532,gid=65532 \
+  --mount "type=bind,src=$TEST_ROOT/fixtures/distro.shuttle,dst=/run/astrid/distro.shuttle,readonly" \
+  --mount "type=bind,src=$TEST_ROOT/mismatched-state,dst=/var/lib/astrid" \
+  --mount "type=bind,src=$TEST_ROOT/mismatched-workspace,dst=/workspace" \
+  --env "ASTRID_DISTRO_SHA256=0000000000000000000000000000000000000000000000000000000000000000" \
+  "$TEST_IMAGE" >"$TEST_ROOT/mismatched.out" 2>"$TEST_ROOT/mismatched.err"; then
+  fail "signed distro with a mismatched expected digest was accepted"
+fi
+if grep -q "FAKE_DAEMON_STARTED" "$TEST_ROOT/mismatched.out"; then
+  fail "mismatched signed distro reached the daemon"
+fi
+grep -q "signed distro SHA-256 does not match" "$TEST_ROOT/mismatched.err" ||
+  fail "mismatched signed distro did not fail at the digest trust gate"
 
 # Deterministically swap the operator path after staging but before init reads
 # its enforced distro. The fake CLI mutates the source itself, then proves the

--- a/container/amd64/test.sh
+++ b/container/amd64/test.sh
@@ -251,6 +251,19 @@ run_as_principal_cli() {
     /usr/local/bin/astrid "$@"
 }
 
+assert_v0104_audit_is_non_gating() {
+  local output=$1
+  local error=$2
+  if run_real_cli audit status \
+    >"$output" 2>"$error"; then
+    fail "v0.10.4 unexpectedly exposed an audit query"
+  fi
+  grep -q "audit trail inspection is not available" "$error" ||
+    fail "unexpected v0.10.4 audit surface; re-evaluate the exact-release proof"
+  printf '%s\n' \
+    "BLOCKED AUDIT (non-gating): v0.10.4 baseline blocker; audit is deferred and exposes no supported chain/head or principal-scoped query."
+}
+
 ARCH=$(docker image inspect "$IMAGE" --format '{{.Architecture}}')
 USER=$(docker image inspect "$IMAGE" --format '{{.Config.User}}')
 ENTRYPOINT=$(docker image inspect "$IMAGE" --format '{{json .Config.Entrypoint}}')
@@ -653,13 +666,7 @@ grep -q "STAGED_DISTRO_SURVIVED_SOURCE_SWAP" "$TEST_ROOT/swap.out" ||
 # The exact v0.10.4 audit command is a registered stub. Record that fact as a
 # non-gating blocker instead of pretending that a global count, absent query,
 # or green test exit proves audit continuity.
-if run_real_cli audit status \
-  >"$TEST_ROOT/audit-probe.out" 2>"$TEST_ROOT/audit-probe.err"; then
-  fail "v0.10.4 unexpectedly exposed an audit query"
-fi
-grep -q "audit trail inspection is not available" "$TEST_ROOT/audit-probe.err" ||
-  fail "unexpected v0.10.4 audit surface; re-evaluate the exact-release proof"
-printf '%s\n' \
-  "BLOCKED AUDIT (non-gating): v0.10.4 baseline blocker; audit is deferred and exposes no supported chain/head or principal-scoped query."
+assert_v0104_audit_is_non_gating \
+  "$TEST_ROOT/audit-probe.out" "$TEST_ROOT/audit-probe.err"
 echo "oci $OCI_TEST_LABEL structure, authentication, principal authority, and fresh-container reopen checks passed"
 echo "Audit continuity remains unproven on v0.10.4; this result does not claim hosted-profile qualification."

--- a/container/amd64/test.sh
+++ b/container/amd64/test.sh
@@ -258,7 +258,8 @@ assert_v0104_audit_is_non_gating() {
     >"$output" 2>"$error"; then
     fail "v0.10.4 unexpectedly exposed an audit query"
   fi
-  grep -q "audit trail inspection is not available" "$error" ||
+  printf '%s\n' "audit trail inspection is not available" |
+    cmp -s - "$error" ||
     fail "unexpected v0.10.4 audit surface; re-evaluate the exact-release proof"
   printf '%s\n' \
     "BLOCKED AUDIT (non-gating): v0.10.4 baseline blocker; audit is deferred and exposes no supported chain/head or principal-scoped query."

--- a/container/amd64/test.sh
+++ b/container/amd64/test.sh
@@ -12,6 +12,7 @@ TEST_BASE_IMAGE="astrid-oci-bound-base:${RANDOM}-${RANDOM}"
 TEST_IMAGE="astrid-oci-entrypoint-test:${RANDOM}-${RANDOM}"
 TEST_SWAP_IMAGE="astrid-oci-swap-test:${RANDOM}-${RANDOM}"
 REAL_CONTAINER=
+FIRST_REAL_CONTAINER=
 
 cleanup() {
   if [[ -n "$REAL_CONTAINER" ]]; then
@@ -88,6 +89,12 @@ start_real_runtime() {
 
 }
 
+stop_real_runtime() {
+  docker stop --time 10 "$REAL_CONTAINER" >/dev/null
+  docker rm "$REAL_CONTAINER" >/dev/null
+  REAL_CONTAINER=
+}
+
 wait_real_runtime() {
   local label=${1:-real}
   local release_ready=false
@@ -113,25 +120,48 @@ wait_real_runtime() {
     fail "authenticated release daemon did not answer status ($label)"
 }
 
+assert_daemon_is_pid_one() {
+  local identity
+  identity=$(docker exec "$REAL_CONTAINER" /bin/sh -ec '
+    [ "$(cat /proc/1/comm)" = astrid-daemon ] ||
+      { printf "comm=%s\n" "$(cat /proc/1/comm)" >&2; exit 1; }
+    exe=$(readlink /proc/1/exe)
+    [ "$(basename "$exe")" = astrid-daemon ] ||
+      { printf "exe=%s\n" "$exe" >&2; exit 1; }
+    uid=$(sed -n "s/^Uid:[[:space:]]*//p" /proc/1/status | cut -d" " -f1)
+    gid=$(sed -n "s/^Gid:[[:space:]]*//p" /proc/1/status | cut -d" " -f1)
+    [ "$uid" = 65532 ] && [ "$gid" = 65532 ] ||
+      { printf "uid=%s gid=%s\n" "$uid" "$gid" >&2; exit 1; }
+    [ "$(readlink /proc/1/cwd)" = /workspace ] ||
+      { printf "cwd=%s\n" "$(readlink /proc/1/cwd)" >&2; exit 1; }
+    printf "PID1 astrid-daemon 65532:65532 /workspace\n"
+    ') || fail "daemon identity probe failed"
+  [[ "$identity" == "PID1 astrid-daemon 65532:65532 /workspace" ]] ||
+    fail "real daemon is not PID 1 as uid/gid 65532 in /workspace: $identity"
+}
+
 run_real_cli() {
   docker exec "$REAL_CONTAINER" /usr/local/bin/astrid "$@"
 }
 
-assert_real_json_has_principals() {
+assert_real_self_list() {
   local path=$1
-  "$PYTHON" - "$path" <<'PY'
+  local principal=$2
+  "$PYTHON" - "$path" "$principal" <<'PY'
 import json
 import sys
 
 path = sys.argv[1]
+principal = sys.argv[2]
 with open(path, encoding="utf-8") as handle:
     items = json.load(handle)
 if not isinstance(items, list):
     raise SystemExit("agent list response is not an array")
-names = {item.get("principal") for item in items if isinstance(item, dict)}
-for expected in ("hosted-alpha", "hosted-beta"):
-    if expected not in names:
-        raise SystemExit(f"restart lost principal {expected!r}: {sorted(names)!r}")
+names = [item.get("principal") for item in items if isinstance(item, dict)]
+if names != [principal]:
+    raise SystemExit(
+        f"agent list did not return exactly {principal!r}: {names!r}"
+    )
 PY
 }
 
@@ -153,6 +183,58 @@ if "restricted" not in alpha.get("groups", []):
 if "restricted" in beta.get("groups", []):
     raise SystemExit("hosted-beta inherited hosted-alpha's capability group")
 PY
+}
+
+read_runtime_state_file() {
+  local relative=$1
+  docker run --rm \
+    --platform "$OCI_PLATFORM" \
+    --user 0:0 \
+    --entrypoint /bin/sh \
+    --mount "type=bind,src=$run_dir/real-state,dst=/runtime,readonly" \
+    "$IMAGE" \
+    -ec 'cat "$1"' \
+    sh "$relative"
+}
+
+assert_runtime_state_file_mode() {
+  local relative=$1
+  local mode
+  mode=$(docker run --rm \
+    --platform "$OCI_PLATFORM" \
+    --user 0:0 \
+    --entrypoint /bin/sh \
+    --mount "type=bind,src=$run_dir/real-state,dst=/runtime,readonly" \
+    "$IMAGE" \
+    -ec 'stat -c "%a %u %g" "$1"' \
+    sh "$relative")
+  [[ "$mode" == "600 65532 65532" ]] ||
+    fail "owner state $relative has unsafe custody metadata: $mode"
+}
+
+assert_runtime_state_values() {
+  local alpha=$1
+  local beta=$2
+  "$PYTHON" - "$alpha" "$beta" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    alpha = json.load(handle)
+with open(sys.argv[2], encoding="utf-8") as handle:
+    beta = json.load(handle)
+if alpha.get("OCI_OWNER_STATE") != "alpha-owner-state":
+    raise SystemExit("hosted-alpha owner state changed or crossed")
+if beta.get("OCI_OWNER_STATE") != "beta-owner-state":
+    raise SystemExit("hosted-beta owner state changed or crossed")
+PY
+}
+
+run_as_principal_cli() {
+  local principal=$1
+  shift
+  docker exec --env "ASTRID_PRINCIPAL=$principal" "$REAL_CONTAINER" \
+    /usr/local/bin/astrid "$@"
 }
 
 ARCH=$(docker image inspect "$IMAGE" --format '{{.Architecture}}')
@@ -189,10 +271,14 @@ prepare_runtime_dir "$run_dir/real-workspace" 0755
 distro_sha256=$(sha256sum "$TEST_ROOT/fixtures/distro.shuttle")
 distro_sha256=${distro_sha256%% *}
 
-# Exercise the authenticated release daemon itself. The readiness sentinel and
-# an authenticated CLI status round trip must both succeed while the daemon is
-# PID 1 under the deployment restrictions claimed by this image.
+# Exercise the authenticated release daemon itself. The readiness sentinel,
+# authenticated CLI status round trip, direct PID 1 identity, distinct owner
+# state, and same mounted workspace must survive a fresh container on the same
+# state/workspace mounts.
 start_real_runtime "$run_dir/real-state" "$run_dir/real-workspace"
+wait_real_runtime initial
+assert_daemon_is_pid_one
+FIRST_REAL_CONTAINER=$REAL_CONTAINER
 
 # Persist two independent owner records and a capability-group change through
 # the authenticated admin path.  This is deliberately done by the real
@@ -215,66 +301,90 @@ run_real_cli agent modify hosted-alpha --add-group restricted \
   cat "$TEST_ROOT/alpha-modify.err" >&2 || true
   fail "could not update hosted-alpha capability group"
 }
+run_real_cli agent create hosted-restricted --group restricted --yes \
+  >"$TEST_ROOT/restricted-create.out" 2>"$TEST_ROOT/restricted-create.err" || {
+  cat "$TEST_ROOT/restricted-create.out" >&2 || true
+  cat "$TEST_ROOT/restricted-create.err" >&2 || true
+  fail "could not create the restricted denial principal"
+}
 run_real_cli agent show hosted-alpha --format json >"$TEST_ROOT/alpha-before.json" \
   || fail "could not inspect hosted-alpha before restart"
 run_real_cli agent show hosted-beta --format json >"$TEST_ROOT/beta-before.json" \
   || fail "could not inspect hosted-beta before restart"
 assert_real_principal_isolation "$TEST_ROOT/alpha-before.json" "$TEST_ROOT/beta-before.json"
-run_real_cli agent list --format json >"$TEST_ROOT/agents-before.json" \
-  || fail "could not list hosted principals before restart"
-assert_real_json_has_principals "$TEST_ROOT/agents-before.json"
-run_real_cli audit stats --format json >"$TEST_ROOT/audit-before.json" \
-  || fail "could not read audit stats before restart"
+run_as_principal_cli hosted-alpha agent list --format json \
+  >"$TEST_ROOT/alpha-self-before.json" \
+  || fail "hosted-alpha could not read its own principal row"
+assert_real_self_list "$TEST_ROOT/alpha-self-before.json" hosted-alpha
+run_as_principal_cli hosted-beta agent list --format json \
+  >"$TEST_ROOT/beta-self-before.json" \
+  || fail "hosted-beta could not read its own principal row"
+assert_real_self_list "$TEST_ROOT/beta-self-before.json" hosted-beta
 
-# Restart/reopen the same owner state/workspace mounts. The image's init
-# path must not turn a restart into a fresh identity or silently reset audit
-# heads. Docker keeps the same container, PID 1, and bind mounts for this gate.
-docker restart --time 10 "$REAL_CONTAINER" >/dev/null
-wait_real_runtime restart
-run_real_cli agent list --format json >"$TEST_ROOT/agents-after.json" \
-  || fail "could not list hosted principals after restart"
-assert_real_json_has_principals "$TEST_ROOT/agents-after.json"
+run_real_cli secret set OCI_OWNER_STATE alpha-owner-state --agent hosted-alpha \
+  >"$TEST_ROOT/alpha-state-write.out" 2>"$TEST_ROOT/alpha-state-write.err" \
+  || fail "could not write hosted-alpha owner state"
+run_real_cli secret set OCI_OWNER_STATE beta-owner-state --agent hosted-beta \
+  >"$TEST_ROOT/beta-state-write.out" 2>"$TEST_ROOT/beta-state-write.err" \
+  || fail "could not write hosted-beta owner state"
+printf 'same-mounted-workspace\n' \
+  >"$run_dir/real-workspace/.astrid-oci-mounted-state"
+read_runtime_state_file home/hosted-alpha/.config/env/default.env.json \
+  >"$TEST_ROOT/alpha-state-before.json"
+read_runtime_state_file home/hosted-beta/.config/env/default.env.json \
+  >"$TEST_ROOT/beta-state-before.json"
+assert_runtime_state_file_mode home/hosted-alpha/.config/env/default.env.json
+assert_runtime_state_file_mode home/hosted-beta/.config/env/default.env.json
+assert_runtime_state_file_mode keys/runtime.key
+assert_runtime_state_values \
+  "$TEST_ROOT/alpha-state-before.json" "$TEST_ROOT/beta-state-before.json"
+
+# Stop and remove the first container before creating the successor. This is
+# a fresh process and container namespace opening the same durable mounts, not
+# Docker resuming or restarting the original PID 1.
+stop_real_runtime
+start_real_runtime "$run_dir/real-state" "$run_dir/real-workspace"
+[[ -n "$FIRST_REAL_CONTAINER" && "$REAL_CONTAINER" != "$FIRST_REAL_CONTAINER" ]] ||
+  fail "fresh-container reopen did not create a new container"
+wait_real_runtime reopen
+assert_daemon_is_pid_one
+[[ "$(cat "$run_dir/real-workspace/.astrid-oci-mounted-state")" == same-mounted-workspace ]] ||
+  fail "workspace mount state did not survive fresh-container reopen"
+read_runtime_state_file home/hosted-alpha/.config/env/default.env.json \
+  >"$TEST_ROOT/alpha-state-after.json"
+read_runtime_state_file home/hosted-beta/.config/env/default.env.json \
+  >"$TEST_ROOT/beta-state-after.json"
+assert_runtime_state_values \
+  "$TEST_ROOT/alpha-state-after.json" "$TEST_ROOT/beta-state-after.json"
 run_real_cli agent show hosted-alpha --format json >"$TEST_ROOT/alpha-after.json" \
   || fail "could not inspect hosted-alpha after restart"
 run_real_cli agent show hosted-beta --format json >"$TEST_ROOT/beta-after.json" \
   || fail "could not inspect hosted-beta after restart"
 assert_real_principal_isolation "$TEST_ROOT/alpha-after.json" "$TEST_ROOT/beta-after.json"
-run_real_cli audit stats --format json >"$TEST_ROOT/audit-after.json" \
-  || fail "could not read audit stats after restart"
-"$PYTHON" - "$TEST_ROOT/audit-before.json" "$TEST_ROOT/audit-after.json" <<'PY'
-import json
-import sys
+run_as_principal_cli hosted-alpha agent list --format json \
+  >"$TEST_ROOT/alpha-self-after.json" \
+  || fail "hosted-alpha lost self-scoped list after fresh-container reopen"
+assert_real_self_list "$TEST_ROOT/alpha-self-after.json" hosted-alpha
+run_as_principal_cli hosted-beta agent list --format json \
+  >"$TEST_ROOT/beta-self-after.json" \
+  || fail "hosted-beta lost self-scoped list after fresh-container reopen"
+assert_real_self_list "$TEST_ROOT/beta-self-after.json" hosted-beta
 
-before = json.load(open(sys.argv[1], encoding="utf-8"))
-after = json.load(open(sys.argv[2], encoding="utf-8"))
-before_stats = before.get("stats", {})
-after_stats = after.get("stats", {})
-before_count = before_stats.get("total_count")
-after_count = after_stats.get("total_count")
-if not isinstance(before_count, int) or not isinstance(after_count, int):
-    raise SystemExit("audit stats omitted total_count across restart")
-if after_count < before_count:
-    raise SystemExit(f"audit count regressed across restart: {before_count} -> {after_count}")
-if after_stats.get("degraded"):
-    raise SystemExit("audit became degraded after restart")
-PY
-
-# A principal's stamped client cannot use its Linux UID or an environment
-# label to gain operator authority.  The kernel must reject admin enumeration
-# for both owner principals even though they share the container UID.
-for principal in hosted-alpha hosted-beta; do
-  if docker exec "$REAL_CONTAINER" env ASTRID_PRINCIPAL="$principal" \
-    /usr/local/bin/astrid agent list >"$TEST_ROOT/$principal-list.out" \
-    2>"$TEST_ROOT/$principal-list.err"; then
-    fail "$principal unexpectedly gained operator agent-list authority"
-  fi
-  grep -Eqi "denied|permission|admin" "$TEST_ROOT/$principal-list.err" ||
-    fail "$principal denial did not identify an authority boundary"
-done
-
-docker stop --time 10 "$REAL_CONTAINER" >/dev/null
-docker rm "$REAL_CONTAINER" >/dev/null
-REAL_CONTAINER=
+# A genuine restricted principal has no implicit self:list capability, so it
+# must not inherit the agent-group self row. An agent principal also cannot
+# modify a peer despite sharing the container UID and state mount.
+if run_as_principal_cli hosted-restricted agent list \
+  >"$TEST_ROOT/restricted-list.out" 2>"$TEST_ROOT/restricted-list.err"; then
+  fail "restricted principal unexpectedly gained agent-list authority"
+fi
+grep -Eqi "denied|permission|capability" "$TEST_ROOT/restricted-list.err" ||
+  fail "restricted principal denial did not identify an authority boundary"
+if run_as_principal_cli hosted-alpha agent modify hosted-beta --add-group restricted \
+  >"$TEST_ROOT/alpha-cross-modify.out" 2>"$TEST_ROOT/alpha-cross-modify.err"; then
+  fail "hosted-alpha unexpectedly modified hosted-beta"
+fi
+grep -Eqi "denied|permission|capability" "$TEST_ROOT/alpha-cross-modify.err" ||
+  fail "cross-principal denial did not identify an authority boundary"
 
 # Reject lifecycle and identity overrides before any distro I/O.
 for forbidden in \
@@ -312,6 +422,21 @@ for override in \
   fi
   grep -q "fixed to" "$TEST_ROOT/$override_name.err" ||
     fail "authority-root override $override did not fail closed"
+done
+
+# Security-sensitive policy overrides are inherited inputs too. The hosted
+# profile denies both, even when the caller supplies an otherwise harmless
+# value, before any distro or runtime initialization can occur.
+for override in \
+  "ASTRID_SANDBOX_POLICY=off" \
+  "ASTRID_ALLOW_LOCAL_IPS=1"; do
+  override_name=${override%%=*}
+  if docker run --rm --platform "$OCI_PLATFORM" --env "$override" "$IMAGE" \
+    >"$TEST_ROOT/$override_name.out" 2>"$TEST_ROOT/$override_name.err"; then
+    fail "hosted profile accepted inherited policy override $override"
+  fi
+  grep -q "override is not permitted" "$TEST_ROOT/$override_name.err" ||
+    fail "inherited policy override $override did not fail closed"
 done
 
 cat > "$TEST_ROOT/fake-daemon" <<'EOF'
@@ -511,4 +636,13 @@ fi
 grep -q "STAGED_DISTRO_SURVIVED_SOURCE_SWAP" "$TEST_ROOT/swap.out" ||
   fail "source pathname swap test did not reach the daemon"
 
-echo "oci $OCI_TEST_LABEL structure, authentication, and restricted startup tests passed"
+# The exact v0.10.4 audit command is a registered stub. Its persistence is not
+# exposed through a supported query, so this profile must stop here rather than
+# passing a global count or inventing release behavior.
+if run_real_cli audit status \
+  >"$TEST_ROOT/audit-probe.out" 2>"$TEST_ROOT/audit-probe.err"; then
+  fail "v0.10.4 unexpectedly exposed an audit query"
+fi
+grep -q "audit trail inspection is not available" "$TEST_ROOT/audit-probe.err" ||
+  fail "unexpected v0.10.4 audit surface; re-evaluate the exact-release proof"
+fail "v0.10.4 baseline blocker: audit is deferred and exposes no supported chain/head or principal-scoped query; audit qualification requires a later exact immutable release"

--- a/container/amd64/test.sh
+++ b/container/amd64/test.sh
@@ -39,6 +39,12 @@ fail() {
   exit 1
 }
 
+parse_proc_status_field() {
+  local status_file=$1
+  local field=$2
+  awk -v field="$field" '$1 == field ":" { print $2; exit }' "$status_file"
+}
+
 prepare_runtime_dir() {
   local directory=$1
   local mode=${2:-0700}
@@ -133,23 +139,31 @@ wait_real_runtime() {
 }
 
 assert_daemon_is_pid_one() {
-  local identity
-  identity=$(docker exec "$REAL_CONTAINER" /bin/sh -ec '
-    [ "$(cat /proc/1/comm)" = astrid-daemon ] ||
-      { printf "comm=%s\n" "$(cat /proc/1/comm)" >&2; exit 1; }
-    exe=$(readlink /proc/1/exe)
+  local status
+  status=$(docker exec "$REAL_CONTAINER" cat /proc/1/status) ||
+    fail "daemon status probe failed"
+  local comm
+  comm=$(docker exec "$REAL_CONTAINER" cat /proc/1/comm) ||
+    fail "daemon command-name probe failed"
+  local exe
+  exe=$(docker exec "$REAL_CONTAINER" readlink /proc/1/exe) ||
+    fail "daemon executable probe failed"
+  local cwd
+  cwd=$(docker exec "$REAL_CONTAINER" readlink /proc/1/cwd) ||
+    fail "daemon working-directory probe failed"
+  local uid
+  uid=$(printf '%s\n' "$status" | parse_proc_status_field /dev/stdin Uid)
+  local gid
+  gid=$(printf '%s\n' "$status" | parse_proc_status_field /dev/stdin Gid)
+  [ "$comm" = astrid-daemon ] ||
+    { printf "comm=%s\n" "$comm" >&2; exit 1; }
     [ "$(basename "$exe")" = astrid-daemon ] ||
       { printf "exe=%s\n" "$exe" >&2; exit 1; }
-    uid=$(sed -n "s/^Uid:[[:space:]]*//p" /proc/1/status | cut -d" " -f1)
-    gid=$(sed -n "s/^Gid:[[:space:]]*//p" /proc/1/status | cut -d" " -f1)
-    [ "$uid" = 65532 ] && [ "$gid" = 65532 ] ||
-      { printf "uid=%s gid=%s\n" "$uid" "$gid" >&2; exit 1; }
-    [ "$(readlink /proc/1/cwd)" = /workspace ] ||
-      { printf "cwd=%s\n" "$(readlink /proc/1/cwd)" >&2; exit 1; }
-    printf "PID1 astrid-daemon 65532:65532 /workspace\n"
-    ') || fail "daemon identity probe failed"
-  [[ "$identity" == "PID1 astrid-daemon 65532:65532 /workspace" ]] ||
-    fail "real daemon is not PID 1 as uid/gid 65532 in /workspace: $identity"
+  [ "$uid" = 65532 ] && [ "$gid" = 65532 ] ||
+    { printf "uid=%s gid=%s\n" "$uid" "$gid" >&2; exit 1; }
+  [ "$cwd" = /workspace ] ||
+    { printf "cwd=%s\n" "$cwd" >&2; exit 1; }
+  printf 'PID1 astrid-daemon 65532:65532 /workspace\n'
 }
 
 run_real_cli() {

--- a/container/amd64/test.sh
+++ b/container/amd64/test.sh
@@ -265,16 +265,42 @@ run_as_principal_cli() {
     /usr/local/bin/astrid "$@"
 }
 
+register_v0104_audit_stderr() {
+  local destination=$1
+
+  # Registered from v0.10.4 / TEST_SOURCE_COMMIT=b6bf5d1d579915eb5d3c944857d84e62a4fcc878.
+  # The stream is exactly 175 bytes, SHA-256 8af9a0342aa14e2f65a9f563a0685f8dc8f806f7eda3d2ae5fa088fe667ae8a4.
+  # Any release or byte drift requires a fresh exact-release re-evaluation.
+  printf '%s\n' \
+    "astrid: audit trail inspection is not available in this release." \
+    >"$destination"
+  printf '%s\n' \
+    "  Tracking issue #675 (Layer 7 audit log routing) — see https://github.com/astrid-runtime/astrid/issues/675" \
+    >>"$destination"
+}
+
 assert_v0104_audit_is_non_gating() {
   local output=$1
   local error=$2
-  if run_real_cli audit status \
-    >"$output" 2>"$error"; then
+  local status=0
+  local expected=$TEST_ROOT/v0104-audit-expected.stderr
+
+  run_real_cli audit status \
+    >"$output" 2>"$error" || status=$?
+  if [ "$status" -eq 0 ]; then
     fail "v0.10.4 unexpectedly exposed an audit query"
   fi
-  printf '%s\n' "audit trail inspection is not available" |
-    cmp -s - "$error" ||
-    fail "unexpected v0.10.4 audit surface; re-evaluate the exact-release proof"
+  if [ "$status" -ne 2 ]; then
+    printf '%s\n' "captured stderr:" >&2
+    cat "$error" >&2
+    fail "v0.10.4 audit stub exited $status, expected 2; re-evaluate the exact-release proof"
+  fi
+  register_v0104_audit_stderr "$expected"
+  if ! cmp -s "$error" "$expected"; then
+    printf '%s\n' "captured stderr:" >&2
+    cat "$error" >&2
+    fail "v0.10.4 audit stderr drifted; re-evaluate the exact-release proof"
+  fi
   printf '%s\n' \
     "BLOCKED AUDIT (non-gating): v0.10.4 baseline blocker; audit is deferred and exposes no supported chain/head or principal-scoped query."
 }

--- a/container/amd64/test.sh
+++ b/container/amd64/test.sh
@@ -72,6 +72,18 @@ runtime_path_is_symlink() {
     sh "$relative"
 }
 
+write_runtime_workspace_marker() {
+  local directory=$1
+  docker run --rm \
+    --platform "$OCI_PLATFORM" \
+    --user 65532:65532 \
+    --entrypoint /bin/sh \
+    --mount "type=bind,src=$directory,dst=/workspace" \
+    "$IMAGE" \
+    -ec 'printf "%s\n" "$1" > "$2"' \
+    sh same-mounted-workspace "/workspace/.astrid-oci-mounted-state"
+}
+
 start_real_runtime() {
   local state_dir=$1
   local workspace_dir=$2
@@ -165,7 +177,7 @@ if names != [principal]:
 PY
 }
 
-assert_real_principal_isolation() {
+assert_real_principal_identity_and_groups() {
   local alpha=$1
   local beta=$2
   "$PYTHON" - "$alpha" "$beta" <<'PY'
@@ -187,18 +199,20 @@ PY
 
 read_runtime_state_file() {
   local relative=$1
+  local runtime_file="/runtime/$relative"
   docker run --rm \
     --platform "$OCI_PLATFORM" \
     --user 0:0 \
     --entrypoint /bin/sh \
     --mount "type=bind,src=$run_dir/real-state,dst=/runtime,readonly" \
     "$IMAGE" \
-    -ec 'cat "$1"' \
-    sh "$relative"
+    -ec 'cat -- "$1"' \
+    sh "$runtime_file"
 }
 
 assert_runtime_state_file_mode() {
   local relative=$1
+  local runtime_file="/runtime/$relative"
   local mode
   mode=$(docker run --rm \
     --platform "$OCI_PLATFORM" \
@@ -207,7 +221,7 @@ assert_runtime_state_file_mode() {
     --mount "type=bind,src=$run_dir/real-state,dst=/runtime,readonly" \
     "$IMAGE" \
     -ec 'stat -c "%a %u %g" "$1"' \
-    sh "$relative")
+    sh "$runtime_file")
   [[ "$mode" == "600 65532 65532" ]] ||
     fail "owner state $relative has unsafe custody metadata: $mode"
 }
@@ -268,6 +282,7 @@ python3 scripts/create_oci_test_shuttle.py \
 run_dir="$TEST_ROOT/run"
 prepare_runtime_dir "$run_dir/real-state"
 prepare_runtime_dir "$run_dir/real-workspace" 0755
+write_runtime_workspace_marker "$run_dir/real-workspace"
 distro_sha256=$(sha256sum "$TEST_ROOT/fixtures/distro.shuttle")
 distro_sha256=${distro_sha256%% *}
 
@@ -280,9 +295,10 @@ wait_real_runtime initial
 assert_daemon_is_pid_one
 FIRST_REAL_CONTAINER=$REAL_CONTAINER
 
-# Persist two independent owner records and a capability-group change through
-# the authenticated admin path.  This is deliberately done by the real
-# release binary, not by writing files from the container's Linux UID.
+# Create principals and update a capability group through the authenticated
+# admin CLI. Then use the release CLI's direct filesystem secret writes to
+# persist distinct owner-state artifacts on the shared state mount. This is
+# persistence evidence, not authenticated admin IPC or secret-read isolation.
 run_real_cli agent create hosted-alpha --group agent --yes \
   >"$TEST_ROOT/alpha-create.out" 2>"$TEST_ROOT/alpha-create.err" || {
   cat "$TEST_ROOT/alpha-create.out" >&2 || true
@@ -311,7 +327,7 @@ run_real_cli agent show hosted-alpha --format json >"$TEST_ROOT/alpha-before.jso
   || fail "could not inspect hosted-alpha before restart"
 run_real_cli agent show hosted-beta --format json >"$TEST_ROOT/beta-before.json" \
   || fail "could not inspect hosted-beta before restart"
-assert_real_principal_isolation "$TEST_ROOT/alpha-before.json" "$TEST_ROOT/beta-before.json"
+assert_real_principal_identity_and_groups "$TEST_ROOT/alpha-before.json" "$TEST_ROOT/beta-before.json"
 run_as_principal_cli hosted-alpha agent list --format json \
   >"$TEST_ROOT/alpha-self-before.json" \
   || fail "hosted-alpha could not read its own principal row"
@@ -327,8 +343,6 @@ run_real_cli secret set OCI_OWNER_STATE alpha-owner-state --agent hosted-alpha \
 run_real_cli secret set OCI_OWNER_STATE beta-owner-state --agent hosted-beta \
   >"$TEST_ROOT/beta-state-write.out" 2>"$TEST_ROOT/beta-state-write.err" \
   || fail "could not write hosted-beta owner state"
-printf 'same-mounted-workspace\n' \
-  >"$run_dir/real-workspace/.astrid-oci-mounted-state"
 read_runtime_state_file home/hosted-alpha/.config/env/default.env.json \
   >"$TEST_ROOT/alpha-state-before.json"
 read_runtime_state_file home/hosted-beta/.config/env/default.env.json \
@@ -360,7 +374,7 @@ run_real_cli agent show hosted-alpha --format json >"$TEST_ROOT/alpha-after.json
   || fail "could not inspect hosted-alpha after restart"
 run_real_cli agent show hosted-beta --format json >"$TEST_ROOT/beta-after.json" \
   || fail "could not inspect hosted-beta after restart"
-assert_real_principal_isolation "$TEST_ROOT/alpha-after.json" "$TEST_ROOT/beta-after.json"
+assert_real_principal_identity_and_groups "$TEST_ROOT/alpha-after.json" "$TEST_ROOT/beta-after.json"
 run_as_principal_cli hosted-alpha agent list --format json \
   >"$TEST_ROOT/alpha-self-after.json" \
   || fail "hosted-alpha lost self-scoped list after fresh-container reopen"
@@ -636,13 +650,16 @@ fi
 grep -q "STAGED_DISTRO_SURVIVED_SOURCE_SWAP" "$TEST_ROOT/swap.out" ||
   fail "source pathname swap test did not reach the daemon"
 
-# The exact v0.10.4 audit command is a registered stub. Its persistence is not
-# exposed through a supported query, so this profile must stop here rather than
-# passing a global count or inventing release behavior.
+# The exact v0.10.4 audit command is a registered stub. Record that fact as a
+# non-gating blocker instead of pretending that a global count, absent query,
+# or green test exit proves audit continuity.
 if run_real_cli audit status \
   >"$TEST_ROOT/audit-probe.out" 2>"$TEST_ROOT/audit-probe.err"; then
   fail "v0.10.4 unexpectedly exposed an audit query"
 fi
 grep -q "audit trail inspection is not available" "$TEST_ROOT/audit-probe.err" ||
   fail "unexpected v0.10.4 audit surface; re-evaluate the exact-release proof"
-fail "v0.10.4 baseline blocker: audit is deferred and exposes no supported chain/head or principal-scoped query; audit qualification requires a later exact immutable release"
+printf '%s\n' \
+  "BLOCKED AUDIT (non-gating): v0.10.4 baseline blocker; audit is deferred and exposes no supported chain/head or principal-scoped query."
+echo "oci $OCI_TEST_LABEL structure, authentication, principal authority, and fresh-container reopen checks passed"
+echo "Audit continuity remains unproven on v0.10.4; this result does not claim hosted-profile qualification."

--- a/scripts/test_oci_container_contract.py
+++ b/scripts/test_oci_container_contract.py
@@ -569,6 +569,7 @@ class RuntimeHarnessContractTests(unittest.TestCase):
             "}\n",
             "REAL_CONTAINER=contract-runtime\n",
             shell_function("run_real_cli"),
+            shell_function("register_v0104_audit_stderr"),
             shell_function("assert_v0104_audit_is_non_gating"),
         ]
         fake_docker_source = (
@@ -577,7 +578,7 @@ class RuntimeHarnessContractTests(unittest.TestCase):
             "  printf '%s\\0' \"$argument\" >> \"$DOCKER_CALL_LOG\"\n"
             "done\n"
             "printf '\\0' >> \"$DOCKER_CALL_LOG\"\n"
-            'printf "%s\\n" "$FAKE_AUDIT_STDERR" >&2\n'
+            'printf "%s" "$FAKE_AUDIT_STDERR" >&2\n'
             'exit "$FAKE_AUDIT_STATUS"\n'
         )
 
@@ -586,27 +587,56 @@ class RuntimeHarnessContractTests(unittest.TestCase):
             "audit is deferred and exposes no supported chain/head or "
             "principal-scoped query.\n"
         )
-        registered_stderr = "audit trail inspection is not available"
+        registered_first = (
+            "astrid: audit trail inspection is not available in this release.\n"
+        )
+        registered_second = (
+            "  Tracking issue #675 (Layer 7 audit log routing) — see "
+            "https://github.com/astrid-runtime/astrid/issues/675\n"
+        )
+        registered_stderr = registered_first + registered_second
         cases = [
-            ("failed-stub", "1", registered_stderr, 0),
-            ("successful-stub", "0", registered_stderr, 1),
-            ("wrong-failed-stub", "1", "audit trail query failed", 1),
+            ("registered-status-two", "2", registered_stderr, 0),
+            ("status-zero", "0", registered_stderr, 1),
+            ("status-one", "1", registered_stderr, 1),
+            ("status-three", "3", registered_stderr, 1),
+            ("old-one-line", "2", "audit trail inspection is not available\n", 1),
+            ("first-line-only", "2", registered_first, 1),
             (
-                "failed-prefix-and-marker",
-                "1",
-                f"prefix {registered_stderr}",
+                "missing-issue-number",
+                "2",
+                registered_first
+                + registered_second.replace("#675 ", "", 1),
                 1,
             ),
             (
-                "failed-marker-and-suffix",
-                "1",
-                f"{registered_stderr} suffix",
+                "prefix",
+                "2",
+                "prefix " + registered_stderr,
                 1,
             ),
             (
-                "failed-marker-and-extra-line",
-                "1",
-                f"{registered_stderr}\nextra detail",
+                "suffix",
+                "2",
+                registered_stderr.removesuffix("\n") + " suffix\n",
+                1,
+            ),
+            (
+                "extra-line",
+                "2",
+                registered_stderr + "extra detail\n",
+                1,
+            ),
+            (
+                "extra-whitespace",
+                "2",
+                registered_first.replace("\n", " \n", 1) + registered_second,
+                1,
+            ),
+            (
+                "ascii-hyphen",
+                "2",
+                registered_first + registered_second.replace("—", "-", 1),
                 1,
             ),
         ]
@@ -628,6 +658,7 @@ class RuntimeHarnessContractTests(unittest.TestCase):
                         "DOCKER_CALL_LOG": str(call_log),
                         "FAKE_AUDIT_STATUS": status,
                         "FAKE_AUDIT_STDERR": stderr,
+                        "TEST_ROOT": str(bin_dir),
                     },
                 )
 
@@ -648,12 +679,33 @@ class RuntimeHarnessContractTests(unittest.TestCase):
                         self.assertEqual(completed.stdout, expected_blocker)
                     else:
                         self.assertEqual(completed.stdout, "")
-                        self.assertIn(
-                            "v0.10.4 unexpectedly exposed an audit query"
-                            if status == "0"
-                            else "unexpected v0.10.4 audit surface",
-                            completed.stderr,
-                        )
+                        if status == "0":
+                            self.assertIn(
+                                "v0.10.4 unexpectedly exposed an audit query",
+                                completed.stderr,
+                            )
+                        else:
+                            self.assertIn("captured stderr", completed.stderr)
+                            self.assertIn(
+                                "re-evaluate the exact-release proof",
+                                completed.stderr,
+                            )
+
+    def test_audit_probe_rejects_status_and_matcher_mutations(self) -> None:
+        registered_function = shell_function("register_v0104_audit_stderr")
+        assert_function = shell_function("assert_v0104_audit_is_non_gating")
+
+        self.assertIn("v0.10.4 / TEST_SOURCE_COMMIT=b6bf5d1", registered_function)
+        self.assertIn(
+            "SHA-256 8af9a0342aa14e2f65a9f563a0685f8dc8f806f7eda3d2ae5fa088fe667ae8a4",
+            registered_function,
+        )
+        self.assertIn("run_real_cli audit status", assert_function)
+        self.assertIn('|| status=$?', assert_function)
+        self.assertNotIn("|| true", assert_function)
+        self.assertIn('[ "$status" -ne 2 ]', assert_function)
+        self.assertNotIn("grep -Fq", assert_function)
+        self.assertIn('cmp -s "$error" "$expected"', assert_function)
 
     def test_harness_rejects_inherited_security_policy_bypasses(self) -> None:
         self.assertIn("ASTRID_SANDBOX_POLICY=off", TEST_HARNESS)

--- a/scripts/test_oci_container_contract.py
+++ b/scripts/test_oci_container_contract.py
@@ -66,6 +66,24 @@ class DockerfileContractTests(unittest.TestCase):
 
 
 class EntrypointContractTests(unittest.TestCase):
+    def test_rejects_inherited_security_policy_bypasses_before_runtime(self) -> None:
+        self.assertIn(
+            "inherited ASTRID_SANDBOX_POLICY override is not permitted",
+            ENTRYPOINT,
+        )
+        self.assertIn(
+            "inherited ASTRID_ALLOW_LOCAL_IPS override is not permitted",
+            ENTRYPOINT,
+        )
+        self.assertLess(
+            ENTRYPOINT.index("ASTRID_SANDBOX_POLICY+set"),
+            ENTRYPOINT.index("for daemon_argument do"),
+        )
+        self.assertLess(
+            ENTRYPOINT.index("ASTRID_ALLOW_LOCAL_IPS+set"),
+            ENTRYPOINT.index("/usr/local/bin/astrid init"),
+        )
+
     def test_requires_external_pin_and_internal_signature_gate(self) -> None:
         self.assertIn("ASTRID_DISTRO_SHA256 is required", ENTRYPOINT)
         self.assertIn("sha256sum", ENTRYPOINT)
@@ -119,19 +137,33 @@ class RuntimeHarnessContractTests(unittest.TestCase):
         self.assertNotIn("FROM $IMAGE", TEST_HARNESS)
         self.assertIn('docker image rm --force "$TEST_BASE_IMAGE"', TEST_HARNESS)
 
-    def test_harness_has_restart_owner_and_audit_isolation_probes(self) -> None:
+    def test_harness_has_fresh_reopen_owner_and_principal_isolation_probes(self) -> None:
         for marker in (
-            "restart/reopen",
-            "audit",
+            "fresh-container reopen",
             "principal",
-            "workspace",
-            "capability",
+            "owner state",
+            "same mounted workspace",
+            "pid1 astrid-daemon",
+            "hosted-restricted agent list",
         ):
             with self.subTest(marker=marker):
                 self.assertIn(marker, TEST_HARNESS.lower())
-        self.assertIn("docker restart", TEST_HARNESS)
+        self.assertNotIn("docker restart", TEST_HARNESS.lower())
         self.assertIn("agent create", TEST_HARNESS)
-        self.assertIn("audit stats", TEST_HARNESS)
+
+    def test_harness_never_uses_unsupported_v0104_audit_query(self) -> None:
+        self.assertNotIn("audit stats", TEST_HARNESS.lower())
+        self.assertIn("audit status", TEST_HARNESS)
+        self.assertIn("v0.10.4 baseline blocker", TEST_HARNESS)
+        self.assertIn(
+            "no supported chain/head or principal-scoped query",
+            TEST_HARNESS.lower(),
+        )
+
+    def test_harness_rejects_inherited_security_policy_bypasses(self) -> None:
+        self.assertIn("ASTRID_SANDBOX_POLICY=off", TEST_HARNESS)
+        self.assertIn("ASTRID_ALLOW_LOCAL_IPS=1", TEST_HARNESS)
+        self.assertIn("inherited policy override", TEST_HARNESS.lower())
 
     def test_harness_rejects_host_socket_and_privileged_runtime(self) -> None:
         lowered = TEST_HARNESS.lower()

--- a/scripts/test_oci_container_contract.py
+++ b/scripts/test_oci_container_contract.py
@@ -288,7 +288,7 @@ class RuntimeHarnessContractTests(unittest.TestCase):
             TEST_HARNESS.lower(),
         )
 
-    def test_audit_probe_requires_failed_stub_status_and_reports_blocker(self) -> None:
+    def test_audit_probe_requires_failed_status_and_exact_stub_stderr(self) -> None:
         audit_functions = [
             "fail() {\n"
             '  printf "audit probe: %s\\n" "$*" >&2\n'
@@ -304,63 +304,64 @@ class RuntimeHarnessContractTests(unittest.TestCase):
             "  printf '%s\\0' \"$argument\" >> \"$DOCKER_CALL_LOG\"\n"
             "done\n"
             "printf '\\0' >> \"$DOCKER_CALL_LOG\"\n"
-            'printf "%s\\n" "audit trail inspection is not available" >&2\n'
+            'printf "%s\\n" "$FAKE_AUDIT_STDERR" >&2\n'
             'exit "$FAKE_AUDIT_STATUS"\n'
         )
 
-        with tempfile.TemporaryDirectory() as temporary:
-            root = pathlib.Path(temporary)
-            bin_dir = root / "failed-stub"
-            bin_dir.mkdir()
-            call_log = root / "failed-audit-calls"
-            fake_docker = bin_dir / "docker"
-            fake_docker.write_text(fake_docker_source, encoding="utf-8")
-            fake_docker.chmod(0o755)
-            completed = run_extracted_shell(
-                audit_functions,
-                "assert_v0104_audit_is_non_gating probe.out probe.err",
-                bin_dir,
-                {
-                    "DOCKER_CALL_LOG": str(call_log),
-                    "FAKE_AUDIT_STATUS": "1",
-                },
-            )
-
-            self.assertEqual(completed.returncode, 0, completed.stderr)
-            self.assertEqual(
-                completed.stdout,
-                "BLOCKED AUDIT (non-gating): v0.10.4 baseline blocker; "
-                "audit is deferred and exposes no supported chain/head or "
-                "principal-scoped query.\n",
-            )
-            calls = docker_call_log(call_log)
-            self.assertEqual(len(calls), 1)
-            self.assertEqual(calls[0][0], "exec")
-            self.assertEqual(
-                calls[0][-3:],
-                ["/usr/local/bin/astrid", "audit", "status"],
-            )
+        expected_blocker = (
+            "BLOCKED AUDIT (non-gating): v0.10.4 baseline blocker; "
+            "audit is deferred and exposes no supported chain/head or "
+            "principal-scoped query.\n"
+        )
+        cases = [
+            ("failed-stub", "1", "audit trail inspection is not available", 0),
+            ("successful-stub", "0", "audit trail inspection is not available", 1),
+            ("wrong-failed-stub", "1", "audit trail query failed", 1),
+        ]
 
         with tempfile.TemporaryDirectory() as temporary:
             root = pathlib.Path(temporary)
-            bin_dir = root / "successful-query"
-            bin_dir.mkdir()
-            fake_docker = bin_dir / "docker"
-            fake_docker.write_text("exit 0\n", encoding="utf-8")
-            fake_docker.chmod(0o755)
-            completed = run_extracted_shell(
-                audit_functions,
-                "assert_v0104_audit_is_non_gating probe.out probe.err",
-                bin_dir,
-                {"FAKE_AUDIT_STATUS": "0"},
-            )
+            for label, status, stderr, expected_status in cases:
+                bin_dir = root / label
+                bin_dir.mkdir()
+                call_log = root / f"{label}-calls"
+                fake_docker = bin_dir / "docker"
+                fake_docker.write_text(fake_docker_source, encoding="utf-8")
+                fake_docker.chmod(0o755)
+                completed = run_extracted_shell(
+                    audit_functions,
+                    "assert_v0104_audit_is_non_gating probe.out probe.err",
+                    bin_dir,
+                    {
+                        "DOCKER_CALL_LOG": str(call_log),
+                        "FAKE_AUDIT_STATUS": status,
+                        "FAKE_AUDIT_STDERR": stderr,
+                    },
+                )
 
-            self.assertNotEqual(completed.returncode, 0)
-            self.assertNotIn("BLOCKED AUDIT", completed.stdout)
-            self.assertIn(
-                "v0.10.4 unexpectedly exposed an audit query",
-                completed.stderr,
-            )
+                with self.subTest(case=label):
+                    self.assertEqual(
+                        completed.returncode,
+                        expected_status,
+                        completed.stderr,
+                    )
+                    calls = docker_call_log(call_log)
+                    self.assertEqual(len(calls), 1)
+                    self.assertEqual(calls[0][0], "exec")
+                    self.assertEqual(
+                        calls[0][-3:],
+                        ["/usr/local/bin/astrid", "audit", "status"],
+                    )
+                    if expected_status == 0:
+                        self.assertEqual(completed.stdout, expected_blocker)
+                    else:
+                        self.assertEqual(completed.stdout, "")
+                        self.assertIn(
+                            "v0.10.4 unexpectedly exposed an audit query"
+                            if status == "0"
+                            else "unexpected v0.10.4 audit surface",
+                            completed.stderr,
+                        )
 
     def test_harness_rejects_inherited_security_policy_bypasses(self) -> None:
         self.assertIn("ASTRID_SANDBOX_POLICY=off", TEST_HARNESS)

--- a/scripts/test_oci_container_contract.py
+++ b/scripts/test_oci_container_contract.py
@@ -379,6 +379,93 @@ class RuntimeHarnessContractTests(unittest.TestCase):
         self.assertNotIn("docker restart", TEST_HARNESS.lower())
         self.assertIn("agent create", TEST_HARNESS)
 
+    def test_daemon_pid1_identity_parses_tab_delimited_proc_status(self) -> None:
+        assert_function = shell_function("assert_daemon_is_pid_one")
+        parse_function = shell_function("parse_proc_status_field")
+        new_parser = (
+            "  awk -v field=\"$field\" "
+            "'$1 == field \":\" { print $2; exit }' \"$status_file\""
+        )
+        old_parser = (
+            '  sed -n "s/^${field}:[[:space:]]*//p" "$status_file" '
+            '| cut -d" " -f1'
+        )
+        fail_function = (
+            "fail() {\n"
+            "  printf 'pid1 contract: %s\\n' \"$*\" >&2\n"
+            "  exit 1\n"
+            "}\n"
+        )
+        self.assertIn(new_parser, parse_function)
+        self.assertNotIn("cut -d", assert_function)
+
+        valid_status = (
+            "Name:\tastrid-daemon\n"
+            "Uid:\t65532\t65532\t65532\t65532\n"
+            "Gid:\t65532\t65532\t65532\t65532\n"
+        )
+        invalid_status = valid_status.replace(
+            "Uid:\t65532",
+            "Uid:\t65533",
+            1,
+        )
+        mutant_parser = parse_function.replace(new_parser, old_parser)
+        cases = [
+            ("tab-delimited-fields", parse_function, valid_status, 0),
+            ("old-space-delimited-cut", mutant_parser, valid_status, 1),
+            ("wrong-uid", parse_function, invalid_status, 1),
+        ]
+
+        for label, parser, status, expected_status in cases:
+            with self.subTest(case=label):
+                with tempfile.TemporaryDirectory() as temporary:
+                    root = pathlib.Path(temporary)
+                    bin_dir = root / "bin"
+                    bin_dir.mkdir()
+                    fake_docker = bin_dir / "docker"
+                    fake_docker.write_text(
+                        "#!/bin/sh\n"
+                        "case \"$*\" in\n"
+                        "*\"cat /proc/1/status\"*)\n"
+                        "  printf '%s\\n' \"$FAKE_STATUS\"\n"
+                        "  ;;\n"
+                        "*\"cat /proc/1/comm\"*)\n"
+                        "  printf '%s\\n' astrid-daemon\n"
+                        "  ;;\n"
+                        "*\"readlink /proc/1/exe\"*)\n"
+                        "  printf '%s\\n' /opt/astrid/release/astrid-daemon\n"
+                        "  ;;\n"
+                        "*\"readlink /proc/1/cwd\"*)\n"
+                        "  printf '%s\\n' /workspace\n"
+                        "  ;;\n"
+                        "*)\n"
+                        "  printf 'unexpected docker call: %s\\n' \"$*\" >&2\n"
+                        "  exit 64\n"
+                        "esac\n",
+                        encoding="utf-8",
+                    )
+                    fake_docker.chmod(0o755)
+                    completed = run_extracted_shell(
+                        [fail_function, parser, assert_function],
+                        "assert_daemon_is_pid_one",
+                        bin_dir,
+                        {
+                            "REAL_CONTAINER": "contract-runtime",
+                            "FAKE_STATUS": status,
+                        },
+                    )
+
+                    self.assertEqual(
+                        completed.returncode,
+                        expected_status,
+                        completed.stderr,
+                    )
+                    if expected_status == 0:
+                        self.assertEqual(
+                            completed.stdout,
+                            "PID1 astrid-daemon 65532:65532 /workspace\n",
+                        )
+
     def test_runtime_state_readers_resolve_through_runtime_mount(self) -> None:
         for function_name in (
             "read_runtime_state_file",

--- a/scripts/test_oci_container_contract.py
+++ b/scripts/test_oci_container_contract.py
@@ -313,10 +313,29 @@ class RuntimeHarnessContractTests(unittest.TestCase):
             "audit is deferred and exposes no supported chain/head or "
             "principal-scoped query.\n"
         )
+        registered_stderr = "audit trail inspection is not available"
         cases = [
-            ("failed-stub", "1", "audit trail inspection is not available", 0),
-            ("successful-stub", "0", "audit trail inspection is not available", 1),
+            ("failed-stub", "1", registered_stderr, 0),
+            ("successful-stub", "0", registered_stderr, 1),
             ("wrong-failed-stub", "1", "audit trail query failed", 1),
+            (
+                "failed-prefix-and-marker",
+                "1",
+                f"prefix {registered_stderr}",
+                1,
+            ),
+            (
+                "failed-marker-and-suffix",
+                "1",
+                f"{registered_stderr} suffix",
+                1,
+            ),
+            (
+                "failed-marker-and-extra-line",
+                "1",
+                f"{registered_stderr}\nextra detail",
+                1,
+            ),
         ]
 
         with tempfile.TemporaryDirectory() as temporary:

--- a/scripts/test_oci_container_contract.py
+++ b/scripts/test_oci_container_contract.py
@@ -19,7 +19,11 @@ class DockerfileContractTests(unittest.TestCase):
     def test_packages_release_bytes_without_building_source(self) -> None:
         self.assertIn("COPY dist/oci-amd64/astrid-release.tar.gz", DOCKERFILE)
         self.assertIn("ARG ASTRID_ARCHIVE_SHA256", DOCKERFILE)
+        self.assertIn("ARG ASTRID_ARCHIVE_BLAKE3", DOCKERFILE)
+        self.assertIn("ARG ASTRID_RELEASE_RECEIPT_SHA256", DOCKERFILE)
+        self.assertIn("ARG ASTRID_RELEASE_MANIFEST_SHA256", DOCKERFILE)
         self.assertIn("sha256sum --check --strict", DOCKERFILE)
+        self.assertIn("/opt/astrid/release-receipt.json", DOCKERFILE)
         self.assertNotIn("cargo build", DOCKERFILE)
         self.assertNotIn("git clone", DOCKERFILE)
         self.assertNotIn("curl ", DOCKERFILE)
@@ -35,6 +39,30 @@ class DockerfileContractTests(unittest.TestCase):
     def test_base_image_is_digest_pinned(self) -> None:
         first_line = DOCKERFILE.splitlines()[0]
         self.assertRegex(first_line, r"^FROM .+@sha256:[0-9a-f]{64}$")
+
+    def test_release_receipt_binds_image_to_exact_source_and_archive(self) -> None:
+        for field in (
+            "repository",
+            "version",
+            "tag",
+            "source-commit",
+            "target",
+            "archive",
+            "archive-sha256",
+            "archive-blake3",
+            "release-manifest-sha256",
+            "release-workflow-identity",
+        ):
+            with self.subTest(field=field):
+                self.assertIn(field, DOCKERFILE)
+        for label in (
+            "io.astrid.release.archive-sha256",
+            "io.astrid.release.archive-blake3",
+            "io.astrid.release.receipt-sha256",
+            "io.astrid.release.manifest-sha256",
+        ):
+            with self.subTest(label=label):
+                self.assertIn(label, DOCKERFILE)
 
 
 class EntrypointContractTests(unittest.TestCase):
@@ -64,6 +92,14 @@ class EntrypointContractTests(unittest.TestCase):
         self.assertIn(".astrid-oci-write-probe.XXXXXX", ENTRYPOINT)
         self.assertNotIn(".astrid-oci-write-probe.$$", ENTRYPOINT)
 
+    def test_hosted_profile_fixes_state_workspace_and_home_identity(self) -> None:
+        self.assertIn("ASTRID_HOME is fixed to /var/lib/astrid", ENTRYPOINT)
+        self.assertIn("ASTRID_WORKSPACE is fixed to /workspace", ENTRYPOINT)
+        self.assertIn("ASTRID_WORKSPACE_STATE_DIR is fixed to .astrid", ENTRYPOINT)
+        self.assertIn("HOME is fixed to /var/lib/astrid", ENTRYPOINT)
+        self.assertIn("ASTRID_HOME=/var/lib/astrid", ENTRYPOINT)
+        self.assertIn("ASTRID_WORKSPACE=/workspace", ENTRYPOINT)
+
     def test_foreground_daemon_allowlist_rejects_ephemeral_and_unknown_flags(self) -> None:
         self.assertIn("exec /usr/local/bin/astrid-daemon", ENTRYPOINT)
         command = ENTRYPOINT.rsplit("exec /usr/local/bin/astrid-daemon", 1)[1]
@@ -82,6 +118,28 @@ class RuntimeHarnessContractTests(unittest.TestCase):
         self.assertEqual(TEST_HARNESS.count("FROM $TEST_BASE_IMAGE"), 2)
         self.assertNotIn("FROM $IMAGE", TEST_HARNESS)
         self.assertIn('docker image rm --force "$TEST_BASE_IMAGE"', TEST_HARNESS)
+
+    def test_harness_has_restart_owner_and_audit_isolation_probes(self) -> None:
+        for marker in (
+            "restart/reopen",
+            "audit",
+            "principal",
+            "workspace",
+            "capability",
+        ):
+            with self.subTest(marker=marker):
+                self.assertIn(marker, TEST_HARNESS.lower())
+        self.assertIn("docker restart", TEST_HARNESS)
+        self.assertIn("agent create", TEST_HARNESS)
+        self.assertIn("audit stats", TEST_HARNESS)
+
+    def test_harness_rejects_host_socket_and_privileged_runtime(self) -> None:
+        lowered = TEST_HARNESS.lower()
+        self.assertNotIn("docker.sock", lowered)
+        self.assertNotIn("--privileged", lowered)
+        self.assertIn("--read-only", lowered)
+        self.assertIn("--cap-drop=all", lowered)
+        self.assertIn("--security-opt=no-new-privileges", lowered)
 
 
 class WorkflowContractTests(unittest.TestCase):
@@ -115,6 +173,13 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertNotIn("type=docker,dest=", build_job)
         self.assertNotIn("--load", build_job)
         self.assertIn('echo "BOUND_IMAGE=$IMAGE_REPO_DIGEST"', build_job)
+        for build_arg in (
+            '"ASTRID_ARCHIVE_BLAKE3=$ARCHIVE_BLAKE3"',
+            '"ASTRID_RELEASE_MANIFEST_SHA256=$RELEASE_MANIFEST_SHA256"',
+            '"ASTRID_RELEASE_RECEIPT_SHA256=$RELEASE_RECEIPT_SHA256"',
+        ):
+            with self.subTest(build_arg=build_arg):
+                self.assertIn(build_arg, build_job)
         first_binding = build_job.index("python3 scripts/oci_export_binding.py")
         runtime_test = build_job.index('container/amd64/test.sh "$BOUND_IMAGE"')
         scan = build_job.index("aquasecurity/trivy-action")

--- a/scripts/test_oci_container_contract.py
+++ b/scripts/test_oci_container_contract.py
@@ -151,10 +151,41 @@ class RuntimeHarnessContractTests(unittest.TestCase):
         self.assertNotIn("docker restart", TEST_HARNESS.lower())
         self.assertIn("agent create", TEST_HARNESS)
 
+    def test_runtime_state_helpers_use_mount_and_uid_for_evidence(self) -> None:
+        self.assertEqual(TEST_HARNESS.count('local runtime_file="/runtime/$relative"'), 2)
+        self.assertIn("direct filesystem secret writes", TEST_HARNESS)
+        self.assertIn("shared state mount", TEST_HARNESS)
+        self.assertIn(
+            "not authenticated admin IPC or secret-read isolation",
+            TEST_HARNESS,
+        )
+        self.assertIn(
+            'write_runtime_workspace_marker "$run_dir/real-workspace"',
+            TEST_HARNESS,
+        )
+        self.assertIn('"/workspace/.astrid-oci-mounted-state"', TEST_HARNESS)
+        self.assertIn("--user 65532:65532", TEST_HARNESS)
+        self.assertLess(
+            TEST_HARNESS.index('prepare_runtime_dir "$run_dir/real-workspace" 0755'),
+            TEST_HARNESS.index(
+                'write_runtime_workspace_marker "$run_dir/real-workspace"'
+            ),
+        )
+        self.assertNotIn(
+            '>"$run_dir/real-workspace/.astrid-oci-mounted-state"',
+            TEST_HARNESS,
+        )
+
     def test_harness_never_uses_unsupported_v0104_audit_query(self) -> None:
         self.assertNotIn("audit stats", TEST_HARNESS.lower())
         self.assertIn("audit status", TEST_HARNESS)
         self.assertIn("v0.10.4 baseline blocker", TEST_HARNESS)
+        self.assertIn("BLOCKED AUDIT (non-gating)", TEST_HARNESS)
+        self.assertIn(
+            "this result does not claim hosted-profile qualification",
+            TEST_HARNESS,
+        )
+        self.assertNotIn('fail "v0.10.4 baseline blocker', TEST_HARNESS)
         self.assertIn(
             "no supported chain/head or principal-scoped query",
             TEST_HARNESS.lower(),

--- a/scripts/test_oci_container_contract.py
+++ b/scripts/test_oci_container_contract.py
@@ -3,8 +3,12 @@
 
 from __future__ import annotations
 
+import os
 import pathlib
 import re
+import shlex
+import subprocess
+import tempfile
 import unittest
 
 
@@ -13,6 +17,44 @@ DOCKERFILE = (ROOT / "container/amd64/Dockerfile").read_text(encoding="utf-8")
 ENTRYPOINT = (ROOT / "container/amd64/entrypoint.sh").read_text(encoding="utf-8")
 TEST_HARNESS = (ROOT / "container/amd64/test.sh").read_text(encoding="utf-8")
 WORKFLOW = (ROOT / ".github/workflows/oci-amd64.yml").read_text(encoding="utf-8")
+
+
+def shell_function(name: str) -> str:
+    match = re.search(rf"(?ms)^{re.escape(name)}\(\) \{{\n.*?^\}}$", TEST_HARNESS)
+    if match is None:
+        raise AssertionError(f"shell function is not extractable: {name}")
+    return match.group(0)
+
+
+def run_extracted_shell(
+    functions: list[str],
+    invocation: str,
+    bin_dir: pathlib.Path,
+    environment: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    inherited_environment = os.environ.copy()
+    inherited_environment["PATH"] = f"{bin_dir}{os.pathsep}{inherited_environment['PATH']}"
+    inherited_environment["IMAGE"] = "contract-fixture-image"
+    inherited_environment["OCI_PLATFORM"] = "linux/amd64"
+    inherited_environment.update(environment or {})
+    script = "\n".join(("set -euo pipefail", *functions, invocation, ""))
+    return subprocess.run(
+        ["bash", "-c", script],
+        cwd=bin_dir,
+        env=inherited_environment,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def docker_call_log(log_path: pathlib.Path) -> list[list[str]]:
+    records = log_path.read_bytes().removesuffix(b"\0\0").split(b"\0\0")
+    return [
+        argument.decode("utf-8").split("\0")
+        for argument in records
+        if argument
+    ]
 
 
 class DockerfileContractTests(unittest.TestCase):
@@ -151,30 +193,85 @@ class RuntimeHarnessContractTests(unittest.TestCase):
         self.assertNotIn("docker restart", TEST_HARNESS.lower())
         self.assertIn("agent create", TEST_HARNESS)
 
-    def test_runtime_state_helpers_use_mount_and_uid_for_evidence(self) -> None:
-        self.assertEqual(TEST_HARNESS.count('local runtime_file="/runtime/$relative"'), 2)
-        self.assertIn("direct filesystem secret writes", TEST_HARNESS)
-        self.assertIn("shared state mount", TEST_HARNESS)
-        self.assertIn(
-            "not authenticated admin IPC or secret-read isolation",
-            TEST_HARNESS,
-        )
-        self.assertIn(
-            'write_runtime_workspace_marker "$run_dir/real-workspace"',
-            TEST_HARNESS,
-        )
-        self.assertIn('"/workspace/.astrid-oci-mounted-state"', TEST_HARNESS)
-        self.assertIn("--user 65532:65532", TEST_HARNESS)
-        self.assertLess(
-            TEST_HARNESS.index('prepare_runtime_dir "$run_dir/real-workspace" 0755'),
-            TEST_HARNESS.index(
-                'write_runtime_workspace_marker "$run_dir/real-workspace"'
-            ),
-        )
-        self.assertNotIn(
-            '>"$run_dir/real-workspace/.astrid-oci-mounted-state"',
-            TEST_HARNESS,
-        )
+    def test_runtime_state_readers_resolve_through_runtime_mount(self) -> None:
+        for function_name in (
+            "read_runtime_state_file",
+            "assert_runtime_state_file_mode",
+        ):
+            function = shell_function(function_name)
+            with self.subTest(function=function_name):
+                self.assertEqual(
+                    function.count('local runtime_file="/runtime/$relative"'),
+                    1,
+                )
+                self.assertEqual(function.count("docker run"), 1)
+                self.assertIn("--mount", function)
+                self.assertIn('dst=/runtime,readonly"', function)
+
+    def test_workspace_marker_helper_uses_runtime_uid_container_not_host_write(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = pathlib.Path(temporary)
+            bin_dir = root / "bin"
+            workspace = root / "workspace"
+            bin_dir.mkdir()
+            workspace.mkdir()
+            call_log = root / "docker-calls"
+            fake_docker = bin_dir / "docker"
+            fake_docker.write_text(
+                "#!/bin/sh\n"
+                "for argument do\n"
+                "  printf '%s\\0' \"$argument\" >> \"$DOCKER_CALL_LOG\"\n"
+                "done\n"
+                "printf '\\0' >> \"$DOCKER_CALL_LOG\"\n",
+                encoding="utf-8",
+            )
+            fake_docker.chmod(0o755)
+
+            completed = run_extracted_shell(
+                [shell_function("write_runtime_workspace_marker")],
+                f"write_runtime_workspace_marker {shlex.quote(str(workspace))}",
+                bin_dir,
+                {"DOCKER_CALL_LOG": str(call_log)},
+            )
+
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            self.assertEqual(
+                completed.stdout,
+                "",
+                "the marker helper must execute inside the container",
+            )
+            self.assertFalse(
+                (workspace / ".astrid-oci-mounted-state").exists(),
+                "the marker helper must not write to the host-side directory",
+            )
+            calls = docker_call_log(call_log)
+            self.assertEqual(len(calls), 1)
+            arguments = calls[0]
+            self.assertEqual(arguments[:2], ["run", "--rm"])
+            self.assertEqual(arguments[arguments.index("--platform") + 1], "linux/amd64")
+            self.assertEqual(arguments[arguments.index("--user") + 1], "65532:65532")
+            self.assertEqual(
+                arguments[arguments.index("--entrypoint") + 1],
+                "/bin/sh",
+            )
+            self.assertEqual(
+                arguments[arguments.index("--mount") + 1],
+                f"type=bind,src={workspace},dst=/workspace",
+            )
+            self.assertEqual(
+                arguments[arguments.index("-ec") + 1],
+                'printf "%s\\n" "$1" > "$2"',
+            )
+            self.assertEqual(
+                arguments[arguments.index("-ec") + 2 :],
+                [
+                    "sh",
+                    "same-mounted-workspace",
+                    "/workspace/.astrid-oci-mounted-state",
+                ],
+            )
 
     def test_harness_never_uses_unsupported_v0104_audit_query(self) -> None:
         self.assertNotIn("audit stats", TEST_HARNESS.lower())
@@ -190,6 +287,80 @@ class RuntimeHarnessContractTests(unittest.TestCase):
             "no supported chain/head or principal-scoped query",
             TEST_HARNESS.lower(),
         )
+
+    def test_audit_probe_requires_failed_stub_status_and_reports_blocker(self) -> None:
+        audit_functions = [
+            "fail() {\n"
+            '  printf "audit probe: %s\\n" "$*" >&2\n'
+            "  exit 1\n"
+            "}\n",
+            "REAL_CONTAINER=contract-runtime\n",
+            shell_function("run_real_cli"),
+            shell_function("assert_v0104_audit_is_non_gating"),
+        ]
+        fake_docker_source = (
+            "#!/bin/sh\n"
+            "for argument do\n"
+            "  printf '%s\\0' \"$argument\" >> \"$DOCKER_CALL_LOG\"\n"
+            "done\n"
+            "printf '\\0' >> \"$DOCKER_CALL_LOG\"\n"
+            'printf "%s\\n" "audit trail inspection is not available" >&2\n'
+            'exit "$FAKE_AUDIT_STATUS"\n'
+        )
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = pathlib.Path(temporary)
+            bin_dir = root / "failed-stub"
+            bin_dir.mkdir()
+            call_log = root / "failed-audit-calls"
+            fake_docker = bin_dir / "docker"
+            fake_docker.write_text(fake_docker_source, encoding="utf-8")
+            fake_docker.chmod(0o755)
+            completed = run_extracted_shell(
+                audit_functions,
+                "assert_v0104_audit_is_non_gating probe.out probe.err",
+                bin_dir,
+                {
+                    "DOCKER_CALL_LOG": str(call_log),
+                    "FAKE_AUDIT_STATUS": "1",
+                },
+            )
+
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            self.assertEqual(
+                completed.stdout,
+                "BLOCKED AUDIT (non-gating): v0.10.4 baseline blocker; "
+                "audit is deferred and exposes no supported chain/head or "
+                "principal-scoped query.\n",
+            )
+            calls = docker_call_log(call_log)
+            self.assertEqual(len(calls), 1)
+            self.assertEqual(calls[0][0], "exec")
+            self.assertEqual(
+                calls[0][-3:],
+                ["/usr/local/bin/astrid", "audit", "status"],
+            )
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = pathlib.Path(temporary)
+            bin_dir = root / "successful-query"
+            bin_dir.mkdir()
+            fake_docker = bin_dir / "docker"
+            fake_docker.write_text("exit 0\n", encoding="utf-8")
+            fake_docker.chmod(0o755)
+            completed = run_extracted_shell(
+                audit_functions,
+                "assert_v0104_audit_is_non_gating probe.out probe.err",
+                bin_dir,
+                {"FAKE_AUDIT_STATUS": "0"},
+            )
+
+            self.assertNotEqual(completed.returncode, 0)
+            self.assertNotIn("BLOCKED AUDIT", completed.stdout)
+            self.assertIn(
+                "v0.10.4 unexpectedly exposed an audit query",
+                completed.stderr,
+            )
 
     def test_harness_rejects_inherited_security_policy_bypasses(self) -> None:
         self.assertIn("ASTRID_SANDBOX_POLICY=off", TEST_HARNESS)

--- a/scripts/test_oci_container_contract.py
+++ b/scripts/test_oci_container_contract.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import pathlib
 import re
@@ -57,6 +58,59 @@ def docker_call_log(log_path: pathlib.Path) -> list[list[str]]:
     ]
 
 
+def dockerfile_run_shell() -> str:
+    lines = DOCKERFILE.splitlines()
+    start = next(
+        index for index, line in enumerate(lines) if line.startswith("RUN ")
+    )
+    command = []
+    for line in lines[start:]:
+        stripped = line.strip()
+        command.append(stripped)
+        if not stripped.endswith("\\"):
+            break
+    else:
+        raise AssertionError("RUN command is missing its terminator")
+    return " ".join(part.removesuffix("\\") for part in command)
+
+
+def receipt_field_matcher() -> str:
+    shell = dockerfile_run_shell()
+    start = shell.index("bind_receipt_field() {")
+    open_brace = shell.index("{", start)
+    depth = 1
+    for end in range(open_brace + 1, len(shell)):
+        if shell[end] == "{":
+            depth += 1
+        elif shell[end] == "}":
+            depth -= 1
+            if depth == 0:
+                return shell[start : end + 1]
+    raise AssertionError("receipt field matcher is not extractable")
+
+
+def run_receipt_matcher(
+    matcher: str,
+    receipt_path: pathlib.Path,
+    key: str,
+    expected: str,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            "sh",
+            "-c",
+            f'{matcher}\nbind_receipt_field "$1" "$2" "$3"',
+            "sh",
+            str(receipt_path),
+            key,
+            expected,
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
 class DockerfileContractTests(unittest.TestCase):
     def test_packages_release_bytes_without_building_source(self) -> None:
         self.assertIn("COPY dist/oci-amd64/astrid-release.tar.gz", DOCKERFILE)
@@ -92,6 +146,7 @@ class DockerfileContractTests(unittest.TestCase):
             "archive",
             "archive-sha256",
             "archive-blake3",
+            "release-manifest",
             "release-manifest-sha256",
             "release-workflow-identity",
         ):
@@ -105,6 +160,137 @@ class DockerfileContractTests(unittest.TestCase):
         ):
             with self.subTest(label=label):
                 self.assertIn(label, DOCKERFILE)
+
+    def test_receipt_matcher_accepts_object_fields_regardless_of_order(self) -> None:
+        matcher = receipt_field_matcher()
+        for forbidden_parser in ("grep ", "python", "jq"):
+            with self.subTest(forbidden_parser=forbidden_parser):
+                self.assertNotIn(forbidden_parser, matcher)
+
+        receipt = {
+            "schema-version": 1,
+            "repository": "astrid-runtime/astrid",
+            "version": "0.10.4",
+            "tag": "v0.10.4",
+            "source-commit": "b6bf5d1d579915eb5d3c944857d84e62a4fcc878",
+            "target": "x86_64-unknown-linux-gnu",
+            "archive": "astrid-0.10.4-x86_64-unknown-linux-gnu.tar.gz",
+            "archive-size": 1024,
+            "archive-sha256": "a" * 64,
+            "archive-blake3": "b" * 64,
+            "release-manifest": "astrid-0.10.4-release.toml",
+            "release-manifest-sha256": "c" * 64,
+            "release-workflow-identity": (
+                "https://github.com/astrid-runtime/astrid/"
+                ".github/workflows/release.yml@refs/tags/v0.10.4"
+            ),
+        }
+        fields = {
+            field: value
+            for field, value in receipt.items()
+            if isinstance(value, str)
+        }
+
+        with tempfile.TemporaryDirectory() as temporary:
+            path = pathlib.Path(temporary) / "release-receipt.json"
+            path.write_text(
+                json.dumps(receipt, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+            self.assertTrue(
+                path.read_text(encoding="utf-8")
+                .splitlines()[-2]
+                .lstrip()
+                .startswith('"version"')
+            )
+            for field, expected in fields.items():
+                with self.subTest(field=field):
+                    completed = run_receipt_matcher(matcher, path, field, expected)
+                    self.assertEqual(completed.returncode, 0, completed.stderr)
+
+            reordered = {"version": receipt["version"], **receipt}
+            path.write_text(json.dumps(reordered, indent=2) + "\n", encoding="utf-8")
+            completed = run_receipt_matcher(
+                matcher,
+                path,
+                "version",
+                receipt["version"],
+            )
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+
+    def test_receipt_matcher_rejects_swapped_object_fields(self) -> None:
+        matcher = receipt_field_matcher()
+        fields = {
+            "repository": "astrid-runtime/astrid",
+            "version": "0.10.4",
+            "tag": "v0.10.4",
+            "source-commit": "b6bf5d1d579915eb5d3c944857d84e62a4fcc878",
+            "target": "x86_64-unknown-linux-gnu",
+            "archive": "astrid-0.10.4-x86_64-unknown-linux-gnu.tar.gz",
+            "archive-sha256": "a" * 64,
+            "archive-blake3": "b" * 64,
+            "release-manifest": "astrid-0.10.4-release.toml",
+            "release-manifest-sha256": "c" * 64,
+            "release-workflow-identity": (
+                "https://github.com/astrid-runtime/astrid/"
+                ".github/workflows/release.yml@refs/tags/v0.10.4"
+            ),
+        }
+
+        for field, expected in fields.items():
+            receipt = dict.fromkeys(fields, "bounded-contract-value")
+            receipt[field] = expected
+            with tempfile.TemporaryDirectory() as temporary:
+                path = pathlib.Path(temporary) / "release-receipt.json"
+                path.write_text(
+                    json.dumps(receipt, indent=2, sort_keys=True) + "\n",
+                    encoding="utf-8",
+                )
+                completed = run_receipt_matcher(matcher, path, field, expected)
+                self.assertEqual(completed.returncode, 0, completed.stderr)
+
+                swapped = dict(receipt)
+                swapped[field] = f"{expected}-swapped"
+                path.write_text(
+                    json.dumps(swapped, indent=2, sort_keys=True) + "\n",
+                    encoding="utf-8",
+                )
+                completed = run_receipt_matcher(matcher, path, field, expected)
+                self.assertNotEqual(completed.returncode, 0)
+
+    def test_old_line_binds_reject_last_key_and_escaped_target(self) -> None:
+        receipt = {
+            "target": "x86_64-unknown-linux-gnu",
+            "version": "0.10.4",
+        }
+        old_version_needle = '  "version": "0.10.4",'
+        old_target_needle = r'  \"target\": \"x86_64-unknown-linux-gnu\",'
+
+        with tempfile.TemporaryDirectory() as temporary:
+            path = pathlib.Path(temporary) / "release-receipt.json"
+            path.write_text(
+                json.dumps(receipt, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+            lines = path.read_text(encoding="utf-8").splitlines()
+            self.assertEqual(lines[-2], '  "version": "0.10.4"')
+            self.assertIn('  "target": "x86_64-unknown-linux-gnu",', lines)
+
+            completed = subprocess.run(
+                ["sh", "-c", 'grep -Fqx "$2" "$1"', "sh", str(path), old_version_needle],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertNotEqual(completed.returncode, 0)
+
+            completed = subprocess.run(
+                ["sh", "-c", 'grep -Fqx "$2" "$1"', "sh", str(path), old_target_needle],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertNotEqual(completed.returncode, 0)
 
 
 class EntrypointContractTests(unittest.TestCase):


### PR DESCRIPTION
## Linked Issue

Tracking #1708

https://github.com/astrid-runtime/astrid/issues/1708 remains open.

## Summary

Trunk-first landable unique ancestry for the hosted-profile evidence harness. Head `157210620353b25c633037907952b0fbbd3be966` has the same tree as dual-accepted evidence SHA `2eac327cbd1f5f295bcea7d5ce5c91fdba1798df`. Unique commit messages use Tracking #1708 only. This PR does not finish #1708, does not claim qualification, and does not claim arm64 parity.

## Changes

- replay the accepted hosted-profile evidence onto a clean unique ancestry from `os/universal` at `d0c01121f50ee5cd7d82761a27aed841ca1bd5a2`
- replace the historical issue-closing trailer with `Tracking #1708`
- preserve the exact tree of `2eac327c` (UID 65532 marker, exact v0.10.4 audit stub, PID1 parser, receipt field binds)
- keep PR #1718 as the dual-accepted evidence vehicle at `2eac327c` until this lander is independently reviewed

## Verification

- `git diff --exit-code 2eac327cbd1f5f295bcea7d5ce5c91fdba1798df 157210620353b25c633037907952b0fbbd3be966` is empty
- unique range from `d0c01121` is nine linear first-parent commits with Tracking #1708 and no issue-closing trailer
- hosted OCI on this SHA: amd64 run 33168222115 job 98838665065 and arm64 run 33168222101 job 98838665081 print `PID1 astrid-daemon 65532:65532 /workspace` twice, then `BLOCKED AUDIT (non-gating)`, then pass
- changelog fragment check is green
- independent exact-head review of this land SHA is still required

## AI / Tool Assistance

Assisted-by: Codex:GLM-5.3-Flash

Codex assisted with replaying the accepted unique commits onto a Tracking-only ancestry. The resulting tree is identical to `2eac327c`. Independent exact-head review of this land SHA is still required.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/1708.added.md`
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
