### PR TITLE
fix(deps): bump wasmparser to 0.257.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,7 +429,7 @@ dependencies = [
  "url",
  "uuid",
  "wasm-encoder 0.256.0",
- "wasmparser 0.256.0",
+ "wasmparser 0.257.1",
  "wasmtime",
  "wasmtime-wasi",
  "wat",
@@ -7779,6 +7779,18 @@ name = "wasmparser"
 version = "0.256.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60bd825ffedc6cba8a642924ba7ae424afbc47811cffbcb7b92031ec24e59b4c"
+dependencies = [
+ "bitflags 2.13.1",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.257.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92fc335fb6d48f46bda1d8b26b69e28320c15ac3272208333833d6e217e2b4a"
 dependencies = [
  "bitflags 2.13.1",
  "hashbrown 0.17.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -256,7 +256,7 @@ uuid = { version = "1.0", default-features = false, features = ["v4", "v5", "ser
 walkdir = "2.5"
 wasm-encoder = "0.256"
 wat = "1.256"
-wasmparser = "0.256"
+wasmparser = "0.257.1"
 windows-sys = "0.61"
 wit-component = "0.256"
 wit-parser = "0.256"

--- a/changes/1728.changed.md
+++ b/changes/1728.changed.md
@@ -1,0 +1,5 @@
+The WASM export pre-scan now uses wasmparser 0.257.1. Offset and range
+types widened upstream, but the scanner reads only export names, kinds,
+and function indices and still fails open on malformed input. Default
+parser proposal changes do not change Astrid admission policy; native
+Wasmtime compilation remains the enforcement gate.

--- a/changes/1728.changed.md
+++ b/changes/1728.changed.md
@@ -1,5 +1,5 @@
 The WASM export pre-scan now uses wasmparser 0.257.1. Offset and range
 types widened upstream, but the scanner reads only export names, kinds,
-and function indices and still fails open on malformed input. Default
-parser proposal changes do not change Astrid admission policy; native
-Wasmtime compilation remains the enforcement gate.
+and function indices. On malformed input it conservatively assumes the
+export exists, disabling timeout classification; native Wasmtime
+compilation remains the admission and policy enforcement gate.


### PR DESCRIPTION
## Linked Issue

Closes #1728

## Summary

Bumps the direct `wasmparser` dependency from 0.256 to 0.257.1 as an individual successor to the grouped dependency update. The direct parser remains used only by the capsule export pre-scan. The refresh shares wasmparser 0.257.1 with the already-landed 0.257.1 WIT tool family while keeping Wasmtime private on 0.254 and the remaining direct wasm-encoder and WAT bumps in their own PRs.

## Changes

- Updated the direct workspace declaration to the patch-compatible `wasmparser 0.257.1` requirement.
- Rebuilt the lockfile from current main and moved only the direct `astrid-capsule` parser edge to 0.257.1, avoiding the duplicate 0.257.1 lock records produced by the nominally clean merge.
- Kept direct `wasm-encoder` and WAT requirements unchanged for their individual PRs; preserved Wasmtime 48.0.1 and the landed WIT 0.257.1 family.
- Added `changes/1728.changed.md`.

## Upstream Audit

Compared the published crate sources:

- 0.256.0: `114be5245f143a8acf858aa236f6fd8ba7496dc2`
- 0.257.1: `3ef3cefcdc958c859a1dca79d677327e9453859d`

Upstream widened parser offsets and ranges from `usize` to `u64`, including `BinaryReader::original_position`, `BinaryReader::range`, and parser payload ranges. Astrid does not consume those APIs. The only consumer is `wasm_exports_contain`, which reads export names, external kinds, and `u32` function indices; it does not read byte offsets or ranges.

Upstream also changed `WasmFeatures::default` for `wide_arithmetic` and `compact_imports` from false to true. Astrid does not use parser results as an admission decision. The pre-scan only detects likely stub aliases. On malformed input it conservatively assumes the export exists, which disables timeout classification; native Wasmtime compilation remains the admission and policy enforcement gate. No proposal-policy coupling was introduced or removed by this bump.

No new regression was added because the existing pre-scan tests already pin Astrid's export/stub and malformed-input behavior; the upstream API widening has no Astrid-owned behavior to capture.

## Verification

At refreshed exact head `1652036e2c3b0703aa445a02b046dbf745c1cffe` against main `63dab8f67a5a0775dbad9b87c3b9eb92f6058e2f`:

- `cargo check -p astrid-capsule --all-features --offline` passed.
- `cargo test -p astrid-capsule prescan_ --offline -- --quiet` — 13 passed.
- `cargo fmt --all -- --check` passed.
- `git diff --check` and current-main diff checks passed.
- Workspace graph audit confirms direct `astrid-capsule` uses wasmparser 0.257.1, Wasmtime 48.0.1 retains its private 0.254 parser, and direct wasm-encoder/WAT remain unchanged.
- Lock audit confirms no duplicate wasmparser 0.257.1 record and preserves `tempfile 3.27.0 -> getrandom 0.3.4`.
- The dependency integration commit remains signed/DCO. A second signed/DCO merge brings in unrelated GitHub Actions-only main commit `63dab8f67a5a0775dbad9b87c3b9eb92f6058e2f`; its parents are `fdcbf3b891efce440951038749887ad53cb2e511` and `63dab8f67a5a0775dbad9b87c3b9eb92f6058e2f`, and the resulting tree is `bc96065467231e4a2df2d68279aa5f4163b19d34`.

The original isolated head also passed the full capsule library, focused Clippy, wasm portability, and exact-head PR suite; fresh CI is required for this integrated head.

## Residuals

- Fresh exact-head CI completed 34/34 green, and independent exact-head follow-up review ACCEPTed the current-main refresh.
- Full-workspace tests and Clippy were not repeated locally; the terminal CI matrix covers those gates.
- New parser proposal defaults are not treated as admission policy; runtime acceptance remains governed by Wasmtime 48.0.1.

## AI / Tool Assistance

Assisted-by: Codex:GLM-5.3 Flash Max
Assisted-by: Codex:gpt-5.6-sol

The operator-directed Codex session reviewed the complete diff, upstream claim boundary, and validation output before submission. Joshua remains accountable for the tool-assisted contribution and DCO certification.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/{issue}.{kind}.md` (docs/CI-only may skip; release PRs roll fragments into the version section instead of adding one)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.