### PR TITLE
fix(mcp): validate RMCP 3.1.4 request-state keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5862,14 +5862,15 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "3.1.2"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8dddc5b1924b9a59fba420166160ca2c4663a4e01803e52eda33070f56d63c8"
+checksum = "1a15bc53261a9dc37e105df006e4656c598379a8f9581f8950debb130f27a7cf"
 dependencies = [
  "base64 0.23.1",
  "chrono",
  "futures",
  "hmac 0.13.0",
+ "indexmap",
  "pastey",
  "pin-project-lite",
  "process-wrap",
@@ -5885,13 +5886,14 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "zeroize",
 ]
 
 [[package]]
 name = "rmcp-macros"
-version = "3.1.2"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6898e24cd16342b59bfa8a53c2c04b9cf62fc8a2cfea57b9c038b09984bfc521"
+checksum = "a85d45508e9b4ba024fe996c2638799635d75b6dd0ba8f32ccf08f8026f0c780"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -199,7 +199,7 @@ reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"
 # changes in minor versions. Cargo.lock is committed, but the patch range also
 # prevents fresh resolution from silently adopting a future incompatible minor.
 # It still admits compatible bug and security fixes.
-rmcp = { version = "~3.1.2", features = ["server", "client", "transport-io", "transport-child-process", "elicitation", "macros", "request-state", "schemars"] }
+rmcp = { version = "~3.1.4", features = ["server", "client", "transport-io", "transport-child-process", "elicitation", "macros", "request-state", "schemars"] }
 rustyline = { version = "18", features = ["derive"] }
 semver = "1"
 serde = { version = "1.0", features = ["derive"] }

--- a/changes/1725.changed.md
+++ b/changes/1725.changed.md
@@ -1,0 +1,3 @@
+RMCP now uses 3.1.4, and MCP MRTR request-state signing keys are validated
+before codec construction. Elicitation conversion follows the peer's property
+order and accepts the RMCP `$schema` dialect field. Closes #1725

--- a/crates/astrid-cli/src/commands/mcp/gateway.rs
+++ b/crates/astrid-cli/src/commands/mcp/gateway.rs
@@ -371,15 +371,14 @@ async fn serve_attach(stream: UnixStream, state: Arc<GatewayState>) -> Result<()
         host_session_id = %registration.host_session_id,
         "MCP gateway accepted attach"
     );
-    let result = run_attached_session(
-        AstridMcpServer::new(client, principal, state.daemon_root.clone(), workspace),
-        reader,
-        write_half,
-        peers,
-        slot_id,
-        cancel,
-    )
-    .await;
+    let server = AstridMcpServer::new(client, principal, state.daemon_root.clone(), workspace)
+        .context("Failed to initialize the MCP request-state codec");
+    let result = match server {
+        Ok(server) => {
+            run_attached_session(server, reader, write_half, peers, slot_id, cancel).await
+        },
+        Err(error) => Err(error),
+    };
     state
         .finish_slot(&host_session_id, slot_id, permit, done)
         .await;

--- a/crates/astrid-cli/src/commands/mcp/mod.rs
+++ b/crates/astrid-cli/src/commands/mcp/mod.rs
@@ -258,7 +258,8 @@ pub(crate) async fn serve(
         caller.clone(),
         daemon_root.clone(),
         workspace_context,
-    );
+    )
+    .context("Failed to initialize the MCP request-state codec")?;
 
     // `rmcp::transport::stdio()` yields the (stdin, stdout) pair the MCP
     // transport drives. `serve` performs the MCP handshake and spawns the

--- a/crates/astrid-cli/src/commands/mcp/mrtr.rs
+++ b/crates/astrid-cli/src/commands/mcp/mrtr.rs
@@ -91,13 +91,20 @@ pub(super) struct MrtrBridge {
 }
 
 impl MrtrBridge {
-    pub(super) fn new() -> Self {
-        let mut key = [0_u8; 32];
+    pub(super) fn new() -> Result<Self, McpError> {
+        let mut key = [0_u8; RequestStateCodec::MIN_KEY_LENGTH];
         rand::rng().fill(&mut key);
-        Self {
-            codec: RequestStateCodec::new(key),
+        Self::from_key(key)
+    }
+
+    fn from_key(key: impl Into<Vec<u8>>) -> Result<Self, McpError> {
+        let codec = RequestStateCodec::try_new(key).map_err(|error| {
+            McpError::internal_error(format!("invalid MRTR signing key: {error}"), None)
+        })?;
+        Ok(Self {
+            codec,
             redeemed: Arc::new(Mutex::new(HashMap::new())),
-        }
+        })
     }
 
     pub(super) fn ingress_required(
@@ -304,7 +311,7 @@ mod tests {
 
     #[test]
     fn state_is_bound_to_principal_tool_and_arguments() {
-        let bridge = MrtrBridge::new();
+        let bridge = MrtrBridge::new().expect("random signing key is length-validated");
         let alice = PrincipalId::new("alice").unwrap();
         let bob = PrincipalId::new("bob").unwrap();
         let arguments = json!({ "path": "/tmp/report" });
@@ -354,7 +361,7 @@ mod tests {
 
     #[test]
     fn cancelled_redemption_can_retry_but_completed_redemption_cannot() {
-        let bridge = MrtrBridge::new();
+        let bridge = MrtrBridge::new().expect("random signing key is length-validated");
         let alice = PrincipalId::new("alice").unwrap();
         let arguments = json!({ "path": "/tmp/report" });
         let state = state_from(
@@ -383,8 +390,20 @@ mod tests {
     }
 
     #[test]
+    fn short_signing_key_is_rejected_before_a_bridge_is_created() {
+        let actual = RequestStateCodec::MIN_KEY_LENGTH - 1;
+
+        let Err(error) = MrtrBridge::from_key(vec![0_u8; actual]) else {
+            panic!("a short signing key must not construct a codec");
+        };
+
+        assert_eq!(error.code, rmcp::model::ErrorCode::INTERNAL_ERROR);
+        assert!(error.message.contains("expected at least 32 bytes, got 31"));
+    }
+
+    #[test]
     fn missing_declined_or_malformed_input_fails_closed() {
-        let bridge = MrtrBridge::new();
+        let bridge = MrtrBridge::new().expect("random signing key is length-validated");
         let alice = PrincipalId::new("alice").unwrap();
         let arguments = json!({});
         for responses in [

--- a/crates/astrid-cli/src/commands/mcp/server.rs
+++ b/crates/astrid-cli/src/commands/mcp/server.rs
@@ -136,15 +136,15 @@ impl AstridMcpServer {
         principal: PrincipalId,
         daemon_root: PathBuf,
         workspace: PathBuf,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, McpError> {
+        Ok(Self {
             client,
             principal,
             daemon_root,
             workspace,
             needs_reconnect: AtomicBool::new(false),
-            mrtr: MrtrBridge::new(),
-        }
+            mrtr: MrtrBridge::new()?,
+        })
     }
 
     /// Reconnect the held uplink without ever retaining a client authenticated

--- a/crates/astrid-mcp/src/capabilities/convert.rs
+++ b/crates/astrid-mcp/src/capabilities/convert.rs
@@ -17,8 +17,26 @@ use serde_json::Value;
 pub(super) fn convert_rmcp_schema(
     schema: &rmcp::model::ElicitationSchema,
 ) -> (ElicitationSchema, Option<String>) {
-    let first = schema.properties.iter().next();
-    let prop_name = first.map(|(name, _)| name.clone());
+    // RMCP records the peer's wire order separately from the compatibility
+    // map. Prefer that order so "first property" follows the offered schema,
+    // then fall back to map order for explicitly constructed schemas.
+    let first = schema
+        .property_order
+        .as_ref()
+        .and_then(|names| {
+            names
+                .iter()
+                .find_map(|name| schema.properties.get_key_value(name))
+        })
+        .map(|(name, definition)| (name.clone(), definition))
+        .or_else(|| {
+            schema
+                .properties
+                .iter()
+                .next()
+                .map(|(name, definition)| (name.clone(), definition))
+        });
+    let prop_name = first.as_ref().map(|(name, _)| name.clone());
 
     if let Some((_, primitive)) = first {
         // Serialize the PrimitiveSchema to JSON to inspect its type without
@@ -156,6 +174,34 @@ mod tests {
             }
         ));
         assert_eq!(prop_name, Some("api_key".to_string()));
+    }
+
+    #[test]
+    fn test_convert_rmcp_schema_honors_property_order_and_dialect() {
+        // Parse from text: the project's JSON map is order-insensitive.
+        let mut rmcp_schema: rmcp::model::ElicitationSchema = serde_json::from_str(
+            r#"{
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "type": "object",
+                "properties": {
+                    "alphabetical": {"type": "boolean"},
+                    "offered": {"type": "boolean"}
+                }
+            }"#,
+        )
+        .unwrap();
+        rmcp_schema.property_order = Some(vec!["offered".to_owned(), "alphabetical".to_owned()]);
+
+        assert_eq!(
+            rmcp_schema.schema.as_deref(),
+            Some("https://json-schema.org/draft/2020-12/schema")
+        );
+        let (schema, prop_name) = convert_rmcp_schema(&rmcp_schema);
+        assert!(matches!(
+            schema,
+            ElicitationSchema::Confirm { default: false }
+        ));
+        assert_eq!(prop_name.as_deref(), Some("offered"));
     }
 
     #[test]

--- a/crates/astrid-mcp/src/capabilities/convert.rs
+++ b/crates/astrid-mcp/src/capabilities/convert.rs
@@ -178,19 +178,27 @@ mod tests {
 
     #[test]
     fn test_convert_rmcp_schema_honors_property_order_and_dialect() {
-        // Parse from text: the project's JSON map is order-insensitive.
-        let mut rmcp_schema: rmcp::model::ElicitationSchema = serde_json::from_str(
+        // Parse the wire representation through RMCP's custom IndexMap-backed
+        // schema deserializer. This proves RMCP records the peer's offered
+        // property order rather than merely exercising a manually populated
+        // compatibility field.
+        let rmcp_schema: rmcp::model::ElicitationSchema = serde_json::from_str(
             r#"{
                 "$schema": "https://json-schema.org/draft/2020-12/schema",
                 "type": "object",
                 "properties": {
-                    "alphabetical": {"type": "boolean"},
-                    "offered": {"type": "boolean"}
+                    "offered": {"type": "boolean"},
+                    "alphabetical": {"type": "boolean"}
                 }
             }"#,
         )
         .unwrap();
-        rmcp_schema.property_order = Some(vec!["offered".to_owned(), "alphabetical".to_owned()]);
+
+        let expected_order = vec!["offered".to_owned(), "alphabetical".to_owned()];
+        assert_eq!(
+            rmcp_schema.property_order.as_deref(),
+            Some(expected_order.as_slice())
+        );
 
         assert_eq!(
             rmcp_schema.schema.as_deref(),


### PR DESCRIPTION
## Linked Issue

Closes #1725

## Summary

Moves the workspace RMCP requirement to the reviewed `~3.1.4` patch line and adopts the fallible request-state key constructor. The MRTR bridge now fails construction cleanly instead of accepting a short signing key, and elicitation conversion understands RMCP 3.1.4's dialect/order metadata. After process-wrap 10 landed, this branch was integrated with current main while keeping Astrid's owned child transport and RMCP's JSON-RPC framing.

## Changes

- Constrained the workspace RMCP requirement to `~3.1.4`; `Cargo.lock` updates `rmcp` and `rmcp-macros` from 3.1.2 to 3.1.4 with RMCP's required `indexmap`/`zeroize` edges.
- Kept RMCP's `transport-child-process` feature disabled, leaving a single process-wrap 10 dependency owned by `astrid-mcp`.
- Replaced `RequestStateCodec::new` with `try_new`; invalid key lengths map to an MCP internal error before an `MrtrBridge` exists.
- Propagated construction failure from `AstridMcpServer::new` through both stdio serving and gateway attach paths while preserving gateway slot cleanup.
- Updated elicitation conversion to honor RMCP `property_order` metadata when populated and to decode the newly supported `$schema` dialect field.
- Added regression coverage for short-key rejection, real MRTR behavior, RMCP lifecycle negotiation, and schema conversion.
- Added `changes/1725.changed.md`.

## Upstream Changes

Reviewed the complete RMCP 3.1.2 to 3.1.4 release delta. Relevant behavior includes broader legacy lifecycle fallback, automatic-discovery timeout, elicitation property-order and `$schema` preservation, request-state signing-key validation and zeroization, pre-initialization metadata error reporting, and OAuth resource/query matching and credential redaction.

## Verification

The refreshed tree is based on signed main commit `2a0e2cce255485e15f8c971f1731e9dbe7c2f662` and was checked with the shared campaign Cargo target:

- `cargo fmt --all -- --check` — pass
- `cargo check -p astrid -p astrid-mcp --locked` — pass
- `cargo test -p astrid-mcp --lib --locked` — 130 passed, 1 intentional subprocess-only ignore
- `cargo test -p astrid --bin astrid commands::mcp --locked` — 86 passed
- `cargo clippy -p astrid -p astrid-mcp --all-targets --locked -- -D warnings` — pass
- `cargo tree --locked -i rmcp` — only RMCP 3.1.4
- `cargo tree --locked -i process-wrap` — only process-wrap 10.0.0, consumed through `astrid-mcp`
- `git diff --check` — pass

The two implementation commits and signed integration commits through `c6739d43db706297da78d2d1a65e90c41b57468d` carry matching `Signed-off-by` trailers.

## Residuals

- Fresh CI and independent exact-head review are required before this draft is eligible to merge.
- RMCP 3.1.4 deserializes elicitation properties through its custom `IndexMap` wire type and records source order in `property_order`; the regression proves that production path. Construction through an order-insensitive intermediate `serde_json::Value` or sorted map can still lose original order, and this PR does not globally enable `serde_json/preserve_order`.
- The ignored RMCP subprocess fixture remains intentionally outside normal unit execution; adjacent owned-transport and process-tree lifecycle tests pass.

## AI / Tool Assistance

Assisted-by: Codex

Codex assisted with the RMCP pin/lock change, fallible MRTR constructor propagation, schema conversion update, regression tests, integration refresh, verification, and this description. I reviewed the upstream comparison and every resulting diff. The GPG/DCO certification is human-authored and commit signing was verified.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/{issue}.{kind}.md`
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
