### PR TITLE
deps(storage): upgrade lz4_flex to 0.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -820,7 +820,7 @@ dependencies = [
  "hex",
  "keyring",
  "libc",
- "lz4_flex",
+ "lz4_flex 0.14.0",
  "nix 0.31.3",
  "parking_lot",
  "serde",
@@ -4327,6 +4327,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lz4_flex"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecbdfe44b1bd960b68170b417450a628c43f7cf56bb3c5317e61cb230ee7f226"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "mac_address"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6790,7 +6799,7 @@ dependencies = [
  "guardian",
  "integer-encoding",
  "log",
- "lz4_flex",
+ "lz4_flex 0.12.2",
  "parking_lot",
  "quick_cache",
  "rand 0.9.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ astrid-workspace = { path = "crates/astrid-workspace", version = "0.10.4" }
 anyhow = "1.0"
 arboard = "3"
 arc-swap = "1.7"
-lz4_flex = "0.12"
+lz4_flex = "0.14"
 # Streaming + HTTP-server deps (async-stream, axum, tokio-stream,
 # tower, tower-http, utoipa) all back the new `astrid-gateway` crate
 # and have no in-workspace substitute. They are scoped to

--- a/changes/1724.changed.md
+++ b/changes/1724.changed.md
@@ -1,6 +1,6 @@
 The direct `lz4_flex` dependency used by persisted WAL storage is now
-0.14.0, bringing upstream invalid-offset, 32-bit maximum-output, and
-no_std/alloc improvements. Existing ASTWAL2 compressed bytes produced by
+0.14.0, bringing the upstream 32-bit maximum-output fix and `std`/`alloc`
+feature split. Existing ASTWAL2 compressed bytes produced by
 0.12.2 decode unchanged, and new compression round-trips preserve canonical
 object bytes. SurrealKV continues to use its separate transitive
 `lz4_flex` 0.12.2 edge. Closes #1724

--- a/changes/1724.changed.md
+++ b/changes/1724.changed.md
@@ -1,0 +1,6 @@
+The direct `lz4_flex` dependency used by persisted WAL storage is now
+0.14.0, bringing upstream invalid-offset, 32-bit maximum-output, and
+no_std/alloc improvements. Existing ASTWAL2 compressed bytes produced by
+0.12.2 decode unchanged, and new compression round-trips preserve canonical
+object bytes. SurrealKV continues to use its separate transitive
+`lz4_flex` 0.12.2 edge. Closes #1724

--- a/crates/astrid-storage/src/engine/durable/wal/lz4_compat_tests.rs
+++ b/crates/astrid-storage/src/engine/durable/wal/lz4_compat_tests.rs
@@ -1,0 +1,137 @@
+use super::codec::{
+    OBJECT_FLAG_LZ4, decode_object_storage_body, digest_record, digest_record_with_flags,
+    encode_begin_body, encode_commit_body, encode_object_storage_body, encode_physical_record,
+    encode_physical_record_with_flags, finish_digest, logical_record_length, new_digest,
+};
+use super::tests::{object_id, record, root, scan_events, scheme};
+use super::types::{WalCount, WalEvent, WalOffset, WalOrdinal, WalRecordKind, WalSequence};
+use crate::engine::durable::RecoveryLimits;
+use crate::engine::durable::format::encode_object_frame;
+use crate::engine::durable::roots::encode_root_record;
+
+// Produced by lz4_flex 0.12.2 for `record(1, 4096)` and the storage crate's
+// canonical ASTWAL2 object-frame construction.
+const LZ4_FLEX_0_12_STORED_BODY: [u8; 66] = [
+    69, 16, 0, 0, 0, 0, 0, 0, 101, 1, 0, 1, 0, 32, 0, 1, 0, 21, 1, 10, 0, 13, 2, 0, 0, 27, 0, 19,
+    16, 22, 0, 4, 8, 0, 10, 2, 0, 0, 34, 0, 15, 2, 0, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 235, 96, 0, 0, 0, 0, 0, 0,
+];
+
+#[test]
+fn lz4_flex_zero_twelve_wal_bytes_decode_with_zero_fourteen() {
+    let canonical = encode_object_frame(scheme(), object_id(1), &record(1, 4096)).unwrap();
+    let limits = RecoveryLimits::process_addressable();
+    let decoded = decode_object_storage_body(
+        &LZ4_FLEX_0_12_STORED_BODY,
+        OBJECT_FLAG_LZ4,
+        limits,
+        WalOffset::new(0),
+    )
+    .unwrap();
+    assert_eq!(decoded.as_ref(), canonical.as_slice());
+
+    let (flags, current) = encode_object_storage_body(&canonical).unwrap();
+    assert_eq!(flags, OBJECT_FLAG_LZ4);
+    let current_decoded =
+        decode_object_storage_body(current.as_ref(), flags, limits, WalOffset::new(0)).unwrap();
+    assert_eq!(current_decoded.as_ref(), canonical.as_slice());
+
+    let events = scan_events(compressed_transaction()).unwrap();
+    assert_eq!(events.len(), 4);
+    assert!(matches!(events.first(), Some(WalEvent::Begin(_))));
+    assert!(matches!(
+        events.get(1),
+        Some(WalEvent::Object(object))
+            if object.logical_bytes.get() == u64::try_from(canonical.len()).unwrap(),
+    ));
+    assert!(matches!(events.get(2), Some(WalEvent::Root(_))));
+    assert!(matches!(events.get(3), Some(WalEvent::Commit(_))));
+}
+
+fn compressed_transaction() -> Vec<u8> {
+    let sequence = WalSequence::new(1).unwrap();
+    let stored = &LZ4_FLEX_0_12_STORED_BODY;
+    let begin_body = encode_begin_body(scheme(), None).unwrap();
+    let root_body = encode_root_record(scheme(), b"alice", None, root(100)).unwrap();
+    let mut digest = new_digest();
+    let mut logical_bytes = logical_record_length(&begin_body).unwrap();
+    digest_record(
+        &mut digest,
+        WalRecordKind::Begin,
+        sequence,
+        WalOrdinal::new(0),
+        &begin_body,
+    )
+    .unwrap();
+    let mut bytes = encode_physical_record(
+        WalRecordKind::Begin,
+        sequence,
+        WalOrdinal::new(0),
+        &begin_body,
+        RecoveryLimits::process_addressable(),
+    )
+    .unwrap();
+    digest_record_with_flags(
+        &mut digest,
+        WalRecordKind::Object,
+        OBJECT_FLAG_LZ4,
+        sequence,
+        WalOrdinal::new(1),
+        stored,
+    )
+    .unwrap();
+    logical_bytes = logical_bytes
+        .checked_add(logical_record_length(stored).unwrap())
+        .unwrap();
+    bytes.extend(
+        encode_physical_record_with_flags(
+            WalRecordKind::Object,
+            OBJECT_FLAG_LZ4,
+            sequence,
+            WalOrdinal::new(1),
+            stored,
+            RecoveryLimits::process_addressable(),
+        )
+        .unwrap(),
+    );
+    digest_record(
+        &mut digest,
+        WalRecordKind::Root,
+        sequence,
+        WalOrdinal::new(2),
+        &root_body,
+    )
+    .unwrap();
+    logical_bytes = logical_bytes
+        .checked_add(logical_record_length(&root_body).unwrap())
+        .unwrap();
+    bytes.extend(
+        encode_physical_record(
+            WalRecordKind::Root,
+            sequence,
+            WalOrdinal::new(2),
+            &root_body,
+            RecoveryLimits::process_addressable(),
+        )
+        .unwrap(),
+    );
+    let commit_body = encode_commit_body(
+        sequence,
+        WalCount::new(3),
+        WalCount::new(1),
+        WalCount::new(1),
+        logical_bytes,
+        finish_digest(&digest),
+    );
+    bytes.extend(
+        encode_physical_record(
+            WalRecordKind::Commit,
+            sequence,
+            WalOrdinal::new(3),
+            &commit_body,
+            RecoveryLimits::process_addressable(),
+        )
+        .unwrap(),
+    );
+    bytes
+}

--- a/crates/astrid-storage/src/engine/durable/wal/mod.rs
+++ b/crates/astrid-storage/src/engine/durable/wal/mod.rs
@@ -84,6 +84,9 @@ pub(super) fn durable_error(error: WalError) -> DurableError {
 }
 
 #[cfg(test)]
+mod lz4_compat_tests;
+
+#[cfg(test)]
 mod tests;
 
 #[cfg(test)]

--- a/crates/astrid-storage/src/engine/durable/wal/tests.rs
+++ b/crates/astrid-storage/src/engine/durable/wal/tests.rs
@@ -256,7 +256,7 @@ impl Seek for FailingProbeReader {
     }
 }
 
-fn scheme() -> IdentityScheme {
+pub(super) fn scheme() -> IdentityScheme {
     IdentityScheme::new(1, 1).unwrap()
 }
 
@@ -271,7 +271,7 @@ fn sequence(value: u64) -> WalSequence {
     WalSequence::new(value).unwrap()
 }
 
-fn record(value: u64, payload_len: usize) -> ObjectRecord {
+pub(super) fn record(value: u64, payload_len: usize) -> ObjectRecord {
     let mut payload = value.to_be_bytes().to_vec();
     payload.resize(payload_len.max(8), 0);
     ObjectRecord::new(
@@ -285,13 +285,13 @@ fn record(value: u64, payload_len: usize) -> ObjectRecord {
     .unwrap()
 }
 
-fn object_id(value: u64) -> ObjectId {
+pub(super) fn object_id(value: u64) -> ObjectId {
     let mut bytes = [0_u8; 32];
     bytes[..8].copy_from_slice(&value.to_be_bytes());
     ObjectId::new(bytes)
 }
 
-fn root(value: u64) -> RootState {
+pub(super) fn root(value: u64) -> RootState {
     RootState {
         generation: RootGeneration::INITIAL,
         commit: object_id(value),
@@ -478,7 +478,7 @@ fn corrupt_record_checksum(bytes: &mut [u8], index: usize) {
     }
 }
 
-fn scan_events(bytes: Vec<u8>) -> Result<Vec<WalEvent>, WalError> {
+pub(super) fn scan_events(bytes: Vec<u8>) -> Result<Vec<WalEvent>, WalError> {
     let mut scanner = WalScanner::new(
         Cursor::new(bytes),
         TestIdentity,


### PR DESCRIPTION
## Linked Issue

Closes #1724

## Summary

Upgrade Astrid's direct workspace `lz4_flex` requirement from 0.12 to 0.14 for the persisted ASTWAL2 storage path. Add old-byte and persisted-WAL compatibility coverage while deliberately preserving SurrealKV's separate transitive `lz4_flex` 0.12.2 edge.

## Changes

- Update the root workspace dependency from `lz4_flex = "0.12"` to `lz4_flex = "0.14"`.
- Update `Cargo.lock` so the direct `astrid-storage` edge resolves to `lz4_flex 0.14.0`; keep `lz4_flex 0.12.2` for `surrealkv 0.21.3`.
- Add focused compatibility coverage in `engine::durable::wal::lz4_compat_tests`:
  - decode a fixed compressed storage body captured from `lz4_flex 0.12.2` for the deterministic 4,165-byte canonical ASTWAL2 object frame;
  - encode and decode a fresh body through the 0.14 path;
  - scan a complete persisted transaction containing that old object body, checking physical checksum, version-two flags, commit counts/digest, object logical bytes, and Begin/Object/Root/Commit ordering.
- Add `changes/1724.changed.md`.

No logical digest grammar changed. The compressed-object digest mode continues to bind the exact stored payload and feature flag; the old fixture validates against the existing commit digest grammar, while the full transaction scanner validates counts and the final digest.

### Upstream `lz4_flex` changes

Primary evidence: [0.14.0 changelog](https://github.com/PSeitz/lz4_flex/blob/0.14.0/CHANGELOG.md) and [tag commit `1bffdcbbf906a234b913937cb2f57c0245915038`](https://github.com/PSeitz/lz4_flex/commit/1bffdcbbf906a234b913937cb2f57c0245915038).

- 0.12.2 → 0.13.0: harden invalid match offsets during decompression, fix `get_maximum_output_size` overflow on 32-bit targets, and add compression-dictionary reuse. The offset fix was also backported to 0.12.1.
- 0.13.0 → 0.13.1: fix short-dictionary compression and the frame `From<io::Error>` conversion panic.
- 0.13.1 → 0.14.0: split `alloc` from `std`; `std` implies `alloc`, and default features remain suitable for Astrid's existing allocating block API usage.

No other dependency was intentionally changed.

## Verification

Lane-local target directory: `target-lz4flex014`; shared Cargo/rustup homes were not isolated or replaced.

Before upgrading, the same compatibility test passed on parent `9c6a6545aa3684949f5ae3c5dded56149b7fb741` while still building `lz4_flex 0.12.2`, proving that the captured fixture and full transaction image were valid old-byte input.

On commit `3a3a119d43e2dd290db3eb7d149d3bd14c02dc1a`:

- `rustfmt --check --edition 2024` passed for the three touched Rust files.
- `cargo test -p astrid-storage` passed: 763 passed, 0 failed, 7 ignored; plus 4 report tests passed and the ignored doc example completed. The suite includes the new compatibility test, all existing WAL compression/digest tests, durable recovery, and crash-replay coverage.
- `cargo clippy -p astrid-storage --all-targets -- -D warnings` passed.
- `cargo check --workspace` passed in 3m 15s.
- `RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo check -p astrid-storage --target wasm32-unknown-unknown` exited successfully. It reported 40 pre-existing `astrid-storage` dead-code/unused warnings.
- The same wasm32 check with `--features legacy-surrealkv` exited successfully and compiled both `lz4_flex 0.12.2` and `0.14.0`; it reported 41 pre-existing warnings, including the additional Surreal-related dead-code warning.
- `cargo tree --workspace -i lz4_flex@0.14.0` resolves the direct edge through `astrid-storage`.
- `cargo tree --workspace -i lz4_flex@0.12.2` resolves only through `surrealkv 0.21.3` → `astrid-storage`.
- `git verify-commit HEAD` reports a good full signature, and the commit has matching author/`Signed-off-by` identity.

## AI / Tool Assistance

Assisted-by: Codex:GLM-5.3 Flash

A Codex coding agent implemented the manifest/lock update, compatibility test, and changelog fragment after reading repository guidance and upstream evidence. The agent generated the fixed 0.12.2 fixture before switching versions, ran and reviewed the listed checks, inspected the source/lock diff and dependency graphs, and created the signed commit. The final commit is authored and signed by Joshua J. Bouw with matching DCO identity.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/{issue}.{kind}.md`
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.

## Independent review follow-up

Independent exact-head review returned ACCEPT with one non-blocking wording correction: `lz4_flex` 0.12.2 already contained the invalid-offset backport, so the changelog now names only the new 32-bit maximum-output fix and `std`/`alloc` feature split. Signed commit `3a3a119d43e2dd290db3eb7d149d3bd14c02dc1a` makes that documentation-only correction; the implementation and compatibility evidence are unchanged.