### PR TITLE
Add PIO journal identity and negative evidence

### DIFF
--- a/changes/1691.added.md
+++ b/changes/1691.added.md
@@ -1,5 +1,6 @@
 Added an isolated q35 isa-ide ATA PIO journal-media evidence harness.
 It proves dedicated-disk attachment, a 4736-byte authenticated round-trip
-across two boots, FLUSH CACHE EXT with guest read-back, and fail-closed
-torn recovery when the commit sector is omitted. This is not native-kernel
-selector wiring. Tracking #1691
+across two boots, IDENTIFY-serial binding, FLUSH CACHE EXT with guest
+read-back, and fail-closed host and emulator recovery negatives for torn,
+stale, forged, invalid, undersized, and cloned media. This is not
+native-kernel selector wiring. Tracking #1691

--- a/changes/1691.changed.md
+++ b/changes/1691.changed.md
@@ -1,0 +1,3 @@
+Bound the ATA IDENTIFY serial into the PIO journal-media MAC and added
+fail-closed host and emulator cases for forged, stale, torn, undersized,
+missing-device, and cloned media. Tracking #1691

--- a/kernel/tools/journal-media-evidence/README.md
+++ b/kernel/tools/journal-media-evidence/README.md
@@ -6,8 +6,11 @@ kernel medium claim, and not a ServiceDriver.
 
 The guest uses ATA PIO (`READ/WRITE SECTORS EXT` plus `FLUSH CACHE EXT`) to
 store a padded 4736-byte `ASTRABJ2` payload and a keyed HMAC-SHA-256 commit
-sector (`PIOJAUT2`). Recovery is fail-closed: frames without a matching commit
-are torn, never a candidate.
+sector (`PIOJAUT2`). The commit MAC binds the raw ATA IDENTIFY serial, the
+complete padded layout, commit metadata, and the fixture key. Recovery is
+fail-closed: a serial mismatch, forged frame, invalid metadata, wrong size,
+pending or invalid commit, or frames without a matching commit is never a
+candidate.
 
 ## Run
 
@@ -20,6 +23,18 @@ python3 scripts/run_qemu.py --name onesector
 python3 scripts/run_qemu.py --name recover --mode recover --reuse-journal target/qemu-runs/onesector/journal.img
 python3 scripts/run_qemu.py --name torn --crash before-commit --kill-after-serial "CRASH-BARRIER BEFORE-COMMIT"
 python3 scripts/run_qemu.py --name torn-recover --mode recover --reuse-journal target/qemu-runs/torn/journal.img
+python3 scripts/run_matrix.py
 ```
 
-QEMU artifacts under `target/qemu-runs/` are local evidence only.
+The QEMU journal disk uses the unique serial `PIO1691-JOURNAL-0001`. The named
+matrix records each observed serial and the SHA-256 of the journal image before
+and after each run. QEMU artifacts under `target/qemu-runs/` are local evidence
+only.
+
+## Claim boundary
+
+This harness is supporting q35/TCG UEFI emulator evidence only. It is not
+selector or native-kernel wiring, does not exercise KVM, does not qualify bare
+metal or physical power-loss behavior, and does not establish A/B recovery.
+Killing the emulator host process with `cache=none` and a guest write cache is
+not a physical power-loss oracle.

--- a/kernel/tools/journal-media-evidence/crates/pio-media-guest/src/main.rs
+++ b/kernel/tools/journal-media-evidence/crates/pio-media-guest/src/main.rs
@@ -12,9 +12,9 @@ use core::panic::PanicInfo;
 use core::ptr::{addr_of, addr_of_mut};
 
 use crate::media::{
-    CommitMetadata, FRAME_COUNT, KEY_ID, MEDIA_LEN, RECORD_LEN, RECORD_SECTORS, Recovery,
-    SECTOR_LEN, STATE_COMMITTED, auth::Authenticator, build_slot_record, canonical_payload,
-    parse_media,
+    CommitMetadata, DEVICE_SERIAL_LEN, FRAME_COUNT, KEY_ID, MEDIA_LEN, RECORD_LEN, RECORD_SECTORS,
+    Recovery, SECTOR_LEN, STATE_COMMITTED, auth::Authenticator, build_slot_record,
+    canonical_payload, parse_media,
 };
 
 const COMMAND_BASE: u16 = 0x1f0;
@@ -69,12 +69,12 @@ fn run() -> ! {
     uart_print(b"PIO1691 BOOT\n");
     load_fw_cfg();
     print_config();
-    identify_device();
+    let device_serial = identify_device();
     read_initial_media();
     let authenticator =
         Authenticator::new(*authenticator_key()).expect("external verifier key is nonzero");
     let fresh_floor = parse_floor();
-    let observed = match parse_media(media_map(), fresh_floor, &authenticator) {
+    let observed = match parse_media(media_map(), fresh_floor, &device_serial, &authenticator) {
         Ok(result) => result,
         Err(_) => guest_panic("media-size"),
     };
@@ -119,6 +119,7 @@ fn run() -> ! {
             epoch: next_epoch,
         },
         target_slot,
+        &device_serial,
         &authenticator,
     );
 
@@ -138,7 +139,7 @@ fn run() -> ! {
     write_commit_sector(target_slot);
     crash_before_commit_flush();
     pio_flush_cache_ext(b"commit");
-    verify_record_guest(&authenticator);
+    verify_record_guest(&authenticator, &device_serial);
     print_exact(&[b"PIO1691 ", b"ROUNDTRIP PASS\n"]);
     finish()
 }
@@ -222,7 +223,7 @@ fn read_back_frames_guest(slot: media::Slot) {
     }
 }
 
-fn verify_record_guest(authenticator: &Authenticator) {
+fn verify_record_guest(authenticator: &Authenticator, device_serial: &[u8; DEVICE_SERIAL_LEN]) {
     let mut observed = [0u8; MEDIA_LEN];
     let mut sector = [0u8; SECTOR_LEN];
     for slot in media::Slot::ALL {
@@ -233,7 +234,7 @@ fn verify_record_guest(authenticator: &Authenticator) {
             observed[destination..destination + SECTOR_LEN].copy_from_slice(&sector);
         }
     }
-    match parse_media(&observed, parse_floor(), authenticator) {
+    match parse_media(&observed, parse_floor(), device_serial, authenticator) {
         Ok(Recovery::Candidate { epoch, payload, .. }) if payload == canonical_payload() => {
             print_exact(&[b"GUEST-AUTH-CANDIDATE ", b"EPOCH="]);
             uart_hex(epoch);
@@ -243,7 +244,7 @@ fn verify_record_guest(authenticator: &Authenticator) {
     }
 }
 
-fn identify_device() {
+fn identify_device() -> [u8; DEVICE_SERIAL_LEN] {
     print_exact(&[b"GUEST-ATA ", b"IDENTIFY-BEGIN\n"]);
     let initial_status = wait_device_ready();
     print_hex_u64(b"GUEST-ATA INITIAL-STATUS=", u64::from(initial_status));
@@ -264,6 +265,15 @@ fn identify_device() {
         *word = read_u16(COMMAND_BASE);
     }
     wait_transfer_complete();
+    let mut device_serial = [0u8; DEVICE_SERIAL_LEN];
+    for (index, word) in words[10..10 + DEVICE_SERIAL_LEN / 2].iter().enumerate() {
+        device_serial[index * 2..index * 2 + 2].copy_from_slice(&word.to_be_bytes());
+    }
+    print_exact(&[b"GUEST-ATA IDENTIFY.SERIAL.TEXT=", b""]);
+    uart_print(trimmed_ascii(&device_serial));
+    print_exact(&[b"\nGUEST-ATA IDENTIFY.SERIAL.HEX=", b""]);
+    uart_hex_bytes(&device_serial);
+    uart_print(b"\n");
     print_hex_u64(b"GUEST-ATA IDENTIFY-WORD83=", u64::from(words[83]));
     print_hex_u64(b"GUEST-ATA IDENTIFY-WORD106=", u64::from(words[106]));
     if words[83] & (1 << 10) == 0 || words[83] & (1 << 13) == 0 {
@@ -273,6 +283,7 @@ fn identify_device() {
         b"GUEST-ATA IDENTIFY.DEVICE=0xEC ",
         b"SECTORS=512 LBA48=YES FLUSH=YES\n",
     ]);
+    device_serial
 }
 
 fn wait_device_ready() -> u8 {
@@ -595,6 +606,21 @@ fn print_zero_terminated(bytes: &[u8]) {
         .position(|byte| *byte == 0)
         .unwrap_or(bytes.len());
     uart_print(&bytes[..end]);
+}
+
+fn trimmed_ascii(bytes: &[u8]) -> &[u8] {
+    let end = bytes
+        .iter()
+        .position(|byte| *byte == 0 || *byte == b' ')
+        .unwrap_or(bytes.len());
+    &bytes[..end]
+}
+
+fn uart_hex_bytes(bytes: &[u8]) {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    for byte in bytes {
+        uart_print(&[HEX[(byte >> 4) as usize], HEX[(byte & 0x0f) as usize]]);
+    }
 }
 
 fn print_recovery(recovery: &Recovery) {

--- a/kernel/tools/journal-media-evidence/crates/pio-media-host/src/lib.rs
+++ b/kernel/tools/journal-media-evidence/crates/pio-media-host/src/lib.rs
@@ -6,27 +6,30 @@ pub mod media;
 #[cfg(test)]
 mod tests {
     use super::media::{
-        CommitMetadata, FRAME_COUNT, KEY_ID, MEDIA_LEN, RECORD_LEN, Recovery, STATE_COMMITTED,
-        Slot, TAG_OFFSET, auth::Authenticator, build_slot_record, canonical_payload, parse_media,
+        CommitMetadata, DEVICE_SERIAL_LEN, FRAME_COUNT, FRAME_LEN, KEY_ID, MEDIA_LEN, RECORD_LEN,
+        Recovery, SECTOR_LEN, STATE_COMMITTED, STATE_PENDING, Slot, TAG_OFFSET,
+        auth::Authenticator, build_slot_record, canonical_payload, parse_media,
     };
     use hmac::{Hmac, Mac};
     use sha2::Sha256;
 
     #[test]
-    fn hmac_is_standard_and_binds_layout_padding() {
+    fn hmac_is_standard_and_binds_serial_layout_padding() {
         let key = [7u8; 32];
         let authenticator = Authenticator::new(key).expect("key");
+        let device_serial = [b'S'; DEVICE_SERIAL_LEN];
         let mut padded_frames = vec![0u8; FRAME_COUNT * 512];
         padded_frames[0] = b'A';
         padded_frames[8191] = b'Z';
         let mut commit_header = [0u8; 64];
         commit_header[..KEY_ID.len()].copy_from_slice(KEY_ID);
 
-        let actual = authenticator.tag(&commit_header, &padded_frames);
+        let actual = authenticator.tag(&device_serial, &commit_header, &padded_frames);
         type HmacSha256 = Hmac<Sha256>;
         let mut mac = <HmacSha256 as Mac>::new_from_slice(&key).expect("valid key length");
         Mac::update(&mut mac, b"astrid.issue-1691.pio.journal.v1");
         Mac::update(&mut mac, KEY_ID);
+        Mac::update(&mut mac, &device_serial);
         Mac::update(&mut mac, &commit_header);
         Mac::update(&mut mac, &padded_frames);
         let expected: [u8; 32] = mac.finalize().into_bytes().into();
@@ -35,21 +38,10 @@ mod tests {
 
     #[test]
     fn build_slot_record_then_parse_media_yields_candidate() {
-        let key = [7u8; 32];
-        let authenticator = Authenticator::new(key).expect("key");
+        let context = TestContext::new();
         let payload = canonical_payload();
-        let record = build_slot_record(
-            &payload,
-            CommitMetadata {
-                state: STATE_COMMITTED,
-                epoch: 1001,
-            },
-            Slot::B,
-            &authenticator,
-        );
-        let mut media = [0u8; MEDIA_LEN];
-        media[RECORD_LEN..].copy_from_slice(&record);
-        match parse_media(&media, 1000, &authenticator) {
+        let media = context.committed_media(Slot::B, 1001);
+        match parse_media(&media, 1000, &context.serial, &context.authenticator) {
             Ok(Recovery::Candidate {
                 epoch,
                 slot,
@@ -72,51 +64,228 @@ mod tests {
     }
 
     #[test]
-    fn parse_rejects_frame0_as_hmac_header() {
-        let key = [7u8; 32];
-        let authenticator = Authenticator::new(key).expect("key");
-        let payload = canonical_payload();
-        let record = build_slot_record(
-            &payload,
+    fn stale_device_serial_fails_closed() {
+        let context = TestContext::new();
+        let media = context.committed_media(Slot::B, 1001);
+        let clone_serial = [b'C'; DEVICE_SERIAL_LEN];
+        expect_torn(
+            parse_media(&media, 1000, &clone_serial, &context.authenticator),
+            "authentication",
+        );
+    }
+
+    #[test]
+    fn forged_frame_fails_closed() {
+        let context = TestContext::new();
+        let mut media = context.committed_media(Slot::B, 1001);
+        media[Slot::B.index() * RECORD_LEN] ^= 1;
+        expect_torn(
+            parse_media(&media, 1000, &context.serial, &context.authenticator),
+            "authentication",
+        );
+    }
+
+    #[test]
+    fn same_epoch_records_conflict() {
+        let context = TestContext::new();
+        let mut media = context.committed_media(Slot::A, 1001);
+        media[RECORD_LEN..].copy_from_slice(&context.committed_record(Slot::B, 1001));
+        match parse_media(&media, 1000, &context.serial, &context.authenticator) {
+            Ok(Recovery::ConflictingSameEpoch { epoch }) => assert_eq!(epoch, 1001),
+            _ => panic!("equal epochs must not yield a candidate"),
+        }
+    }
+
+    #[test]
+    fn impossible_slot_order_fails_closed() {
+        let context = TestContext::new();
+        let mut media = context.committed_media(Slot::A, 1001);
+        media[RECORD_LEN..].copy_from_slice(&context.committed_record(Slot::B, u64::MAX));
+        expect_torn(
+            parse_media(&media, 1000, &context.serial, &context.authenticator),
+            "epoch-exhausted",
+        );
+    }
+
+    #[test]
+    fn reordered_slot_records_fail_closed() {
+        let context = TestContext::new();
+        let mut media = [0u8; MEDIA_LEN];
+        media[..RECORD_LEN].copy_from_slice(&context.committed_record(Slot::B, 1002));
+        media[RECORD_LEN..].copy_from_slice(&context.committed_record(Slot::A, 1001));
+        expect_torn(
+            parse_media(&media, 1000, &context.serial, &context.authenticator),
+            "layout-or-copy",
+        );
+    }
+
+    #[test]
+    fn undersized_media_fails_closed() {
+        let context = TestContext::new();
+        let media = vec![0u8; MEDIA_LEN - 1];
+        assert_eq!(
+            parse_media(&media, 1000, &context.serial, &context.authenticator),
+            Err("wrong-media-size")
+        );
+    }
+
+    #[test]
+    fn pending_commit_is_uncommitted_not_a_candidate() {
+        let context = TestContext::new();
+        let mut media = [0u8; MEDIA_LEN];
+        media[RECORD_LEN..].copy_from_slice(&context.signed_record(
             CommitMetadata {
-                state: STATE_COMMITTED,
+                state: STATE_PENDING,
                 epoch: 1001,
             },
             Slot::B,
-            &authenticator,
+        ));
+        match parse_media(&media, 1000, &context.serial, &context.authenticator) {
+            Ok(Recovery::Uncommitted { epoch }) => assert_eq!(epoch, 1001),
+            _ => panic!("pending commit must not yield a candidate"),
+        }
+    }
+
+    #[test]
+    fn invalidated_commit_leaves_no_candidate() {
+        let context = TestContext::new();
+        let mut media = context.committed_media(Slot::B, 1001);
+        let commit_start = RECORD_LEN + FRAME_COUNT * 512;
+        media[commit_start..commit_start + 8].copy_from_slice(super::media::INVALID_MAGIC);
+        media[commit_start + 15] = super::media::STATE_INVALIDATED;
+        expect_torn(
+            parse_media(&media, 1000, &context.serial, &context.authenticator),
+            "missing-commit",
         );
-        let frames = &record[..FRAME_COUNT * 512];
-        let commit = &record[FRAME_COUNT * 512..];
-        let wrong = authenticator.tag(&frames[..TAG_OFFSET], frames);
-        let stored: [u8; 32] = commit[TAG_OFFSET..TAG_OFFSET + 32].try_into().unwrap();
-        assert_ne!(wrong, stored);
-        let right = authenticator.tag(&commit[..TAG_OFFSET], frames);
-        assert_eq!(right, stored);
+    }
+
+    #[test]
+    fn authenticated_commit_padding_fails_closed() {
+        let context = TestContext::new();
+        for offset in [13, SECTOR_LEN - 1] {
+            let mut record = context.committed_record(Slot::B, 1001);
+            record[FRAME_COUNT * 512 + offset] ^= 1;
+            context.sign_record(&mut record);
+            let mut media = [0u8; MEDIA_LEN];
+            media[RECORD_LEN..].copy_from_slice(&record);
+            expect_torn(
+                parse_media(&media, 1000, &context.serial, &context.authenticator),
+                "commit-padding",
+            );
+        }
+    }
+
+    #[test]
+    fn forged_frame_boundary_fails_closed() {
+        let context = TestContext::new();
+        let mut media = context.committed_media(Slot::B, 1001);
+        let start = Slot::B.index() * RECORD_LEN;
+        media[start + FRAME_LEN - 1] ^= 1;
+        media[start + FRAME_LEN] ^= 1;
+        expect_torn(
+            parse_media(&media, 1000, &context.serial, &context.authenticator),
+            "authentication",
+        );
     }
 
     #[test]
     fn torn_frames_without_commit_are_not_candidates() {
-        let key = [7u8; 32];
-        let authenticator = Authenticator::new(key).expect("key");
-        let payload = canonical_payload();
-        let record = build_slot_record(
-            &payload,
-            CommitMetadata {
-                state: STATE_COMMITTED,
-                epoch: 1001,
-            },
-            Slot::B,
-            &authenticator,
-        );
+        let context = TestContext::new();
+        let record = context.committed_record(Slot::B, 1001);
         let mut media = [0u8; MEDIA_LEN];
         media[RECORD_LEN..RECORD_LEN + FRAME_COUNT * 512]
             .copy_from_slice(&record[..FRAME_COUNT * 512]);
-        match parse_media(&media, 1000, &authenticator) {
-            Ok(Recovery::Torn {
-                reason: "missing-commit",
-            }) => {},
-            Ok(Recovery::Candidate { .. }) => panic!("partial frames must not authenticate"),
-            Ok(Recovery::Torn { reason }) => panic!("unexpected torn: {reason}"),
+        expect_torn(
+            parse_media(&media, 1000, &context.serial, &context.authenticator),
+            "missing-commit",
+        );
+    }
+
+    #[test]
+    fn valid_record_below_floor_is_stale() {
+        let context = TestContext::new();
+        let media = context.committed_media(Slot::B, 1001);
+        match parse_media(&media, 1002, &context.serial, &context.authenticator) {
+            Ok(Recovery::StaleEpoch { found, floor }) => {
+                assert_eq!((found, floor), (1001, 1002));
+            },
+            _ => panic!("authenticated record below floor must be stale"),
+        }
+    }
+
+    #[test]
+    fn parse_rejects_frame0_as_hmac_header() {
+        let context = TestContext::new();
+        let record = context.committed_record(Slot::B, 1001);
+        let frames = &record[..FRAME_COUNT * 512];
+        let commit = &record[FRAME_COUNT * 512..];
+        let wrong = context
+            .authenticator
+            .tag(&context.serial, &frames[..TAG_OFFSET], frames);
+        let stored: [u8; 32] = commit[TAG_OFFSET..TAG_OFFSET + 32].try_into().unwrap();
+        assert_ne!(wrong, stored);
+        let right = context
+            .authenticator
+            .tag(&context.serial, &commit[..TAG_OFFSET], frames);
+        assert_eq!(right, stored);
+    }
+
+    struct TestContext {
+        authenticator: Authenticator,
+        serial: [u8; DEVICE_SERIAL_LEN],
+    }
+
+    impl TestContext {
+        fn new() -> Self {
+            Self {
+                authenticator: Authenticator::new([7u8; 32]).expect("key"),
+                serial: *b"PIO1691-JOURNAL-0001",
+            }
+        }
+
+        fn committed_record(&self, slot: Slot, epoch: u64) -> [u8; RECORD_LEN] {
+            self.signed_record(
+                CommitMetadata {
+                    state: STATE_COMMITTED,
+                    epoch,
+                },
+                slot,
+            )
+        }
+
+        fn signed_record(&self, metadata: CommitMetadata, slot: Slot) -> [u8; RECORD_LEN] {
+            build_slot_record(
+                &canonical_payload(),
+                metadata,
+                slot,
+                &self.serial,
+                &self.authenticator,
+            )
+        }
+
+        fn committed_media(&self, slot: Slot, epoch: u64) -> [u8; MEDIA_LEN] {
+            let mut media = [0u8; MEDIA_LEN];
+            let start = slot.index() * RECORD_LEN;
+            media[start..start + RECORD_LEN].copy_from_slice(&self.committed_record(slot, epoch));
+            media
+        }
+
+        fn sign_record(&self, record: &mut [u8; RECORD_LEN]) {
+            let commit_start = FRAME_COUNT * 512;
+            let tag = self.authenticator.tag(
+                &self.serial,
+                &record[commit_start..commit_start + TAG_OFFSET],
+                &record[..commit_start],
+            );
+            record[commit_start + TAG_OFFSET..commit_start + TAG_OFFSET + tag.len()]
+                .copy_from_slice(&tag);
+        }
+    }
+
+    fn expect_torn(result: Result<Recovery, &'static str>, expected: &'static str) {
+        match result {
+            Ok(Recovery::Torn { reason }) => assert_eq!(reason, expected),
+            Ok(Recovery::Candidate { .. }) => panic!("fail-closed result must not be a candidate"),
             Ok(Recovery::ConflictingSameEpoch { epoch }) => panic!("conflict {epoch}"),
             Ok(Recovery::Uncommitted { epoch }) => panic!("uncommitted {epoch}"),
             Ok(Recovery::StaleEpoch { found, floor }) => panic!("stale {found} {floor}"),

--- a/kernel/tools/journal-media-evidence/scripts/run_matrix.py
+++ b/kernel/tools/journal-media-evidence/scripts/run_matrix.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Repeatable evidence-only negative and crash matrix for the q35 harness."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+QEMU_RUNS = ROOT / "target" / "qemu-runs"
+RUNNER = ROOT / "scripts" / "run_qemu.py"
+JOURNAL_SERIAL = "PIO1691-JOURNAL-0001"
+CLONE_SERIAL = "PIO1691-CLONE-000001"
+
+
+def serial_evidence(serial_text: str) -> list[str]:
+    prefixes = (
+        "CRASH-BARRIER ",
+        "GUEST-ATA IDENTIFY.SERIAL.",
+        "GUEST-AUTH-CANDIDATE",
+        "PIO1691 ROUNDTRIP PASS",
+        "PIO1691 SUCCESS",
+        "PIO-GUEST-PANIC ",
+        "RECOVERY=",
+    )
+    return [
+        line
+        for line in serial_text.splitlines()
+        if line.startswith(prefixes)
+    ]
+
+
+def remove_run_dir(name: str) -> None:
+    shutil.rmtree(QEMU_RUNS / name, ignore_errors=True)
+
+
+def run_case(
+    name: str, *, preserve_run: bool = False, **arguments: str | Path | int | bool
+) -> dict[str, object]:
+    command = [sys.executable, str(RUNNER), "--name", name]
+    for key, value in arguments.items():
+        flag = "--" + key.replace("_", "-")
+        if value is True:
+            command.append(flag)
+            continue
+        if value is False:
+            continue
+        command.extend([flag, str(value)])
+
+    completed = subprocess.run(command, cwd=ROOT, check=False)
+    summary_path = QEMU_RUNS / name / "summary.json"
+    serial_path = QEMU_RUNS / name / "serial.log"
+    if not summary_path.exists() or not serial_path.exists():
+        raise AssertionError(f"{name}: runner did not produce evidence")
+
+    summary = json.loads(summary_path.read_text())
+    result: dict[str, object] = {
+        "name": name,
+        "runner_rc": completed.returncode,
+        "summary": summary,
+        "serial_evidence": serial_evidence(serial_path.read_text(errors="replace")),
+    }
+    expected_serial = "" if arguments.get("no_journal_device") else JOURNAL_SERIAL
+    if summary.get("journal_serial") != expected_serial:
+        result["serial_error"] = [
+            summary.get("journal_serial"),
+            "expected",
+            expected_serial,
+        ]
+    if not preserve_run:
+        remove_run_dir(name)
+    return result
+
+
+def require(result: dict[str, object], *keys: str) -> None:
+    summary = result["summary"]
+    assert isinstance(summary, dict)
+    name = result["name"]
+    for key in keys:
+        if not summary.get(key):
+            raise AssertionError(f"{name}: missing {key}: {summary}")
+
+
+def require_absent(result: dict[str, object], *keys: str) -> None:
+    summary = result["summary"]
+    assert isinstance(summary, dict)
+    name = result["name"]
+    for key in keys:
+        if summary.get(key):
+            raise AssertionError(f"{name}: unexpectedly set {key}: {summary}")
+
+
+def main() -> int:
+    if QEMU_RUNS.exists():
+        QEMU_RUNS.mkdir(exist_ok=True)
+    else:
+        QEMU_RUNS.mkdir(parents=True)
+    inputs = QEMU_RUNS / "matrix-inputs"
+    inputs.mkdir(exist_ok=True)
+    results: list[dict[str, object]] = []
+
+    try:
+        clean = run_case("clean-two-boot", preserve_run=True)
+        require(clean, "changed", "serial_ok", "auth_candidate", "roundtrip")
+        source = inputs / "clean.img"
+        shutil.copyfile(QEMU_RUNS / "clean-two-boot" / "journal.img", source)
+        remove_run_dir("clean-two-boot")
+        results.append(clean)
+
+        recover = run_case(
+            "recover", mode="recover", reuse_journal=source, keep_journal=True
+        )
+        require(recover, "serial_ok", "auth_candidate")
+        require_absent(recover, "changed", "panic")
+        results.append(recover)
+
+        for frame in (0, 8, 15):
+            crash = run_case(
+                f"crash-frame-{frame}",
+                preserve_run=True,
+                crash=f"frame:{frame}",
+                kill_after_serial=f"CRASH-BARRIER FRAME={frame:016x}",
+            )
+            assert crash["runner_rc"] == 137
+            require(crash, "serial_ok", "missing_commit")
+            require_absent(crash, "auth_candidate", "panic")
+            crashed = inputs / f"crash-frame-{frame}.img"
+            shutil.copyfile(QEMU_RUNS / f"crash-frame-{frame}" / "journal.img", crashed)
+            remove_run_dir(f"crash-frame-{frame}")
+            results.append(crash)
+
+            recovery = run_case(
+                f"crash-frame-{frame}-recover",
+                mode="recover",
+                reuse_journal=crashed,
+            )
+            require(recovery, "serial_ok", "torn")
+            require_absent(recovery, "auth_candidate", "panic")
+            results.append(recovery)
+
+        pre_commit = run_case(
+            "crash-pre-commit",
+            crash="before-commit",
+            kill_after_serial="CRASH-BARRIER BEFORE-COMMIT\n",
+        )
+        assert pre_commit["runner_rc"] == 137
+        require(pre_commit, "changed", "serial_ok", "missing_commit")
+        require_absent(pre_commit, "auth_candidate", "panic")
+        results.append(pre_commit)
+
+        pre_flush = run_case(
+            "crash-pre-flush",
+            crash="commit-flush-begin",
+            kill_after_serial="CRASH-BARRIER COMMIT-FLUSH-BEGIN\n",
+        )
+        assert pre_flush["runner_rc"] == 137
+        require(pre_flush, "changed", "serial_ok")
+        require_absent(pre_flush, "auth_candidate", "panic")
+        results.append(pre_flush)
+
+        forged = inputs / "forged.img"
+        shutil.copyfile(source, forged)
+        with forged.open("r+b") as handle:
+            handle.seek(0x11 * 512)
+            original = handle.read(1)
+            handle.seek(0x11 * 512)
+            handle.write(bytes([original[0] ^ 1]))
+        forged_case = run_case(
+            "negative-forged-byte",
+            mode="recover",
+            reuse_journal=forged,
+        )
+        require(forged_case, "serial_ok", "torn")
+        require_absent(forged_case, "auth_candidate", "panic")
+        results.append(forged_case)
+
+        stale_floor = run_case(
+            "negative-stale-floor",
+            mode="recover",
+            reuse_journal=source,
+            floor="1002",
+        )
+        require(stale_floor, "serial_ok", "stale", "panic")
+        require_absent(stale_floor, "auth_candidate")
+        results.append(stale_floor)
+
+        clone = run_case(
+            "negative-cloned-old-media",
+            mode="recover",
+            reuse_journal=source,
+            journal_serial=CLONE_SERIAL,
+        )
+        require(clone, "torn")
+        require_absent(clone, "auth_candidate", "panic")
+        summary = clone["summary"]
+        assert isinstance(summary, dict)
+        assert summary["journal_serial"] == CLONE_SERIAL
+        results.append(clone)
+
+        missing_device = run_case("negative-missing-device", no_journal_device=True)
+        require(missing_device, "panic")
+        require_absent(missing_device, "auth_candidate", "success_line")
+        results.append(missing_device)
+
+        wrong_size = run_case("negative-wrong-size", journal_bytes=16384)
+        require(wrong_size, "panic")
+        require_absent(wrong_size, "auth_candidate", "success_line")
+        results.append(wrong_size)
+    finally:
+        report = {
+            "claim_boundary": "q35/TCG emulator evidence only; not physical power-loss qualification",
+            "cases": results,
+        }
+        (QEMU_RUNS / "matrix-results.json").write_text(
+            json.dumps(report, indent=2) + "\n"
+        )
+        shutil.rmtree(inputs, ignore_errors=True)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/kernel/tools/journal-media-evidence/scripts/run_matrix.py
+++ b/kernel/tools/journal-media-evidence/scripts/run_matrix.py
@@ -14,6 +14,11 @@ QEMU_RUNS = ROOT / "target" / "qemu-runs"
 RUNNER = ROOT / "scripts" / "run_qemu.py"
 JOURNAL_SERIAL = "PIO1691-JOURNAL-0001"
 CLONE_SERIAL = "PIO1691-CLONE-000001"
+RUNNER_SUCCESS = 0
+RUNNER_TORN_RECOVERY = 33
+RUNNER_GUEST_PANIC = 67
+HOST_PROCESS_KILL = 137
+RUNNER_TIMEOUT = 124
 
 
 def serial_evidence(serial_text: str) -> list[str]:
@@ -38,7 +43,11 @@ def remove_run_dir(name: str) -> None:
 
 
 def run_case(
-    name: str, *, preserve_run: bool = False, **arguments: str | Path | int | bool
+    name: str,
+    *,
+    expected_runner_rc: int,
+    preserve_run: bool = False,
+    **arguments: str | Path | int | bool,
 ) -> dict[str, object]:
     command = [sys.executable, str(RUNNER), "--name", name]
     for key, value in arguments.items():
@@ -57,19 +66,31 @@ def run_case(
         raise AssertionError(f"{name}: runner did not produce evidence")
 
     summary = json.loads(summary_path.read_text())
+    runner_rc = completed.returncode
+    if runner_rc == RUNNER_TIMEOUT:
+        raise AssertionError(f"{name}: runner timed out")
+    if runner_rc != expected_runner_rc:
+        raise AssertionError(
+            f"{name}: runner rc {runner_rc}, expected {expected_runner_rc}"
+        )
     result: dict[str, object] = {
         "name": name,
-        "runner_rc": completed.returncode,
+        "runner_rc": runner_rc,
         "summary": summary,
         "serial_evidence": serial_evidence(serial_path.read_text(errors="replace")),
     }
-    expected_serial = "" if arguments.get("no_journal_device") else JOURNAL_SERIAL
+    expected_serial = (
+        ""
+        if arguments.get("no_journal_device")
+        else str(arguments.get("journal_serial", JOURNAL_SERIAL))
+    )
     if summary.get("journal_serial") != expected_serial:
         result["serial_error"] = [
             summary.get("journal_serial"),
             "expected",
             expected_serial,
         ]
+        raise AssertionError(f"{name}: serial mismatch: {result['serial_error']}")
     if not preserve_run:
         remove_run_dir(name)
     return result
@@ -103,7 +124,11 @@ def main() -> int:
     results: list[dict[str, object]] = []
 
     try:
-        clean = run_case("clean-two-boot", preserve_run=True)
+        clean = run_case(
+            "clean-two-boot",
+            expected_runner_rc=RUNNER_SUCCESS,
+            preserve_run=True,
+        )
         require(clean, "changed", "serial_ok", "auth_candidate", "roundtrip")
         source = inputs / "clean.img"
         shutil.copyfile(QEMU_RUNS / "clean-two-boot" / "journal.img", source)
@@ -111,7 +136,11 @@ def main() -> int:
         results.append(clean)
 
         recover = run_case(
-            "recover", mode="recover", reuse_journal=source, keep_journal=True
+            "recover",
+            expected_runner_rc=RUNNER_SUCCESS,
+            mode="recover",
+            reuse_journal=source,
+            keep_journal=True,
         )
         require(recover, "serial_ok", "auth_candidate")
         require_absent(recover, "changed", "panic")
@@ -120,11 +149,11 @@ def main() -> int:
         for frame in (0, 8, 15):
             crash = run_case(
                 f"crash-frame-{frame}",
+                expected_runner_rc=HOST_PROCESS_KILL,
                 preserve_run=True,
                 crash=f"frame:{frame}",
                 kill_after_serial=f"CRASH-BARRIER FRAME={frame:016x}",
             )
-            assert crash["runner_rc"] == 137
             require(crash, "serial_ok", "missing_commit")
             require_absent(crash, "auth_candidate", "panic")
             crashed = inputs / f"crash-frame-{frame}.img"
@@ -134,6 +163,7 @@ def main() -> int:
 
             recovery = run_case(
                 f"crash-frame-{frame}-recover",
+                expected_runner_rc=RUNNER_TORN_RECOVERY,
                 mode="recover",
                 reuse_journal=crashed,
             )
@@ -143,20 +173,20 @@ def main() -> int:
 
         pre_commit = run_case(
             "crash-pre-commit",
+            expected_runner_rc=HOST_PROCESS_KILL,
             crash="before-commit",
             kill_after_serial="CRASH-BARRIER BEFORE-COMMIT\n",
         )
-        assert pre_commit["runner_rc"] == 137
         require(pre_commit, "changed", "serial_ok", "missing_commit")
         require_absent(pre_commit, "auth_candidate", "panic")
         results.append(pre_commit)
 
         pre_flush = run_case(
             "crash-pre-flush",
+            expected_runner_rc=HOST_PROCESS_KILL,
             crash="commit-flush-begin",
             kill_after_serial="CRASH-BARRIER COMMIT-FLUSH-BEGIN\n",
         )
-        assert pre_flush["runner_rc"] == 137
         require(pre_flush, "changed", "serial_ok")
         require_absent(pre_flush, "auth_candidate", "panic")
         results.append(pre_flush)
@@ -170,6 +200,7 @@ def main() -> int:
             handle.write(bytes([original[0] ^ 1]))
         forged_case = run_case(
             "negative-forged-byte",
+            expected_runner_rc=RUNNER_TORN_RECOVERY,
             mode="recover",
             reuse_journal=forged,
         )
@@ -179,6 +210,7 @@ def main() -> int:
 
         stale_floor = run_case(
             "negative-stale-floor",
+            expected_runner_rc=RUNNER_GUEST_PANIC,
             mode="recover",
             reuse_journal=source,
             floor="1002",
@@ -189,23 +221,32 @@ def main() -> int:
 
         clone = run_case(
             "negative-cloned-old-media",
+            expected_runner_rc=RUNNER_TORN_RECOVERY,
             mode="recover",
             reuse_journal=source,
             journal_serial=CLONE_SERIAL,
         )
-        require(clone, "torn")
+        require(clone, "serial_ok", "torn")
         require_absent(clone, "auth_candidate", "panic")
         summary = clone["summary"]
         assert isinstance(summary, dict)
         assert summary["journal_serial"] == CLONE_SERIAL
         results.append(clone)
 
-        missing_device = run_case("negative-missing-device", no_journal_device=True)
+        missing_device = run_case(
+            "negative-missing-device",
+            expected_runner_rc=RUNNER_GUEST_PANIC,
+            no_journal_device=True,
+        )
         require(missing_device, "panic")
         require_absent(missing_device, "auth_candidate", "success_line")
         results.append(missing_device)
 
-        wrong_size = run_case("negative-wrong-size", journal_bytes=16384)
+        wrong_size = run_case(
+            "negative-wrong-size",
+            expected_runner_rc=RUNNER_GUEST_PANIC,
+            journal_bytes=16384,
+        )
         require(wrong_size, "panic")
         require_absent(wrong_size, "auth_candidate", "success_line")
         results.append(wrong_size)

--- a/kernel/tools/journal-media-evidence/scripts/run_qemu.py
+++ b/kernel/tools/journal-media-evidence/scripts/run_qemu.py
@@ -18,6 +18,7 @@ OVMF = Path("/opt/homebrew/share/qemu/edk2-x86_64-code.fd")
 QEMU = Path("/opt/homebrew/bin/qemu-system-x86_64")
 TIMEOUT_S = 90
 JOURNAL_BYTES = 1024 * 1024
+JOURNAL_SERIAL = "PIO1691-JOURNAL-0001"
 DEBUG_SUCCESS = 33
 DEBUG_PANIC = 67
 
@@ -72,6 +73,9 @@ def main() -> int:
     parser.add_argument("--reuse-journal", type=Path)
     parser.add_argument("--keep-journal", action="store_true")
     parser.add_argument("--kill-after-serial")
+    parser.add_argument("--journal-serial", default=JOURNAL_SERIAL)
+    parser.add_argument("--journal-bytes", type=int, default=JOURNAL_BYTES)
+    parser.add_argument("--no-journal-device", action="store_true")
     args = parser.parse_args()
 
     root = Path(__file__).resolve().parents[1]
@@ -100,7 +104,7 @@ def main() -> int:
     if args.reuse_journal:
         shutil.copyfile(args.reuse_journal, journal)
     else:
-        journal.write_bytes(b"\x00" * JOURNAL_BYTES)
+        journal.write_bytes(b"\x00" * args.journal_bytes)
 
     before = sha256(journal)
     (run_dir / "journal.before.sha").write_text(f"{before}  {journal}\n")
@@ -134,12 +138,6 @@ def main() -> int:
         f"if=none,id=root,format=raw,file={root_img}",
         "-device",
         "ide-hd,drive=root",
-        "-drive",
-        f"if=none,id=journal,format=raw,file={journal},readonly=off,cache=none",
-        "-device",
-        "isa-ide,id=astrid-pio",
-        "-device",
-        "ide-hd,bus=astrid-pio.0,drive=journal,unit=0,write-cache=on",
         "-fw_cfg",
         f"name=opt/astrid.pio.key,file={key}",
         "-fw_cfg",
@@ -149,6 +147,18 @@ def main() -> int:
         "-fw_cfg",
         f"name=opt/astrid.pio.crash,file={run_dir / 'crash.txt'}",
     ]
+    if not args.no_journal_device:
+        qemu_cmd.extend(
+            [
+                "-drive",
+                f"if=none,id=journal,format=raw,file={journal},readonly=off,cache=none",
+                "-device",
+                "isa-ide,id=astrid-pio",
+                "-device",
+                "ide-hd,bus=astrid-pio.0,drive=journal,unit=0,write-cache=on,"
+                f"serial={args.journal_serial}",
+            ]
+        )
     (run_dir / "qemu.cmd").write_text(" ".join(qemu_cmd) + "\n")
 
     if qmp.exists():
@@ -193,6 +203,10 @@ def main() -> int:
     after = sha256(journal)
     (run_dir / "journal.after.sha").write_text(f"{after}  {journal}\n")
     serial_text = serial.read_text(errors="replace") if serial.exists() else ""
+    marker = "GUEST-ATA IDENTIFY.SERIAL.TEXT="
+    observed_serial = (
+        serial_text.split(marker, 1)[1].splitlines()[0] if marker in serial_text else ""
+    )
     summary = {
         "name": args.name,
         "mode": args.mode,
@@ -202,10 +216,21 @@ def main() -> int:
         "before": before,
         "after": after,
         "changed": before != after,
-        "lba11": sector_head(journal, 0x11).hex(),
-        "lba11_nonzero": nonzero_count(journal, 0x11),
-        "lba21": sector_head(journal, 0x21).hex(),
-        "lba21_nonzero": nonzero_count(journal, 0x21),
+        "journal_serial": observed_serial,
+        "serial_ok": observed_serial == args.journal_serial,
+        **(
+            {
+                "lba11": sector_head(journal, 0x11).hex(),
+                "lba11_nonzero": nonzero_count(journal, 0x11),
+                "lba21": sector_head(journal, 0x21).hex(),
+                "lba21_nonzero": nonzero_count(journal, 0x21),
+            }
+            if journal.stat().st_size >= 0x22 * 512
+            else {}
+        ),
+        "torn": "RECOVERY=TORN" in serial_text,
+        "missing_commit": "RECOVERY=TORN REASON=missing-commit" in serial_text,
+        "stale": "RECOVERY=STALE" in serial_text,
         "success_line": "PIO1691 SUCCESS" in serial_text,
         "auth_candidate": "GUEST-AUTH-CANDIDATE" in serial_text,
         "roundtrip": "ROUNDTRIP PASS" in serial_text,
@@ -213,7 +238,12 @@ def main() -> int:
     }
     (run_dir / "summary.json").write_text(json.dumps(summary, indent=2) + "\n")
     print(json.dumps(summary))
-    if rc == DEBUG_SUCCESS and summary["success_line"]:
+    if (
+        rc == DEBUG_SUCCESS
+        and summary["success_line"]
+        and summary["serial_ok"]
+        and summary["auth_candidate"]
+    ):
         return 0
     if rc == 124:
         return 124

--- a/kernel/tools/journal-media-evidence/shared/media.rs
+++ b/kernel/tools/journal-media-evidence/shared/media.rs
@@ -11,6 +11,7 @@ pub const MAGIC: &[u8; 8] = b"ASTRABJ2";
 pub const COMMIT_MAGIC: &[u8; 8] = b"PIOJAUT2";
 pub const INVALID_MAGIC: &[u8; 8] = b"PIOJINV2";
 pub const KEY_ID: &[u8; 16] = b"PIO1691-KEY-0001";
+pub const DEVICE_SERIAL_LEN: usize = 20;
 pub const STATE_PENDING: u8 = 1;
 pub const STATE_INVALIDATED: u8 = 0;
 pub const STATE_COMMITTED: u8 = 2;
@@ -74,7 +75,7 @@ fn get_u64(bytes: &[u8]) -> u64 {
 }
 
 pub mod auth {
-    use super::KEY_ID;
+    use super::{DEVICE_SERIAL_LEN, KEY_ID};
 
     pub const KEY_LEN: usize = 32;
     pub const TAG_LEN: usize = 32;
@@ -95,9 +96,14 @@ pub mod auth {
             }
         }
 
-        /// HMAC-SHA-256 over the exact commit header (through its tag field)
-        /// plus every byte of the sixteen 512-byte padded frame sectors.
-        pub fn tag(&self, media_header: &[u8], padded_payload: &[u8]) -> Tag {
+        /// HMAC-SHA-256 over the raw ATA IDENTIFY serial, the exact commit
+        /// header (through its tag field), and every padded frame sector.
+        pub fn tag(
+            &self,
+            device_serial: &[u8; DEVICE_SERIAL_LEN],
+            media_header: &[u8],
+            padded_payload: &[u8],
+        ) -> Tag {
             let mut inner = Sha256::new();
             let mut ipad = [0x36u8; 64];
             for (pad_byte, key_byte) in ipad.iter_mut().zip(self.key.iter()) {
@@ -106,6 +112,7 @@ pub mod auth {
             inner.update(&ipad);
             inner.update(DOMAIN);
             inner.update(KEY_ID);
+            inner.update(device_serial);
             inner.update(media_header);
             inner.update(padded_payload);
             let inner_digest = inner.finalize();
@@ -270,6 +277,7 @@ pub mod auth {
 use auth::{Authenticator, tags_equal};
 
 #[allow(clippy::large_enum_variant)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Recovery {
     Candidate {
         epoch: u64,
@@ -314,6 +322,7 @@ pub fn build_slot_record(
     payload: &[u8; PAYLOAD_LEN],
     metadata: CommitMetadata,
     slot: Slot,
+    device_serial: &[u8; DEVICE_SERIAL_LEN],
     authenticator: &Authenticator,
 ) -> [u8; RECORD_LEN] {
     let mut record = [0; RECORD_LEN];
@@ -338,6 +347,7 @@ pub fn build_slot_record(
     // The authenticator sees the complete on-media representation, including
     // each sector's trailing padding and the copy identity.
     let tag = authenticator.tag(
+        device_serial,
         &record[start..start + TAG_OFFSET],
         &record[..FRAME_COUNT * SECTOR_LEN],
     );
@@ -348,6 +358,7 @@ pub fn build_slot_record(
 pub fn parse_media(
     media: &[u8],
     fresh_floor: u64,
+    device_serial: &[u8; DEVICE_SERIAL_LEN],
     authenticator: &Authenticator,
 ) -> Result<Recovery, &'static str> {
     if media.len() < MEDIA_LEN || !media.len().is_multiple_of(SECTOR_LEN) {
@@ -410,6 +421,7 @@ pub fn parse_media(
         // Authenticator binds the commit header through TAG_OFFSET plus the
         // sixteen padded frame sectors, matching `build_slot_record`.
         let expected = authenticator.tag(
+            device_serial,
             &commit[..TAG_OFFSET],
             &media[base..base + FRAME_COUNT * SECTOR_LEN],
         );
@@ -421,6 +433,11 @@ pub fn parse_media(
         }
         if state == STATE_PENDING {
             return Ok(Recovery::Uncommitted { epoch });
+        }
+        if epoch == u64::MAX {
+            return Ok(Recovery::Torn {
+                reason: "epoch-exhausted",
+            });
         }
         if state != STATE_COMMITTED {
             return Ok(Recovery::Torn { reason: "state" });


### PR DESCRIPTION
## Linked Issue

Tracking #1691

This draft tracks the isolated emulator journal-media evidence slice. It does not close the campaign issue.

## Summary

Bind the ATA IDENTIFY serial into the authenticated journal MAC, expand the fail-closed host-negative matrix, and add an evidence-only q35/TCG UEFI crash and recovery matrix for the dedicated second raw disk.

## Changes

- Bind the ATA IDENTIFY serial into the journal MAC and set a unique serial on the QEMU journal disk.
- Add fail-closed host cases for stale serial, forged content, same-epoch conflict, impossible epoch, reordered records, wrong size, pending and invalid commits, padding, frame boundaries, missing commits, and stale floors.
- Add an evidence-only q35/TCG UEFI matrix for two-boot recovery, frame crash points, pre-commit and pre-flush kills, forged bytes, stale floors, cloned media on another serial, missing device, and undersized media.
- Record observed serial plus journal SHA-256 before and after each QEMU case and prune local run directories.

## Verification

- `cargo fmt --all --check`
- `cargo test -p pio-media-host --locked`
- `cargo +1.95.0 build -p pio-media-guest --profile guest --target x86_64-unknown-uefi --locked`
- `cargo +1.95.0 build -p pio-media-host --bin build-fat --locked`
- `python3 scripts/run_matrix.py`

This is supporting emulator evidence only. It does not wire the selector or native kernel, exercise KVM, qualify physical durability or power loss, or establish A/B recovery. Same-device restoration of an older image remains recovery authorization work.

## AI / Tool Assistance

Assisted-by: Codex: GLM-5.3-Flash

Codex drafted the isolated journal-media evidence updates, host-negative tests, and emulator matrix. The submitter reviewed the IDENTIFY-serial MAC binding, fail-closed cases, claim boundary, signed ancestry, and local matrix evidence before opening this draft.
