### PR TITLE
build(deps): upgrade wit-parser to 0.257.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,7 +361,7 @@ dependencies = [
  "tracing",
  "uuid",
  "wit-component",
- "wit-parser 0.256.0",
+ "wit-parser 0.257.1",
 ]
 
 [[package]]
@@ -7788,6 +7788,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmparser"
+version = "0.257.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92fc335fb6d48f46bda1d8b26b69e28320c15ac3272208333833d6e217e2b4a"
+dependencies = [
+ "bitflags 2.13.1",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
 name = "wasmprinter"
 version = "0.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8776,6 +8787,25 @@ dependencies = [
  "serde_json",
  "unicode-ident",
  "wasmparser 0.256.0",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.257.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f815340f0bb65d9775ae21e56b503b496683557b9b627b195d2766c25fb24ae"
+dependencies = [
+ "anyhow",
+ "hashbrown 0.17.1",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-ident",
+ "wasmparser 0.257.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -259,7 +259,7 @@ wat = "1.256"
 wasmparser = "0.256"
 windows-sys = "0.61"
 wit-component = "0.256"
-wit-parser = "0.256"
+wit-parser = "0.257.1"
 wasmtime = { version = "47.0.3", features = ["component-model", "cranelift"] }
 wasmtime-wasi = "47.0.3"
 unicode-normalization = "=0.1.25"

--- a/changes/1733.changed.md
+++ b/changes/1733.changed.md
@@ -1,0 +1,4 @@
+The direct `wit-parser` dependency moves from 0.256 to 0.257.1. The
+`Resolve`-based schema output remains unchanged, while `wit-component` and
+Wasmtime retain their existing parser versions until their dedicated upgrades.
+Closes #1733


### PR DESCRIPTION
## Linked Issue

Closes #1733

## Summary

Upgrade Astrid's direct `wit-parser` declaration from 0.256 to 0.257.1 as an individual successor to grouped Dependabot PR #1709. The refresh is layered on the already-landed Wasmtime 48 and `wit-component` 0.257.1 updates while keeping the remaining direct wasm-tools dependencies in their own lanes.

## Changes

- Change the direct workspace `wit-parser` requirement from 0.256 to 0.257.1.
- Reuse the matching 0.257.1 parser already required by `wit-component`, remove the now-redundant direct 0.256 parser node, and preserve Wasmtime's internal 0.254 family.
- Keep direct `wasmparser`, `wasm-encoder`, and WAT requirements unchanged for their individual PRs.
- Preserve the byte-identical `Resolve`-based public WIT schema behavior.
- Update `changes/1733.changed.md` to describe the landed dependency graph accurately.

## Verification

At refreshed exact head `f62db02f1bf5e0acaa21f7ca2836db1e304ee53a` against main commit `7b5a540a140b12c092d3baaefaa5fc78c293cd1b`:

- `cargo fmt --all -- --check`
- `cargo test -p astrid-build --locked` — 29 passed.
- `cargo check -p astrid-build -p astrid-capsule-install --all-features --locked`
- `git diff --check`
- Lock audit confirms `wit-parser` 0.254 remains private to Wasmtime, direct `astrid-build` and `wit-component` share 0.257.1, and the unrelated `tempfile 3.27.0 -> getrandom 0.3.4` edge is unchanged.
- The signed/DCO integration commit has parents `c05b2a42ee923c18298c524fc31d1f8f0295f3ce` and landed wit-component commit `7b5a540a140b12c092d3baaefaa5fc78c293cd1b`.

Evidence collected on the unchanged direct-parser adaptation before integration:

- Focused `astrid-build` schema tests passed on both 0.256 and 0.257.1.
- The comprehensive public WIT schema snapshot was byte-for-byte identical at 1308 bytes.
- Locked metadata, formatting, focused check and Clippy, Wasm portability, and all 34 original exact-head PR checks passed.
- Upstream `wit-parser` 0.256.0 to 0.257.1 is metadata-only for Astrid's consumed `Resolve` surface; behavior changes in the release belong to the already-reviewed `wit-component` encoder lane.

## Residuals

- Fresh exact-head CI, independent review, and the prior wit-component post-merge main workflows are complete and green.

## AI / Tool Assistance

Assisted-by: Codex:GLM-5.3 Flash Max
Assisted-by: Codex:gpt-5.6-sol

Tool assistance covered the direct dependency change, upstream and consumer-boundary review, schema comparison, lock reconciliation, changelog correction, and verification. The final diff, graph, signatures, and test evidence were reviewed before publishing.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/{issue}.{kind}.md`
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.