### PR TITLE
chore(deps): update syn to 3.0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,7 +285,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sigstore-verify",
- "syn 3.0.3",
+ "syn 3.0.4",
  "syntect",
  "tar",
  "tempfile",
@@ -1173,7 +1173,7 @@ checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1743,7 +1743,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -2306,7 +2306,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -2317,7 +2317,7 @@ checksum = "68f5792fa0d41cd2325ce0ffa64f0a340eaebd4971a3a0c5e1ffd2cc488a355e"
 dependencies = [
  "darling_core",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -2564,7 +2564,7 @@ checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -3023,7 +3023,7 @@ checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -3903,7 +3903,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -5698,7 +5698,7 @@ checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -5897,7 +5897,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -6122,7 +6122,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -6229,7 +6229,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -6240,7 +6240,7 @@ checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -6286,7 +6286,7 @@ checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -6831,9 +6831,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7030,7 +7030,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -7159,7 +7159,7 @@ checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -9068,7 +9068,7 @@ checksum = "47402523226a02bfe5230160dc3ccc089aa6f6f19e7fcbb4e6f824bbb1b4aa62"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -212,7 +212,7 @@ sha2 = "0.11"
 sigstore-verify = { version = "=0.11.0", default-features = false, features = ["rustls", "tuf"] }
 subtle = "2"
 surrealkv = "0.21"
-syn = { version = "3", features = ["full", "visit"] }
+syn = { version = "~3.0.4", features = ["full", "visit"] }
 syntect = { version = "5", default-features = false, features = ["parsing", "default-syntaxes", "default-themes", "regex-fancy"] }
 tar = "0.4"
 teloxide = { version = "0.13", default-features = false, features = ["macros", "rustls", "ctrlc_handler"] }

--- a/changes/1722.changed.md
+++ b/changes/1722.changed.md
@@ -1,0 +1,1 @@
+Upgrade Syn to 3.0.4 after verifying the `astrid capsule check` source-scanning boundary.


### PR DESCRIPTION
## Linked Issue

Closes #1722

## Summary

Updates the workspace Syn 3 resolution from 3.0.3 to 3.0.4 as an individual successor to grouped Dependabot PR #1709. The direct workspace requirement is constrained to the reviewed 3.0 patch line.

Upstream 3.0.4 changes `Parse for ForeignItemFn` to accept safe foreign functions. Astrid's direct consumer is the CLI source scanner, which calls `syn::parse_file` and then visits item, impl, and trait functions. A before-bump check confirmed that this full-file path already accepts a safe foreign function on 3.0.3, so no production adaptation or synthetic regression test is warranted.

## Changes

- resolve Syn 3 at 3.0.4 while leaving the Syn 1 and Syn 2 transitive resolutions unchanged;
- constrain the direct workspace dependency to the Syn 3.0 patch line;
- add the dependency changelog fragment.

## Verification

- `cargo fmt --check --all`
- `cargo test -p astrid --locked commands::capsule::check::tests` (15 passed)
- `cargo check --workspace --locked`
- `cargo clippy -p astrid --all-targets --all-features --locked -- -D warnings`
- before-bump consumer probe: the real `tool_names_in_source` full-file parser accepted `unsafe extern "C" { safe fn host_status() -> i32; }` under Syn 3.0.3, confirming the upstream direct-`ForeignItemFn` parser fix is outside Astrid's call path
- reviewed upstream compare `dtolnay/syn` 3.0.3...3.0.4; the only library behavior change is commit `d454333f5bb7` (`Allow safe fn in impl Parse for ForeignItemFn`)
- commit `9ddf56227cd9fdab155e4bd326702ed8ce85f4a5` has a verified GPG signature and matching DCO trailer

## AI / Tool Assistance

Assisted-by: Codex:gpt-5.6-sol

Codex traced the direct and transitive consumers, reviewed the upstream compare, attempted the consumer-boundary regression, removed it after proving it passed before the bump, and prepared the dependency/changelog changes. I reviewed the final diff and validated it with the commands above.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/{issue}.{kind}.md` (docs/CI-only may skip; release PRs roll fragments into the version section instead of adding one)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
