### PR TITLE
deps(mcp): upgrade process-wrap to 10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5201,9 +5201,9 @@ dependencies = [
 
 [[package]]
 name = "process-wrap"
-version = "9.1.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
+checksum = "0e3f4237d0e4741eb50bc5584db701f1299c85fa31ff0274dd6445e79dc42d12"
 dependencies = [
  "futures",
  "indexmap",
@@ -5872,7 +5872,6 @@ dependencies = [
  "hmac 0.13.0",
  "pastey",
  "pin-project-lite",
- "process-wrap",
  "rmcp-macros",
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,7 +145,7 @@ keyring = { version = "3", features = [
 landlock = "0.4"
 libc = "0.2"
 nix = { version = "0.31", features = ["process", "signal", "user", "fs", "resource"] }
-process-wrap = { version = "9", features = ["tokio1"] }
+process-wrap = { version = "10", features = ["tokio1"] }
 # Async-signal-safe signal handling on a dedicated OS thread. Used by the
 # daemon's SIGTERM/SIGINT/SIGHUP watchdog, which owns those signals off the
 # tokio runtime so the daemon is killable even when every worker is pinned.
@@ -199,7 +199,7 @@ reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"
 # changes in minor versions. Cargo.lock is committed, but the patch range also
 # prevents fresh resolution from silently adopting a future incompatible minor.
 # It still admits compatible bug and security fixes.
-rmcp = { version = "~3.1.2", features = ["server", "client", "transport-io", "transport-child-process", "elicitation", "macros", "request-state", "schemars"] }
+rmcp = { version = "~3.1.2", features = ["server", "client", "transport-io", "elicitation", "macros", "request-state", "schemars"] }
 rustyline = { version = "18", features = ["derive"] }
 semver = "1"
 serde = { version = "1.0", features = ["derive"] }

--- a/changes/1731.changed.md
+++ b/changes/1731.changed.md
@@ -1,0 +1,1 @@
+Upgraded direct MCP process ownership to process-wrap 10 through an Astrid-owned stdio transport that preserves process-tree teardown.

--- a/crates/astrid-mcp/src/lib.rs
+++ b/crates/astrid-mcp/src/lib.rs
@@ -68,6 +68,7 @@ pub(crate) mod capabilities;
 mod client;
 mod config;
 mod error;
+mod process_transport;
 mod secure;
 mod server;
 mod server_process;

--- a/crates/astrid-mcp/src/process_transport.rs
+++ b/crates/astrid-mcp/src/process_transport.rs
@@ -1,0 +1,112 @@
+//! RMCP stdio transport over an Astrid-owned process-wrap 10 child.
+
+use std::future::Future;
+use std::io;
+use std::process::Stdio;
+use std::time::Duration;
+
+use process_wrap::tokio::{ChildWrapper, CommandWrap};
+use rmcp::service::{RoleClient, RxJsonRpcMessage, TxJsonRpcMessage};
+use rmcp::transport::Transport;
+use rmcp::transport::async_rw::AsyncRwTransport;
+use tokio::process::{ChildStdin, ChildStdout};
+use tracing::warn;
+
+/// RMCP's child transport waits this long for a cooperative child after
+/// closing protocol writes before forcing tree termination. Preserve the
+/// upstream contract rather than inventing a second Astrid timeout.
+const GRACEFUL_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(3);
+
+pub(crate) struct OwnedProcessTransport {
+    child: Option<Box<dyn ChildWrapper>>,
+    transport: AsyncRwTransport<RoleClient, ChildStdout, ChildStdin>,
+}
+
+impl OwnedProcessTransport {
+    pub(crate) fn new(mut command: CommandWrap) -> io::Result<Self> {
+        command
+            .command_mut()
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit());
+
+        let child = command.spawn()?;
+        let (child, stdout, stdin) = take_stdio(child)?;
+        Ok(Self {
+            child: Some(child),
+            transport: AsyncRwTransport::new(stdout, stdin),
+        })
+    }
+
+    async fn graceful_shutdown(&mut self) -> io::Result<()> {
+        self.transport.close().await?;
+
+        let Some(mut child) = self.child.take() else {
+            return Ok(());
+        };
+
+        let Ok(result) = tokio::time::timeout(GRACEFUL_SHUTDOWN_TIMEOUT, child.wait()).await else {
+            if let Err(error) = Box::into_pin(child.kill()).await {
+                warn!(error = %error, "Error killing MCP child process tree");
+                return Err(error);
+            }
+            return Ok(());
+        };
+
+        match result {
+            Ok(status) => {
+                tracing::info!(?status, "MCP child exited gracefully");
+                Ok(())
+            },
+            Err(error) => {
+                warn!(error = %error, "Error waiting for MCP child");
+                Err(error)
+            },
+        }
+    }
+}
+
+fn take_stdio(
+    mut child: Box<dyn ChildWrapper>,
+) -> io::Result<(Box<dyn ChildWrapper>, ChildStdout, ChildStdin)> {
+    let stdin = child
+        .stdin()
+        .take()
+        .ok_or_else(|| io::Error::other("MCP child stdin was unavailable or already taken"))?;
+    let stdout = child
+        .stdout()
+        .take()
+        .ok_or_else(|| io::Error::other("MCP child stdout was unavailable or already taken"))?;
+    Ok((child, stdout, stdin))
+}
+
+impl Drop for OwnedProcessTransport {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            tokio::spawn(async move {
+                if let Err(error) = Box::into_pin(child.kill()).await {
+                    warn!(error = %error, "Error killing dropped MCP child process tree");
+                }
+            });
+        }
+    }
+}
+
+impl Transport<RoleClient> for OwnedProcessTransport {
+    type Error = io::Error;
+
+    fn send(
+        &mut self,
+        item: TxJsonRpcMessage<RoleClient>,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send + 'static {
+        self.transport.send(item)
+    }
+
+    fn receive(&mut self) -> impl Future<Output = Option<RxJsonRpcMessage<RoleClient>>> + Send {
+        self.transport.receive()
+    }
+
+    fn close(&mut self) -> impl Future<Output = Result<(), Self::Error>> + Send {
+        self.graceful_shutdown()
+    }
+}

--- a/crates/astrid-mcp/src/server.rs
+++ b/crates/astrid-mcp/src/server.rs
@@ -12,13 +12,13 @@ use tracing::{error, info, warn};
 use astrid_core::retry::RetryConfig;
 
 use rmcp::service::{Peer, RoleClient, RunningService};
-use rmcp::transport::TokioChildProcess;
 use rmcp::{ClientCacheConfig, ClientServiceExt};
 
 use crate::capabilities::CapabilitiesHandler;
 use crate::capabilities::{AstridClientHandler, ServerNotice};
 use crate::config::{RestartPolicy, ServerConfig, ServersConfig, Transport};
 use crate::error::{McpError, McpResult};
+use crate::process_transport::OwnedProcessTransport;
 use crate::server_process::{
     build_unsandboxed_command, mcp_client_lifecycle, today_date_string, wrap_process_tree,
 };
@@ -352,7 +352,7 @@ impl ServerManager {
         }
 
         // Create transport (spawns the child process)
-        let transport = TokioChildProcess::new(wrap_process_tree(cmd)).map_err(|e| {
+        let transport = OwnedProcessTransport::new(wrap_process_tree(cmd)).map_err(|e| {
             McpError::ServerStartFailed {
                 name: name.to_string(),
                 reason: e.to_string(),

--- a/crates/astrid-mcp/src/server_tests.rs
+++ b/crates/astrid-mcp/src/server_tests.rs
@@ -364,9 +364,8 @@ async fn process_tree_wrapper_kills_descendants_without_touching_peer_group() {
         .arg("astrid-mcp-test")
         .arg(&descendant_effect)
         .arg(&ready);
-    let mut owned = wrap_process_tree(owned_command)
-        .spawn()
-        .expect("spawn owned tree");
+    let owned = OwnedProcessTransport::new(wrap_process_tree(owned_command))
+        .expect("spawn owned transport");
 
     let mut peer = tokio::process::Command::new("/bin/sh");
     peer.arg("-c")
@@ -383,9 +382,7 @@ async fn process_tree_wrapper_kills_descendants_without_touching_peer_group() {
     .await
     .expect("owned descendant should start");
 
-    Box::into_pin(owned.kill())
-        .await
-        .expect("kill owned process group");
+    drop(owned);
     peer.wait().await.expect("wait for peer");
     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
@@ -397,6 +394,58 @@ async fn process_tree_wrapper_kills_descendants_without_touching_peer_group() {
         peer_effect.exists(),
         "an unrelated process group must survive"
     );
+}
+
+#[tokio::test]
+async fn owned_transport_reports_startup_failure_without_spawning() {
+    let missing = std::env::temp_dir().join("astrid-mcp-process-wrap-missing-executable");
+    let command = tokio::process::Command::new(missing);
+    let Err(error) = OwnedProcessTransport::new(wrap_process_tree(command)) else {
+        panic!("missing MCP executable should fail startup");
+    };
+
+    assert_eq!(error.kind(), std::io::ErrorKind::NotFound);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn owned_transport_frames_jsonrpc_messages() {
+    use rmcp::service::TxJsonRpcMessage;
+    use rmcp::transport::Transport as _;
+
+    let mut command = tokio::process::Command::new("/bin/sh");
+    command
+        .arg("-c")
+        .arg("IFS= read -r line; printf '%s\\n' \"$line\"");
+    let mut transport =
+        OwnedProcessTransport::new(wrap_process_tree(command)).expect("spawn echo transport");
+
+    let outgoing_message = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "notifications/initialized",
+    });
+    let mut expected_message = outgoing_message.clone();
+    expected_message["params"] = serde_json::Value::Null;
+    let outgoing: TxJsonRpcMessage<RoleClient> =
+        serde_json::from_value(outgoing_message).expect("valid client notification");
+    transport
+        .send(outgoing)
+        .await
+        .expect("write framed JSON-RPC message");
+
+    let received = tokio::time::timeout(std::time::Duration::from_secs(2), transport.receive())
+        .await
+        .expect("receive should not hang")
+        .expect("newline should frame one JSON-RPC message");
+    assert_eq!(
+        serde_json::to_value(&received).expect("serialize receive"),
+        expected_message
+    );
+
+    tokio::time::timeout(std::time::Duration::from_secs(3), transport.close())
+        .await
+        .expect("close should not hang")
+        .expect("echo child should shut down");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Linked Issue

Closes #1731

## Summary

Moves MCP stdio child ownership onto process-wrap 10 without preserving RMCP's child-process transport handoff. Astrid now owns the RMCP `Transport` boundary around the wrapped child, while RMCP continues to own newline-delimited JSON-RPC framing.

## Changes

- Bump Astrid's direct `process-wrap` dependency from 9 to 10.
- Add `OwnedProcessTransport`, an RMCP client transport that spawns the platform process-tree wrapper, extracts Tokio stdio pipes, closes protocol writes, and kill/reaps the tree on close or drop.
- Reuse RMCP's public async read/write transport for protocol framing, preserving compatibility handling for malformed and non-standard lines.
- Disable RMCP's now-unused `transport-child-process` feature so RMCP no longer pulls process-wrap 9.
- Add regressions for startup failures, newline framing, transport drop teardown, peer process-group isolation, and the existing end-to-end reluctant MCP process-tree teardown.

## Verification

- `cargo test -p astrid-mcp` — 129 passed, 0 failed, 1 ignored; 2 doctests passed. The ignored test is the intentionally subprocess-only fixture. The end-to-end reluctant-server test ran and passed.
- `cargo clippy -p astrid-mcp --all-targets -- -D warnings` — passed.
- `cargo fmt --all -- --check` — passed.
- `cargo check -p astrid --all-targets` — passed for the other direct RMCP consumer.
- `cargo check -p astrid-mcp --target x86_64-pc-windows-msvc --lib` — passed, compiling the Windows Job Object path. Runtime Windows teardown was not executed on this macOS host.
- `cargo tree -i process-wrap` shows only Astrid's direct process-wrap 10.0.0 edge; RMCP remains locked at 3.1.2 and no longer depends on process-wrap.
- A cross-target Windows `--all-targets` check reaches two unrelated Unix-only tests in `server_tests.rs` that use `std::os::unix::ffi` without platform gates. Those pre-existing failures were not changed by this PR.

## AI / Tool Assistance

Assisted-by: Codex:GLM-5.3 Flash (max)

Codex generated the dependency update, process transport adaptation, tests, changelog fragment, and PR text. The lane owner reviewed the upstream process-wrap 10 API changes and RMCP transport contract, inspected the complete diff and dependency graph, and executed the verification above.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/{issue}.{kind}.md` (docs/CI-only may skip; release PRs roll fragments into the version section instead of adding one)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
