### PR TITLE
fix(runtime): upgrade Wasmtime family to 48

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,7 +360,7 @@ dependencies = [
  "toml_edit",
  "tracing",
  "uuid",
- "wit-component",
+ "wit-component 0.256.0",
  "wit-parser 0.256.0",
 ]
 
@@ -1533,9 +1533,9 @@ dependencies = [
 
 [[package]]
 name = "cap-fs-ext"
-version = "4.0.2"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78e5a3368ae89b7cb68186411452b4b9fac8b41be9c19bf3f47c2d2c8e36e6b"
+checksum = "56ff379b70af8e08307a8f65e7040c7301cb4a572538ade16b4984f0da77847f"
 dependencies = [
  "cap-primitives",
  "cap-std",
@@ -1545,9 +1545,9 @@ dependencies = [
 
 [[package]]
 name = "cap-primitives"
-version = "4.0.2"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdadbd7c002d3a484b35243669abdae85a0ebaded5a61117169dc3400f9a7ff0"
+checksum = "8b5f74729fd2f44701d1a8eb47e906cdb3ccd9ec0f02baad85a744b791940b18"
 dependencies = [
  "ambient-authority",
  "fs-set-times",
@@ -1563,9 +1563,9 @@ dependencies = [
 
 [[package]]
 name = "cap-std"
-version = "4.0.2"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7281235d6e96d3544ca18bba9049be92f4190f8d923e3caef1b5f66cfa752608"
+checksum = "c1ec78e242cfa2cfe276807ac2ecc00315a6c97786977414bcd1c3963b6c91b8"
 dependencies = [
  "cap-primitives",
  "io-extras",
@@ -1971,27 +1971,27 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.134.3"
+version = "0.135.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d552bd33b7a56dc70aeb1e1c960e51a218fa0db50f23873b500a310379450b2d"
+checksum = "9903e767cc0a95a59950de099a6b1d61e1476f774be1cdfa06d7ccdc9bfae56f"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.134.3"
+version = "0.135.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "078e80e4c222279e3330f6aa1a256ca77ddf156d4453166a9f09defedc4594dd"
+checksum = "e777252ea3ec9daffa71408fbfe0793ab0a7b7bc3b2cf0f417dd0fa33964b8ef"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.134.3"
+version = "0.135.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "820ce15d4ad3562d613c31a67b6d0434d403e7091a68d1349903842f7d31737e"
+checksum = "7828208a36e6627481cea61bd24c6234e31411d5c58b48e80ca094a1d593b944"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -1999,9 +1999,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.134.3"
+version = "0.135.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61bca563d4b86d285928d9e27f97f27039bb33a0fc524fa130d7d0c106bf8ab3"
+checksum = "a58c8447cc59ef98c49096679f81392ad0acec2224cea2bef52011f5169f9d02"
 dependencies = [
  "serde",
  "serde_derive",
@@ -2010,9 +2010,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.134.3"
+version = "0.135.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "709f4b7c0fb57d952658d5b5c07fbdc4149acd7b7f0de9678ae754b9c981949a"
+checksum = "ce520e899df1de583e7b564eafd66760fbc147d72894d2278ddac57a1489fcc0"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -2041,9 +2041,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.134.3"
+version = "0.135.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "903dc8915af62aad1d9d0f39a5968d33fa80b9aa899ed6f56e47f40ca4512e1e"
+checksum = "8d8ab23e63d78ea6bbda18ae1ed9c958bc1cb88d90fb5e95f5ba62e9c019474b"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -2054,24 +2054,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.134.3"
+version = "0.135.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0522d74c227e49f3fd49ab055311486ae4f09083262b66705bed676952491469"
+checksum = "24319a996b1ef40ebf8af69b39c868c790b35a42cfe38edacfd8c9deb75ea712"
 
 [[package]]
 name = "cranelift-control"
-version = "0.134.3"
+version = "0.135.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66560ea1c5cef72e170b18e46d263dba2d3169c9d39e8cafdab2173c6362cc1a"
+checksum = "cf9856d68cc2cefb83229cb2c55b620dd38427555c2fe87d73f8a4421616f628"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.134.3"
+version = "0.135.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ef5b17cc814d27e96b66a5b46da0e4ce2b8ac55a6d478048bb99d04b05526"
+checksum = "e0ec225d6b79c5d61358cb5ea081a1384ec541dbf8c1a8c618d187875af326ad"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -2081,9 +2081,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.134.3"
+version = "0.135.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a87e0aaa39dbf70693b348a221e45904111704ee8f9fef140498471005f9842d"
+checksum = "7d3a96a09bd9bd3cf6df2de2ea15d7418f493e946a8eaa1acfe39297a67ed3f3"
 dependencies = [
  "cranelift-codegen",
  "hashbrown 0.17.1",
@@ -2094,15 +2094,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.134.3"
+version = "0.135.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf79003ebfa1eed5e87f3b84446ad5236f540268289960e14f387dc9b28e40b7"
+checksum = "bd28f593c36afbdc9aa17305c0bb66c39ce0530e1caffcf389fbec053950083e"
 
 [[package]]
 name = "cranelift-native"
-version = "0.134.3"
+version = "0.135.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05bf4f235743c81e67ee4db617c5a4a0b65d58d3f0cfc575ee0f1a4e0cd58273"
+checksum = "2987ca47affc261aa31ac643fb80dd7f8274cebf878003ba9f50cd6ff2c1055f"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -2111,9 +2111,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.134.3"
+version = "0.135.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6977c2a71ab1e0d1e62f966b411a498aa04c4dce47d93d52f8a360a06058922"
+checksum = "b7431dd8c9def94aca43b27915dee0d42103d9b13922cfb044febcd975547d68"
 
 [[package]]
 name = "crc32fast"
@@ -5245,9 +5245,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "47.0.3"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5c8c21ea032e4efbdf2d067dc45171779dbe0c8ecf20ef4a57efa7474f2b0a"
+checksum = "f755d75e0809a4738a3e4880eeeb852fadbe1de5a437505b84f09c381657012a"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -5257,9 +5257,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "47.0.3"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f10925455d5dde962e3604eade797ba5488644c8ee14a44191e2f2b58980574"
+checksum = "c7e69fa1c4a555946f82e7894a7df88b0e9ee03b4266829b4811467c616ce51d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7701,9 +7701,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-compose"
-version = "0.252.0"
+version = "0.254.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59b710751a35d54732a63851cdfacbfb2266b7160ce174faf269d3f4e84e31b"
+checksum = "8fd717357bff09b5f1ea49aea8ed1cd149b0c521823a1cc70bc2ac16b90b651a"
 dependencies = [
  "anyhow",
  "heck",
@@ -7711,19 +7711,19 @@ dependencies = [
  "log",
  "petgraph",
  "smallvec",
- "wasm-encoder 0.252.0",
- "wasmparser 0.252.0",
+ "wasm-encoder 0.254.0",
+ "wasmparser 0.254.0",
  "wat",
 ]
 
 [[package]]
 name = "wasm-encoder"
-version = "0.252.0"
+version = "0.254.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8185ae345fa5687c054626ff9a50e7089797a343d9904d1dc9820eb4c4d3196f"
+checksum = "09480d646178e5fdd12bb06e812d0af9a3a191dbc9cd697fdc86687beade7393"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.252.0",
+ "wasmparser 0.254.0",
 ]
 
 [[package]]
@@ -7734,6 +7734,18 @@ checksum = "ec1492381bfd5ea51c2a99a919b676662559925cb8d7490547ec2e14c1ad3eb1"
 dependencies = [
  "leb128fmt",
  "wasmparser 0.256.0",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.254.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b01df5f3b4ca7881e843f3bc0fb8a3905d79c68692250dcb8e33e698705ccdb6"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder 0.254.0",
+ "wasmparser 0.254.0",
 ]
 
 [[package]]
@@ -7763,9 +7775,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.252.0"
+version = "0.254.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3eb099dcadcde5be9eef55e3a337128efd4e44b4c93122487e4d2e4e1c6627c"
+checksum = "d5769a29f799fbab136aaf65b4fe5384cd7d93fe6fc9ba0dcb6c8382a1f16e27"
 dependencies = [
  "bitflags 2.13.1",
  "hashbrown 0.17.1",
@@ -7789,27 +7801,26 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.252.0"
+version = "0.254.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7142797de29b35ab8dbf15c00f55fda75d409da4c423a8ab8bd6b667a785824b"
+checksum = "64e3ba11e024f504698f87b629b2b66c22a1231758de7607754963f7d198be39"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.252.0",
+ "wasmparser 0.254.0",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "47.0.3"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c80ca6098e0d4d06886d91d7f2cc3cb6623eb583c4c0ab3c89cbfb6098c8586c"
+checksum = "1bd39f78fe9bc82cee4025ec9d52118269e9a1498016cc60119b14f2e1d86a8d"
 dependencies = [
  "addr2line",
  "async-trait",
  "bitflags 2.13.1",
  "bumpalo",
  "cc",
- "cfg-if",
  "encoding_rs",
  "futures",
  "fxprof-processed-profile",
@@ -7833,8 +7844,8 @@ dependencies = [
  "target-lexicon",
  "tempfile",
  "wasm-compose",
- "wasm-encoder 0.252.0",
- "wasmparser 0.252.0",
+ "wasm-encoder 0.254.0",
+ "wasmparser 0.254.0",
  "wasmtime-environ",
  "wasmtime-internal-cache",
  "wasmtime-internal-component-macro",
@@ -7848,14 +7859,14 @@ dependencies = [
  "wasmtime-internal-versioned-export-macros",
  "wat",
  "windows-sys 0.61.2",
- "wit-parser 0.252.0",
+ "wit-parser 0.254.0",
 ]
 
 [[package]]
 name = "wasmtime-environ"
-version = "47.0.3"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134f9d136d29c76f6c1b4c9b468e97a2efc38c7d49fd188e39b64870b2fea701"
+checksum = "00c1070d95484d048994ec109cd42c4932ac07e6ee3cc1886fb90c7a18ec29da"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -7875,8 +7886,8 @@ dependencies = [
  "sha2 0.10.9",
  "smallvec",
  "target-lexicon",
- "wasm-encoder 0.252.0",
- "wasmparser 0.252.0",
+ "wasm-encoder 0.254.0",
+ "wasmparser 0.254.0",
  "wasmprinter",
  "wasmtime-internal-component-util",
  "wasmtime-internal-core",
@@ -7884,9 +7895,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "47.0.3"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65db2eb1bfc5371a3b4107dbf539d0b93d05016fc29625b1648146b47db02071"
+checksum = "9d447fd40f3e149cda8c0cd808660a1d1de438f3ff28627abb9bcda90dfb4895"
 dependencies = [
  "base64 0.22.1",
  "directories-next",
@@ -7904,9 +7915,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "47.0.3"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bf7b91fed3fc34781d57f9c6654ea2513bf0a99f7b0b0523c00de1e6efebe1c"
+checksum = "f3d2b2f9f89a65bb2277d82fbdd49263d27d8233bc717d750c4b13a23d57721c"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -7914,20 +7925,20 @@ dependencies = [
  "syn 2.0.119",
  "wasmtime-internal-component-util",
  "wasmtime-internal-wit-bindgen",
- "wit-parser 0.252.0",
+ "wit-parser 0.254.0",
 ]
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "47.0.3"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc8a678149885cae00289f806fbe74c7863084cf74cace0b8dc73602279400e1"
+checksum = "2c0fe8292115fda08875f29064ae9f7f0b2c1ffbb323146eae538ae34b8a613f"
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "47.0.3"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0092c4b9d070ac5e278b6d0db10f5e71214190f0347ca57502b4692f796321"
+checksum = "821385794cf44baf2967fd2515368429ed2bff9b9b256f62d09a0f1301474fd8"
 dependencies = [
  "anyhow",
  "hashbrown 0.17.1",
@@ -7937,11 +7948,10 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "47.0.3"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6851ebc9e03cab23d9821d2b2505d380bdfe38f35ccec945247b05274d85c98b"
+checksum = "0238b4a52773457ad1b8a1a26be90486e0ca0108cf46b9be16cc1d8d8cabdfa1"
 dependencies = [
- "cfg-if",
  "cranelift-codegen",
  "cranelift-control",
  "cranelift-entity",
@@ -7955,7 +7965,7 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.20",
- "wasmparser 0.252.0",
+ "wasmparser 0.254.0",
  "wasmtime-environ",
  "wasmtime-internal-core",
  "wasmtime-internal-unwinder",
@@ -7964,12 +7974,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "47.0.3"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b26da6d5f60d4c438da70bba3553fe810a840533a64156be287dca2081c6991"
+checksum = "596f1d85e06cbf9c9add9c78ea135171c5753264ffe94a83dcc082a1ff49fc9b"
 dependencies = [
  "cc",
- "cfg-if",
  "libc",
  "rustix",
  "wasmtime-environ",
@@ -7979,9 +7988,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "47.0.3"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed621ba25d7bf78b7edd7b4749abbb27c2e5cdba836c9504a424ee74b6c23149"
+checksum = "365faed74827bb0116785bab5872372df1baaec9ec0003c83bc99ccdc595f689"
 dependencies = [
  "cc",
  "object",
@@ -7991,11 +8000,10 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "47.0.3"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5684ba160951baad06a725696f3c590e2fb0e8067c2aebee27bf7f9259058e85"
+checksum = "3cce25afd9e7ac4957292a5c6a219951dd0f140b8417e7378a97f50b67c3b96f"
 dependencies = [
- "cfg-if",
  "libc",
  "wasmtime-internal-core",
  "windows-sys 0.61.2",
@@ -8003,11 +8011,10 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "47.0.3"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112eead527bffa8ff0646a11fb4339a9d52ddd1da2b9a6fce4aff84c815dd94f"
+checksum = "a1fdea09d51e39c774984ca68a7d7486767e5b2935f5e686fa654aabcfc3c42d"
 dependencies = [
- "cfg-if",
  "cranelift-codegen",
  "log",
  "object",
@@ -8016,9 +8023,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "47.0.3"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "153592e0bed824fc13c6696203fa1bd7bd20eb355316475e39a55f081ef80eca"
+checksum = "97e48a5f514c38c2f74249724cb3501e45548d3311ca9e3881694859fd6ba116"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8027,31 +8034,30 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "47.0.3"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c456ad6e81e0f46abfeca43687d18ea15e289c395b262ea6e0023e2682e088be"
+checksum = "07429ab53576255be2d298e04b2e1f381e39645465adbaebd69314b5430165c0"
 dependencies = [
  "anyhow",
  "bitflags 2.13.1",
  "heck",
  "indexmap",
- "wit-parser 0.252.0",
+ "wit-component 0.254.0",
+ "wit-parser 0.254.0",
 ]
 
 [[package]]
 name = "wasmtime-wasi"
-version = "47.0.3"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c1cf60cd6a565213af7074b4aad7bb5e110e3c6c6aae54425aa0500a0e15e86"
+checksum = "85dd81ee95792682ea5b279c9ed352f6b8a2cba084c2f8abdb225e6933323fed"
 dependencies = [
  "async-trait",
  "bitflags 2.13.1",
  "bytes",
  "cap-fs-ext",
- "cap-std",
- "cfg-if",
+ "cap-primitives",
  "futures",
- "io-lifetimes 3.0.1",
  "rand 0.10.2",
  "rustix",
  "thiserror 2.0.20",
@@ -8066,9 +8072,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "47.0.3"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fb08e1d7755aaa467ce14080b7b01e33c914a920f6000696f1e42e40ea6387e"
+checksum = "6a557bc8a7232cd079f6b423a9bb385f3ff9148824f3c26c07a028b499fab2bf"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8255,9 +8261,9 @@ checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "wiggle"
-version = "47.0.3"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89091642df051b84a7e00bdff75e985e507f2298384e477cc9310b0ddd79f004"
+checksum = "b871ea219ad85c1e59ee7d013563814e86d2e6aa094d3bc66b7675ec4ca58bb7"
 dependencies = [
  "bitflags 2.13.1",
  "thiserror 2.0.20",
@@ -8269,9 +8275,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "47.0.3"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12247f46f31bb5e7593947f9bba07317d0c1978e0d02250b979dd08f56f46e9f"
+checksum = "ed981675756e748a4725286a4059c9be006749a8db4120d54e2021d0f167bac3"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -8283,9 +8289,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "47.0.3"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e556a0880c9506fdcc662b1e226c7ced692f4977fed5b1ed40a3f3f0a48356f2"
+checksum = "7f3927729af874585c58b85710128e40d459a7064bb9aea9b0b420fb5eafd555"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8723,6 +8729,25 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-component"
+version = "0.254.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0e65bb94c369b3c4741ce3d1d2704b1fec93db7c540df0e521a097e7ceeb5be"
+dependencies = [
+ "anyhow",
+ "bitflags 2.13.1",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder 0.254.0",
+ "wasm-metadata 0.254.0",
+ "wasmparser 0.254.0",
+ "wit-parser 0.254.0",
+]
+
+[[package]]
+name = "wit-component"
 version = "0.256.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d537ec182eed18f560184b870287cf443c4eccc315af178db3eae8811c3b6c"
@@ -8735,16 +8760,16 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "wasm-encoder 0.256.0",
- "wasm-metadata",
+ "wasm-metadata 0.256.0",
  "wasmparser 0.256.0",
  "wit-parser 0.256.0",
 ]
 
 [[package]]
 name = "wit-parser"
-version = "0.252.0"
+version = "0.254.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4266bea110371c620ccf3201c5023676046bc4556e5c7cfb5d500bda5ebc162d"
+checksum = "1655131e4f7d3f0cb141f6eca71315ca40eff0f3d4de7cff0a82bacedd8c89b4"
 dependencies = [
  "anyhow",
  "hashbrown 0.17.1",
@@ -8756,7 +8781,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-ident",
- "wasmparser 0.252.0",
+ "wasmparser 0.254.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -260,8 +260,8 @@ wasmparser = "0.256"
 windows-sys = "0.61"
 wit-component = "0.256"
 wit-parser = "0.256"
-wasmtime = { version = "47.0.3", features = ["component-model", "cranelift"] }
-wasmtime-wasi = "47.0.3"
+wasmtime = { version = "48.0.1", features = ["component-model", "cranelift"] }
+wasmtime-wasi = "48.0.1"
 unicode-normalization = "=0.1.25"
 unicode-width = "0.2"
 which = "8"

--- a/changes/1736.changed.md
+++ b/changes/1736.changed.md
@@ -1,4 +1,6 @@
 The Wasmtime runtime family is upgraded coherently to 48.0.1. Compiled
 components are keyed to the Wasmtime 48 ABI and stale Wasmtime 47 cache
-entries are rejected and recompiled. Guest GC/exceptions, fuel, epoch,
-component-model, and network policy remain explicit. Closes #1736
+entries are rejected and recompiled. The capsule engine retains its explicit
+guest-proposal policy, and the hook engine now disables GC and exceptions to
+match it. Existing fuel, epoch, component-model, and network policy is retained.
+Closes #1736

--- a/changes/1736.changed.md
+++ b/changes/1736.changed.md
@@ -1,0 +1,4 @@
+The Wasmtime runtime family is upgraded coherently to 48.0.1. Compiled
+components are keyed to the Wasmtime 48 ABI and stale Wasmtime 47 cache
+entries are rejected and recompiled. Guest GC/exceptions, fuel, epoch,
+component-model, and network policy remain explicit. Closes #1736

--- a/crates/astrid-capsule/src/engine/wasm/mod.rs
+++ b/crates/astrid-capsule/src/engine/wasm/mod.rs
@@ -845,7 +845,7 @@ pub fn call_hook_trigger(
 
 fn build_wasmtime_engine() -> CapsuleResult<wasmtime::Engine> {
     let mut config = wasmtime::Config::new();
-    // Wasmtime 47 enables GC and exception handling by default. Astrid's guest
+    // Wasmtime 48 enables GC and exception handling by default. Astrid's guest
     // language is a security boundary, so an engine upgrade must not silently
     // expand the accepted proposal set. Enable new proposals only after an
     // explicit runtime design and compatibility decision.
@@ -1699,7 +1699,7 @@ struct CompiledWasmArtifact {
     _epoch_ticker: EpochTickerGuard,
 }
 
-const COMPILED_ENGINE_ABI: &str = "astrid-wasmtime47-component-abi-v1";
+const COMPILED_ENGINE_ABI: &str = "astrid-wasmtime48-component-abi-v1";
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 struct CompiledArtifactKey(String);
@@ -1731,6 +1731,14 @@ impl CompiledWasmCache {
         // This domain is part of the cache identity. Bump it whenever the
         // engine configuration or linked host ABI changes incompatibly.
         let key = CompiledArtifactKey::new(verified_hash);
+        self.compile_with_key(key, wasm_bytes)
+    }
+
+    fn compile_with_key(
+        &self,
+        key: CompiledArtifactKey,
+        wasm_bytes: &[u8],
+    ) -> CapsuleResult<Arc<CompiledWasmArtifact>> {
         let mut entries = self
             .entries
             .lock()
@@ -1781,11 +1789,32 @@ mod compiled_artifact_cache_tests {
     }
 
     #[test]
-    fn compiled_cache_key_is_bound_to_the_wasmtime_47_abi() {
+    fn compiled_cache_key_is_bound_to_the_wasmtime_48_abi() {
         assert_eq!(
             CompiledArtifactKey::new("verified"),
-            CompiledArtifactKey("astrid-wasmtime47-component-abi-v1:verified".to_owned())
+            CompiledArtifactKey("astrid-wasmtime48-component-abi-v1:verified".to_owned())
         );
+    }
+
+    #[test]
+    fn stale_wasmtime_47_cache_entry_is_rejected_and_recompiled() {
+        let bytes = wasm_encoder::Component::new().finish();
+        let hash = blake3::hash(&bytes).to_hex().to_string();
+        let stale_key = CompiledArtifactKey(format!("astrid-wasmtime47-component-abi-v1:{hash}"));
+        let cache = CompiledWasmCache::default();
+
+        let stale = cache
+            .compile_with_key(stale_key.clone(), &bytes)
+            .expect("stale generation");
+        let current = cache.compile(&hash, &bytes).expect("current generation");
+
+        assert!(!Arc::ptr_eq(&stale, &current));
+        let entries = cache
+            .entries
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        assert!(entries.contains_key(&stale_key));
+        assert!(entries.contains_key(&CompiledArtifactKey::new(&hash)));
     }
 
     #[test]

--- a/crates/astrid-hooks/src/handler/wasm.rs
+++ b/crates/astrid-hooks/src/handler/wasm.rs
@@ -67,6 +67,17 @@ fn resolve_http_limits() -> astrid_capsule::HttpLimits {
     )
 }
 
+/// Build the hook engine with Astrid's explicit guest-feature boundary.
+fn build_hook_engine() -> wasmtime::Engine {
+    let mut wt_config = wasmtime::Config::new();
+    wt_config
+        .wasm_component_model(true)
+        .wasm_gc(false)
+        .wasm_exceptions(false)
+        .epoch_interruption(true);
+    wasmtime::Engine::new(&wt_config).expect("failed to create wasmtime engine for hooks")
+}
+
 /// Handler for WASM components.
 ///
 /// Lazily compiles the WASM component on first invocation and caches the
@@ -98,12 +109,7 @@ impl WasmHandler {
     /// Create a new WASM handler.
     #[must_use]
     pub(crate) fn new(workspace_root: PathBuf) -> Self {
-        let mut wt_config = wasmtime::Config::new();
-        wt_config
-            .wasm_component_model(true)
-            .epoch_interruption(true);
-        let engine =
-            wasmtime::Engine::new(&wt_config).expect("failed to create wasmtime engine for hooks");
+        let engine = build_hook_engine();
 
         // Spawn epoch ticker so that epoch deadlines on Store actually fire.
         let epoch_stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
@@ -438,6 +444,15 @@ mod tests {
     #[test]
     fn test_wasm_available() {
         assert!(WasmHandler::is_available());
+    }
+
+    #[test]
+    fn test_hook_engine_preserves_explicit_guest_feature_boundary() {
+        let features = build_hook_engine().get_wasm_features();
+
+        assert!(!features.contains(wasmtime::WasmFeatures::GC));
+        assert!(!features.contains(wasmtime::WasmFeatures::EXCEPTIONS));
+        assert!(features.contains(wasmtime::WasmFeatures::COMPONENT_MODEL));
     }
 
     #[test]


### PR DESCRIPTION
## Linked Issue

Closes #1736

## Summary

Upgrades Astrid coherently from the Wasmtime 47 runtime family to Wasmtime 48.0.1, keeping `wasmtime` and `wasmtime-wasi` on the same reviewed patch line.

## Changes

- Bump the direct `wasmtime` and `wasmtime-wasi` dependencies together from `47.0.3` to `48.0.1`.
- Change the compiled-component cache identity to `astrid-wasmtime48-component-abi-v1` and add a regression proving a planted Wasmtime 47 entry is rejected while the same verified bytes are recompiled under the Wasmtime 48 key.
- Preserve the capsule engine's explicit proposal boundary: component model enabled, GC and exceptions disabled, fuel and epoch interruption unchanged.
- Harden the hook engine by explicitly disabling GC and exceptions to match the capsule boundary, and test that policy through the real engine builder.
- Align the lockfile only with the Wasmtime 48 family: Wasmtime, its internal crates, Cranelift, Pulley, Wiggle, and Wasmtime's required internal wasm-tools `0.254` set. The direct Astrid `wasm-encoder`, `wat`, `wasmparser`, `wit-component`, and `wit-parser` requirements remain `0.256` / `1.256` and are not bumped.
- Retain the already-landed direct `cap-std 4.0.3` resolution. Wasmtime 48's `cap-fs-ext ^4.0.3` requirement now shares that same Cap-std family without introducing another version.

## Security / Policy Rationale

Wasmtime 48 requires Rust `1.95.0`, matching the repository MSRV. The reviewed `48.0.1` patch fixes component-composition context-slot management and sets the WASIp2 HTTP `Host` header by default. Wasmtime-WASI 48 also denies socket creation by default; Astrid does not expose WASI imports and continues to enforce explicit host-side connect/bind policy. The change preserves the capsule proposal boundary and closes a policy asymmetry by applying the same explicit GC/exceptions denial to the hook engine.

## Verification

Code verification was run at `57324b3eba359aed172d8a7acb0084bebf745dac`; the only follow-up at `60beb37369be9ad3da1e2d7a97e4b59823dcebeb` corrects changelog wording after exact-head review and passes `git diff --check`.

- `cargo fmt --all -- --check`
- `cargo test -p astrid-capsule -p astrid-hooks -p astrid-runtime --locked` — 687 capsule tests, 73 hooks tests, and runtime tests passed; the capsule run includes the new stale-cache regression.
- `cargo test -p astrid-capsule --lib --locked compiled_artifact_cache_tests` — 5 passed.
- `cargo test -p astrid-hooks --lib --locked test_hook_engine_preserves_explicit_guest_feature_boundary` — 1 passed.
- `cargo test -p astrid-capsule --lib --locked -- security::manifest_gate::tests::check_net engine::wasm::host::audit_sink_tests::audit_net connect_tcp_denial_lands_on_the_chain` — 10 network-denial and audit tests passed.
- `cargo check --workspace --all-features --locked`
- `cargo clippy --workspace --all-features --locked -- -D warnings`
- `cargo +1.95.0 check --workspace --locked`
- `CARGO_NET_OFFLINE=true ./scripts/check-wasm-portability.sh` — all wasm32-unknown-unknown checks passed.
- Audited every Cargo.lock version delta; no unrelated dependency bump was introduced.
- Both commits are GPG-signed and carry matching `Signed-off-by: Joshua J. Bouw <jjb@unicity-labs.com>` trailers.

## AI / Tool Assistance

Assisted-by: Codex:GLM-5.3 Flash (Coding Plan)
Assisted-by: Codex:gpt-5.6-sol

Tool assistance covered dependency investigation, the lock and engine updates, regression tests, validation commands, and exact-head wording review. The complete diff, Cargo.lock propagation, release evidence, security policy, and verification results were reviewed before the signed submissions.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/{issue}.{kind}.md` (docs/CI-only may skip; release PRs roll fragments into the version section instead of adding one)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.

## Residuals

- The full Linux Runtime CLI + HTTP sweep is not claimed locally; this host is macOS and the repository policy reserves that harness for Linux. Runtime E2E is expected from PR CI.
- `crates/astrid-integration-tests/tests/fixtures/` was absent locally, so the focused fixture-based Wasm E2E would have silently skipped; no local E2E pass is claimed from it.
- Exact-head PR CI is terminal green. Current-main integration is validated separately before landing.