### PR TITLE
build(deps): upgrade toml to 1.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,7 +292,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tokio",
  "tokio-util",
- "toml",
+ "toml 1.1.4+spec-1.1.0",
  "toml_edit",
  "tracing",
  "unicode-width",
@@ -424,7 +424,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tokio",
  "tokio-util",
- "toml",
+ "toml 1.1.4+spec-1.1.0",
  "tracing",
  "url",
  "uuid",
@@ -457,7 +457,7 @@ dependencies = [
  "tar",
  "tempfile",
  "tokio",
- "toml",
+ "toml 1.1.4+spec-1.1.0",
  "tracing",
  "uuid",
  "wat",
@@ -475,7 +475,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
- "toml",
+ "toml 1.1.4+spec-1.1.0",
  "web-time",
 ]
 
@@ -489,7 +489,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror 2.0.20",
- "toml",
+ "toml 1.1.4+spec-1.1.0",
  "tracing",
 ]
 
@@ -513,7 +513,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.20",
  "tokio",
- "toml",
+ "toml 1.1.4+spec-1.1.0",
  "uuid",
  "windows-sys 0.61.2",
 ]
@@ -553,7 +553,7 @@ dependencies = [
  "nix 0.31.3",
  "signal-hook 0.4.4",
  "tokio",
- "toml",
+ "toml 1.1.4+spec-1.1.0",
  "tracing",
  "uuid",
 ]
@@ -632,7 +632,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "toml",
+ "toml 1.1.4+spec-1.1.0",
  "tower",
  "tower-http 0.7.0",
  "tracing",
@@ -662,7 +662,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tokio",
  "tokio-util",
- "toml",
+ "toml 1.1.4+spec-1.1.0",
  "tracing",
  "uuid",
  "wasmtime",
@@ -743,7 +743,7 @@ dependencies = [
  "subtle",
  "tempfile",
  "tokio",
- "toml",
+ "toml 1.1.4+spec-1.1.0",
  "tracing",
  "uuid",
  "wat",
@@ -768,7 +768,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.20",
  "tokio",
- "toml",
+ "toml 1.1.4+spec-1.1.0",
  "tracing",
  "uuid",
  "which",
@@ -7214,6 +7214,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "1.1.4+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.4",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7896,7 +7911,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "sha2 0.10.9",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
  "wasmtime-environ",
  "windows-sys 0.61.2",
  "zstd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -232,7 +232,7 @@ thiserror = "2.0"
 # `rt-multi-thread`).
 tokio = { version = "1.49", features = ["sync", "macros", "time", "rt", "io-util"] }
 tokio-util = "0.7"
-toml = "0.9"
+toml = "1.1"
 # Middleware substrate axum is built on (`Service` trait composition,
 # request-id, trace, CORS, body-size limit, response-header injection).
 # Dropping `tower-http` means re-implementing each middleware by hand;

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -232,7 +232,7 @@ thiserror = "2.0"
 # `rt-multi-thread`).
 tokio = { version = "1.49", features = ["sync", "macros", "time", "rt", "io-util"] }
 tokio-util = "0.7"
-toml = "1.1"
+toml = "~1.1.4"
 # Middleware substrate axum is built on (`Service` trait composition,
 # request-id, trace, CORS, body-size limit, response-header injection).
 # Dropping `tower-http` means re-implementing each middleware by hand;

--- a/changes/1726.changed.md
+++ b/changes/1726.changed.md
@@ -1,4 +1,4 @@
-The workspace TOML requirement moves to 1.1 and locks `toml
+The workspace TOML requirement moves to `~1.1.4` and locks `toml
 1.1.4+spec-1.1.0` without adopting `preserve_order`. Existing layered
 config, capsule-manifest, and principal-identity compatibility is covered by
 updated parse, merge, round-trip, datetime, and stable-text tests. The

--- a/changes/1726.changed.md
+++ b/changes/1726.changed.md
@@ -1,0 +1,5 @@
+The workspace TOML requirement moves to 1.1 and locks `toml
+1.1.4+spec-1.1.0` without adopting `preserve_order`. Existing layered
+config, capsule-manifest, and principal-identity compatibility is covered by
+updated parse, merge, round-trip, datetime, and stable-text tests. The
+transitive `toml 0.9` required by Wasmtime remains. Closes #1726

--- a/crates/astrid-capsule-types/src/manifest/mod.rs
+++ b/crates/astrid-capsule-types/src/manifest/mod.rs
@@ -758,4 +758,89 @@ file = "skills/ignored/SKILL.md"
         assert!(!encoded.contains("[[skill]]"));
         assert!(!encoded.contains("skills/ignored/SKILL.md"));
     }
+
+    #[test]
+    fn representative_manifest_round_trips_with_stable_text() {
+        let source = r#"
+[package]
+name = "compatibility-probe"
+version = "1.2.3"
+
+[[component]]
+id = "worker"
+file = "worker.wasm"
+type = "executable"
+
+[imports.astrid]
+session = { version = "^1.0", optional = true }
+
+[exports]
+"astrid:worker" = "1.2.3"
+"#;
+        let manifest: CapsuleManifest = toml::from_str(source).unwrap();
+        assert_eq!(manifest.package.name, "compatibility-probe");
+        assert_eq!(manifest.components[0].id, "worker");
+        assert_eq!(
+            manifest.imports["astrid"]["session"].version.to_string(),
+            "^1.0"
+        );
+        assert!(manifest.imports["astrid"]["session"].optional);
+        assert_eq!(
+            manifest.exports["astrid"]["worker"].version.to_string(),
+            "1.2.3"
+        );
+
+        let encoded = toml::to_string_pretty(&manifest).unwrap();
+        assert_eq!(
+            encoded,
+            concat!(
+                "tool = []\n",
+                "context_file = []\n",
+                "command = []\n",
+                "mcp_server = []\n",
+                "uplink = []\n",
+                "\n",
+                "[package]\n",
+                "name = \"compatibility-probe\"\n",
+                "version = \"1.2.3\"\n",
+                "authors = []\n",
+                "keywords = []\n",
+                "categories = []\n",
+                "\n",
+                "[[component]]\n",
+                "id = \"worker\"\n",
+                "file = \"worker.wasm\"\n",
+                "type = \"executable\"\n",
+                "link = []\n",
+                "\n",
+                "[imports.astrid.session]\n",
+                "version = \"^1.0\"\n",
+                "optional = true\n",
+                "\n",
+                "[exports.astrid.worker]\n",
+                "version = \"1.2.3\"\n",
+                "\n",
+                "[publish]\n",
+                "\n",
+                "[subscribe]\n",
+                "\n",
+                "[capabilities]\n",
+                "uplink = false\n",
+                "net = []\n",
+                "kv = []\n",
+                "fs_read = []\n",
+                "fs_write = []\n",
+                "host_process = []\n",
+                "allow_persistent = false\n",
+                "net_bind = []\n",
+                "net_connect = []\n",
+                "identity = []\n",
+                "allow_prompt_injection = false\n",
+                "\n",
+                "[env]\n",
+            )
+        );
+        let round_trip: CapsuleManifest = toml::from_str(&encoded).unwrap();
+        assert_eq!(toml::to_string_pretty(&round_trip).unwrap(), encoded);
+    }
 }

--- a/crates/astrid-config/src/merge/tests.rs
+++ b/crates/astrid-config/src/merge/tests.rs
@@ -2,6 +2,49 @@ use super::path::set_nested;
 use super::*;
 
 #[test]
+fn layered_values_preserve_datetime_and_stable_text() {
+    let mut base: toml::Value = toml::from_str(
+        r#"
+        [metadata]
+        created = 1979-05-27T00:32:00-07:00
+
+        [model]
+        provider = "claude"
+    "#,
+    )
+    .unwrap();
+    let overlay: toml::Value = toml::from_str(
+        r"
+        [model]
+        max_tokens = 8192
+    ",
+    )
+    .unwrap();
+    let mut sources = FieldSources::new();
+
+    deep_merge_tracking(&mut base, &overlay, "", &ConfigLayer::User, &mut sources);
+
+    assert_eq!(
+        base["metadata"]["created"]
+            .as_datetime()
+            .map(ToString::to_string)
+            .as_deref(),
+        Some("1979-05-27T00:32:00-07:00")
+    );
+    assert_eq!(
+        toml::to_string_pretty(&base).unwrap(),
+        concat!(
+            "[metadata]\n",
+            "created = 1979-05-27T00:32:00-07:00\n",
+            "\n",
+            "[model]\n",
+            "max_tokens = 8192\n",
+            "provider = \"claude\"\n",
+        )
+    );
+}
+
+#[test]
 fn test_deep_merge_scalars() {
     let mut base: toml::Value = toml::from_str(
         r#"

--- a/crates/astrid-core/src/identity/principal.rs
+++ b/crates/astrid-core/src/identity/principal.rs
@@ -324,8 +324,19 @@ mod tests {
     fn serde_round_trip_keeps_canonical_text() {
         let identity = PrincipalIdentity::from_genesis(genesis()).unwrap();
         let encoded = toml::to_string(&identity).unwrap();
-        assert!(encoded.contains(&format!("uid = \"{}\"", identity.uid)));
-        assert!(encoded.contains(&format!("initial_public_key = \"{}\"", "5a".repeat(32))));
+        assert_eq!(
+            encoded,
+            concat!(
+                "uid = \"c2bcce8a2372c53b60ad922845ffd591b475e15f4005de34bf4039198d5b6987\"\n",
+                "\n",
+                "[genesis]\n",
+                "format_version = 1\n",
+                "identity_id = \"00112233-4455-6677-8899-aabbccddeeff\"\n",
+                "created_at_seconds = 1700000000\n",
+                "created_at_nanoseconds = 123456789\n",
+                "initial_public_key = \"5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a\"\n",
+            )
+        );
         let decoded: PrincipalIdentity = toml::from_str(&encoded).unwrap();
         assert_eq!(decoded, identity);
         decoded.validate().unwrap();


### PR DESCRIPTION
## Linked Issue

Closes #1726

## Summary

Moves the direct workspace `toml` requirement from `0.9` to the patch-tight `~1.1.4`. The lock resolves that requirement to `toml 1.1.4+spec-1.1.0`. This is the scoped `toml` successor to grouped Dependabot PR #1709.

`toml_edit` remains unchanged, and the transitive `toml 0.9.12+spec-1.1.0` required by Wasmtime remains in the lock. No wire or manifest schema changes are intended.

## Changes

- Changed the root workspace requirement from `toml = "0.9"` to `toml = "~1.1.4"` in `Cargo.toml`.
- Added direct `toml 1.1.4+spec-1.1.0` to `Cargo.lock` and repointed all direct workspace consumers to it.
- Kept `toml 0.9.12+spec-1.1.0` only on the `wasmtime-internal-cache` path.
- Kept `preserve_order` disabled; TOML retains its default map behavior.
- Added a layered-config test covering parse, tracked merge, TOML datetime preservation, and stable serialization text.
- Added a representative capsule-manifest round-trip with normalized import/export surfaces and an exact producer-output snapshot.
- Strengthened principal-identity persistence coverage with an exact serialized-file snapshot while retaining parse round-trip and UID validation.
- Added `changes/1726.changed.md`.

### Upstream and Lock Evidence

- The published `toml 1.1.4+spec-1.1.0` package manifest shows `preserve_order` remains an opt-in feature.
- The required lock family aligns with upstream: `toml_datetime 1.1.1+spec-1.1.0`, `toml_parser 1.1.3+spec-1.1.0`, and `toml_writer 1.1.2+spec-1.1.0`.
- `cargo tree -i toml@1.1.4+spec-1.1.0` confirms all direct workspace consumers use 1.1.4.
- `cargo tree -i toml@0.9.12+spec-1.1.0` confirms 0.9.12 is retained only through Wasmtime.
- The feature-tree audit finds no `preserve_order` edge.

## Verification

All Cargo commands used the lane-local `CARGO_TARGET_DIR` for this isolated worktree.

- `cargo fmt --all -- --check`: pass.
- `cargo check --workspace`: pass.
- `cargo clippy --workspace --all-targets -- -D warnings`: pass.
- `cargo test --workspace`: pass, including doctests. Existing platform-specific, production-runtime, durability, and performance diagnostics remain ignored by design.
- Focused checks also passed for `astrid-config`, `astrid-capsule-types`, and `astrid-core`.
- `python3 scripts/changelog.py check --base 9c6a6545aa3684949f5ae3c5dded56149b7fb741 --head HEAD --labels dependencies`: pass.
- Commit is GPG-signed and carries a matching `Signed-off-by` trailer.

Local checks are evidence, not GO; review and CI remain separate gates.

## Residuals

- Exact-head CI completed successfully. One Ubuntu provisioning-lock reacquisition job failed transiently, then passed on targeted rerun; the identical test also passed on main. Final merge still requires a current-main integration check.
- The live FSKit mount test remains ignored; this lane did not exercise a signed macOS 26 FSKit extension.
- WinFsp protocol tests run, but a live Windows mount was not exercised.
- No production Linux boot or full deployment lifecycle was exercised locally.
- No persisted contract currently uses TOML's native datetime type, so datetime compatibility is proven at the real raw layered-config boundary before typed conversion rather than through a persisted datetime field.

## AI / Tool Assistance

Assisted-by: Codex:GLM-5.3 Flash (Coding Plan)

Codex implemented the scoped dependency update, lock audit, focused compatibility tests, changelog fragment, local validation, and PR draft under the explicit FLEET assignment. The contributor reviewed the complete diff, direct and inverse dependency trees, feature-tree output, exact upstream package evidence, and validation results before authorizing the push.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/{issue}.{kind}.md`
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.