### PR TITLE
fix(storage): preserve odd FastCDC profiles on v5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,7 +814,8 @@ dependencies = [
  "caseless",
  "chrono",
  "ed25519-dalek",
- "fastcdc",
+ "fastcdc 4.0.1",
+ "fastcdc 5.0.0",
  "fs2",
  "getrandom 0.4.3",
  "hex",
@@ -843,7 +844,7 @@ dependencies = [
  "anyhow",
  "astrid-storage",
  "blake3",
- "fastcdc",
+ "fastcdc 5.0.0",
  "hex",
  "mincdc",
  "mothcdc",
@@ -2774,6 +2775,12 @@ name = "fastcdc"
 version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77af40d8a8dadb92dc178569a5f5edb5f3056e98255c2de48ab5d59a52892e0c"
+
+[[package]]
+name = "fastcdc"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0431c3132902a1bed6fe77dcfa5d03844e083f263b81288246a2d43dd7d4b2ad"
 
 [[package]]
 name = "faster-hex"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,9 +118,10 @@ directories = "6.0"
 ed25519-dalek = { version = "3.0", features = ["rand_core", "zeroize", "serde"] }
 flate2 = "1.0"
 # Chunk boundaries are persistent principal-store format, not merely an
-# implementation detail. Exact-pin the audited FastCDC 2020 implementation;
-# upgrades require golden-boundary verification and a new chunking profile.
-fastcdc = "=4.0.1"
+# implementation detail. Exact-pin FastCDC 5 for even profiles and preserve the
+# audited FastCDC 4 scan for the legacy odd revision-1 compatibility edge.
+fastcdc = "=5.0.0"
+fastcdc-v4 = { package = "fastcdc", version = "=4.0.1" }
 fs2 = "0.4"
 futures = "0.3"
 globset = "0.4"

--- a/changes/1730.changed.md
+++ b/changes/1730.changed.md
@@ -1,0 +1,1 @@
+Principal-store content construction now uses FastCDC 5 for even revision-1 profiles while retaining an exact FastCDC 4 compatibility edge for legacy odd profiles. Default chunk boundaries and persisted file identities remain unchanged, and slice and streaming builders agree across both routes. Closes #1730

--- a/crates/astrid-storage-chunker-evidence/src/algorithm.rs
+++ b/crates/astrid-storage-chunker-evidence/src/algorithm.rs
@@ -173,7 +173,7 @@ pub fn candidates(target_kib: u32) -> Result<Vec<Candidate>> {
             algorithm: Algorithm::FastCdc2020,
             minimum_bytes: fast_minimum,
             maximum_bytes: fast_maximum,
-            implementation: "fastcdc=4.0.1",
+            implementation: "fastcdc=5.0.0 (even profiles only)",
             boundary_semantics: BoundarySemantics {
                 non_final_bounds: "minimum <= length <= maximum",
                 final_chunk: "may be shorter than minimum; never exceeds maximum",
@@ -323,6 +323,9 @@ mod tests {
                 .unwrap()
                 .contains("\"target_bytes\":65536")
         );
+        assert_eq!(fastcdc.implementation, "fastcdc=5.0.0 (even profiles only)");
+        assert!(fastcdc.minimum_bytes.is_multiple_of(2));
+        assert!(fastcdc.maximum_bytes.is_multiple_of(2));
     }
 
     #[test]

--- a/crates/astrid-storage-chunker-evidence/src/main.rs
+++ b/crates/astrid-storage-chunker-evidence/src/main.rs
@@ -33,7 +33,7 @@ struct EvidenceReport {
     corpus_privacy: &'static str,
     benchmark_environment: environment::BenchmarkEnvironment,
     object_cost_model: &'static str,
-    sources: [SourceRecord; 3],
+    sources: [SourceRecord; 4],
     unavailable_candidates: [UnavailableCandidate; 1],
     results: Vec<CandidateResult>,
     edit_stability: Vec<StabilityResult>,

--- a/crates/astrid-storage-chunker-evidence/src/source.rs
+++ b/crates/astrid-storage-chunker-evidence/src/source.rs
@@ -19,15 +19,23 @@ pub struct UnavailableCandidate {
     pub reasons: [&'static str; 4],
 }
 
-pub fn source_records() -> [SourceRecord; 3] {
+pub fn source_records() -> [SourceRecord; 4] {
     [
         SourceRecord {
             component: "fastcdc",
+            version: "5.0.0",
+            source_revision: "eeb3cbe8ed4eeef020aa346707bbdb29abd814ad",
+            repository: "https://github.com/nlfiedler/fastcdc-rs",
+            license: "MIT",
+            role: "production algorithm and evidence baseline for even profiles",
+        },
+        SourceRecord {
+            component: "fastcdc-v4",
             version: "4.0.1",
             source_revision: "2e47aa3146c6dbae34896997eebd162b280a7052",
             repository: "https://github.com/nlfiedler/fastcdc-rs",
             license: "MIT",
-            role: "current production algorithm and evidence baseline",
+            role: "legacy compatibility scan for odd revision-1 profiles",
         },
         SourceRecord {
             component: "mincdc",

--- a/crates/astrid-storage/Cargo.toml
+++ b/crates/astrid-storage/Cargo.toml
@@ -26,6 +26,7 @@ async-trait = { workspace = true }
 blake3 = { workspace = true }
 chrono = { workspace = true, features = ["clock"] }
 fastcdc = { workspace = true }
+fastcdc-v4 = { workspace = true }
 hex = { workspace = true }
 lz4_flex = { workspace = true }
 keyring = { workspace = true, optional = true }
@@ -44,6 +45,7 @@ base64 = { workspace = true }
 blake3 = { workspace = true }
 ed25519-dalek = { workspace = true }
 fastcdc = { workspace = true }
+fastcdc-v4 = { workspace = true }
 serde = { workspace = true }
 sha2 = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/astrid-storage/src/content_dag/build.rs
+++ b/crates/astrid-storage/src/content_dag/build.rs
@@ -5,6 +5,7 @@ use crate::storage_model::{
     ReferenceLabel,
 };
 use fastcdc::v2020::{FastCDC, Normalization};
+use fastcdc_v4::v2020::{FastCDC as FastCDCV4, Normalization as NormalizationV4};
 
 use crate::content_dag::{
     CHUNK_TREE_FANOUT, CONTENT_LABEL, ChunkingProfile, ContentDescriptor, ContentError,
@@ -93,6 +94,33 @@ pub fn build_content<I: ObjectIdentity>(
                 &mut unique_chunks,
                 source,
             )?;
+        } else if profile.uses_legacy_fastcdc_v4() {
+            let chunker = FastCDCV4::with_level_and_seed(
+                source,
+                usize::try_from(profile.minimum_bytes())
+                    .map_err(|_| ContentError::LengthOverflow)?,
+                usize::try_from(profile.average_bytes())
+                    .map_err(|_| ContentError::LengthOverflow)?,
+                maximum,
+                NormalizationV4::Level1,
+                profile.gear_seed(),
+            );
+            for chunk in chunker {
+                let end = chunk
+                    .offset
+                    .checked_add(chunk.length)
+                    .ok_or(ContentError::LengthOverflow)?;
+                let bytes = source
+                    .get(chunk.offset..end)
+                    .ok_or(ContentError::LengthOverflow)?;
+                push_chunk(
+                    identity,
+                    &mut records,
+                    &mut chunks,
+                    &mut unique_chunks,
+                    bytes,
+                )?;
+            }
         } else {
             let chunker = FastCDC::with_level_and_seed(
                 source,

--- a/crates/astrid-storage/src/content_dag/mod.rs
+++ b/crates/astrid-storage/src/content_dag/mod.rs
@@ -138,6 +138,17 @@ impl ChunkingProfile {
     pub const fn gear_seed(self) -> u64 {
         self.gear_seed
     }
+
+    /// Return whether this persisted profile requires the `FastCDC` 4 scan.
+    ///
+    /// `FastCDC` 5 documents even profile sizes as a precondition. Revision 1
+    /// deliberately admits odd minimum and maximum sizes, so only those legacy
+    /// profiles retain the exact `FastCDC` 4 implementation revision.
+    pub(crate) const fn uses_legacy_fastcdc_v4(self) -> bool {
+        !self.minimum_bytes.is_multiple_of(2)
+            || !self.average_bytes.is_multiple_of(2)
+            || !self.maximum_bytes.is_multiple_of(2)
+    }
 }
 
 impl Default for ChunkingProfile {

--- a/crates/astrid-storage/src/content_dag/stream.rs
+++ b/crates/astrid-storage/src/content_dag/stream.rs
@@ -5,6 +5,7 @@ use std::io::{self, Cursor, Read};
 
 use crate::storage_model::{ObjectId, ObjectRecord};
 use fastcdc::v2020::{Normalization, StreamCDC};
+use fastcdc_v4::v2020::{Normalization as NormalizationV4, StreamCDC as StreamCDCV4};
 
 use crate::content_dag::build::{Child, chunk_record, file_record, tree_record};
 use crate::content_dag::{
@@ -138,6 +139,21 @@ where
     if prefix.len() <= maximum {
         if !prefix.is_empty() {
             let child = stage_chunk(sink, &prefix, &mut logical_bytes)?;
+            tree.push(sink, child)?;
+        }
+    } else if profile.uses_legacy_fastcdc_v4() {
+        let chunker = StreamCDCV4::with_level_and_seed(
+            Cursor::new(prefix).chain(source),
+            minimum,
+            average,
+            maximum,
+            NormalizationV4::Level1,
+            profile.gear_seed(),
+        );
+        for result in chunker {
+            let chunk =
+                result.map_err(|error| ContentStreamError::Source(io::Error::from(error)))?;
+            let child = stage_chunk(sink, &chunk.data, &mut logical_bytes)?;
             tree.push(sink, child)?;
         }
     } else {

--- a/crates/astrid-storage/src/content_dag/stream_tests.rs
+++ b/crates/astrid-storage/src/content_dag/stream_tests.rs
@@ -117,6 +117,20 @@ fn streaming_matches_slice_for_boundary_and_multilevel_inputs() {
 }
 
 #[test]
+fn streaming_matches_slice_for_a_legacy_odd_profile() {
+    let profile = ChunkingProfile::fastcdc_v2020(65, 256, 1024, 17).unwrap();
+    assert!(profile.uses_legacy_fastcdc_v4());
+    for length in [
+        0, 1, 63, 64, 65, 255, 256, 1023, 1024, 1025, 16_384, 262_144,
+    ] {
+        let bytes = deterministic_bytes(length);
+        for fragment in [1, 7, 257, 4096] {
+            assert_stream_matches_slice(profile, &bytes, fragment);
+        }
+    }
+}
+
+#[test]
 fn streaming_preserves_the_whole_small_file_rule() {
     let profile = ChunkingProfile::ASTRID_V1;
     let bytes = deterministic_bytes(usize::try_from(profile.maximum_bytes()).unwrap());

--- a/crates/astrid-storage/src/content_dag/tests.rs
+++ b/crates/astrid-storage/src/content_dag/tests.rs
@@ -516,12 +516,12 @@ fn profile_identity_is_deterministic_and_seeded() {
 fn odd_minimum_profile_keeps_its_pre_freeze_boundaries() {
     let bytes = deterministic_bytes(4096);
     let profile = ChunkingProfile::fastcdc_v2020(65, 256, 1024, 0).unwrap();
-    let boundaries: Vec<_> = fastcdc::v2020::FastCDC::with_level_and_seed(
+    let boundaries: Vec<_> = fastcdc_v4::v2020::FastCDC::with_level_and_seed(
         &bytes,
         65,
         256,
         1024,
-        fastcdc::v2020::Normalization::Level1,
+        fastcdc_v4::v2020::Normalization::Level1,
         0,
     )
     .map(|chunk| chunk.length)
@@ -544,12 +544,12 @@ fn odd_minimum_profile_keeps_its_pre_freeze_boundaries() {
     // can canonically cut one byte below the declared minimum.
     let mut edge_bytes = vec![1_u8; 2048];
     edge_bytes[64] = 248;
-    let edge_boundaries: Vec<_> = fastcdc::v2020::FastCDC::with_level_and_seed(
+    let edge_boundaries: Vec<_> = fastcdc_v4::v2020::FastCDC::with_level_and_seed(
         &edge_bytes,
         65,
         256,
         1024,
-        fastcdc::v2020::Normalization::Level1,
+        fastcdc_v4::v2020::Normalization::Level1,
         0,
     )
     .map(|chunk| chunk.length)

--- a/docs/astrid-principal-content-dag.md
+++ b/docs/astrid-principal-content-dag.md
@@ -39,7 +39,8 @@ durable I/O, and authorization remain outside the primitive crate.
 Version one records:
 
 - algorithm: FastCDC 2020;
-- implementation revision: `fastcdc` 4.0.1;
+- implementation revision: one; even profiles are built with `fastcdc` 5.0.0
+  and legacy odd profiles retain an exact `fastcdc` 4.0.1 compatibility edge;
 - normalization: level one;
 - minimum: 16 KiB;
 - target average: 64 KiB;

--- a/docs/astrid-storage-chunker-evidence.md
+++ b/docs/astrid-storage-chunker-evidence.md
@@ -218,7 +218,8 @@ revisions:
 
 | Component | Version | Source revision | License | Role |
 |---|---|---|---|---|
-| `fastcdc` | 4.0.1 | `2e47aa3146c6dbae34896997eebd162b280a7052` | MIT | production baseline |
+| `fastcdc` | 5.0.0 | `eeb3cbe8ed4eeef020aa346707bbdb29abd814ad` | MIT | production baseline for even profiles |
+| `fastcdc-v4` | 4.0.1 | `2e47aa3146c6dbae34896997eebd162b280a7052` | MIT | legacy odd-profile compatibility edge |
 | `mincdc` | 0.1.0 | `638840e6809274e3e8e9916951d3c3ae4f3f5191` | Zlib | accelerated evidence oracle |
 | `mothcdc` | 0.7.2 | `3900c1e4e6c311bf832cb5099b2e0170e070970f` | Zlib | representation evidence oracle |
 


### PR DESCRIPTION
## Linked Issue

Closes #1730

Refs #1709 without closing it or including any other grouped dependency bump.

## Summary

Moves direct FastCDC construction to exact-pinned 5.0.0 for even revision-1 profiles and retains an exact-pinned FastCDC 4.0.1 alias solely for legacy odd revision-1 profiles. The persistent algorithm/implementation revision remains format one; no public wire or profile revision changes.

The default 16/64/256 KiB profile takes the v5 route. Its gear tables, masks, normalization, seed handling, and cut points remain compatible. The upstream v5 tail-fingerprint fix does not affect Astrid because the upstream hash is not an identity input; Astrid derives identities from canonical chunk bytes and graph structure.

## Changes

- adds `fastcdc = "=5.0.0"` and an exact `fastcdc-v4` package alias for FastCDC 4.0.1
- routes a persisted profile to v4 only when any profile size is odd; average sizes are already constrained to powers of two
- uses v5 for the slice and streaming builders on even profiles and v4 for both on legacy odd profiles
- retains the frozen local boundary verifier and principal-store revision-1 profile encoding
- distinguishes the v5 production/evidence route and v4 compatibility edge in evidence metadata and provenance docs
- adds odd-profile slice/stream parity and pins evidence implementation routing metadata
- adds the issue changelog fragment

Does not expose FastCDC 5's new `rechunk` API, async front end, or upstream chunk hashes.

## Verification

Base: `9c6a6545aa3684949f5ae3c5dded56149b7fb741`  
Head: `769b736a93948e58a721f7e5e3876da86c9d717d`

All commands used the lane-local `CARGO_TARGET_DIR=/Users/joshuaj.bouw/dev/astrid.worktrees/dep1709-fastcdc/target/dep1709-fastcdc` and preserved shared Cargo/rustup homes.

- `cargo fmt --all -- --check`
- `cargo check -p astrid-storage --no-default-features`
- `cargo test --locked -p astrid-storage --no-default-features content_dag` — 28 passed, including:
  - even default and seeded FastCDC golden boundary vectors
  - legacy odd minimum/effective-bound vectors
  - canonical boundary and final-chunk rejection
  - even and odd slice/stream identity parity
- `cargo test --locked -p astrid-storage-chunker-evidence --no-default-features` — 32 passed
- `cargo clippy --locked -p astrid-storage -p astrid-storage-chunker-evidence --all-targets --no-default-features -- -D warnings`
- `cargo test -p astrid-storage --no-default-features independent_reader_accepts_a_rust_produced_volume` — 1 passed; writes the 1 MiB default-profile golden through production principal state and validates the reopened volume with the independent RÚNATAL reader
- `PYTHONPATH=scripts python3 -c 'from runatal_v1_reader import verify_golden_vectors; verify_golden_vectors()'`
- `RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo check --target wasm32-unknown-unknown -p astrid-storage --no-default-features`; existing wasm-only dead-code warnings remain unchanged
- inspected `cargo tree -i fastcdc@4.0.1` and `cargo tree -i fastcdc@5.0.0`; both versions resolve only through the intended storage edges
- audited the lock diff: adds only FastCDC 5.0.0 and updates unambiguous package references while retaining 4.0.1
- `git verify-commit HEAD`; GPG Good signature with key `7CD32E7697286B11593246B9FA53358CB4127512`
- commit has matching `Signed-off-by: Joshua J. Bouw <jjb@unicity-labs.com>`
- local worktree is clean at the reported head

## Claim boundary

This draft proves compatibility of the persisted revision-1 routing described above. It does not approve merging, release publication, or movement of any production artifact. It does not close grouped PR #1709 and does not include its other dependency bumps.

## Residuals

- GitHub CI is pending; this PR must remain draft until reviewed and CI is green.
- Full workspace tests were not run locally; verification was focused to the changed storage and evidence crates plus the production-reader round trip.
- Existing wasm target dead-code warnings in `astrid-storage` remain and are unrelated to FastCDC.
- No new empirical CDC corpus measurements were generated. The historical evidence conclusions are unchanged; only implementation routing/provenance metadata is updated.
- Performance effects of v5's array-typed gear lookups and size-hint correction are not locally benchmarked.
- Consumers supplying custom profiles must retain odd values only where legacy revision-1 semantics are already accepted; new format work should prefer explicit even bounds.

## AI / Tool Assistance

Assisted-by: Codex: GLM-5.3 Flash

Codex implemented the dependency routing, tests, documentation, changelog, commit draft, and verification commands under Joshua's task direction. Joshua J. Bouw reviewed the diff, compatibility boundary, evidence, and DCO/GPG state and remains accountable for the submission.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/{issue}.{kind}.md`
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching Signed-off-by trailer.
