### PR TITLE
Add private typed object relation projection

### DIFF
--- a/changes/1758.added.md
+++ b/changes/1758.added.md
@@ -10,3 +10,5 @@ relation construction.
 Reclaim observations and live-row rejection are now projection-scoped, reader
 retirement fails closed without losing its slot or rows on epoch overflow, and
 batch capacity is planned from net row count rather than the pre-batch count.
+Fold replay orders deletes before upserts within each batch epoch, matching the
+authoritative staged mutation order at the fixed row ceiling.

--- a/changes/1758.added.md
+++ b/changes/1758.added.md
@@ -1,2 +1,8 @@
 Added kernel- and harness-private typed object relations with bounded snapshot,
 delta, fold, generation-checked reader, and reclaim-observation semantics.
+
+The amended projection advances a visible authoritative batch by one
+projection-local epoch, binds cursors to full reader identity, retires
+old-generation rows with delete deltas, keeps logical deletes distinct from
+scoped reclaim observations, and enforces capability/object scope invariants at
+relation construction.

--- a/changes/1758.added.md
+++ b/changes/1758.added.md
@@ -1,0 +1,2 @@
+Added kernel- and harness-private typed object relations with bounded snapshot,
+delta, fold, generation-checked reader, and reclaim-observation semantics.

--- a/changes/1758.added.md
+++ b/changes/1758.added.md
@@ -6,3 +6,7 @@ projection-local epoch, binds cursors to full reader identity, retires
 old-generation rows with delete deltas, keeps logical deletes distinct from
 scoped reclaim observations, and enforces capability/object scope invariants at
 relation construction.
+
+Reclaim observations and live-row rejection are now projection-scoped, reader
+retirement fails closed without losing its slot or rows on epoch overflow, and
+batch capacity is planned from net row count rather than the pre-batch count.

--- a/kernel/crates/astrid-native-kernel/src/lib.rs
+++ b/kernel/crates/astrid-native-kernel/src/lib.rs
@@ -21,6 +21,9 @@ pub mod ipc;
 #[cfg(not(test))]
 pub mod memory;
 pub mod platform;
+// Production-compiled ahead of its first consumer so the native target keeps
+// typechecking the frozen relation semantics.
+#[allow(dead_code)]
 mod relations;
 #[cfg(not(test))]
 pub mod serial;

--- a/kernel/crates/astrid-native-kernel/src/lib.rs
+++ b/kernel/crates/astrid-native-kernel/src/lib.rs
@@ -21,7 +21,7 @@ pub mod ipc;
 #[cfg(not(test))]
 pub mod memory;
 pub mod platform;
-pub mod relations;
+mod relations;
 #[cfg(not(test))]
 pub mod serial;
 #[cfg(not(test))]

--- a/kernel/crates/astrid-native-kernel/src/lib.rs
+++ b/kernel/crates/astrid-native-kernel/src/lib.rs
@@ -21,6 +21,7 @@ pub mod ipc;
 #[cfg(not(test))]
 pub mod memory;
 pub mod platform;
+pub mod relations;
 #[cfg(not(test))]
 pub mod serial;
 #[cfg(not(test))]

--- a/kernel/crates/astrid-native-kernel/src/relations/delta.rs
+++ b/kernel/crates/astrid-native-kernel/src/relations/delta.rs
@@ -1,0 +1,98 @@
+//! Canonical cursors and fixed-capacity delta records.
+
+use super::types::{DELTA_RING_ENTRIES, RelationChange};
+
+/// Canonical position from which a reader replay starts.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DeltaCursor {
+    pub(crate) reader_generation: u64,
+    pub(crate) after_epoch: u64,
+}
+
+impl DeltaCursor {
+    pub const fn new(reader_generation: u64, after_epoch: u64) -> Self {
+        Self {
+            reader_generation,
+            after_epoch,
+        }
+    }
+
+    pub(crate) const fn matches(self, reader_generation: u64, after_epoch: u64) -> bool {
+        self.reader_generation == reader_generation && self.after_epoch == after_epoch
+    }
+}
+
+/// Canonical page position. It is reader-generation checked by the projection.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PageCursor {
+    pub(crate) reader_generation: u64,
+    pub(crate) epoch: u64,
+    pub(crate) page: u32,
+}
+
+impl PageCursor {
+    pub const fn new(reader_generation: u64, epoch: u64, page: u32) -> Self {
+        Self {
+            reader_generation,
+            epoch,
+            page,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct RelationDelta {
+    epoch: u64,
+    change: RelationChange,
+}
+
+impl RelationDelta {
+    pub(crate) const fn new(epoch: u64, change: RelationChange) -> Self {
+        Self { epoch, change }
+    }
+
+    pub(crate) const fn epoch(self) -> u64 {
+        self.epoch
+    }
+
+    pub(crate) const fn change(self) -> RelationChange {
+        self.change
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct DeltaRing {
+    entries: [Option<RelationDelta>; DELTA_RING_ENTRIES],
+    len: usize,
+    overflowed: bool,
+}
+
+impl DeltaRing {
+    pub(crate) const fn empty() -> Self {
+        Self {
+            entries: [None; DELTA_RING_ENTRIES],
+            len: 0,
+            overflowed: false,
+        }
+    }
+
+    pub(crate) fn push(&mut self, delta: RelationDelta) {
+        if self.overflowed {
+            return;
+        }
+        if self.len == DELTA_RING_ENTRIES {
+            self.overflowed = true;
+            return;
+        }
+        self.entries[self.len] = Some(delta);
+        self.len += 1;
+    }
+
+    pub(crate) const fn overflowed(&self) -> bool {
+        self.overflowed
+    }
+
+    pub(crate) fn deltas(&self) -> [Option<RelationDelta>; DELTA_RING_ENTRIES] {
+        self.entries
+    }
+}

--- a/kernel/crates/astrid-native-kernel/src/relations/delta.rs
+++ b/kernel/crates/astrid-native-kernel/src/relations/delta.rs
@@ -1,39 +1,39 @@
 //! Canonical cursors and fixed-capacity delta records.
 
-use super::types::{DELTA_RING_ENTRIES, RelationChange};
+use super::types::{DELTA_RING_ENTRIES, ReaderIdentity, RelationChange};
 
 /// Canonical position from which a reader replay starts.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct DeltaCursor {
-    pub(crate) reader_generation: u64,
+    pub(crate) reader: ReaderIdentity,
     pub(crate) after_epoch: u64,
 }
 
 impl DeltaCursor {
-    pub const fn new(reader_generation: u64, after_epoch: u64) -> Self {
+    pub const fn new(reader: ReaderIdentity, after_epoch: u64) -> Self {
         Self {
-            reader_generation,
+            reader,
             after_epoch,
         }
     }
 
-    pub(crate) const fn matches(self, reader_generation: u64, after_epoch: u64) -> bool {
-        self.reader_generation == reader_generation && self.after_epoch == after_epoch
+    pub(crate) fn matches(self, reader: ReaderIdentity, after_epoch: u64) -> bool {
+        self.reader == reader && self.after_epoch == after_epoch
     }
 }
 
 /// Canonical page position. It is reader-generation checked by the projection.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PageCursor {
-    pub(crate) reader_generation: u64,
+    pub(crate) reader: ReaderIdentity,
     pub(crate) epoch: u64,
     pub(crate) page: u32,
 }
 
 impl PageCursor {
-    pub const fn new(reader_generation: u64, epoch: u64, page: u32) -> Self {
+    pub const fn new(reader: ReaderIdentity, epoch: u64, page: u32) -> Self {
         Self {
-            reader_generation,
+            reader,
             epoch,
             page,
         }

--- a/kernel/crates/astrid-native-kernel/src/relations/mod.rs
+++ b/kernel/crates/astrid-native-kernel/src/relations/mod.rs
@@ -1,8 +1,8 @@
 //! Kernel- and harness-private typed object relations.
 
-pub mod delta;
-pub mod projection;
-pub mod types;
+mod delta;
+mod projection;
+mod types;
 
 #[cfg(test)]
 mod projection_tests;

--- a/kernel/crates/astrid-native-kernel/src/relations/mod.rs
+++ b/kernel/crates/astrid-native-kernel/src/relations/mod.rs
@@ -1,0 +1,8 @@
+//! Kernel- and harness-private typed object relations.
+
+pub mod delta;
+pub mod projection;
+pub mod types;
+
+#[cfg(test)]
+mod projection_tests;

--- a/kernel/crates/astrid-native-kernel/src/relations/projection.rs
+++ b/kernel/crates/astrid-native-kernel/src/relations/projection.rs
@@ -434,18 +434,31 @@ impl ProjectionStore {
 
             // A batch is one projection-local epoch even when it contains many
             // full-row changes; every change still participates in the replay.
+            // Replays order deletes before upserts within the epoch, matching
+            // the authoritative staged mutation order, so a later DELETE still
+            // funds an earlier UPSERT at the fixed row ceiling.
             let batch_epoch = delta.epoch();
-            while delta_index < deltas.len() {
-                let Some(batch_delta) = deltas[delta_index] else {
-                    delta_index += 1;
-                    continue;
-                };
-                if batch_delta.epoch() != batch_epoch {
-                    break;
+            let mut batch_end = delta_index;
+            while batch_end < deltas.len() {
+                match deltas[batch_end] {
+                    Some(batch_delta) if batch_delta.epoch() == batch_epoch => batch_end += 1,
+                    Some(_) => break,
+                    None => batch_end += 1,
                 }
-                apply_to_rows(&mut rows, &mut len, batch_delta.change());
-                delta_index += 1;
             }
+            for replay_deletes in [true, false] {
+                let mut scan = delta_index;
+                while scan < batch_end {
+                    if let Some(batch_delta) = deltas[scan] {
+                        let is_delete = matches!(batch_delta.change(), RelationChange::Delete(_));
+                        if is_delete == replay_deletes {
+                            apply_to_rows(&mut rows, &mut len, batch_delta.change());
+                        }
+                    }
+                    scan += 1;
+                }
+            }
+            delta_index = batch_end;
         }
         if expected_epoch != reader.epoch {
             return Err(ProjectionError::ResnapshotRequired);

--- a/kernel/crates/astrid-native-kernel/src/relations/projection.rs
+++ b/kernel/crates/astrid-native-kernel/src/relations/projection.rs
@@ -215,12 +215,17 @@ impl ProjectionStore {
             });
         }
 
-        let retired = self.readers[slot].take();
-        if let Some(mut old) = retired {
-            let epoch = old
-                .epoch
-                .checked_add(1)
-                .ok_or(ProjectionError::ResnapshotRequired)?;
+        let retirement_epoch = self.readers[slot]
+            .as_ref()
+            .map(|old| {
+                old.epoch
+                    .checked_add(1)
+                    .ok_or(ProjectionError::ResnapshotRequired)
+            })
+            .transpose()?;
+        let token = self.mint_token()?;
+        if let Some(mut old) = self.readers[slot].take() {
+            let epoch = retirement_epoch.expect("checked before retirement");
             let mut index = 0usize;
             while index < self.row_count {
                 let Some(row) = self.rows[index] else {
@@ -255,7 +260,6 @@ impl ProjectionStore {
             }
         }
 
-        let token = self.mint_token()?;
         self.readers[slot] = Some(Reader::new(token, identity));
         Ok(ReaderLease {
             token,
@@ -457,6 +461,11 @@ impl ProjectionStore {
     pub fn apply(&mut self, batch: AuthoritativeBatch) -> Result<usize, ProjectionError> {
         let plan = self.plan_batch(batch)?;
 
+        // Stage capacity-sensitive row mutations before publishing them. This
+        // lets a later DELETE fund an earlier UPSERT in the same batch without
+        // exposing intermediate state.
+        let mut planned_rows = self.rows;
+        let mut planned_row_count = self.row_count;
         let mut changed = [false; READER_SLOTS];
         let mut applied = 0usize;
         for index in 0..plan.len {
@@ -464,11 +473,38 @@ impl ProjectionStore {
                 continue;
             }
             let mutation = batch.mutations().nth(index).expect("planned batch index");
+            if !matches!(mutation.change, RelationChange::Delete(_)) {
+                continue;
+            }
             let reader_index = plan.reader_indexes[index];
-            let mutated = apply_to_rows(&mut self.rows, &mut self.row_count, mutation.change);
+            let mutated = apply_to_rows(&mut planned_rows, &mut planned_row_count, mutation.change);
             debug_assert!(mutated);
             changed[reader_index] = true;
             applied += 1;
+        }
+        for index in 0..plan.len {
+            if !plan.effective[index] {
+                continue;
+            }
+            let mutation = batch.mutations().nth(index).expect("planned batch index");
+            if !matches!(mutation.change, RelationChange::Upsert(_)) {
+                continue;
+            }
+            let reader_index = plan.reader_indexes[index];
+            let mutated = apply_to_rows(&mut planned_rows, &mut planned_row_count, mutation.change);
+            debug_assert!(mutated);
+            changed[reader_index] = true;
+            applied += 1;
+        }
+
+        self.rows = planned_rows;
+        self.row_count = planned_row_count;
+        for index in 0..plan.len {
+            if !plan.effective[index] {
+                continue;
+            }
+            let mutation = batch.mutations().nth(index).expect("planned batch index");
+            let reader_index = plan.reader_indexes[index];
             let delta = RelationDelta::new(plan.batch_epochs[reader_index], mutation.change);
             if let Some(reader) = &mut self.readers[reader_index] {
                 reader.deltas.push(delta);
@@ -492,6 +528,24 @@ impl ProjectionStore {
         let mut plan = BatchPlan::empty();
         let mut final_row_count = self.row_count;
 
+        // A batch is atomic, so count every effective mutation before
+        // validating capacity. A later DELETE can make room for an earlier
+        // UPSERT even at the fixed ceiling.
+        for mutation in batch.mutations() {
+            let existing = relation_index(&self.rows, mutation.change.key());
+            match mutation.change {
+                RelationChange::Upsert(_) if existing.is_none() => {
+                    final_row_count = final_row_count
+                        .checked_add(1)
+                        .ok_or(ProjectionError::NoSpace)?;
+                },
+                RelationChange::Delete(_) if existing.is_some() => {
+                    final_row_count = final_row_count.saturating_sub(1);
+                },
+                _ => {},
+            }
+        }
+
         for (index, mutation) in batch.mutations().enumerate() {
             let key = mutation.change.key();
             if mutation.reader.token != key.scope()
@@ -514,23 +568,15 @@ impl ProjectionStore {
             plan.reader_indexes[index] = reader_index;
 
             let existing = relation_index(&self.rows, key);
+            let is_new = existing.is_none();
             match mutation.change {
                 RelationChange::Upsert(relation) => {
-                    self.validate_upsert(relation)?;
-                    let is_new = existing.is_none();
+                    self.validate_upsert(relation, is_new, final_row_count)?;
                     plan.effective[index] =
                         existing.is_none_or(|at| self.rows[at] != Some(relation));
-                    if is_new && plan.effective[index] {
-                        final_row_count = final_row_count
-                            .checked_add(1)
-                            .ok_or(ProjectionError::NoSpace)?;
-                    }
                 },
                 RelationChange::Delete(_) => {
                     plan.effective[index] = existing.is_some();
-                    if plan.effective[index] {
-                        final_row_count -= 1;
-                    }
                 },
             }
             plan.len = index + 1;
@@ -557,10 +603,13 @@ impl ProjectionStore {
         *slot = Some(key);
     }
 
-    fn validate_upsert(&self, relation: Relation) -> Result<(), ProjectionError> {
-        if relation_index(&self.rows, relation.key()).is_none()
-            && (self.row_count == MAX_RELATION_ROWS || self.logical_deletions_overflowed)
-        {
+    fn validate_upsert(
+        &self,
+        relation: Relation,
+        is_new: bool,
+        final_row_count: usize,
+    ) -> Result<(), ProjectionError> {
+        if is_new && (final_row_count > MAX_RELATION_ROWS || self.logical_deletions_overflowed) {
             return Err(ProjectionError::NoSpace);
         }
         if self.logical_deletions.contains(&Some(relation.key())) {
@@ -571,18 +620,25 @@ impl ProjectionStore {
             .object_refs()
             .into_iter()
             .flatten()
-            .any(|object| self.reclaim_for_object(object).is_some())
+            .any(|object| {
+                self.reclaim_for_object(relation.key().scope(), object)
+                    .is_some()
+            })
         {
             return Err(ProjectionError::Resurrection);
         }
         Ok(())
     }
 
-    fn reclaim_for_object(&self, object: ObjectRef) -> Option<ReclaimObservation> {
+    fn reclaim_for_object(
+        &self,
+        scope: DomainProjectionToken,
+        object: ObjectRef,
+    ) -> Option<ReclaimObservation> {
         self.reclaim
             .into_iter()
             .flatten()
-            .find(|observation| observation.object_ref() == object)
+            .find(|observation| observation.scope() == scope && observation.object_ref() == object)
     }
 
     pub fn record_reclaim(
@@ -592,11 +648,11 @@ impl ProjectionStore {
         outcome: ReclaimOutcome,
     ) -> Result<bool, ProjectionError> {
         self.reader_at(lease)?;
-        if self
-            .rows
-            .iter()
-            .any(|row| row.is_some_and(|relation| relation_is_dead(relation, object)))
-        {
+        if self.rows.iter().any(|row| {
+            row.is_some_and(|relation| {
+                relation.key().scope() == lease.token && relation_is_dead(relation, object)
+            })
+        }) {
             return Err(ProjectionError::Denied);
         }
         if self.reclaim.iter().any(|observation| {
@@ -619,8 +675,7 @@ impl ProjectionStore {
         object: ObjectRef,
     ) -> Result<ReclaimObservation, ProjectionError> {
         self.reader_at(lease)?;
-        self.reclaim_for_object(object)
-            .filter(|observation| observation.scope() == lease.token)
+        self.reclaim_for_object(lease.token, object)
             .ok_or(ProjectionError::Denied)
     }
 

--- a/kernel/crates/astrid-native-kernel/src/relations/projection.rs
+++ b/kernel/crates/astrid-native-kernel/src/relations/projection.rs
@@ -1,0 +1,561 @@
+//! Fixed-capacity projection state, readers, snapshots, and replay.
+
+use super::delta::{DeltaCursor, DeltaRing, PageCursor, RelationDelta};
+use super::types::{
+    DomainProjectionToken, MAX_OBJECT_OBSERVATIONS, MAX_RELATION_ROWS, ObjectToken,
+    ProjectionError, READER_SLOTS, ReclaimObservation, ReclaimOutcome, Relation, RelationChange,
+    RelationKey,
+};
+use crate::ipc::DomainToken;
+
+/// A generation-checked projection reader bound to one domain identity.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ReaderLease {
+    token: DomainProjectionToken,
+    reader: ReaderId,
+}
+
+impl ReaderLease {
+    pub const fn token(self) -> DomainProjectionToken {
+        self.token
+    }
+
+    pub const fn reader_generation(self) -> u64 {
+        self.reader.domain.generation().get()
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct ReaderId {
+    domain: DomainToken,
+}
+
+#[derive(Clone, Copy)]
+struct Reader {
+    token: DomainProjectionToken,
+    identity: ReaderId,
+    epoch: u64,
+    deltas: DeltaRing,
+}
+
+impl Reader {
+    const fn new(token: DomainProjectionToken, identity: ReaderId) -> Self {
+        Self {
+            token,
+            identity,
+            epoch: 0,
+            deltas: DeltaRing::empty(),
+        }
+    }
+}
+
+/// Full canonical snapshot. Rows outside the reader's authority are absent.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Snapshot {
+    epoch: u64,
+    rows: [Option<Relation>; MAX_RELATION_ROWS],
+    len: usize,
+}
+
+impl Snapshot {
+    pub fn rows(&self) -> impl Iterator<Item = Relation> + '_ {
+        self.rows[..self.len].iter().copied().flatten()
+    }
+
+    pub const fn row(&self, index: usize) -> Option<Relation> {
+        if index < self.len {
+            self.rows[index]
+        } else {
+            None
+        }
+    }
+
+    pub const fn len(&self) -> usize {
+        self.len
+    }
+
+    pub const fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    pub const fn epoch(&self) -> u64 {
+        self.epoch
+    }
+}
+
+/// One canonical snapshot page, bounded by `RELATION_PAGE_ROWS`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SnapshotPage {
+    epoch: u64,
+    page: u32,
+    rows: [Option<Relation>; super::types::RELATION_PAGE_ROWS],
+    len: usize,
+    has_more: bool,
+}
+
+impl SnapshotPage {
+    pub fn rows(&self) -> impl Iterator<Item = Relation> + '_ {
+        self.rows[..self.len].iter().copied().flatten()
+    }
+
+    pub const fn len(&self) -> usize {
+        self.len
+    }
+
+    pub const fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    pub const fn has_more(&self) -> bool {
+        self.has_more
+    }
+}
+
+/// An atomically validated sequence of authoritative relation mutations.
+#[derive(Clone, Copy)]
+pub struct RelationMutation {
+    reader: ReaderLease,
+    change: RelationChange,
+}
+
+impl RelationMutation {
+    pub const fn new(reader: ReaderLease, change: RelationChange) -> Self {
+        Self { reader, change }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct AuthoritativeBatch {
+    entries: [Option<RelationMutation>; MAX_RELATION_ROWS],
+    len: usize,
+}
+
+impl AuthoritativeBatch {
+    pub const fn empty() -> Self {
+        Self {
+            entries: [None; MAX_RELATION_ROWS],
+            len: 0,
+        }
+    }
+
+    pub fn push(&mut self, mutation: RelationMutation) -> Result<(), ProjectionError> {
+        if self.len == self.entries.len() {
+            return Err(ProjectionError::NoSpace);
+        }
+        self.entries[self.len] = Some(mutation);
+        self.len += 1;
+        Ok(())
+    }
+
+    fn mutations(&self) -> impl Iterator<Item = RelationMutation> + '_ {
+        self.entries[..self.len].iter().copied().flatten()
+    }
+}
+
+/// Projection state only. Authoritative tables remain outside this type.
+#[derive(Clone, Copy)]
+pub struct ProjectionStore {
+    next_token: u64,
+    readers: [Option<Reader>; READER_SLOTS],
+    rows: [Option<Relation>; MAX_RELATION_ROWS],
+    row_count: usize,
+    reclaim: [Option<ReclaimObservation>; MAX_OBJECT_OBSERVATIONS],
+}
+
+impl ProjectionStore {
+    pub const fn empty() -> Self {
+        Self {
+            next_token: 1,
+            readers: [None; READER_SLOTS],
+            rows: [None; MAX_RELATION_ROWS],
+            row_count: 0,
+            reclaim: [None; MAX_OBJECT_OBSERVATIONS],
+        }
+    }
+
+    pub fn register_reader(&mut self, domain: DomainToken) -> Result<ReaderLease, ProjectionError> {
+        let slot = domain.slot().index();
+        if slot >= READER_SLOTS {
+            return Err(ProjectionError::Denied);
+        }
+        let identity = ReaderId { domain };
+        if let Some(existing) = self.readers[slot]
+            && existing.identity == identity
+        {
+            return Ok(ReaderLease {
+                token: existing.token,
+                reader: identity,
+            });
+        }
+
+        let token = self.mint_token()?;
+        self.readers[slot] = Some(Reader::new(token, identity));
+        Ok(ReaderLease {
+            token,
+            reader: identity,
+        })
+    }
+
+    fn mint_token(&mut self) -> Result<DomainProjectionToken, ProjectionError> {
+        let token = DomainProjectionToken::new(self.next_token).ok_or(ProjectionError::NoSpace)?;
+        self.next_token = self
+            .next_token
+            .checked_add(1)
+            .ok_or(ProjectionError::NoSpace)?;
+        Ok(token)
+    }
+
+    fn reader_at(&self, lease: ReaderLease) -> Result<&Reader, ProjectionError> {
+        let slot = lease.reader.domain.slot().index();
+        match &self.readers[slot] {
+            None => Err(ProjectionError::Denied),
+            Some(reader) if reader.token == lease.token && reader.identity == lease.reader => {
+                Ok(reader)
+            },
+            Some(_) => Err(ProjectionError::ResnapshotRequired),
+        }
+    }
+
+    fn reader_index(&self, lease: ReaderLease) -> Result<usize, ProjectionError> {
+        let reader = self.reader_at(lease)?;
+        Ok(reader.identity.domain.slot().index())
+    }
+
+    pub fn relation_epoch(&self, lease: ReaderLease) -> Result<u64, ProjectionError> {
+        Ok(self.reader_at(lease)?.epoch)
+    }
+
+    pub fn delta_cursor(&self, lease: ReaderLease) -> Result<DeltaCursor, ProjectionError> {
+        let reader = self.reader_at(lease)?;
+        Ok(DeltaCursor::new(
+            reader.identity.domain.generation().get(),
+            reader.epoch,
+        ))
+    }
+
+    pub fn snapshot(&self, lease: ReaderLease) -> Result<Snapshot, ProjectionError> {
+        let reader = self.reader_at(lease)?;
+        if reader.deltas.overflowed() {
+            return Err(ProjectionError::ResnapshotRequired);
+        }
+        let (rows, len) = scoped_rows(&self.rows, lease.token);
+        Ok(Snapshot {
+            epoch: reader.epoch,
+            rows,
+            len,
+        })
+    }
+
+    fn direct_snapshot(&self, lease: ReaderLease) -> Result<Snapshot, ProjectionError> {
+        let reader = self.reader_at(lease)?;
+        let (rows, len) = scoped_rows(&self.rows, lease.token);
+        Ok(Snapshot {
+            epoch: reader.epoch,
+            rows,
+            len,
+        })
+    }
+
+    pub fn snapshot_page(
+        &self,
+        lease: ReaderLease,
+        cursor: PageCursor,
+    ) -> Result<SnapshotPage, ProjectionError> {
+        let reader = self.reader_at(lease)?;
+        if reader.deltas.overflowed()
+            || cursor.reader_generation != reader.identity.domain.generation().get()
+            || cursor.epoch != reader.epoch
+            || cursor.page as usize * super::types::RELATION_PAGE_ROWS > MAX_RELATION_ROWS
+        {
+            return Err(ProjectionError::ResnapshotRequired);
+        }
+
+        let (rows, len) = scoped_rows(&self.rows, lease.token);
+        let start = cursor.page as usize * super::types::RELATION_PAGE_ROWS;
+        let mut page = [None; super::types::RELATION_PAGE_ROWS];
+        let mut page_len = 0usize;
+        if start > len {
+            return Err(ProjectionError::ResnapshotRequired);
+        }
+        for row in rows
+            .iter()
+            .skip(start)
+            .take(((start + super::types::RELATION_PAGE_ROWS).min(len)) - start)
+        {
+            page[page_len] = *row;
+            page_len += 1;
+        }
+        Ok(SnapshotPage {
+            epoch: reader.epoch,
+            page: cursor.page,
+            rows: page,
+            len: page_len,
+            has_more: start + page_len < len,
+        })
+    }
+
+    pub fn base_snapshot(&mut self, lease: ReaderLease) -> Result<Snapshot, ProjectionError> {
+        let snapshot = self.direct_snapshot(lease)?;
+        let index = self.reader_index(lease)?;
+        if let Some(reader) = &mut self.readers[index] {
+            reader.deltas = DeltaRing::empty();
+        }
+        Ok(snapshot)
+    }
+
+    pub fn fold(
+        &self,
+        lease: ReaderLease,
+        base: Snapshot,
+        cursor: DeltaCursor,
+    ) -> Result<Snapshot, ProjectionError> {
+        let reader = self.reader_at(lease)?;
+        if reader.deltas.overflowed()
+            || !cursor.matches(reader.identity.domain.generation().get(), base.epoch)
+            || base.epoch > reader.epoch
+        {
+            return Err(ProjectionError::ResnapshotRequired);
+        }
+
+        let mut rows = [None; MAX_RELATION_ROWS];
+        let mut len = 0usize;
+        for relation in base.rows().filter(|row| row.key().scope() == lease.token) {
+            rows[len] = Some(relation);
+            len += 1;
+        }
+        sort_rows(&mut rows, &mut len);
+
+        let deltas = reader.deltas.deltas();
+        if reader.epoch != base.epoch {
+            let Some(first) = deltas.iter().copied().flatten().next() else {
+                return Err(ProjectionError::ResnapshotRequired);
+            };
+            if first.epoch() != base.epoch.saturating_add(1) {
+                return Err(ProjectionError::ResnapshotRequired);
+            }
+        }
+
+        let mut expected_epoch = base.epoch;
+        for delta in deltas.into_iter().flatten() {
+            if delta.epoch() <= base.epoch {
+                continue;
+            }
+            expected_epoch = match expected_epoch.checked_add(1) {
+                Some(epoch) => epoch,
+                None => return Err(ProjectionError::ResnapshotRequired),
+            };
+            if delta.epoch() != expected_epoch {
+                return Err(ProjectionError::ResnapshotRequired);
+            }
+            apply_to_rows(&mut rows, &mut len, delta.change());
+        }
+        if expected_epoch != reader.epoch {
+            return Err(ProjectionError::ResnapshotRequired);
+        }
+        sort_rows(&mut rows, &mut len);
+        Ok(Snapshot {
+            epoch: reader.epoch,
+            rows,
+            len,
+        })
+    }
+
+    pub fn apply(&mut self, batch: AuthoritativeBatch) -> Result<usize, ProjectionError> {
+        let mut reader_indexes = [None; MAX_RELATION_ROWS];
+        let mut next_epochs = [0u64; MAX_RELATION_ROWS];
+        for (index, mutation) in batch.mutations().enumerate() {
+            if mutation.reader.token != mutation.change.key().scope() {
+                return Err(ProjectionError::Denied);
+            }
+            let reader_index = self.reader_index(mutation.reader)?;
+            let Some(reader) = &self.readers[reader_index] else {
+                return Err(ProjectionError::Denied);
+            };
+            let Some(next_epoch) = reader.epoch.checked_add(1) else {
+                return Err(ProjectionError::ResnapshotRequired);
+            };
+            next_epochs[index] = next_epoch;
+            reader_indexes[index] = Some(reader_index);
+            if let RelationChange::Upsert(relation) = mutation.change {
+                self.validate_upsert(relation)?;
+            }
+        }
+
+        let mut changed = [false; READER_SLOTS];
+        let mut applied = 0usize;
+        for (index, mutation) in batch.mutations().enumerate() {
+            let reader_index = reader_indexes[index].unwrap_or(READER_SLOTS);
+            let mutated = apply_to_rows(&mut self.rows, &mut self.row_count, mutation.change);
+            if mutated {
+                changed[reader_index] = true;
+                applied += 1;
+                let delta = RelationDelta::new(next_epochs[index], mutation.change);
+                if let Some(reader) = &mut self.readers[reader_index] {
+                    reader.deltas.push(delta);
+                }
+            }
+        }
+
+        for (index, reader) in self.readers.iter_mut().enumerate() {
+            if changed[index]
+                && let Some(reader) = reader
+            {
+                reader.epoch += 1;
+            }
+        }
+        Ok(applied)
+    }
+
+    fn validate_upsert(&self, relation: Relation) -> Result<(), ProjectionError> {
+        if relation_index(&self.rows, relation.key()).is_none()
+            && self.row_count == MAX_RELATION_ROWS
+        {
+            return Err(ProjectionError::NoSpace);
+        }
+        if relation
+            .key()
+            .object_tokens()
+            .into_iter()
+            .flatten()
+            .any(|object| self.reclaim_for_object(object).is_some())
+        {
+            return Err(ProjectionError::Resurrection);
+        }
+        Ok(())
+    }
+
+    fn reclaim_for_object(&self, object: ObjectToken) -> Option<ReclaimObservation> {
+        self.reclaim
+            .into_iter()
+            .flatten()
+            .find(|observation| observation.object() == object)
+    }
+
+    pub fn record_reclaim(
+        &mut self,
+        lease: ReaderLease,
+        object: ObjectToken,
+        outcome: ReclaimOutcome,
+    ) -> Result<bool, ProjectionError> {
+        self.reader_at(lease)?;
+        if self
+            .rows
+            .iter()
+            .any(|row| row.is_some_and(|relation| relation_is_dead(relation, object)))
+        {
+            return Err(ProjectionError::Denied);
+        }
+        if self.reclaim.iter().any(|observation| {
+            observation.is_some_and(|existing| {
+                existing.scope() == lease.token && existing.object() == object
+            })
+        }) {
+            return Ok(false);
+        }
+        let Some(slot) = self.reclaim.iter_mut().find(|slot| slot.is_none()) else {
+            return Err(ProjectionError::NoSpace);
+        };
+        *slot = Some(ReclaimObservation::new(lease.token, object, outcome));
+        Ok(true)
+    }
+
+    pub fn reclaim_observation(
+        &self,
+        lease: ReaderLease,
+        object: ObjectToken,
+    ) -> Result<ReclaimObservation, ProjectionError> {
+        self.reader_at(lease)?;
+        self.reclaim_for_object(object)
+            .filter(|observation| observation.scope() == lease.token)
+            .ok_or(ProjectionError::Denied)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn force_epoch_overflow(
+        &mut self,
+        lease: ReaderLease,
+    ) -> Result<(), ProjectionError> {
+        let index = self.reader_index(lease)?;
+        if let Some(reader) = &mut self.readers[index] {
+            reader.epoch = u64::MAX;
+        }
+        Ok(())
+    }
+}
+
+fn relation_is_dead(relation: Relation, object: ObjectToken) -> bool {
+    relation
+        .key()
+        .object_tokens()
+        .into_iter()
+        .flatten()
+        .any(|candidate| candidate == object)
+}
+
+fn relation_index(rows: &[Option<Relation>; MAX_RELATION_ROWS], key: RelationKey) -> Option<usize> {
+    rows.iter()
+        .position(|row| row.is_some_and(|relation| relation.key() == key))
+}
+
+fn apply_to_rows(
+    rows: &mut [Option<Relation>; MAX_RELATION_ROWS],
+    len: &mut usize,
+    change: RelationChange,
+) -> bool {
+    let key = change.key();
+    let index = relation_index(rows, key);
+    match change {
+        RelationChange::Upsert(relation) => {
+            if let Some(index) = index {
+                rows[index] = Some(relation);
+                true
+            } else if *len < rows.len() {
+                rows[*len] = Some(relation);
+                *len += 1;
+                true
+            } else {
+                false
+            }
+        },
+        RelationChange::Delete(_) => index
+            .map(|index| {
+                rows[index] = None;
+                *len -= 1;
+                for source in index + 1..*len + 1 {
+                    rows[source - 1] = rows[source];
+                }
+                rows[*len] = None;
+            })
+            .is_some(),
+    }
+}
+
+fn scoped_rows(
+    rows: &[Option<Relation>; MAX_RELATION_ROWS],
+    scope: DomainProjectionToken,
+) -> ([Option<Relation>; MAX_RELATION_ROWS], usize) {
+    let mut scoped = [None; MAX_RELATION_ROWS];
+    let mut len = 0usize;
+    for relation in rows.iter().copied().flatten() {
+        if relation.key().scope() == scope {
+            scoped[len] = Some(relation);
+            len += 1;
+        }
+    }
+    sort_rows(&mut scoped, &mut len);
+    (scoped, len)
+}
+
+fn sort_rows(rows: &mut [Option<Relation>; MAX_RELATION_ROWS], len: &mut usize) {
+    for index in 1..*len {
+        let mut target = index;
+        while target > 0
+            && rows[target - 1]
+                .is_some_and(|left| rows[target].is_some_and(|right| right.key() < left.key()))
+        {
+            rows.swap(target - 1, target);
+            target -= 1;
+        }
+    }
+    rows.iter_mut().skip(*len).for_each(|row| *row = None);
+}

--- a/kernel/crates/astrid-native-kernel/src/relations/projection.rs
+++ b/kernel/crates/astrid-native-kernel/src/relations/projection.rs
@@ -2,8 +2,8 @@
 
 use super::delta::{DeltaCursor, DeltaRing, PageCursor, RelationDelta};
 use super::types::{
-    DomainProjectionToken, MAX_OBJECT_OBSERVATIONS, MAX_RELATION_ROWS, ObjectToken,
-    ProjectionError, READER_SLOTS, ReclaimObservation, ReclaimOutcome, Relation, RelationChange,
+    DomainProjectionToken, MAX_OBJECT_OBSERVATIONS, MAX_RELATION_ROWS, ObjectRef, ProjectionError,
+    READER_SLOTS, ReaderIdentity, ReclaimObservation, ReclaimOutcome, Relation, RelationChange,
     RelationKey,
 };
 use crate::ipc::DomainToken;
@@ -152,6 +152,25 @@ impl AuthoritativeBatch {
     }
 }
 
+#[derive(Clone, Copy)]
+struct BatchPlan {
+    reader_indexes: [usize; MAX_RELATION_ROWS],
+    batch_epochs: [u64; READER_SLOTS],
+    effective: [bool; MAX_RELATION_ROWS],
+    len: usize,
+}
+
+impl BatchPlan {
+    const fn empty() -> Self {
+        Self {
+            reader_indexes: [READER_SLOTS; MAX_RELATION_ROWS],
+            batch_epochs: [0; READER_SLOTS],
+            effective: [false; MAX_RELATION_ROWS],
+            len: 0,
+        }
+    }
+}
+
 /// Projection state only. Authoritative tables remain outside this type.
 #[derive(Clone, Copy)]
 pub struct ProjectionStore {
@@ -160,6 +179,10 @@ pub struct ProjectionStore {
     rows: [Option<Relation>; MAX_RELATION_ROWS],
     row_count: usize,
     reclaim: [Option<ReclaimObservation>; MAX_OBJECT_OBSERVATIONS],
+    logical_deletions: [Option<RelationKey>; MAX_RELATION_ROWS],
+    logical_deletions_overflowed: bool,
+    #[cfg(test)]
+    retired_delete_counts: [usize; READER_SLOTS],
 }
 
 impl ProjectionStore {
@@ -170,6 +193,10 @@ impl ProjectionStore {
             rows: [None; MAX_RELATION_ROWS],
             row_count: 0,
             reclaim: [None; MAX_OBJECT_OBSERVATIONS],
+            logical_deletions: [None; MAX_RELATION_ROWS],
+            logical_deletions_overflowed: false,
+            #[cfg(test)]
+            retired_delete_counts: [0; READER_SLOTS],
         }
     }
 
@@ -186,6 +213,46 @@ impl ProjectionStore {
                 token: existing.token,
                 reader: identity,
             });
+        }
+
+        let retired = self.readers[slot].take();
+        if let Some(mut old) = retired {
+            let epoch = old
+                .epoch
+                .checked_add(1)
+                .ok_or(ProjectionError::ResnapshotRequired)?;
+            let mut index = 0usize;
+            while index < self.row_count {
+                let Some(row) = self.rows[index] else {
+                    index += 1;
+                    continue;
+                };
+                if row.key().scope() == old.token {
+                    let key = row.key();
+                    old.deltas
+                        .push(RelationDelta::new(epoch, RelationChange::Delete(key)));
+                    remove_row_at(&mut self.rows, &mut self.row_count, index);
+                } else {
+                    index += 1;
+                }
+            }
+            #[cfg(test)]
+            {
+                self.retired_delete_counts[slot] = old
+                    .deltas
+                    .deltas()
+                    .iter()
+                    .filter(|delta| {
+                        delta.is_some_and(|delta| {
+                            delta.epoch() == epoch
+                                && matches!(
+                                    delta.change(),
+                                    RelationChange::Delete(key) if key.scope() == old.token
+                                )
+                        })
+                    })
+                    .count();
+            }
         }
 
         let token = self.mint_token()?;
@@ -221,16 +288,33 @@ impl ProjectionStore {
         Ok(reader.identity.domain.slot().index())
     }
 
+    fn reader_identity(&self, reader: &Reader) -> Result<ReaderIdentity, ProjectionError> {
+        ReaderIdentity::new(
+            reader.identity.domain.slot().index(),
+            reader.identity.domain.generation().get(),
+            reader.token,
+        )
+        .ok_or(ProjectionError::Denied)
+    }
+
     pub fn relation_epoch(&self, lease: ReaderLease) -> Result<u64, ProjectionError> {
         Ok(self.reader_at(lease)?.epoch)
     }
 
     pub fn delta_cursor(&self, lease: ReaderLease) -> Result<DeltaCursor, ProjectionError> {
         let reader = self.reader_at(lease)?;
-        Ok(DeltaCursor::new(
-            reader.identity.domain.generation().get(),
-            reader.epoch,
-        ))
+        let identity = self.reader_identity(reader)?;
+        Ok(DeltaCursor::new(identity, reader.epoch))
+    }
+
+    pub fn page_cursor(
+        &self,
+        lease: ReaderLease,
+        page: u32,
+    ) -> Result<PageCursor, ProjectionError> {
+        let reader = self.reader_at(lease)?;
+        let identity = self.reader_identity(reader)?;
+        Ok(PageCursor::new(identity, reader.epoch, page))
     }
 
     pub fn snapshot(&self, lease: ReaderLease) -> Result<Snapshot, ProjectionError> {
@@ -262,8 +346,9 @@ impl ProjectionStore {
         cursor: PageCursor,
     ) -> Result<SnapshotPage, ProjectionError> {
         let reader = self.reader_at(lease)?;
+        let identity = self.reader_identity(reader)?;
         if reader.deltas.overflowed()
-            || cursor.reader_generation != reader.identity.domain.generation().get()
+            || cursor.reader != identity
             || cursor.epoch != reader.epoch
             || cursor.page as usize * super::types::RELATION_PAGE_ROWS > MAX_RELATION_ROWS
         {
@@ -310,8 +395,9 @@ impl ProjectionStore {
         cursor: DeltaCursor,
     ) -> Result<Snapshot, ProjectionError> {
         let reader = self.reader_at(lease)?;
+        let identity = self.reader_identity(reader)?;
         if reader.deltas.overflowed()
-            || !cursor.matches(reader.identity.domain.generation().get(), base.epoch)
+            || !cursor.matches(identity, base.epoch)
             || base.epoch > reader.epoch
         {
             return Err(ProjectionError::ResnapshotRequired);
@@ -325,29 +411,37 @@ impl ProjectionStore {
         }
         sort_rows(&mut rows, &mut len);
 
-        let deltas = reader.deltas.deltas();
-        if reader.epoch != base.epoch {
-            let Some(first) = deltas.iter().copied().flatten().next() else {
-                return Err(ProjectionError::ResnapshotRequired);
-            };
-            if first.epoch() != base.epoch.saturating_add(1) {
-                return Err(ProjectionError::ResnapshotRequired);
-            }
-        }
-
         let mut expected_epoch = base.epoch;
-        for delta in deltas.into_iter().flatten() {
+        let deltas = reader.deltas.deltas();
+        let mut delta_index = 0usize;
+        while delta_index < deltas.len() {
+            let Some(delta) = deltas[delta_index] else {
+                delta_index += 1;
+                continue;
+            };
             if delta.epoch() <= base.epoch {
+                delta_index += 1;
                 continue;
             }
-            expected_epoch = match expected_epoch.checked_add(1) {
-                Some(epoch) => epoch,
-                None => return Err(ProjectionError::ResnapshotRequired),
-            };
-            if delta.epoch() != expected_epoch {
+            if delta.epoch() != expected_epoch.saturating_add(1) {
                 return Err(ProjectionError::ResnapshotRequired);
             }
-            apply_to_rows(&mut rows, &mut len, delta.change());
+            expected_epoch = delta.epoch();
+
+            // A batch is one projection-local epoch even when it contains many
+            // full-row changes; every change still participates in the replay.
+            let batch_epoch = delta.epoch();
+            while delta_index < deltas.len() {
+                let Some(batch_delta) = deltas[delta_index] else {
+                    delta_index += 1;
+                    continue;
+                };
+                if batch_delta.epoch() != batch_epoch {
+                    break;
+                }
+                apply_to_rows(&mut rows, &mut len, batch_delta.change());
+                delta_index += 1;
+            }
         }
         if expected_epoch != reader.epoch {
             return Err(ProjectionError::ResnapshotRequired);
@@ -361,38 +455,26 @@ impl ProjectionStore {
     }
 
     pub fn apply(&mut self, batch: AuthoritativeBatch) -> Result<usize, ProjectionError> {
-        let mut reader_indexes = [None; MAX_RELATION_ROWS];
-        let mut next_epochs = [0u64; MAX_RELATION_ROWS];
-        for (index, mutation) in batch.mutations().enumerate() {
-            if mutation.reader.token != mutation.change.key().scope() {
-                return Err(ProjectionError::Denied);
-            }
-            let reader_index = self.reader_index(mutation.reader)?;
-            let Some(reader) = &self.readers[reader_index] else {
-                return Err(ProjectionError::Denied);
-            };
-            let Some(next_epoch) = reader.epoch.checked_add(1) else {
-                return Err(ProjectionError::ResnapshotRequired);
-            };
-            next_epochs[index] = next_epoch;
-            reader_indexes[index] = Some(reader_index);
-            if let RelationChange::Upsert(relation) = mutation.change {
-                self.validate_upsert(relation)?;
-            }
-        }
+        let plan = self.plan_batch(batch)?;
 
         let mut changed = [false; READER_SLOTS];
         let mut applied = 0usize;
-        for (index, mutation) in batch.mutations().enumerate() {
-            let reader_index = reader_indexes[index].unwrap_or(READER_SLOTS);
+        for index in 0..plan.len {
+            if !plan.effective[index] {
+                continue;
+            }
+            let mutation = batch.mutations().nth(index).expect("planned batch index");
+            let reader_index = plan.reader_indexes[index];
             let mutated = apply_to_rows(&mut self.rows, &mut self.row_count, mutation.change);
-            if mutated {
-                changed[reader_index] = true;
-                applied += 1;
-                let delta = RelationDelta::new(next_epochs[index], mutation.change);
-                if let Some(reader) = &mut self.readers[reader_index] {
-                    reader.deltas.push(delta);
-                }
+            debug_assert!(mutated);
+            changed[reader_index] = true;
+            applied += 1;
+            let delta = RelationDelta::new(plan.batch_epochs[reader_index], mutation.change);
+            if let Some(reader) = &mut self.readers[reader_index] {
+                reader.deltas.push(delta);
+            }
+            if let RelationChange::Delete(key) = mutation.change {
+                self.record_logical_deletion(key);
             }
         }
 
@@ -406,15 +488,87 @@ impl ProjectionStore {
         Ok(applied)
     }
 
+    fn plan_batch(&self, batch: AuthoritativeBatch) -> Result<BatchPlan, ProjectionError> {
+        let mut plan = BatchPlan::empty();
+        let mut final_row_count = self.row_count;
+
+        for (index, mutation) in batch.mutations().enumerate() {
+            let key = mutation.change.key();
+            if mutation.reader.token != key.scope()
+                || batch
+                    .mutations()
+                    .take(index)
+                    .any(|previous| previous.change.key() == key)
+            {
+                return Err(ProjectionError::Denied);
+            }
+
+            let reader_index = self.reader_index(mutation.reader)?;
+            let Some(reader) = &self.readers[reader_index] else {
+                return Err(ProjectionError::Denied);
+            };
+            let Some(batch_epoch) = reader.epoch.checked_add(1) else {
+                return Err(ProjectionError::ResnapshotRequired);
+            };
+            plan.batch_epochs[reader_index] = batch_epoch;
+            plan.reader_indexes[index] = reader_index;
+
+            let existing = relation_index(&self.rows, key);
+            match mutation.change {
+                RelationChange::Upsert(relation) => {
+                    self.validate_upsert(relation)?;
+                    let is_new = existing.is_none();
+                    plan.effective[index] =
+                        existing.is_none_or(|at| self.rows[at] != Some(relation));
+                    if is_new && plan.effective[index] {
+                        final_row_count = final_row_count
+                            .checked_add(1)
+                            .ok_or(ProjectionError::NoSpace)?;
+                    }
+                },
+                RelationChange::Delete(_) => {
+                    plan.effective[index] = existing.is_some();
+                    if plan.effective[index] {
+                        final_row_count -= 1;
+                    }
+                },
+            }
+            plan.len = index + 1;
+        }
+
+        if final_row_count > MAX_RELATION_ROWS {
+            return Err(ProjectionError::NoSpace);
+        }
+        Ok(plan)
+    }
+
+    fn record_logical_deletion(&mut self, key: RelationKey) {
+        if self.logical_deletions.contains(&Some(key)) {
+            return;
+        }
+        let Some(slot) = self
+            .logical_deletions
+            .iter_mut()
+            .find(|slot| slot.is_none())
+        else {
+            self.logical_deletions_overflowed = true;
+            return;
+        };
+        *slot = Some(key);
+    }
+
     fn validate_upsert(&self, relation: Relation) -> Result<(), ProjectionError> {
         if relation_index(&self.rows, relation.key()).is_none()
-            && self.row_count == MAX_RELATION_ROWS
+            && (self.row_count == MAX_RELATION_ROWS || self.logical_deletions_overflowed)
         {
             return Err(ProjectionError::NoSpace);
         }
+        if self.logical_deletions.contains(&Some(relation.key())) {
+            return Err(ProjectionError::Resurrection);
+        }
         if relation
             .key()
-            .object_tokens()
+            .object_refs()
             .into_iter()
             .flatten()
             .any(|object| self.reclaim_for_object(object).is_some())
@@ -424,17 +578,17 @@ impl ProjectionStore {
         Ok(())
     }
 
-    fn reclaim_for_object(&self, object: ObjectToken) -> Option<ReclaimObservation> {
+    fn reclaim_for_object(&self, object: ObjectRef) -> Option<ReclaimObservation> {
         self.reclaim
             .into_iter()
             .flatten()
-            .find(|observation| observation.object() == object)
+            .find(|observation| observation.object_ref() == object)
     }
 
     pub fn record_reclaim(
         &mut self,
         lease: ReaderLease,
-        object: ObjectToken,
+        object: ObjectRef,
         outcome: ReclaimOutcome,
     ) -> Result<bool, ProjectionError> {
         self.reader_at(lease)?;
@@ -447,7 +601,7 @@ impl ProjectionStore {
         }
         if self.reclaim.iter().any(|observation| {
             observation.is_some_and(|existing| {
-                existing.scope() == lease.token && existing.object() == object
+                existing.scope() == lease.token && existing.object_ref() == object
             })
         }) {
             return Ok(false);
@@ -462,7 +616,7 @@ impl ProjectionStore {
     pub fn reclaim_observation(
         &self,
         lease: ReaderLease,
-        object: ObjectToken,
+        object: ObjectRef,
     ) -> Result<ReclaimObservation, ProjectionError> {
         self.reader_at(lease)?;
         self.reclaim_for_object(object)
@@ -481,12 +635,17 @@ impl ProjectionStore {
         }
         Ok(())
     }
+
+    #[cfg(test)]
+    pub(crate) fn retired_delete_count(&self, slot: usize) -> usize {
+        self.retired_delete_counts[slot]
+    }
 }
 
-fn relation_is_dead(relation: Relation, object: ObjectToken) -> bool {
+fn relation_is_dead(relation: Relation, object: ObjectRef) -> bool {
     relation
         .key()
-        .object_tokens()
+        .object_refs()
         .into_iter()
         .flatten()
         .any(|candidate| candidate == object)
@@ -495,6 +654,15 @@ fn relation_is_dead(relation: Relation, object: ObjectToken) -> bool {
 fn relation_index(rows: &[Option<Relation>; MAX_RELATION_ROWS], key: RelationKey) -> Option<usize> {
     rows.iter()
         .position(|row| row.is_some_and(|relation| relation.key() == key))
+}
+
+fn remove_row_at(rows: &mut [Option<Relation>; MAX_RELATION_ROWS], len: &mut usize, index: usize) {
+    debug_assert!(index < *len);
+    for source in index + 1..*len {
+        rows[source - 1] = rows[source];
+    }
+    *len -= 1;
+    rows[*len] = None;
 }
 
 fn apply_to_rows(

--- a/kernel/crates/astrid-native-kernel/src/relations/projection_tests.rs
+++ b/kernel/crates/astrid-native-kernel/src/relations/projection_tests.rs
@@ -1,0 +1,521 @@
+//! Kernel/harness-private regressions for relation projection semantics.
+
+use super::delta::{DeltaCursor, PageCursor};
+use super::projection::{
+    AuthoritativeBatch, ProjectionStore, ReaderLease, RelationMutation, Snapshot,
+};
+use super::types::{
+    AuthorityObject, CapabilityGeneration, CapabilityInstance, CapabilitySlot, DELTA_RING_ENTRIES,
+    DomainProjectionToken, ObjectKind, ObjectRef, ObjectToken, ProjectionError, RELATION_PAGE_ROWS,
+    ReclaimOutcome, Relation, RelationChange, RelationKey, RelationRights,
+};
+use crate::ipc::DomainToken;
+
+fn store() -> ProjectionStore {
+    ProjectionStore::empty()
+}
+
+fn reader(store: &mut ProjectionStore, slot: u64, generation: u64) -> ReaderLease {
+    store
+        .register_reader(DomainToken::new(slot, generation).unwrap())
+        .unwrap()
+}
+
+fn generation(value: u64) -> CapabilityGeneration {
+    CapabilityGeneration::new(value).unwrap()
+}
+
+fn token(value: u64) -> ObjectToken {
+    ObjectToken::new(value).unwrap()
+}
+
+fn object(kind: ObjectKind, value: u64) -> ObjectRef {
+    ObjectRef::new(kind, token(value))
+}
+
+fn capability(lease: ReaderLease, slot: usize, generation_value: u64) -> CapabilityInstance {
+    CapabilityInstance::new(
+        lease.token(),
+        CapabilitySlot::try_new(slot).unwrap(),
+        generation(generation_value),
+    )
+}
+
+fn object_relation(scope: DomainProjectionToken, kind: ObjectKind, value: u64) -> Relation {
+    Relation::object(scope, object(kind, value))
+}
+
+fn holds_relation(
+    lease: ReaderLease,
+    slot: usize,
+    generation_value: u64,
+    object_value: u64,
+) -> Relation {
+    Relation::holds(
+        lease.token(),
+        capability(lease, slot, generation_value),
+        object(ObjectKind::Endpoint, object_value),
+        RelationRights::SEND,
+    )
+}
+
+fn derive_relation(
+    lease: ReaderLease,
+    parent: CapabilityInstance,
+    child: CapabilityInstance,
+) -> Relation {
+    Relation::derives(lease.token(), parent, child)
+}
+
+fn apply_one(store: &mut ProjectionStore, lease: ReaderLease, relation: Relation) {
+    apply_change(store, lease, RelationChange::Upsert(relation)).unwrap();
+}
+
+fn apply_change(
+    store: &mut ProjectionStore,
+    lease: ReaderLease,
+    change: RelationChange,
+) -> Result<usize, ProjectionError> {
+    let mut batch = AuthoritativeBatch::empty();
+    batch.push(RelationMutation::new(lease, change))?;
+    store.apply(batch)
+}
+
+fn fold_base(store: &mut ProjectionStore, lease: ReaderLease) -> (Snapshot, DeltaCursor) {
+    let snapshot = store.base_snapshot(lease).unwrap();
+    let cursor = store.delta_cursor(lease).unwrap();
+    (snapshot, cursor)
+}
+
+fn assert_canonical(snapshot: &Snapshot) {
+    let mut previous = snapshot.row(0);
+    for index in 1..snapshot.len() {
+        let current = snapshot.row(index);
+        if let (Some(left), Some(right)) = (previous, current) {
+            assert!(left.key() < right.key());
+        }
+        previous = current;
+    }
+}
+
+#[test]
+fn constants_match_the_private_relation_freeze() {
+    assert_eq!(RELATION_PAGE_ROWS, 16);
+    assert_eq!(DELTA_RING_ENTRIES, 32);
+}
+
+#[test]
+fn object_capability_and_endpoint_tables_project_without_message_rows() {
+    let mut store = store();
+    let first = reader(&mut store, 0, 1);
+    let second = reader(&mut store, 1, 1);
+
+    apply_one(
+        &mut store,
+        first,
+        object_relation(first.token(), ObjectKind::Domain, 10),
+    );
+    apply_one(
+        &mut store,
+        first,
+        object_relation(first.token(), ObjectKind::Endpoint, 11),
+    );
+    apply_one(&mut store, second, holds_relation(second, 3, 7, 11));
+
+    let first_snapshot = store.snapshot(first).unwrap();
+    assert_eq!(first_snapshot.len(), 2);
+    assert!(first_snapshot.rows().any(|row| row.key()
+        == RelationKey::Object {
+            scope: first.token(),
+            object: object(ObjectKind::Domain, 10),
+        }));
+    assert!(first_snapshot.rows().any(|row| row.key()
+        == RelationKey::Object {
+            scope: first.token(),
+            object: object(ObjectKind::Endpoint, 11),
+        }));
+
+    let second_snapshot = store.snapshot(second).unwrap();
+    let held = second_snapshot.rows().next().unwrap();
+    assert!(matches!(
+        held.state(),
+        super::types::RelationState::Holds { rights } if rights == RelationRights::SEND
+    ));
+    assert_eq!(
+        held.key(),
+        RelationKey::Holds {
+            scope: second.token(),
+            capability: capability(second, 3, 7),
+            object: object(ObjectKind::Endpoint, 11),
+        }
+    );
+
+    assert_eq!(AuthorityObject::Message.relation_kind(), None);
+    assert_eq!(AuthorityObject::Message.token(), None);
+}
+
+#[test]
+fn relation_identities_use_full_capability_instances_across_reuse() {
+    let mut store = store();
+    let source = reader(&mut store, 0, 1);
+    let target = reader(&mut store, 1, 1);
+    let parent_a = capability(source, 3, 5);
+    let parent_b = capability(source, 3, 6);
+    let child_a = capability(target, 3, 7);
+    let child_b = capability(target, 3, 8);
+
+    apply_one(
+        &mut store,
+        target,
+        derive_relation(target, parent_a, child_a),
+    );
+    apply_one(
+        &mut store,
+        target,
+        derive_relation(target, parent_b, child_b),
+    );
+
+    let snapshot = store.snapshot(target).unwrap();
+    assert_eq!(snapshot.len(), 2);
+    assert!(snapshot.rows().any(|row| row.key()
+        == RelationKey::Derives {
+            scope: target.token(),
+            parent: parent_a,
+            child: child_a,
+        }));
+    assert!(snapshot.rows().any(|row| row.key()
+        == RelationKey::Derives {
+            scope: target.token(),
+            parent: parent_b,
+            child: child_b,
+        }));
+}
+
+#[test]
+fn domain_slot_reuse_clears_the_old_generation_reader() {
+    let mut store = store();
+    let old = reader(&mut store, 0, 1);
+    apply_one(
+        &mut store,
+        old,
+        object_relation(old.token(), ObjectKind::Domain, 1),
+    );
+    assert_eq!(store.relation_epoch(old).unwrap(), 1);
+
+    let fresh = reader(&mut store, 0, 2);
+    assert_eq!(
+        store.snapshot(old).unwrap_err(),
+        ProjectionError::ResnapshotRequired
+    );
+    assert_eq!(
+        store.delta_cursor(old).unwrap_err(),
+        ProjectionError::ResnapshotRequired
+    );
+    assert_eq!(
+        apply_change(
+            &mut store,
+            old,
+            RelationChange::Delete(object_relation(old.token(), ObjectKind::Domain, 1).key()),
+        )
+        .unwrap_err(),
+        ProjectionError::ResnapshotRequired
+    );
+
+    let fresh_snapshot = store.snapshot(fresh).unwrap();
+    assert_eq!(fresh_snapshot.epoch(), 0);
+    assert!(fresh_snapshot.is_empty());
+}
+
+#[test]
+fn epochs_are_projection_local_and_batches_advance_exactly_once() {
+    let mut store = store();
+    let first = reader(&mut store, 0, 1);
+    let second = reader(&mut store, 1, 1);
+    let child = capability(first, 1, 2);
+
+    let mut batch = AuthoritativeBatch::empty();
+    for relation in [
+        object_relation(first.token(), ObjectKind::Domain, 1),
+        object_relation(first.token(), ObjectKind::Endpoint, 2),
+        holds_relation(first, 1, 2, 2),
+    ] {
+        batch
+            .push(RelationMutation::new(
+                first,
+                RelationChange::Upsert(relation),
+            ))
+            .unwrap();
+    }
+    batch
+        .push(RelationMutation::new(
+            first,
+            RelationChange::Upsert(derive_relation(first, child, child)),
+        ))
+        .unwrap();
+    assert_eq!(store.apply(batch).unwrap(), 4);
+    assert_eq!(store.relation_epoch(first).unwrap(), 1);
+    assert_eq!(store.relation_epoch(second).unwrap(), 0);
+
+    apply_one(
+        &mut store,
+        second,
+        object_relation(second.token(), ObjectKind::Domain, 3),
+    );
+    assert_eq!(store.relation_epoch(first).unwrap(), 1);
+    assert_eq!(store.relation_epoch(second).unwrap(), 1);
+}
+
+#[test]
+fn epoch_overflow_fails_closed_and_does_not_wrap() {
+    let mut store = store();
+    let lease = reader(&mut store, 0, 1);
+    store.force_epoch_overflow(lease).unwrap();
+
+    let result = apply_one_or_error(
+        &mut store,
+        lease,
+        object_relation(lease.token(), ObjectKind::Domain, 1),
+    );
+    assert_eq!(result, Err(ProjectionError::ResnapshotRequired));
+    assert_eq!(store.relation_epoch(lease).unwrap(), u64::MAX);
+    assert!(store.snapshot(lease).unwrap().is_empty());
+}
+
+fn apply_one_or_error(
+    store: &mut ProjectionStore,
+    lease: ReaderLease,
+    relation: Relation,
+) -> Result<(), ProjectionError> {
+    apply_change(store, lease, RelationChange::Upsert(relation)).map(|_| ())
+}
+
+#[test]
+fn deterministic_fold_equals_direct_snapshot_and_rejects_bad_cursors() {
+    let mut store = store();
+    let lease = reader(&mut store, 0, 1);
+    apply_one(
+        &mut store,
+        lease,
+        object_relation(lease.token(), ObjectKind::Endpoint, 1),
+    );
+    let (base, cursor) = fold_base(&mut store, lease);
+
+    apply_one(
+        &mut store,
+        lease,
+        object_relation(lease.token(), ObjectKind::Domain, 2),
+    );
+    apply_one(&mut store, lease, holds_relation(lease, 2, 9, 1));
+    let revoked = holds_relation(lease, 3, 9, 1);
+    apply_one(&mut store, lease, revoked);
+    apply_change(&mut store, lease, RelationChange::Delete(revoked.key())).unwrap();
+
+    let direct = store.snapshot(lease).unwrap();
+    let replayed = store.fold(lease, base, cursor).unwrap();
+    assert_eq!(replayed, direct);
+    assert_eq!(replayed.epoch(), 5);
+    assert_canonical(&direct);
+
+    assert_eq!(
+        store
+            .fold(lease, base, DeltaCursor::new(lease.reader_generation(), 0))
+            .unwrap_err(),
+        ProjectionError::ResnapshotRequired
+    );
+    assert_eq!(
+        store
+            .fold(
+                lease,
+                base,
+                DeltaCursor::new(lease.reader_generation() + 1, base.epoch())
+            )
+            .unwrap_err(),
+        ProjectionError::ResnapshotRequired
+    );
+}
+
+#[test]
+fn delta_ring_overflow_requires_a_new_base_and_then_resumes() {
+    let mut store = store();
+    let lease = reader(&mut store, 0, 1);
+    let relation = object_relation(lease.token(), ObjectKind::Endpoint, 1);
+    apply_one(&mut store, lease, relation);
+
+    for epoch in 2..=(DELTA_RING_ENTRIES + 2) {
+        apply_one(&mut store, lease, relation);
+        assert_eq!(store.relation_epoch(lease).unwrap(), epoch as u64);
+    }
+    assert_eq!(
+        store.snapshot(lease).unwrap_err(),
+        ProjectionError::ResnapshotRequired
+    );
+
+    let (base, cursor) = fold_base(&mut store, lease);
+    assert_eq!(base.epoch(), (DELTA_RING_ENTRIES + 2) as u64);
+    apply_one(&mut store, lease, relation);
+    let replayed = store.fold(lease, base, cursor).unwrap();
+    assert_eq!(replayed, store.snapshot(lease).unwrap());
+}
+
+#[test]
+fn delete_is_once_and_reclaim_failure_cannot_resurrect() {
+    let mut store = store();
+    let lease = reader(&mut store, 0, 1);
+    let endpoint = object(ObjectKind::Endpoint, 7);
+    let object_row = Relation::object(lease.token(), endpoint);
+    let hold = holds_relation(lease, 2, 4, 7);
+    apply_one(&mut store, lease, object_row);
+    apply_one(&mut store, lease, hold);
+
+    let mut batch = AuthoritativeBatch::empty();
+    batch
+        .push(RelationMutation::new(
+            lease,
+            RelationChange::Delete(hold.key()),
+        ))
+        .unwrap();
+    batch
+        .push(RelationMutation::new(
+            lease,
+            RelationChange::Delete(object_row.key()),
+        ))
+        .unwrap();
+    assert_eq!(store.apply(batch).unwrap(), 2);
+    assert_eq!(store.relation_epoch(lease).unwrap(), 3);
+
+    let repeated = AuthoritativeBatch::empty();
+    assert_eq!(store.apply(repeated).unwrap(), 0);
+    assert_eq!(
+        apply_change(&mut store, lease, RelationChange::Delete(hold.key())).unwrap(),
+        0
+    );
+    assert_eq!(store.relation_epoch(lease).unwrap(), 3);
+    assert!(store.snapshot(lease).unwrap().is_empty());
+
+    assert!(
+        store
+            .record_reclaim(lease, token(7), ReclaimOutcome::ReleaseFailed)
+            .unwrap()
+    );
+    assert_eq!(
+        store
+            .reclaim_observation(lease, token(7))
+            .unwrap()
+            .outcome(),
+        ReclaimOutcome::ReleaseFailed
+    );
+    assert_eq!(
+        apply_one_or_error(&mut store, lease, object_row),
+        Err(ProjectionError::Resurrection)
+    );
+    assert!(store.snapshot(lease).unwrap().is_empty());
+}
+
+#[test]
+fn reclaim_blocked_is_observable_after_logical_delete() {
+    let mut store = store();
+    let lease = reader(&mut store, 0, 1);
+    let relation = object_relation(lease.token(), ObjectKind::Endpoint, 8);
+    apply_one(&mut store, lease, relation);
+    apply_change(&mut store, lease, RelationChange::Delete(relation.key())).unwrap();
+
+    assert!(
+        store
+            .record_reclaim(lease, token(8), ReclaimOutcome::ReclaimBlocked)
+            .unwrap()
+    );
+    assert_eq!(
+        store
+            .reclaim_observation(lease, token(8))
+            .unwrap()
+            .outcome(),
+        ReclaimOutcome::ReclaimBlocked
+    );
+    assert!(
+        !store
+            .record_reclaim(lease, token(8), ReclaimOutcome::ReclaimBlocked)
+            .unwrap()
+    );
+}
+
+#[test]
+fn unauthorized_scope_is_denied_without_resnapshot_or_partial_fill() {
+    let mut store = store();
+    let authorized = reader(&mut store, 0, 1);
+    let foreign = reader(&mut store, 1, 1);
+    let foreign_relation = object_relation(foreign.token(), ObjectKind::Domain, 4);
+
+    let mut batch = AuthoritativeBatch::empty();
+    batch
+        .push(RelationMutation::new(
+            authorized,
+            RelationChange::Upsert(object_relation(authorized.token(), ObjectKind::Endpoint, 3)),
+        ))
+        .unwrap();
+    batch
+        .push(RelationMutation::new(
+            authorized,
+            RelationChange::Upsert(foreign_relation),
+        ))
+        .unwrap();
+    assert_eq!(store.apply(batch).unwrap_err(), ProjectionError::Denied);
+    assert_eq!(store.relation_epoch(authorized).unwrap(), 0);
+    assert!(store.snapshot(authorized).unwrap().is_empty());
+
+    assert!(DomainToken::new(2, 1).is_none());
+    assert_eq!(
+        apply_change(
+            &mut store,
+            authorized,
+            RelationChange::Upsert(foreign_relation),
+        )
+        .unwrap_err(),
+        ProjectionError::Denied
+    );
+}
+
+#[test]
+fn pages_are_bounded_and_invalid_cursors_resnapshot() {
+    let mut store = store();
+    let lease = reader(&mut store, 0, 1);
+    for value in 0..RELATION_PAGE_ROWS + 4 {
+        apply_one(
+            &mut store,
+            lease,
+            holds_relation(lease, 1, 5, value as u64 + 1),
+        );
+    }
+
+    let epoch = store.relation_epoch(lease).unwrap();
+    let page0 = store
+        .snapshot_page(lease, PageCursor::new(1, epoch, 0))
+        .unwrap();
+    assert_eq!(page0.len(), RELATION_PAGE_ROWS);
+    assert!(page0.has_more());
+    assert_canonical(&store.snapshot(lease).unwrap());
+
+    let page1 = store
+        .snapshot_page(lease, PageCursor::new(1, epoch, 1))
+        .unwrap();
+    assert_eq!(page1.len(), 4);
+    assert!(!page1.has_more());
+
+    assert_eq!(
+        store
+            .snapshot_page(lease, PageCursor::new(2, epoch, 0))
+            .unwrap_err(),
+        ProjectionError::ResnapshotRequired
+    );
+    assert_eq!(
+        store
+            .snapshot_page(lease, PageCursor::new(1, epoch + 1, 0))
+            .unwrap_err(),
+        ProjectionError::ResnapshotRequired
+    );
+    assert_eq!(
+        store
+            .snapshot_page(lease, PageCursor::new(1, epoch, 5))
+            .unwrap_err(),
+        ProjectionError::ResnapshotRequired
+    );
+}

--- a/kernel/crates/astrid-native-kernel/src/relations/projection_tests.rs
+++ b/kernel/crates/astrid-native-kernel/src/relations/projection_tests.rs
@@ -527,6 +527,49 @@ fn batch_delete_makes_room_for_a_new_key_at_capacity() {
     );
 }
 
+#[test]
+fn batch_upsert_then_delete_at_capacity_folds_in_authoritative_order() {
+    let mut store = store();
+    let lease = reader(&mut store, 0, 1);
+    for value in 1..=MAX_RELATION_ROWS as u64 {
+        apply_one(&mut store, lease, holds_relation(lease, 1, 3, value));
+    }
+    let (base, cursor) = fold_base(&mut store, lease);
+
+    let retained = holds_relation(lease, 1, 3, 1);
+    let inserted = holds_relation(lease, 1, 4, MAX_RELATION_ROWS as u64 + 1);
+    let mut batch = AuthoritativeBatch::empty();
+    batch
+        .push(RelationMutation::new(
+            lease,
+            RelationChange::Upsert(inserted),
+        ))
+        .unwrap();
+    batch
+        .push(RelationMutation::new(
+            lease,
+            RelationChange::Delete(retained.key()),
+        ))
+        .unwrap();
+    assert_eq!(store.apply(batch).unwrap(), 2);
+
+    let direct = store.snapshot(lease).unwrap();
+    let replayed = store.fold(lease, base, cursor).unwrap();
+    assert_eq!(replayed, direct);
+    assert_eq!(replayed.len(), MAX_RELATION_ROWS);
+    assert!(
+        replayed
+            .rows()
+            .any(|relation| relation.key() == inserted.key())
+    );
+    assert!(
+        !replayed
+            .rows()
+            .any(|relation| relation.key() == retained.key())
+    );
+    assert_canonical(&replayed);
+}
+
 fn apply_one_or_error(
     store: &mut ProjectionStore,
     lease: ReaderLease,

--- a/kernel/crates/astrid-native-kernel/src/relations/projection_tests.rs
+++ b/kernel/crates/astrid-native-kernel/src/relations/projection_tests.rs
@@ -6,8 +6,9 @@ use super::projection::{
 };
 use super::types::{
     AuthorityObject, CapabilityGeneration, CapabilityInstance, CapabilitySlot, DELTA_RING_ENTRIES,
-    DomainProjectionToken, ObjectKind, ObjectRef, ObjectToken, ProjectionError, RELATION_PAGE_ROWS,
-    ReclaimOutcome, Relation, RelationChange, RelationKey, RelationRights,
+    DomainProjectionToken, MAX_RELATION_ROWS, ObjectKind, ObjectRef, ObjectToken, ProjectionError,
+    RELATION_PAGE_ROWS, ReaderIdentity, ReclaimOutcome, Relation, RelationChange, RelationKey,
+    RelationRights,
 };
 use crate::ipc::DomainToken;
 
@@ -33,12 +34,19 @@ fn object(kind: ObjectKind, value: u64) -> ObjectRef {
     ObjectRef::new(kind, token(value))
 }
 
-fn capability(lease: ReaderLease, slot: usize, generation_value: u64) -> CapabilityInstance {
-    CapabilityInstance::new(
+fn capability(
+    lease: ReaderLease,
+    slot: usize,
+    generation_value: u64,
+    object_value: u64,
+) -> CapabilityInstance {
+    CapabilityInstance::try_new(
         lease.token(),
         CapabilitySlot::try_new(slot).unwrap(),
+        object(ObjectKind::Endpoint, object_value),
         generation(generation_value),
     )
+    .unwrap()
 }
 
 fn object_relation(scope: DomainProjectionToken, kind: ObjectKind, value: u64) -> Relation {
@@ -53,10 +61,27 @@ fn holds_relation(
 ) -> Relation {
     Relation::holds(
         lease.token(),
-        capability(lease, slot, generation_value),
+        capability(lease, slot, generation_value, object_value),
         object(ObjectKind::Endpoint, object_value),
         RelationRights::SEND,
     )
+    .unwrap()
+}
+
+fn hold_with_rights(
+    lease: ReaderLease,
+    slot: usize,
+    generation_value: u64,
+    object_value: u64,
+    rights: RelationRights,
+) -> Relation {
+    Relation::holds(
+        lease.token(),
+        capability(lease, slot, generation_value, object_value),
+        object(ObjectKind::Endpoint, object_value),
+        rights,
+    )
+    .unwrap()
 }
 
 fn derive_relation(
@@ -64,7 +89,7 @@ fn derive_relation(
     parent: CapabilityInstance,
     child: CapabilityInstance,
 ) -> Relation {
-    Relation::derives(lease.token(), parent, child)
+    Relation::derives(lease.token(), parent, child).unwrap()
 }
 
 fn apply_one(store: &mut ProjectionStore, lease: ReaderLease, relation: Relation) {
@@ -145,7 +170,7 @@ fn object_capability_and_endpoint_tables_project_without_message_rows() {
         held.key(),
         RelationKey::Holds {
             scope: second.token(),
-            capability: capability(second, 3, 7),
+            capability: capability(second, 3, 7, 11),
             object: object(ObjectKind::Endpoint, 11),
         }
     );
@@ -159,10 +184,10 @@ fn relation_identities_use_full_capability_instances_across_reuse() {
     let mut store = store();
     let source = reader(&mut store, 0, 1);
     let target = reader(&mut store, 1, 1);
-    let parent_a = capability(source, 3, 5);
-    let parent_b = capability(source, 3, 6);
-    let child_a = capability(target, 3, 7);
-    let child_b = capability(target, 3, 8);
+    let parent_a = capability(source, 3, 5, 20);
+    let parent_b = capability(source, 3, 6, 20);
+    let child_a = capability(target, 3, 7, 20);
+    let child_b = capability(target, 3, 8, 20);
 
     apply_one(
         &mut store,
@@ -231,7 +256,7 @@ fn epochs_are_projection_local_and_batches_advance_exactly_once() {
     let mut store = store();
     let first = reader(&mut store, 0, 1);
     let second = reader(&mut store, 1, 1);
-    let child = capability(first, 1, 2);
+    let child = capability(first, 1, 2, 2);
 
     let mut batch = AuthoritativeBatch::empty();
     for relation in [
@@ -266,6 +291,118 @@ fn epochs_are_projection_local_and_batches_advance_exactly_once() {
 }
 
 #[test]
+fn batch_fold_applies_every_visible_change_at_one_projection_epoch() {
+    let mut store = store();
+    let lease = reader(&mut store, 0, 1);
+    let parent = capability(lease, 1, 4, 10);
+    let child = capability(lease, 2, 5, 10);
+
+    let mut batch = AuthoritativeBatch::empty();
+    batch
+        .push(RelationMutation::new(
+            lease,
+            RelationChange::Upsert(object_relation(lease.token(), ObjectKind::Endpoint, 10)),
+        ))
+        .unwrap();
+    batch
+        .push(RelationMutation::new(
+            lease,
+            RelationChange::Upsert(holds_relation(lease, 1, 4, 10)),
+        ))
+        .unwrap();
+    batch
+        .push(RelationMutation::new(
+            lease,
+            RelationChange::Upsert(derive_relation(lease, parent, child)),
+        ))
+        .unwrap();
+
+    let (base, cursor) = fold_base(&mut store, lease);
+    assert_eq!(store.apply(batch).unwrap(), 3);
+    assert_eq!(store.relation_epoch(lease).unwrap(), 1);
+    assert_eq!(store.snapshot(lease).unwrap().len(), 3);
+    assert_eq!(
+        store.fold(lease, base, cursor).unwrap(),
+        store.snapshot(lease).unwrap()
+    );
+}
+
+#[test]
+fn cursors_cannot_move_between_readers_with_the_same_generation() {
+    let mut store = store();
+    let first = reader(&mut store, 0, 1);
+    let second = reader(&mut store, 1, 1);
+    let first_base = store.base_snapshot(first).unwrap();
+    let second_base = store.base_snapshot(second).unwrap();
+
+    apply_one(
+        &mut store,
+        first,
+        object_relation(first.token(), ObjectKind::Endpoint, 1),
+    );
+    assert_eq!(
+        store
+            .fold(first, first_base, store.delta_cursor(second).unwrap())
+            .unwrap_err(),
+        ProjectionError::ResnapshotRequired
+    );
+    assert_eq!(
+        store
+            .snapshot_page(first, store.page_cursor(second, 0).unwrap())
+            .unwrap_err(),
+        ProjectionError::ResnapshotRequired
+    );
+    assert!(
+        store
+            .fold(second, second_base, store.delta_cursor(second).unwrap())
+            .is_ok()
+    );
+}
+
+#[test]
+fn generation_reuse_retires_rows_without_leaving_them_in_capacity() {
+    let mut store = store();
+    let old = reader(&mut store, 0, 1);
+    let live = reader(&mut store, 1, 1);
+    apply_one(
+        &mut store,
+        old,
+        object_relation(old.token(), ObjectKind::Endpoint, 1),
+    );
+    apply_one(
+        &mut store,
+        live,
+        object_relation(live.token(), ObjectKind::Domain, 2),
+    );
+
+    let fresh = reader(&mut store, 0, 2);
+    assert_eq!(store.retired_delete_count(0), 1);
+    assert_eq!(
+        store.snapshot(old).unwrap_err(),
+        ProjectionError::ResnapshotRequired
+    );
+    assert_eq!(store.snapshot(live).unwrap().len(), 1);
+
+    apply_change(
+        &mut store,
+        live,
+        RelationChange::Delete(object_relation(live.token(), ObjectKind::Domain, 2).key()),
+    )
+    .unwrap();
+
+    for value in 0..MAX_RELATION_ROWS {
+        apply_one(
+            &mut store,
+            fresh,
+            holds_relation(fresh, 1, 7, value as u64 + 3),
+        );
+    }
+    let final_base = store.base_snapshot(fresh).unwrap();
+    assert_eq!(final_base.len(), MAX_RELATION_ROWS);
+    assert_eq!(store.snapshot(fresh).unwrap().len(), MAX_RELATION_ROWS);
+}
+
+#[test]
 fn epoch_overflow_fails_closed_and_does_not_wrap() {
     let mut store = store();
     let lease = reader(&mut store, 0, 1);
@@ -293,6 +430,7 @@ fn apply_one_or_error(
 fn deterministic_fold_equals_direct_snapshot_and_rejects_bad_cursors() {
     let mut store = store();
     let lease = reader(&mut store, 0, 1);
+    let other = reader(&mut store, 1, 1);
     apply_one(
         &mut store,
         lease,
@@ -318,7 +456,7 @@ fn deterministic_fold_equals_direct_snapshot_and_rejects_bad_cursors() {
 
     assert_eq!(
         store
-            .fold(lease, base, DeltaCursor::new(lease.reader_generation(), 0))
+            .fold(lease, base, store.delta_cursor(other).unwrap())
             .unwrap_err(),
         ProjectionError::ResnapshotRequired
     );
@@ -327,7 +465,10 @@ fn deterministic_fold_equals_direct_snapshot_and_rejects_bad_cursors() {
             .fold(
                 lease,
                 base,
-                DeltaCursor::new(lease.reader_generation() + 1, base.epoch())
+                DeltaCursor::new(
+                    ReaderIdentity::new(0, lease.reader_generation() + 1, lease.token()).unwrap(),
+                    base.epoch()
+                )
             )
             .unwrap_err(),
         ProjectionError::ResnapshotRequired
@@ -342,7 +483,12 @@ fn delta_ring_overflow_requires_a_new_base_and_then_resumes() {
     apply_one(&mut store, lease, relation);
 
     for epoch in 2..=(DELTA_RING_ENTRIES + 2) {
-        apply_one(&mut store, lease, relation);
+        let rights = if epoch % 2 == 0 {
+            RelationRights::RECV
+        } else {
+            RelationRights::SEND
+        };
+        apply_one(&mut store, lease, hold_with_rights(lease, 1, 9, 1, rights));
         assert_eq!(store.relation_epoch(lease).unwrap(), epoch as u64);
     }
     assert_eq!(
@@ -394,12 +540,16 @@ fn delete_is_once_and_reclaim_failure_cannot_resurrect() {
 
     assert!(
         store
-            .record_reclaim(lease, token(7), ReclaimOutcome::ReleaseFailed)
+            .record_reclaim(
+                lease,
+                object(ObjectKind::Endpoint, 7),
+                ReclaimOutcome::ReleaseFailed,
+            )
             .unwrap()
     );
     assert_eq!(
         store
-            .reclaim_observation(lease, token(7))
+            .reclaim_observation(lease, object(ObjectKind::Endpoint, 7))
             .unwrap()
             .outcome(),
         ReclaimOutcome::ReleaseFailed
@@ -408,7 +558,136 @@ fn delete_is_once_and_reclaim_failure_cannot_resurrect() {
         apply_one_or_error(&mut store, lease, object_row),
         Err(ProjectionError::Resurrection)
     );
+    assert_eq!(
+        apply_one_or_error(&mut store, lease, hold),
+        Err(ProjectionError::Resurrection)
+    );
     assert!(store.snapshot(lease).unwrap().is_empty());
+}
+
+#[test]
+fn logical_deletion_is_a_tombstone_distinct_from_reclaim() {
+    let mut store = store();
+    let lease = reader(&mut store, 0, 1);
+    let relation = object_relation(lease.token(), ObjectKind::Endpoint, 12);
+    apply_one(&mut store, lease, relation);
+    apply_change(&mut store, lease, RelationChange::Delete(relation.key())).unwrap();
+
+    assert_eq!(
+        apply_one_or_error(&mut store, lease, relation),
+        Err(ProjectionError::Resurrection)
+    );
+    assert!(
+        store
+            .record_reclaim(
+                lease,
+                object(ObjectKind::Endpoint, 12),
+                ReclaimOutcome::ReleaseFailed,
+            )
+            .unwrap()
+    );
+}
+
+#[test]
+fn derives_and_reclaim_carry_object_kind_identity() {
+    let mut store = store();
+    let lease = reader(&mut store, 0, 1);
+    let parent = capability(lease, 1, 4, 14);
+    let child = capability(lease, 2, 5, 14);
+    let derivation = derive_relation(lease, parent, child);
+    apply_one(&mut store, lease, derivation);
+    apply_change(&mut store, lease, RelationChange::Delete(derivation.key())).unwrap();
+
+    assert!(
+        store
+            .record_reclaim(
+                lease,
+                object(ObjectKind::Endpoint, 14),
+                ReclaimOutcome::ReclaimBlocked,
+            )
+            .unwrap()
+    );
+    assert_eq!(
+        apply_one_or_error(&mut store, lease, derivation),
+        Err(ProjectionError::Resurrection)
+    );
+
+    let domain_lease = reader(&mut store, 1, 1);
+    assert!(
+        store
+            .record_reclaim(
+                domain_lease,
+                object(ObjectKind::Domain, 15),
+                ReclaimOutcome::ReleaseFailed,
+            )
+            .unwrap()
+    );
+    assert_eq!(
+        apply_one_or_error(
+            &mut store,
+            domain_lease,
+            object_relation(domain_lease.token(), ObjectKind::Domain, 15),
+        ),
+        Err(ProjectionError::Resurrection)
+    );
+    let endpoint_with_reused_number =
+        object_relation(domain_lease.token(), ObjectKind::Endpoint, 15);
+    apply_one(&mut store, domain_lease, endpoint_with_reused_number);
+}
+
+#[test]
+fn relation_constructors_enforce_scoped_capability_and_endpoint_identity() {
+    let mut store = store();
+    let first = reader(&mut store, 0, 1);
+    let second = reader(&mut store, 1, 1);
+
+    assert!(
+        CapabilityInstance::try_new(
+            first.token(),
+            CapabilitySlot::try_new(1).unwrap(),
+            object(ObjectKind::Domain, 1),
+            generation(2),
+        )
+        .is_none()
+    );
+    assert!(
+        Relation::holds(
+            first.token(),
+            capability(second, 1, 2, 3),
+            object(ObjectKind::Endpoint, 3),
+            RelationRights::SEND,
+        )
+        .is_none()
+    );
+    assert!(
+        Relation::holds(
+            first.token(),
+            capability(first, 1, 2, 3),
+            object(ObjectKind::Endpoint, 4),
+            RelationRights::SEND,
+        )
+        .is_none()
+    );
+    assert!(
+        Relation::holds(
+            first.token(),
+            capability(first, 1, 2, 3),
+            object(ObjectKind::Domain, 3),
+            RelationRights::SEND,
+        )
+        .is_none()
+    );
+
+    let foreign_child = capability(second, 2, 3, 3);
+    assert!(Relation::derives(first.token(), capability(first, 1, 2, 3), foreign_child).is_none());
+    assert!(
+        Relation::derives(
+            first.token(),
+            capability(first, 1, 2, 3),
+            capability(first, 2, 3, 4),
+        )
+        .is_none()
+    );
 }
 
 #[test]
@@ -421,19 +700,27 @@ fn reclaim_blocked_is_observable_after_logical_delete() {
 
     assert!(
         store
-            .record_reclaim(lease, token(8), ReclaimOutcome::ReclaimBlocked)
+            .record_reclaim(
+                lease,
+                object(ObjectKind::Endpoint, 8),
+                ReclaimOutcome::ReclaimBlocked,
+            )
             .unwrap()
     );
     assert_eq!(
         store
-            .reclaim_observation(lease, token(8))
+            .reclaim_observation(lease, object(ObjectKind::Endpoint, 8))
             .unwrap()
             .outcome(),
         ReclaimOutcome::ReclaimBlocked
     );
     assert!(
         !store
-            .record_reclaim(lease, token(8), ReclaimOutcome::ReclaimBlocked)
+            .record_reclaim(
+                lease,
+                object(ObjectKind::Endpoint, 8),
+                ReclaimOutcome::ReclaimBlocked,
+            )
             .unwrap()
     );
 }
@@ -488,33 +775,36 @@ fn pages_are_bounded_and_invalid_cursors_resnapshot() {
 
     let epoch = store.relation_epoch(lease).unwrap();
     let page0 = store
-        .snapshot_page(lease, PageCursor::new(1, epoch, 0))
+        .snapshot_page(lease, store.page_cursor(lease, 0).unwrap())
         .unwrap();
     assert_eq!(page0.len(), RELATION_PAGE_ROWS);
     assert!(page0.has_more());
     assert_canonical(&store.snapshot(lease).unwrap());
 
     let page1 = store
-        .snapshot_page(lease, PageCursor::new(1, epoch, 1))
+        .snapshot_page(lease, store.page_cursor(lease, 1).unwrap())
         .unwrap();
     assert_eq!(page1.len(), 4);
     assert!(!page1.has_more());
 
     assert_eq!(
         store
-            .snapshot_page(lease, PageCursor::new(2, epoch, 0))
+            .snapshot_page(lease, store.page_cursor(lease, 2).unwrap())
             .unwrap_err(),
         ProjectionError::ResnapshotRequired
     );
     assert_eq!(
         store
-            .snapshot_page(lease, PageCursor::new(1, epoch + 1, 0))
+            .snapshot_page(
+                lease,
+                PageCursor::new(store.page_cursor(lease, 0).unwrap().reader, epoch + 1, 0)
+            )
             .unwrap_err(),
         ProjectionError::ResnapshotRequired
     );
     assert_eq!(
         store
-            .snapshot_page(lease, PageCursor::new(1, epoch, 5))
+            .snapshot_page(lease, store.page_cursor(lease, 5).unwrap())
             .unwrap_err(),
         ProjectionError::ResnapshotRequired
     );

--- a/kernel/crates/astrid-native-kernel/src/relations/projection_tests.rs
+++ b/kernel/crates/astrid-native-kernel/src/relations/projection_tests.rs
@@ -418,6 +418,115 @@ fn epoch_overflow_fails_closed_and_does_not_wrap() {
     assert!(store.snapshot(lease).unwrap().is_empty());
 }
 
+#[test]
+fn reader_retirement_overflow_leaves_the_slot_and_rows_intact() {
+    let mut store = store();
+    let old = reader(&mut store, 0, 1);
+    let relation = object_relation(old.token(), ObjectKind::Endpoint, 1);
+    apply_one(&mut store, old, relation);
+    store.force_epoch_overflow(old).unwrap();
+
+    assert_eq!(
+        store
+            .register_reader(DomainToken::new(0, 2).unwrap())
+            .unwrap_err(),
+        ProjectionError::ResnapshotRequired
+    );
+    assert_eq!(
+        store
+            .register_reader(DomainToken::new(0, 3).unwrap())
+            .unwrap_err(),
+        ProjectionError::ResnapshotRequired
+    );
+    assert_eq!(store.relation_epoch(old).unwrap(), u64::MAX);
+    assert_eq!(store.snapshot(old).unwrap().rows().count(), 1);
+}
+
+#[test]
+fn reclaim_resurrection_is_bound_to_reader_scope() {
+    let mut store = store();
+    let first = reader(&mut store, 0, 1);
+    let second = reader(&mut store, 1, 1);
+    let first_relation = object_relation(first.token(), ObjectKind::Endpoint, 7);
+    apply_one(&mut store, first, first_relation);
+    apply_change(
+        &mut store,
+        first,
+        RelationChange::Delete(first_relation.key()),
+    )
+    .unwrap();
+    assert!(
+        store
+            .record_reclaim(
+                first,
+                object(ObjectKind::Endpoint, 7),
+                ReclaimOutcome::ReleaseFailed,
+            )
+            .unwrap()
+    );
+
+    assert_eq!(
+        store
+            .reclaim_observation(second, object(ObjectKind::Endpoint, 7))
+            .unwrap_err(),
+        ProjectionError::Denied
+    );
+    assert_eq!(
+        apply_one_or_error(
+            &mut store,
+            second,
+            object_relation(second.token(), ObjectKind::Endpoint, 7),
+        ),
+        Ok(())
+    );
+}
+
+#[test]
+fn batch_delete_makes_room_for_a_new_key_at_capacity() {
+    let mut store = store();
+    let lease = reader(&mut store, 0, 1);
+    for value in 1..=MAX_RELATION_ROWS as u64 {
+        apply_one(&mut store, lease, holds_relation(lease, 1, 3, value));
+    }
+    store.base_snapshot(lease).unwrap();
+    let retained = holds_relation(lease, 1, 3, 1);
+    let inserted = holds_relation(lease, 1, 4, MAX_RELATION_ROWS as u64 + 1);
+
+    let mut batch = AuthoritativeBatch::empty();
+    batch
+        .push(RelationMutation::new(
+            lease,
+            RelationChange::Upsert(inserted),
+        ))
+        .unwrap();
+    batch
+        .push(RelationMutation::new(
+            lease,
+            RelationChange::Delete(retained.key()),
+        ))
+        .unwrap();
+    assert_eq!(store.apply(batch).unwrap(), 2);
+    assert_eq!(
+        store.relation_epoch(lease).unwrap(),
+        MAX_RELATION_ROWS as u64 + 1
+    );
+    assert_eq!(store.snapshot(lease).unwrap().len(), MAX_RELATION_ROWS);
+    assert!(
+        !store
+            .snapshot(lease)
+            .unwrap()
+            .rows()
+            .any(|relation| relation.key() == retained.key())
+    );
+    assert!(
+        store
+            .snapshot(lease)
+            .unwrap()
+            .rows()
+            .any(|relation| relation.key() == inserted.key())
+    );
+}
+
 fn apply_one_or_error(
     store: &mut ProjectionStore,
     lease: ReaderLease,

--- a/kernel/crates/astrid-native-kernel/src/relations/types.rs
+++ b/kernel/crates/astrid-native-kernel/src/relations/types.rs
@@ -30,6 +30,33 @@ impl DomainProjectionToken {
     }
 }
 
+/// The complete projection identity of a cursor's owner. The slot is kept
+/// alongside the kernel token so a token minting error can never collapse two
+/// readers onto one cursor.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ReaderIdentity {
+    domain_slot: u8,
+    domain_generation: NonZeroU64,
+    projection_token: DomainProjectionToken,
+}
+
+impl ReaderIdentity {
+    pub fn new(
+        domain_slot: usize,
+        domain_generation: u64,
+        projection_token: DomainProjectionToken,
+    ) -> Option<Self> {
+        if domain_slot > u8::MAX as usize {
+            return None;
+        }
+        Some(Self {
+            domain_slot: domain_slot as u8,
+            domain_generation: NonZeroU64::new(domain_generation)?,
+            projection_token,
+        })
+    }
+}
+
 /// Caller-known capability-table slot in the landed eight-slot domain table.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct CapabilitySlot(u8);
@@ -164,20 +191,26 @@ impl RelationRights {
 pub struct CapabilityInstance {
     domain: DomainProjectionToken,
     slot: CapabilitySlot,
+    object: ObjectRef,
     generation: CapabilityGeneration,
 }
 
 impl CapabilityInstance {
-    pub const fn new(
+    pub fn try_new(
         domain: DomainProjectionToken,
         slot: CapabilitySlot,
+        object: ObjectRef,
         generation: CapabilityGeneration,
-    ) -> Self {
-        Self {
+    ) -> Option<Self> {
+        if object.kind() != ObjectKind::Endpoint {
+            return None;
+        }
+        Some(Self {
             domain,
             slot,
+            object,
             generation,
-        }
+        })
     }
 
     pub const fn domain(self) -> DomainProjectionToken {
@@ -186,6 +219,10 @@ impl CapabilityInstance {
 
     pub const fn slot(self) -> CapabilitySlot {
         self.slot
+    }
+
+    pub const fn object(self) -> ObjectRef {
+        self.object
     }
 
     pub const fn generation(self) -> CapabilityGeneration {
@@ -220,11 +257,15 @@ impl RelationKey {
         }
     }
 
-    pub(crate) const fn object_tokens(self) -> [Option<ObjectToken>; 2] {
+    pub(crate) const fn object_refs(self) -> [Option<ObjectRef>; 3] {
         match self {
-            Self::Object { object, .. } => [Some(object.token()), None],
-            Self::Holds { object, .. } => [Some(object.token()), None],
-            Self::Derives { .. } => [None, None],
+            Self::Object { object, .. } => [Some(object), None, None],
+            Self::Holds {
+                capability, object, ..
+            } => [Some(object), Some(capability.object()), None],
+            Self::Derives { parent, child, .. } => {
+                [Some(parent.object()), Some(child.object()), None]
+            },
         }
     }
 }
@@ -250,35 +291,44 @@ impl Relation {
         }
     }
 
-    pub const fn holds(
+    pub fn holds(
         scope: DomainProjectionToken,
         capability: CapabilityInstance,
         object: ObjectRef,
         rights: RelationRights,
-    ) -> Self {
-        Self {
+    ) -> Option<Self> {
+        if capability.domain() != scope
+            || object.kind() != ObjectKind::Endpoint
+            || capability.object() != object
+        {
+            return None;
+        }
+        Some(Self {
             key: RelationKey::Holds {
                 scope,
                 capability,
                 object,
             },
             state: RelationState::Holds { rights },
-        }
+        })
     }
 
-    pub const fn derives(
+    pub fn derives(
         scope: DomainProjectionToken,
         parent: CapabilityInstance,
         child: CapabilityInstance,
-    ) -> Self {
-        Self {
+    ) -> Option<Self> {
+        if child.domain() != scope || parent.object() != child.object() {
+            return None;
+        }
+        Some(Self {
             key: RelationKey::Derives {
                 scope,
                 parent,
                 child,
             },
             state: RelationState::Derives,
-        }
+        })
     }
 
     pub const fn key(self) -> RelationKey {
@@ -314,16 +364,12 @@ pub enum ReclaimOutcome {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ReclaimObservation {
     scope: DomainProjectionToken,
-    object: ObjectToken,
+    object: ObjectRef,
     outcome: ReclaimOutcome,
 }
 
 impl ReclaimObservation {
-    pub const fn new(
-        scope: DomainProjectionToken,
-        object: ObjectToken,
-        outcome: ReclaimOutcome,
-    ) -> Self {
+    pub fn new(scope: DomainProjectionToken, object: ObjectRef, outcome: ReclaimOutcome) -> Self {
         Self {
             scope,
             object,
@@ -336,6 +382,10 @@ impl ReclaimObservation {
     }
 
     pub const fn object(self) -> ObjectToken {
+        self.object.token()
+    }
+
+    pub const fn object_ref(self) -> ObjectRef {
         self.object
     }
 

--- a/kernel/crates/astrid-native-kernel/src/relations/types.rs
+++ b/kernel/crates/astrid-native-kernel/src/relations/types.rs
@@ -1,0 +1,354 @@
+//! Typed identities and rows for the private relation projection.
+
+use core::num::NonZeroU64;
+
+/// Rows visible in one page. This is a private protocol ceiling, not a
+/// configuration knob.
+pub const RELATION_PAGE_ROWS: usize = 16;
+/// Per-reader delta-ring ceiling. Losing older deltas is a resnapshot, never
+/// an extrapolation.
+pub const DELTA_RING_ENTRIES: usize = 32;
+/// Matches the landed native-domain slot count.
+pub const READER_SLOTS: usize = 2;
+pub(crate) const MAX_RELATION_ROWS: usize = 64;
+pub(crate) const MAX_OBJECT_OBSERVATIONS: usize = 16;
+
+/// Opaque, kernel-assigned domain projection identity.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct DomainProjectionToken(NonZeroU64);
+
+impl DomainProjectionToken {
+    pub(crate) const fn new(value: u64) -> Option<Self> {
+        match NonZeroU64::new(value) {
+            Some(value) => Some(Self(value)),
+            None => None,
+        }
+    }
+
+    pub const fn get(self) -> u64 {
+        self.0.get()
+    }
+}
+
+/// Caller-known capability-table slot in the landed eight-slot domain table.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct CapabilitySlot(u8);
+
+impl CapabilitySlot {
+    pub const fn try_new(value: usize) -> Option<Self> {
+        if value < 8 {
+            Some(Self(value as u8))
+        } else {
+            None
+        }
+    }
+
+    pub const fn index(self) -> usize {
+        self.0 as usize
+    }
+}
+
+/// Projection view of the landed, distinct capability-object generation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct CapabilityGeneration(NonZeroU64);
+
+impl CapabilityGeneration {
+    pub const fn new(value: u64) -> Option<Self> {
+        match NonZeroU64::new(value) {
+            Some(value) => Some(Self(value)),
+            None => None,
+        }
+    }
+
+    pub const fn get(self) -> u64 {
+        self.0.get()
+    }
+}
+
+/// Opaque kernel-assigned endpoint or domain object identity.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ObjectToken(NonZeroU64);
+
+impl ObjectToken {
+    pub const fn new(value: u64) -> Option<Self> {
+        match NonZeroU64::new(value) {
+            Some(value) => Some(Self(value)),
+            None => None,
+        }
+    }
+
+    pub const fn get(self) -> u64 {
+        self.0.get()
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ObjectKind {
+    Domain,
+    Endpoint,
+}
+
+/// Authority inputs that are not objects are represented only at this
+/// projection boundary and deliberately produce no relation row.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AuthorityObject {
+    Domain(ObjectToken),
+    Endpoint(ObjectToken),
+    Message,
+}
+
+impl AuthorityObject {
+    pub const fn relation_kind(self) -> Option<ObjectKind> {
+        match self {
+            Self::Domain(_) => Some(ObjectKind::Domain),
+            Self::Endpoint(_) => Some(ObjectKind::Endpoint),
+            Self::Message => None,
+        }
+    }
+
+    pub const fn token(self) -> Option<ObjectToken> {
+        match self {
+            Self::Domain(token) | Self::Endpoint(token) => Some(token),
+            Self::Message => None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ObjectRef {
+    kind: ObjectKind,
+    token: ObjectToken,
+}
+
+impl ObjectRef {
+    pub const fn new(kind: ObjectKind, token: ObjectToken) -> Self {
+        Self { kind, token }
+    }
+
+    pub const fn kind(self) -> ObjectKind {
+        self.kind
+    }
+
+    pub const fn token(self) -> ObjectToken {
+        self.token
+    }
+}
+
+/// Projection view of the landed rights bits. No relation-only right exists.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RelationRights(u16);
+
+impl RelationRights {
+    pub const SEND: Self = Self(1);
+    pub const RECV: Self = Self(2);
+    pub const GRANT: Self = Self(4);
+    pub const IDENTIFY: Self = Self(8);
+    pub(crate) const ALL_BITS: u16 = 15;
+
+    pub const fn from_landed(bits: u16) -> Option<Self> {
+        if bits & !Self::ALL_BITS == 0 && bits != 0 {
+            Some(Self(bits))
+        } else {
+            None
+        }
+    }
+
+    pub const fn bits(self) -> u16 {
+        self.0
+    }
+}
+
+/// Full exported capability-instance identity, including all three components
+/// needed to distinguish reuse across domains and object generations.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct CapabilityInstance {
+    domain: DomainProjectionToken,
+    slot: CapabilitySlot,
+    generation: CapabilityGeneration,
+}
+
+impl CapabilityInstance {
+    pub const fn new(
+        domain: DomainProjectionToken,
+        slot: CapabilitySlot,
+        generation: CapabilityGeneration,
+    ) -> Self {
+        Self {
+            domain,
+            slot,
+            generation,
+        }
+    }
+
+    pub const fn domain(self) -> DomainProjectionToken {
+        self.domain
+    }
+
+    pub const fn slot(self) -> CapabilitySlot {
+        self.slot
+    }
+
+    pub const fn generation(self) -> CapabilityGeneration {
+        self.generation
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum RelationKey {
+    Object {
+        scope: DomainProjectionToken,
+        object: ObjectRef,
+    },
+    Holds {
+        scope: DomainProjectionToken,
+        capability: CapabilityInstance,
+        object: ObjectRef,
+    },
+    Derives {
+        scope: DomainProjectionToken,
+        parent: CapabilityInstance,
+        child: CapabilityInstance,
+    },
+}
+
+impl RelationKey {
+    pub const fn scope(self) -> DomainProjectionToken {
+        match self {
+            Self::Object { scope, .. }
+            | Self::Holds { scope, .. }
+            | Self::Derives { scope, .. } => scope,
+        }
+    }
+
+    pub(crate) const fn object_tokens(self) -> [Option<ObjectToken>; 2] {
+        match self {
+            Self::Object { object, .. } => [Some(object.token()), None],
+            Self::Holds { object, .. } => [Some(object.token()), None],
+            Self::Derives { .. } => [None, None],
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RelationState {
+    Object,
+    Holds { rights: RelationRights },
+    Derives,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Relation {
+    key: RelationKey,
+    state: RelationState,
+}
+
+impl Relation {
+    pub const fn object(scope: DomainProjectionToken, object: ObjectRef) -> Self {
+        Self {
+            key: RelationKey::Object { scope, object },
+            state: RelationState::Object,
+        }
+    }
+
+    pub const fn holds(
+        scope: DomainProjectionToken,
+        capability: CapabilityInstance,
+        object: ObjectRef,
+        rights: RelationRights,
+    ) -> Self {
+        Self {
+            key: RelationKey::Holds {
+                scope,
+                capability,
+                object,
+            },
+            state: RelationState::Holds { rights },
+        }
+    }
+
+    pub const fn derives(
+        scope: DomainProjectionToken,
+        parent: CapabilityInstance,
+        child: CapabilityInstance,
+    ) -> Self {
+        Self {
+            key: RelationKey::Derives {
+                scope,
+                parent,
+                child,
+            },
+            state: RelationState::Derives,
+        }
+    }
+
+    pub const fn key(self) -> RelationKey {
+        self.key
+    }
+
+    pub const fn state(self) -> RelationState {
+        self.state
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RelationChange {
+    Upsert(Relation),
+    Delete(RelationKey),
+}
+
+impl RelationChange {
+    pub(crate) const fn key(self) -> RelationKey {
+        match self {
+            Self::Upsert(relation) => relation.key(),
+            Self::Delete(key) => key,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ReclaimOutcome {
+    ReleaseFailed,
+    ReclaimBlocked,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ReclaimObservation {
+    scope: DomainProjectionToken,
+    object: ObjectToken,
+    outcome: ReclaimOutcome,
+}
+
+impl ReclaimObservation {
+    pub const fn new(
+        scope: DomainProjectionToken,
+        object: ObjectToken,
+        outcome: ReclaimOutcome,
+    ) -> Self {
+        Self {
+            scope,
+            object,
+            outcome,
+        }
+    }
+
+    pub const fn scope(self) -> DomainProjectionToken {
+        self.scope
+    }
+
+    pub const fn object(self) -> ObjectToken {
+        self.object
+    }
+
+    pub const fn outcome(self) -> ReclaimOutcome {
+        self.outcome
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ProjectionError {
+    Denied,
+    NoSpace,
+    Resurrection,
+    ReaderSlotsExhausted,
+    ResnapshotRequired,
+}


### PR DESCRIPTION
## Linked Issue

Tracking #1758.

## Summary

Repair the private native-kernel relation projection so fold replays each visible batch in the same transactional order as authoritative row mutation: deletes before upserts within one projection-local epoch. A full-store UPSERT-then-DELETE batch at the fixed row ceiling now folds to the direct snapshot.

This remains kernel- and harness-private. It does not add a public ABI, WIT world, guest operation, relation-read right, or qualified-machine claim.

## Changes

- Replay each batch epoch as deletes-then-upserts, matching staged authoritative mutation, so an earlier UPSERT is funded by a later DELETE at `MAX_RELATION_ROWS`.
- Add a focused UPSERT-first/DELETE-at-capacity fold-equivalence regression proving the contiguous fold equals the direct snapshot.
- Keep page and delta cursors bound to domain slot, DomainGeneration, and the kernel-issued projection token.
- Keep Holds and Derives on full capability-instance identity, including object kind, with scoped constructor invariants.
- Keep logical-delete tombstones distinct from ReleaseFailed/ReclaimBlocked observations; reclaim remains projection-scoped.
- Keep the relations module private and production-compiled, with a documented module-local dead-code allowance until a later adapter lands.
- Integrate trunk-first onto live `os/universal` without rewriting exclusive paths or the disjoint #1691/#1766 slices.

## Verification

- Integration head: `3fd53bba309d2a0eff8a2c628808b3bfaf37bb09`
- First parent / base: `os/universal` `d39dacf78d128b2b25a833b53243a025e3dfb459`
- Second parent / repair: `de3cf8a42f8873c6d6c21c6a7749eaa7b6697048`
- Repair parent: `c790d439011b70ee55d189c6de9f335a8d700a52`
- `cargo test -p astrid-native-kernel --lib relations:: --locked`
- `cargo test -p astrid-native-kernel --lib --locked`
- `cargo fmt -p astrid-native-kernel -- --check`
- `cargo clippy -p astrid-native-kernel --target x86_64-unknown-none --locked -- -D warnings`

## AI / Tool Assistance

Assisted-by: Codex:GLM-5.3-Flash

Implementation of the private relation-projection fold-order repair, including focused tests, trunk-first integration, and local verification. Author reviewed the exclusive-path diff and validated with the commands above. Trivial formatting is not separately disclosed.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/{issue}.{kind}.md` (docs/CI-only may skip; release PRs roll fragments into the version section instead of adding one)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
