### PR TITLE
deps: bump wasm-encoder to 0.257.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,7 +428,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
- "wasm-encoder 0.256.0",
+ "wasm-encoder 0.257.1",
  "wasmparser 0.256.0",
  "wasmtime",
  "wasmtime-wasi",
@@ -7737,6 +7737,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.257.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8ad9f0a39050867bda22e6486c316e2e52d20a42154d5bc433934bf738d085"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.257.1",
+]
+
+[[package]]
 name = "wasm-metadata"
 version = "0.256.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7785,6 +7795,17 @@ dependencies = [
  "indexmap",
  "semver",
  "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.257.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92fc335fb6d48f46bda1d8b26b69e28320c15ac3272208333833d6e217e2b4a"
+dependencies = [
+ "bitflags 2.13.1",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -254,7 +254,7 @@ url = "2"
 utoipa = { version = "5", features = ["axum_extras"] }
 uuid = { version = "1.0", default-features = false, features = ["v4", "v5", "serde", "rng-getrandom"] }
 walkdir = "2.5"
-wasm-encoder = "0.256"
+wasm-encoder = "0.257.1"
 wat = "1.256"
 wasmparser = "0.256"
 windows-sys = "0.61"

--- a/changes/1732.changed.md
+++ b/changes/1732.changed.md
@@ -1,0 +1,3 @@
+Upgrade the direct capsule-test `wasm-encoder` dependency to 0.257.1. The
+generated component and core-module fixtures remain compatible with the
+existing parser and Wasmtime runtime. Closes #1732


### PR DESCRIPTION
## Linked Issue

Closes #1732

## Summary

Upgrade the direct capsule-test `wasm-encoder` dependency from 0.256 to 0.257.1 as an individual successor to grouped Dependabot PR #1709. The refresh shares the already-landed 0.257.1 WIT tool family while keeping direct WAT on 1.256 and Wasmtime 48.0.1 on its private 0.254 family.

## Changes

- Change the direct workspace `wasm-encoder` requirement from 0.256 to 0.257.1.
- Rebuild the lockfile from current main and move only the direct `astrid-capsule` encoder edge to the existing 0.257.1 node.
- Preserve WAT 1.256 and its encoder 0.256 path for the final individual WAT PR.
- Preserve Wasmtime 48.0.1 and its private encoder/parser 0.254 family.
- Keep direct `wasmparser`, `wit-component`, and `wit-parser` at their already-landed 0.257.1 versions.
- Add `changes/1732.changed.md`.

## Upstream Audit

Upstream `wasm-encoder` 0.257.1 corresponds to wasm-tools v1.257.1. The source delta updates `Reencode` and `ReencodeComponent` range and offset handling for widened `u64` parser ranges, asserts component re-encoding begins at parser offset zero, and adjusts a documentation example. Astrid uses direct `Component` and `Module` builders for test fixtures rather than the re-encoding APIs, so no call-site adaptation is required.

The current dependency graph is intentional:

- `wasm-encoder 0.257.1`: shared by direct `astrid-capsule` tests and the landed WIT 0.257.1 family.
- `wasm-encoder 0.256.0`: retained through WAT 1.256 / wast 256 pending PR #1753.
- `wasm-encoder 0.254.0`: retained privately by Wasmtime 48.0.1.

## Verification

At refreshed exact head `9b908ac3f887f1f7b2e1904c927052b9464c46d1` against main `2fa81750991e8345db0bdc58f56638c7e748a309`:

- `cargo check -p astrid-capsule --all-features --offline` passed.
- `cargo test -p astrid-capsule compiled_artifact_cache_tests --offline -- --quiet` — 5 passed.
- `cargo test -p astrid-capsule prescan_ --offline -- --quiet` — 13 passed.
- `cargo fmt --all -- --check` passed.
- `git diff --check` and current-main diff checks passed.
- The current-main diff is exactly `Cargo.toml`, `Cargo.lock`, and `changes/1732.changed.md`.
- Lock audit confirms only the direct encoder edge changes and preserves `tempfile 3.27.0 -> getrandom 0.3.4`.
- The signed/DCO integration commit has parents `3d84669763ba8e463c7cc7ce4364fc8fbf4c783c` and `2fa81750991e8345db0bdc58f56638c7e748a309`; resulting tree is `011e61f37d1bf94b33c97d44acc60f5b23143279`.

The original isolated head also passed the full capsule library, focused Clippy, wasm portability, and exact-head PR suite; fresh CI is required for this integrated head.

## Residuals

- Exact-head CI completed successfully (34/34 checks), and independent review accepted `9b908ac3f887f1f7b2e1904c927052b9464c46d1` with no findings.
- Full-workspace tests and Clippy were not repeated locally; CI owns those gates.
- The remaining WAT convergence is intentionally deferred to PR #1753.

## AI / Tool Assistance

Assisted-by: Codex:GLM-5.3 Flash Max
Assisted-by: Codex:gpt-5.6-sol

Tool assistance covered the direct dependency change, upstream and consumer-boundary review, lock reconciliation, graph audit, and verification. The final diff, signatures, and evidence were reviewed before publishing.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/{issue}.{kind}.md`
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.