### PR TITLE
fix(deps): constrain uuid to 1.25

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6902,7 +6902,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -7567,9 +7567,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.24.1"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
+checksum = "f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc"
 dependencies = [
  "atomic",
  "getrandom 0.4.3",
@@ -7582,9 +7582,9 @@ dependencies = [
 
 [[package]]
 name = "uuid-rng-internal"
-version = "1.24.1"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb6e4d912010d7646ef4e5a0ba89bafc6d9f8fd617c53433fe2aa86d26a3b77"
+checksum = "cb1596b859c597925b27dd155f87464948332e138bb64c4eea1bfee057bf1ae7"
 dependencies = [
  "getrandom 0.4.3",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -252,7 +252,7 @@ url = "2"
 # other OpenAPI generator. `axum_extras` plugs into axum's extractor
 # system so `#[utoipa::path]` annotations on handlers carry through.
 utoipa = { version = "5", features = ["axum_extras"] }
-uuid = { version = "1.0", default-features = false, features = ["v4", "v5", "serde", "rng-getrandom"] }
+uuid = { version = "~1.25.0", default-features = false, features = ["v4", "v5", "serde", "rng-getrandom"] }
 walkdir = "2.5"
 wasm-encoder = "0.256"
 wat = "1.256"

--- a/changes/1727.changed.md
+++ b/changes/1727.changed.md
@@ -1,0 +1,1 @@
+Constrain the workspace uuid dependency to the reviewed 1.25 patch line and resolve it to 1.25.0. Existing string-based serde output, deterministic v5 identities, v4 generation through rng-getrandom, and wasm feature wiring remain unchanged. Closes #1727


### PR DESCRIPTION
## Linked Issue

Closes #1727

## Summary

Constrains the workspace `uuid` selector from `1.0` to `~1.25.0` so the reviewed patch line cannot drift to 1.26. The lock now resolves both `uuid` and `uuid-rng-internal` to 1.25.0. Existing feature selection, UUID behavior, and string-shaped serde representation remain unchanged.

## Changes

- Changed the workspace `uuid` requirement to `~1.25.0`, preserving `default-features = false` and the `v4`, `v5`, `serde`, and `rng-getrandom` features.
- Updated the lock to `uuid 1.25.0` and `uuid-rng-internal 1.25.0`.
- Added `changes/1727.changed.md`.
- Deliberately did not enable or adopt `serde::bytes`; Astrid UUIDs remain string-shaped across JSON, OpenAPI, topics, and persisted records.

## Verification

### Upstream evidence

[uuid 1.25.0](https://github.com/uuid-rs/uuid/releases/tag/1.25.0) adds the opt-in `serde::bytes` byte-string encoding module and release preparation. That encoding is not enabled in Astrid, so the default string serialization is unchanged.

### Lock and graph

- `cargo metadata --locked` succeeds and resolves `uuid@1.25.0`.
- `cargo tree -i uuid@1.25.0 --locked` confirms the direct workspace consumers and transitive `debugid`/`rmcp` consumers all use 1.25.0.
- `cargo tree --target all -i uuid-rng-internal@1.25.0 --locked` confirms it is reached by `uuid`.
- During lock resolution, pinning `uuid` to 1.25.0 initially selected `uuid-rng-internal 1.26.0`; it was explicitly resolved to 1.25.0. Cargo then normalized `tempfile 3.27.0`'s valid `getrandom >=0.3,<0.5` requirement from `getrandom 0.4.3` to the already-present compatible `getrandom 0.3.4`. This was resolver-produced, not hand-edited, and preserves a valid lock edge.

### Local checks

All builds and checks used a lane-local `CARGO_TARGET_DIR` with `CARGO_PROFILE_DEV_DEBUG=0` and `CARGO_INCREMENTAL=0`.

- `cargo test -p astrid-types --features clock --lib` — 55 passed.
- `cargo test -p astrid-events --lib` — 81 passed.
- `cargo test -p astrid-gateway --lib source_id` — 7 passed.
- `cargo test -p astrid-capsule --lib uuid_mapping` — 4 passed.
- `cargo test -p astrid --bin astrid` — 620 passed, 2 ignored.
- Focused real-consumer checks covered UUID string serialization, deterministic v5 identities, v4 generation, and `rng-getrandom` behavior.
- `cargo fmt --all -- --check` passed.
- `cargo check --workspace --locked` passed.
- `cargo clippy --workspace --all-features --locked -- -D warnings` passed.
- `scripts/check-wasm-portability.sh` passed all twelve configured checks for `wasm32-unknown-unknown`, including `astrid-capsule` and `astrid-kernel`.

## AI / Tool Assistance

Assisted-by: Codex:GLM-5.3 Flash

Codex assisted with upstream release review, dependency resolution, edit construction, and running the listed checks. The exact diff, resolver output, inverse dependency graph, upstream release notes, and verification results were reviewed before publishing. No internal task or orchestration identifiers are included.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/{issue}.{kind}.md` (docs/CI-only may skip; release PRs roll fragments into the version section instead of adding one)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.

### Residuals

- Full-workspace tests and repository CI were not run locally; the focused test matrix, workspace check, all-feature clippy, and Wasm portability gate are complete.
- Exact-head repository CI completed successfully. Final merge still requires a current-main integration check.