### PR TITLE
build(deps): bump gix-discover to 0.55

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3159,9 +3159,9 @@ dependencies = [
 
 [[package]]
 name = "gix-actor"
-version = "0.41.2"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33f9308ad6fd35b2a865cbe4117ac61b2be59e4a9ef1621c7a9794f7c8e52c5b"
+checksum = "e37efa99929ac62f980fb1a7dcd09dea85b3aa6ead6ba0498362add3f4e698de"
 dependencies = [
  "bstr",
  "gix-date",
@@ -3170,9 +3170,9 @@ dependencies = [
 
 [[package]]
 name = "gix-date"
-version = "0.15.6"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e47b9e8cdc688296609b706428de570f88b1e0eed7156dde7b4a89d26fa4567"
+checksum = "e63d9aa18f29facd571c8953e66224ee0075b9e16622024794555ed4acceea85"
 dependencies = [
  "bstr",
  "gix-error",
@@ -3182,9 +3182,9 @@ dependencies = [
 
 [[package]]
 name = "gix-discover"
-version = "0.54.0"
+version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f517766fa1101dfe2606c1a19a8ffa699099030995a9194445446dfe261bdf"
+checksum = "ec32a30ec2934735599c2545f30067e80bd255fd3454b52a5d59bc02b52874a3"
 dependencies = [
  "bstr",
  "dunce",
@@ -3197,18 +3197,18 @@ dependencies = [
 
 [[package]]
 name = "gix-error"
-version = "0.2.5"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9292309fd944e71b2a3c96d3c03a6feb8852db646febdde7cbb9f79cb5f329"
+checksum = "e73b2794a6a746953c24d4ed51e4d408b83d8d599ed4e5c39a47736d75687cf0"
 dependencies = [
  "bstr",
 ]
 
 [[package]]
 name = "gix-features"
-version = "0.49.0"
+version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20aa09e83a48dc02c5f5f08578aa79d3ab1bab4618b8c362f88684645a02bdcc"
+checksum = "39c0e59d9d253dcccc38c3a46b91bfb9b46bd63eed54fe1a719e12194884d52a"
 dependencies = [
  "gix-path",
  "gix-trace",
@@ -3220,9 +3220,9 @@ dependencies = [
 
 [[package]]
 name = "gix-fs"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "865cf13fcaf5455220546cb9607c416bd1be9a6caafd143655a362fdeab64e80"
+checksum = "ebcfa9fd253f25350a3b21b3dd74034a446098e373c6123d4cee3519894f12ef"
 dependencies = [
  "bstr",
  "gix-features",
@@ -3233,9 +3233,9 @@ dependencies = [
 
 [[package]]
 name = "gix-hash"
-version = "0.26.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13adaa73415fd6c902310923f68d0b98e8cecf14b33ea58c02cc387cee56f54e"
+checksum = "380b9c423a54f0821064b954b5a5ab25c660812f6a91da03c3f1cb4b10762aa5"
 dependencies = [
  "faster-hex",
  "gix-features",
@@ -3268,9 +3268,9 @@ dependencies = [
 
 [[package]]
 name = "gix-object"
-version = "0.63.0"
+version = "0.64.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e48c235e7f886eb819fc878af75be889333dd3c38bee02ed7af48ae2cf596c4"
+checksum = "56fef799ca40cdeab4de5a3e74a696d8fa9b9c6264592646bf022e026f13ce2c"
 dependencies = [
  "bstr",
  "gix-actor",
@@ -3287,9 +3287,9 @@ dependencies = [
 
 [[package]]
 name = "gix-path"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "751d6bd162106f8c1e7e9aaccb5bbdd605267e91a930a17a4560c46e33a9100c"
+checksum = "2b075e730586bba7341304d6fc1b4efc1d10cf64532622521c0e07f30e661046"
 dependencies = [
  "bstr",
  "gix-trace",
@@ -3299,9 +3299,9 @@ dependencies = [
 
 [[package]]
 name = "gix-ref"
-version = "0.66.0"
+version = "0.67.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeb0c90a8f6202ceaaa22996cbf837c943ccb2d8af9ff3490f0758305e6b7883"
+checksum = "8328387e7ab354e1dc3afb63e6b4d1866f82d7ce035222bc9d5baaf36bc88020"
 dependencies = [
  "gix-actor",
  "gix-features",
@@ -3349,9 +3349,9 @@ checksum = "be3eb81d9dc914335923e50d52829c551feefd6a72d176c4130c546b67a60814"
 
 [[package]]
 name = "gix-utils"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1795bd2a970ca8b2185318c2abb97d955c71992f1cf28de73ad3b593a9f3ce8"
+checksum = "0da1c46491b49458a446cc76f0085860f8164c2290742e0aa8c653ce67240a97"
 dependencies = [
  "fastrand",
  "getrandom 0.4.3",
@@ -3360,9 +3360,9 @@ dependencies = [
 
 [[package]]
 name = "gix-validate"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a034e84d1e04e1b1f20f51f12491da230b6ac8b925d0c8e1b89bcd87a7c5ccc"
+checksum = "4dae8780f63ed8a803b8bdabbd7aa5f5c5d74592c8b50eed875c1bb4f6545a6a"
 dependencies = [
  "bstr",
 ]

--- a/changes/1723.changed.md
+++ b/changes/1723.changed.md
@@ -1,0 +1,4 @@
+Git-managed workspace detection now uses gix-discover 0.55. Discovery resolves
+Unix symlinked workspaces through their physical ancestors, so direct-write
+classification follows the repository the workspace targets instead of an
+unrelated lexical parent.

--- a/crates/astrid-capsule/Cargo.toml
+++ b/crates/astrid-capsule/Cargo.toml
@@ -84,7 +84,7 @@ bytes = "1"
 # hash kind. Both are on so discovery succeeds regardless of a repo's object
 # format; with `sha1` alone, a SHA-256 repo in a detached-HEAD state would be
 # missed and fall back to the CoW overlay.
-gix-discover = { version = "0.54.0", default-features = false, features = ["sha1", "sha256"] }
+gix-discover = { version = "0.55.0", default-features = false, features = ["sha1", "sha256"] }
 notify = "8"
 # `astrid:http@1.1.0` `auto-decompress` toggles gzip/brotli/deflate/zstd per
 # request; those builder methods are feature-gated in reqwest. Enabled here so

--- a/crates/astrid-capsule/src/engine/wasm/mod.rs
+++ b/crates/astrid-capsule/src/engine/wasm/mod.rs
@@ -57,7 +57,7 @@ mod pool;
 mod storage_vfs;
 #[cfg(test)]
 mod test_fixtures;
-#[cfg(test)]
+#[cfg(all(test, unix))]
 #[path = "workspace_git_discovery_tests.rs"]
 mod workspace_git_discovery_tests;
 

--- a/crates/astrid-capsule/src/engine/wasm/mod.rs
+++ b/crates/astrid-capsule/src/engine/wasm/mod.rs
@@ -57,6 +57,9 @@ mod pool;
 mod storage_vfs;
 #[cfg(test)]
 mod test_fixtures;
+#[cfg(test)]
+#[path = "workspace_git_discovery_tests.rs"]
+mod workspace_git_discovery_tests;
 
 /// Today's date as `YYYY-MM-DD` for daily log rotation.
 fn today_date_string() -> String {

--- a/crates/astrid-capsule/src/engine/wasm/workspace_git_discovery_tests.rs
+++ b/crates/astrid-capsule/src/engine/wasm/workspace_git_discovery_tests.rs
@@ -1,0 +1,49 @@
+use super::workspace_is_git_managed;
+
+fn init_git_worktree(root: &std::path::Path) {
+    let git_dir = root.join(".git");
+    std::fs::create_dir_all(git_dir.join("objects")).unwrap();
+    std::fs::create_dir_all(git_dir.join("refs")).unwrap();
+    std::fs::write(git_dir.join("HEAD"), "ref: refs/heads/main\n").unwrap();
+}
+
+#[test]
+#[cfg(unix)]
+fn symlinked_workspace_follows_physical_git_target() {
+    let root = tempfile::tempdir().unwrap();
+    let lexical_parent = root.path().join("lexical-parent");
+    let physical_workspace = root.path().join("physical").join("workspace");
+    std::fs::create_dir_all(&lexical_parent).unwrap();
+    std::fs::create_dir_all(&physical_workspace).unwrap();
+    init_git_worktree(&lexical_parent);
+    init_git_worktree(&physical_workspace);
+
+    let workspace_link = lexical_parent.join("workspace-link");
+    std::os::unix::fs::symlink(&physical_workspace, &workspace_link).unwrap();
+
+    assert!(workspace_is_git_managed(&workspace_link));
+    let (candidate, _) = gix_discover::upwards(&workspace_link).unwrap();
+    let (git_dir, worktree) = candidate.into_repository_and_work_tree_directories();
+    assert_eq!(git_dir, workspace_link.join(".git"));
+    assert_eq!(worktree.as_deref(), Some(workspace_link.as_path()));
+    assert_eq!(
+        std::fs::canonicalize(git_dir).unwrap(),
+        physical_workspace.join(".git").canonicalize().unwrap()
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn symlink_to_non_git_target_is_not_git_managed() {
+    let root = tempfile::tempdir().unwrap();
+    let lexical_parent = root.path().join("lexical-parent");
+    let physical_workspace = root.path().join("physical").join("workspace");
+    std::fs::create_dir_all(&lexical_parent).unwrap();
+    std::fs::create_dir_all(&physical_workspace).unwrap();
+    init_git_worktree(&lexical_parent);
+
+    let workspace_link = lexical_parent.join("workspace-link");
+    std::os::unix::fs::symlink(&physical_workspace, &workspace_link).unwrap();
+
+    assert!(!workspace_is_git_managed(&workspace_link));
+}


### PR DESCRIPTION
## Linked Issue

Closes #1723

## Summary

Bumps the capsule's direct `gix-discover` dependency from 0.54.0 to 0.55.0 and updates only the semver-compatible gix lock family required by the resolver. The 0.55 discovery fix uses a physical ancestor cursor after a symlink while retaining the caller's spelling when it identifies the same repository. This matters because `workspace_is_git_managed` decides whether a capsule workspace bypasses the copy-on-write overlay and writes directly to disk.

## Changes

- Updated `gix-discover` to `0.55.0` with `default-features = false` and both `sha1` and `sha256` retained.
- Updated the required transitive gix lock entries listed below.
- Added Unix-only regressions at `workspace_is_git_managed`:
  - a symlinked workspace selects the symlink target's repository (canonicalized `.git`), even though discovery preserves the caller-visible workspace spelling;
  - a symlink whose lexical parent is a repository but whose physical target is not does not classify as git-managed.
- Kept existing root, subdirectory, gitfile, plain-workspace, and malformed-`.git` coverage unchanged.
- Added `changes/1723.changed.md`.

### Per-dependency lock changes

All resolved packages are from [GitoxideLabs/gitoxide](https://github.com/GitoxideLabs/gitoxide). Breaking upstream API changes are contained inside the gix graph; Astrid consumes only `gix-discover::upwards`, and the locked build compiles successfully.

| Package | Lock change | Upstream change reviewed |
| --- | --- | --- |
| `gix-discover` | `0.54.0` -> `0.55.0` | Physical symlink-parent traversal, ceiling handling, preservation of caller spelling, and rejection of an invalid child `.git` before ancestor discovery. Primary commits: [`d8ed5a3`](https://github.com/GitoxideLabs/gitoxide/commit/d8ed5a3ecba10cf017be4506ea423de0c368010c), [`a939478`](https://github.com/GitoxideLabs/gitoxide/commit/a939478d0bfb13cad31dbfbda1ed9fcde6fb7073). |
| `gix-path` | `0.12.4` -> `0.12.5` | Normalization skips current-directory components before resolving parent components. |
| `gix-ref` | `0.66.0` -> `0.67.1` | `0.67.0` removes `object_hash` from options and requires explicit hash selection; `0.67.1` adds heterogeneous reference/name comparisons and tests. |
| `gix-object` | `0.63.0` -> `0.64.1` | `0.64.0` adds explicit commit and annotated-tag signing support; `0.64.1` is a test-focused patch. |
| `gix-actor` | `0.41.2` -> `0.42.0` | Upstream notes identify release and test-tool adaptation only; no functional behavior is called out. |
| `gix-date` | `0.15.6` -> `0.16.0` | Git-compatible month-end rollover and case-insensitive/unit-order handling for relative dates. |
| `gix-error` | `0.2.5` -> `0.3.1` | `0.3.0` preserves and classifies typed error source graphs; `0.3.1` adds `BoxedResultExt`. |
| `gix-features` | `0.49.0` -> `0.49.1` | Avoids appending the full periodic interrupt sleep to every parallel slice call. |
| `gix-fs` | `0.22.0` -> `0.22.1` | Upstream notes are release/metadata-focused; no functional behavior is called out. |
| `gix-hash` | `0.26.0` -> `0.26.2` | `0.26.1` adds allocation-free prefix hex utilities and JJ-compatible change IDs; `0.26.2` adds allocation-free textual comparisons. |
| `gix-utils` | `0.3.5` -> `0.3.6` | Preserves combining-mark order while precomposing macOS paths. |
| `gix-validate` | `0.11.3` -> `0.11.4` | Rejects a lone `@` as a reference name, matching Git. |

## Verification

All local commands used the lane-local `target/lane-dep1709-gix` directory:

- `cargo test -p astrid-capsule --lib -- git_managed symlinked_workspace_follows_physical_git_target`: 7 passed, 0 failed.
- `cargo fmt --check -p astrid-capsule`: passed.
- `cargo check -p astrid-capsule --locked`: passed.
- `cargo clippy -p astrid-capsule --all-targets --locked -- -D warnings`: passed.
- `cargo check -p gix-discover --locked --target x86_64-pc-windows-msvc`: passed.
- `cargo check -p gix-discover --locked --target x86_64-unknown-linux-gnu`: passed.
- `cargo tree --locked -p astrid-capsule -i gix-discover -e normal,features`: confirms `gix-discover 0.55.0` with `sha1` and `sha256` enabled.
- Commit `2d642be875cbe8d29134df34144a52f7b1bc853d` has a good GPG signature and matching DCO trailer.

## AI / Tool Assistance

Assisted-by: Codex: GLM-5.3 Flash (Coding Plan)

Codex drafted the dependency/lock update, symlink regressions, changelog fragment, and PR material under Joshua's delegated implementation instruction. The work used primary upstream commits and release notes, a staged-diff audit, and the exact local tests listed above. The operator remains accountable for the delegated submission.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/{issue}.{kind}.md` (docs/CI-only may skip; release PRs roll fragments into the version section instead of adding one)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.

## CI follow-up

Windows Clippy initially failed because the Unix-only regression module was compiled on Windows after its `#[cfg(unix)]` tests were removed, leaving the module import and helper unused. Commit `f92de056e3247e2009c0f682e88d332b101eaa85` gates the test module itself with `#[cfg(all(test, unix))]`. The two Unix regressions still pass, and `cargo clippy -p astrid-capsule --all-targets --all-features --locked -- -D warnings` passes locally. The Windows CI rerun is the authoritative cross-target evidence.