### PR TITLE
build(deps): update wit-component to 0.257.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6912,7 +6912,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,7 +361,7 @@ dependencies = [
  "tracing",
  "uuid",
  "wit-component",
- "wit-parser 0.256.0",
+ "wit-parser 0.257.1",
 ]
 
 [[package]]
@@ -428,8 +428,8 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
- "wasm-encoder 0.256.0",
- "wasmparser 0.256.0",
+ "wasm-encoder 0.257.1",
+ "wasmparser 0.257.1",
  "wasmtime",
  "wasmtime-wasi",
  "wat",
@@ -7737,15 +7737,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-metadata"
-version = "0.256.0"
+name = "wasm-encoder"
+version = "0.257.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6187f9fce741db43bea48f1ec42174897d763b8cdea7df726f2dd05561848d7"
+checksum = "7d8ad9f0a39050867bda22e6486c316e2e52d20a42154d5bc433934bf738d085"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.257.1",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.257.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57460ad9bce753e8a80d47a445cb87c8724ea57f463d9c906a947c41032ce1ac"
 dependencies = [
  "anyhow",
  "indexmap",
- "wasm-encoder 0.256.0",
- "wasmparser 0.256.0",
+ "wasm-encoder 0.257.1",
+ "wasmparser 0.257.1",
 ]
 
 [[package]]
@@ -7779,6 +7789,17 @@ name = "wasmparser"
 version = "0.256.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60bd825ffedc6cba8a642924ba7ae424afbc47811cffbcb7b92031ec24e59b4c"
+dependencies = [
+ "bitflags 2.13.1",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.257.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92fc335fb6d48f46bda1d8b26b69e28320c15ac3272208333833d6e217e2b4a"
 dependencies = [
  "bitflags 2.13.1",
  "hashbrown 0.17.1",
@@ -8723,9 +8744,9 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-component"
-version = "0.256.0"
+version = "0.257.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d537ec182eed18f560184b870287cf443c4eccc315af178db3eae8811c3b6c"
+checksum = "2e8b7d04a4c9491ffea354923ed70c8826d52c699fe20a52e8ceca95017dddb8"
 dependencies = [
  "anyhow",
  "bitflags 2.13.1",
@@ -8734,10 +8755,10 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.256.0",
+ "wasm-encoder 0.257.1",
  "wasm-metadata",
- "wasmparser 0.256.0",
- "wit-parser 0.256.0",
+ "wasmparser 0.257.1",
+ "wit-parser 0.257.1",
 ]
 
 [[package]]
@@ -8761,9 +8782,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.256.0"
+version = "0.257.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa073dadefba859cb03f689a0c2e3efc51f883bf86b907eaa9709bfd9e3a00a9"
+checksum = "6f815340f0bb65d9775ae21e56b503b496683557b9b627b195d2766c25fb24ae"
 dependencies = [
  "anyhow",
  "hashbrown 0.17.1",
@@ -8775,7 +8796,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-ident",
- "wasmparser 0.256.0",
+ "wasmparser 0.257.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,7 +361,7 @@ dependencies = [
  "tracing",
  "uuid",
  "wit-component",
- "wit-parser 0.257.1",
+ "wit-parser 0.256.0",
 ]
 
 [[package]]
@@ -428,8 +428,8 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
- "wasm-encoder 0.257.1",
- "wasmparser 0.257.1",
+ "wasm-encoder 0.256.0",
+ "wasmparser 0.256.0",
  "wasmtime",
  "wasmtime-wasi",
  "wat",
@@ -7791,8 +7791,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60bd825ffedc6cba8a642924ba7ae424afbc47811cffbcb7b92031ec24e59b4c"
 dependencies = [
  "bitflags 2.13.1",
+ "hashbrown 0.17.1",
  "indexmap",
  "semver",
+ "serde",
 ]
 
 [[package]]
@@ -7805,7 +7807,6 @@ dependencies = [
  "hashbrown 0.17.1",
  "indexmap",
  "semver",
- "serde",
 ]
 
 [[package]]
@@ -8778,6 +8779,25 @@ dependencies = [
  "serde_json",
  "unicode-ident",
  "wasmparser 0.252.0",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.256.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa073dadefba859cb03f689a0c2e3efc51f883bf86b907eaa9709bfd9e3a00a9"
+dependencies = [
+ "anyhow",
+ "hashbrown 0.17.1",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-ident",
+ "wasmparser 0.256.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -254,12 +254,12 @@ url = "2"
 utoipa = { version = "5", features = ["axum_extras"] }
 uuid = { version = "1.0", default-features = false, features = ["v4", "v5", "serde", "rng-getrandom"] }
 walkdir = "2.5"
-wasm-encoder = "0.257.1"
+wasm-encoder = "0.256"
 wat = "1.256"
-wasmparser = "0.257.1"
+wasmparser = "0.256"
 windows-sys = "0.61"
 wit-component = "0.257.1"
-wit-parser = "0.257.1"
+wit-parser = "0.256"
 wasmtime = { version = "47.0.3", features = ["component-model", "cranelift"] }
 wasmtime-wasi = "47.0.3"
 unicode-normalization = "=0.1.25"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -254,12 +254,12 @@ url = "2"
 utoipa = { version = "5", features = ["axum_extras"] }
 uuid = { version = "1.0", default-features = false, features = ["v4", "v5", "serde", "rng-getrandom"] }
 walkdir = "2.5"
-wasm-encoder = "0.256"
+wasm-encoder = "0.257.1"
 wat = "1.256"
-wasmparser = "0.256"
+wasmparser = "0.257.1"
 windows-sys = "0.61"
-wit-component = "0.256"
-wit-parser = "0.256"
+wit-component = "0.257.1"
+wit-parser = "0.257.1"
 wasmtime = { version = "47.0.3", features = ["component-model", "cranelift"] }
 wasmtime-wasi = "47.0.3"
 unicode-normalization = "=0.1.25"

--- a/changes/1735.changed.md
+++ b/changes/1735.changed.md
@@ -1,0 +1,2 @@
+Updated component encoding to wit-component 0.257.1 and adapted the encoder
+builder for its mutable-reference API while retaining validation.

--- a/changes/1735.changed.md
+++ b/changes/1735.changed.md
@@ -1,2 +1,3 @@
 Updated component encoding to wit-component 0.257.1 and adapted the encoder
-builder for its mutable-reference API while retaining validation.
+builder for its mutable-reference API while retaining validation. Its matching
+wasm-tools family is confined to transitive implementation dependencies.

--- a/crates/astrid-build/src/rust.rs
+++ b/crates/astrid-build/src/rust.rs
@@ -302,7 +302,8 @@ fn ensure_component(wasm_path: &Path) -> Result<PathBuf> {
         return Ok(wasm_path.to_path_buf());
     }
     info!("   Wrapping core wasm into Component Model component...");
-    let component = wit_component::ComponentEncoder::default()
+    let mut encoder = wit_component::ComponentEncoder::default();
+    let component = encoder
         .validate(true)
         .module(&bytes)
         .context("ComponentEncoder rejected the core wasm — wit-bindgen `generate!` may be missing or producing the wrong section")?


### PR DESCRIPTION
## Linked Issue

Closes #1735

## Summary

Updates the component encoder to `wit-component` 0.257.1 as an individual dependency change. `ComponentEncoder` is adapted to its mutable-reference builder API, with output validation still enabled.

## Changes

- Bump only Astrid's direct `wit-component` requirement from 0.256 to 0.257.1.
- Keep Astrid's direct `wasm-encoder`, `wasmparser`, and `wit-parser` requirements at 0.256 for their own individual dependency PRs.
- Allow `wit-component`'s required matching `wasm-encoder`, `wasmparser`, `wit-parser`, and `wasm-metadata` 0.257.1 implementation family to remain transitive in the lockfile.
- Keep the landed Wasmtime 48 line and its separate internal 0.254 wasm-tools family unchanged.
- Adapt the single `ComponentEncoder` call to the upstream mutable-builder signatures without changing validation, module input, or error behavior.
- Keep `shim_return_call_ref` disabled: `ComponentEncoder::default()` leaves it false and Astrid never calls the opt-in setter. The 0.257.1 encoder's imported-memory, `__wasm_task_hook`, and realloc-fallback handling is intrinsic and input-driven rather than an enabled proposal knob; this PR accepts that upstream correctness handling while leaving Astrid's runtime proposal policy unchanged.

## Verification

At corrected exact head `b2ff360b4e6aec14d9a6aff2698d149e8495587b` against Wasmtime 48 main:

- `cargo fmt --all -- --check`
- `cargo test -p astrid-build --locked` — 29 passed.
- `cargo check -p astrid-build -p astrid-capsule-install --all-features --locked`
- `git diff --check`
- Lock audit confirms Wasmtime retains its internal 0.254 family, Astrid's direct wasm-tools packages remain 0.256 pending their individual PRs, and wit-component uses its matching transitive 0.257.1 family. The unrelated `tempfile 3.27.0 -> getrandom` edge is explicitly preserved at main's 0.3.4 resolution.
- The signed/DCO integration commit has parents `461cf25ac2060737d058f89b703e4f27dfe12023` and landed Wasmtime commit `a6567a8ddac12a8272c6ebe653a4e46c3f845085`; follow-up `b2ff360b4e6aec14d9a6aff2698d149e8495587b` restores the unrelated tempfile RNG edge. All four PR commits are signed and carry matching DCO trailers.

The pre-integration exact head `461cf25ac2060737d058f89b703e4f27dfe12023` also passed locked metadata, workspace check, and focused all-targets/all-features Clippy.

The production encoder adaptation is unchanged from `90317ef75e4d05590c520a93a2d5ec7b27362aa5`, where additional operational evidence was collected:

- Built the adversarial E2E fixture through `astrid capsule build`; the wrapped `wasm32-unknown-unknown` artifact had component headers, passed `wasm-tools validate`, and exposed the expected component WIT.
- Installed the resulting archive in an isolated `ASTRID_HOME`; the daemon live-loaded it, a capsule command dispatched successfully, listing showed the installed capsule, forced removal succeeded, listing reported no capsules, and the isolated daemon stopped cleanly.
- `cargo test -p astrid-capsule clear_on_return` — 3 passed.
- `cargo test -p astrid-capsule cancel` — 23 passed.

Residuals: exact-head CI is terminal green after the Wasmtime 48 integration and lock-scope correction. Runtime coverage exercised the canonical `wasm32-unknown-unknown` encoder path; `wasm32-wasip2` already emits components and skips this wrapping path. The isolated lifecycle run did not add a new imported-memory or task-hook fixture.

## AI / Tool Assistance

Assisted-by: Codex:GLM Flash Max
Assisted-by: Codex:gpt-5.6-sol

Tool assistance covered upstream release inspection, the builder adaptation, isolated lifecycle execution, and exact-head dependency-scope review. The final manifest, complete lock delta, emitted component/WIT archive, runtime output, signatures, and verification results were reviewed before publishing.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/{issue}.{kind}.md` (docs/CI-only may skip; release PRs roll fragments into the version section instead of adding one)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.