### PR TITLE
build(deps): pin wat to 1.257.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7737,6 +7737,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.257.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8ad9f0a39050867bda22e6486c316e2e52d20a42154d5bc433934bf738d085"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.257.1",
+]
+
+[[package]]
 name = "wasm-metadata"
 version = "0.256.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7785,6 +7795,17 @@ dependencies = [
  "indexmap",
  "semver",
  "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.257.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92fc335fb6d48f46bda1d8b26b69e28320c15ac3272208333833d6e217e2b4a"
+dependencies = [
+ "bitflags 2.13.1",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -8102,24 +8123,24 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "256.0.0"
+version = "257.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ad42723fc9222da007f05812a3249c9a4ee7af79d497fc2a2079579ad7efe6"
+checksum = "3c416ee8044cf88c5280e3d87c322b009525eb25142cf7428f0a90ea88febc3b"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.256.0",
+ "wasm-encoder 0.257.1",
 ]
 
 [[package]]
 name = "wat"
-version = "1.256.0"
+version = "1.257.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37cc86c54d8011b3202e265bfebada440733ea3a788ffaf46d395f7d2fdeacfb"
+checksum = "672e5495f00c5fc6c6b502205bae4708aa4dd13d969754438743afe0a8af0f1d"
 dependencies = [
- "wast 256.0.0",
+ "wast 257.0.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -255,7 +255,7 @@ utoipa = { version = "5", features = ["axum_extras"] }
 uuid = { version = "1.0", default-features = false, features = ["v4", "v5", "serde", "rng-getrandom"] }
 walkdir = "2.5"
 wasm-encoder = "0.256"
-wat = "1.256"
+wat = "=1.257.1"
 wasmparser = "0.256"
 windows-sys = "0.61"
 wit-component = "0.256"

--- a/changes/1729.changed.md
+++ b/changes/1729.changed.md
@@ -1,0 +1,1 @@
+Pin `wat` to 1.257.1 so WAT test fixtures resolve to the reviewed release instead of drifting to newer compatible versions.


### PR DESCRIPTION
## Linked Issue

Closes #1729

## Summary

Pin the workspace `wat` dependency to the reviewed 1.257.1 release as the final individual successor to grouped Dependabot PR #1709. The target converges WAT fixture parsing onto the already-landed wasm-tools 0.257.1 family instead of permitting resolver drift.

## Changes

- Change the direct workspace requirement from `wat = "1.256"` to `wat = "=1.257.1"`.
- Move `wat 1.256.0` to 1.257.1 and `wast 256.0.0` to 257.0.1.
- Remove the no-longer-needed `wasm-encoder`/`wasmparser 0.256.0` nodes because WAST now shares the already-landed direct 0.257.1 family.
- Record Cargo 1.95’s necessary lock-edge reselection for `tempfile 3.27.0` from the already-present `getrandom 0.3.4` node to the already-present 0.4.3 node. `tempfile` supports `>=0.3,<0.5`; no getrandom package version is added or removed.
- Add `changes/1729.changed.md`.

## Upstream Audit

The published `wat` and `wast` source trees have no Rust source changes between 1.256.0/256.0.0 and the target 1.257.1/257.0.1. The behavioral dependency change is WAST moving from `wasm-encoder 0.256` to 0.257.1, whose direct Astrid fixture-builder boundary was independently reviewed and landed in PR #1754.

The currently latest WAT 1.258.0 was also checked. Its `wat`/`wast` Rust source is unchanged from 1.257.1/257.0.1, but WAST moves to `wasm-encoder 0.258.0`. Taking that release here would reintroduce a second wasm-tools family beside Astrid’s deliberately aligned direct 0.257.1 dependencies and expand beyond the reviewed #1709 successor. It is intentionally not included.

## Verification

At refreshed exact head `84e5706bbd1e33c042ef86c66c5bdbaf49d16fa2` against main `768a51db3e26606468fc6272ec72728bf3e296b3`:

- `cargo check -p astrid-capsule --all-features --locked --offline` passed.
- `cargo test -p astrid-capsule prescan_ --locked --offline -- --quiet` — 13 passed.
- `cargo test -p astrid-capsule-install --lib --locked --offline -- --quiet` — 85 passed.
- `cargo test -p astrid-capsule-install --test install --locked --offline -- --quiet` — 14 passed.
- `cargo fmt --all -- --check`, `git diff --check`, and current-main diff checks passed.
- The current-main diff is exactly `Cargo.toml`, `Cargo.lock`, and `changes/1729.changed.md`.
- Lock graph audit confirms WAT/WAST share `wasm-encoder 0.257.1`, the 0.256 encoder/parser nodes disappear, and Wasmtime 48 retains its private 0.254 family.
- The signed/DCO integration commit has parents `087ada4c9b38f5bb4ad520695121f5091a69ebed` and `768a51db3e26606468fc6272ec72728bf3e296b3`; resulting tree is `563e7efc268fd34075f5305afee4168bc8aba9b5`.

The original isolated head also passed the full capsule and capsule-install suites plus focused Clippy.

## Residuals

- Independent review accepted exact head `84e5706bbd1e33c042ef86c66c5bdbaf49d16fa2` with no findings, and exact-head CI completed successfully (all 48 reported checks green).
- Full-workspace tests and Clippy were not repeated locally; CI owns those gates.
- WAT 1.258.0 and its wasm-tools 0.258 family remain a separate future dependency decision.

## AI / Tool Assistance

Assisted-by: Codex:GLM-5.3 Flash Max
Assisted-by: Codex:gpt-5.6-sol

Tool assistance covered the dependency change, upstream and latest-release audits, lock reconciliation, consumer/graph review, and verification. The final diff, signatures, and evidence were reviewed before publishing.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/{issue}.{kind}.md`
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.