### PR TITLE
Upgrade cap-std to 4.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1533,9 +1533,9 @@ dependencies = [
 
 [[package]]
 name = "cap-fs-ext"
-version = "4.0.2"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78e5a3368ae89b7cb68186411452b4b9fac8b41be9c19bf3f47c2d2c8e36e6b"
+checksum = "56ff379b70af8e08307a8f65e7040c7301cb4a572538ade16b4984f0da77847f"
 dependencies = [
  "cap-primitives",
  "cap-std",
@@ -1545,9 +1545,9 @@ dependencies = [
 
 [[package]]
 name = "cap-primitives"
-version = "4.0.2"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdadbd7c002d3a484b35243669abdae85a0ebaded5a61117169dc3400f9a7ff0"
+checksum = "8b5f74729fd2f44701d1a8eb47e906cdb3ccd9ec0f02baad85a744b791940b18"
 dependencies = [
  "ambient-authority",
  "fs-set-times",
@@ -1563,9 +1563,9 @@ dependencies = [
 
 [[package]]
 name = "cap-std"
-version = "4.0.2"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7281235d6e96d3544ca18bba9049be92f4190f8d923e3caef1b5f66cfa752608"
+checksum = "c1ec78e242cfa2cfe276807ac2ecc00315a6c97786977414bcd1c3963b6c91b8"
 dependencies = [
  "cap-primitives",
  "io-extras",

--- a/changes/1720.fixed.md
+++ b/changes/1720.fixed.md
@@ -1,0 +1,4 @@
+Upgrade the direct `cap-std` dependency resolution to 4.0.3 to pick up the
+upstream fix for trailing-slash symlink handling with `O_NOFOLLOW`. Existing
+storage and VFS capability tests confirm that Astrid's current boundaries did
+not reproduce the upstream exposure. Closes #1720

--- a/crates/astrid-storage/Cargo.toml
+++ b/crates/astrid-storage/Cargo.toml
@@ -63,7 +63,7 @@ harness = false
 getrandom = { version = "0.4", features = ["wasm_js"] }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-cap-std = "4.0.2"
+cap-std = "4.0.3"
 caseless = { workspace = true }
 fs2 = { workspace = true }
 libc = { workspace = true }

--- a/crates/astrid-vfs/Cargo.toml
+++ b/crates/astrid-vfs/Cargo.toml
@@ -12,7 +12,7 @@ description = "Virtual File System and Capability sandbox for Astrid agent runti
 astrid-capabilities = { workspace = true }
 astrid-core = { workspace = true }
 async-trait = { workspace = true }
-cap-std = "4.0.2"
+cap-std = "4.0.3"
 dashmap = { workspace = true }
 ignore = { workspace = true }
 serde = { workspace = true, features = ["derive"] }


### PR DESCRIPTION
## Linked Issue

Closes #1720

## Summary

Raise the direct `cap-std` requirement in `astrid-storage` and `astrid-vfs` from 4.0.2 to 4.0.3 and resolve the resulting cap-std family to the fixed release. The upstream change prevents a trailing slash from causing cap-primitives to bypass `O_NOFOLLOW` when resolving the final path component.

Consistent with the implementation audit on #1720, this PR does **not** claim a reproduced Astrid exploit. Storage prevalidates symlink redirects, and the host VFS lexically removes a trailing slash before its capability open. Existing real-boundary tests pass on both 4.0.2 and 4.0.3. The update removes the vulnerable crate family and improves defense-in-depth for unsupported or future call patterns; no misleading version-sensitive Astrid regression is added.

## Changes

- Set the direct `cap-std` declarations in `astrid-storage` and `astrid-vfs` to `4.0.3`.
- Update only `cap-std`, `cap-primitives`, and `cap-fs-ext` in `Cargo.lock`.
- Add `changes/1720.fixed.md`, including the honest no-reproduced-exposure boundary.
- Add no source or test changes beyond the dependency and changelog files.

Upstream evidence: production change [a8c93210536815fac607ed236a085f19219978bb](https://github.com/bytecodealliance/cap-std/commit/a8c93210536815fac607ed236a085f19219978bb), test coverage from [cf65c7bd18ad4f6a865324679052929886d66131](https://github.com/bytecodealliance/cap-std/commit/cf65c7bd18ad4f6a865324679052929886d66131), and the 4.0.3 release commit [b7acf8e8807fe3fab991884d2208b7e03d35a409](https://github.com/bytecodealliance/cap-std/commit/b7acf8e8807fe3fab991884d2208b7e03d35a409). Public GitHub/OSV advisory APIs returned 404 during this run.

## Verification

Baseline on macOS/aarch64 at 4.0.2, with `CARGO_TARGET_DIR=target/dep1709-cap-std`:

- `cargo test -p astrid-storage --locked symlink` — 8 passed.
- `cargo test -p astrid-storage --locked redirect` — 1 passed.
- `cargo test -p astrid-vfs --locked` — 31 passed.

After the upgrade on macOS/aarch64 at 4.0.3, with the same target directory:

- The same three storage/VFS commands pass with the same counts.
- `cargo fmt --all -- --check` passes.
- `cargo check --workspace --locked` passes.
- `cargo clippy --workspace --all-targets --locked -- -D warnings` passes.

Linux/aarch64 on `rust:1.95-slim`, using lane-local Cargo and target volumes:

```sh
cargo test -p astrid-storage --locked symlink
cargo test -p astrid-storage --locked redirect
cargo test -p astrid-vfs --locked
```

Results: 8 and 1 storage tests passed; 29 VFS tests passed and 1 was ignored because the container lacks unprivileged overlayfs/user namespace support.

Dependency evidence:

- Baseline reverse trees resolved `cap-std`, `cap-primitives`, and `cap-fs-ext` to 4.0.2.
- `cargo update -p cap-std -p cap-fs-ext -p cap-primitives` updated exactly those three packages to 4.0.3.
- Post-upgrade `cargo tree` reverse trees resolve all three to 4.0.3.

The commit is GPG-signed and carries the matching `Signed-off-by` trailer.

## AI / Tool Assistance

Assisted-by: Codex:zai-coding-responses/glm-5.3-flash

Codex assisted with advisory/upstream investigation, local and Linux verification, the dependency and changelog edits, and this PR text. The complete four-file diff was reviewed. Existing repository tests and all gates listed above were executed to validate the tool-assisted result.

## Residual Coverage

- No Astrid-specific exploit is reproduced by design, per the issue audit; the existing boundary tests are intentionally not a misleading fail-on-4.0.2 regression.
- Full storage tests were not run on Windows locally. CI provides Windows coverage but does not run the full storage suite on Windows.
- The Docker Linux VFS run ignores the existing overlayfs test when unprivileged user namespaces are unavailable; that path remains covered by CI.
- Upstream fallback platforms beyond the locally exercised macOS and Linux targets are covered by the dependency fix and upstream tests rather than an Astrid exploit regression.
- Draft CI status is pending at PR creation.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/{issue}.{kind}.md`
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
