### PR TITLE
fix(kernel): retain verified generation admission

### DIFF
--- a/changes/1766.fixed.md
+++ b/changes/1766.fixed.md
@@ -1,6 +1,6 @@
-Ring 0 retains the verified System Generation identity after canonical
-manifest verification, derives native component admission from the verified
-component set, and privately binds manifest and component identities to each
-domain handle generation. Stale or substituted admission identities fail
-closed. This is identity-retention and admission evidence only, not returning
+Ring 0 consumes one verifier-owned admitted generation after canonical
+manifest verification. Component admission and each native domain handle
+generation derive from that same manifest/component tuple; reclamation marks
+the adapter record stale, and substituted admission identities fail closed.
+This is identity-retention and admission evidence only, not returning
 lifecycle or publication evidence. Refs #1766

--- a/changes/1766.fixed.md
+++ b/changes/1766.fixed.md
@@ -1,0 +1,6 @@
+Ring 0 retains the verified System Generation identity after canonical
+manifest verification, derives native component admission from the verified
+component set, and privately binds manifest and component identities to each
+domain handle generation. Stale or substituted admission identities fail
+closed. This is identity-retention and admission evidence only, not returning
+lifecycle or publication evidence. Refs #1766

--- a/kernel/crates/astrid-native-kernel/src/closure.rs
+++ b/kernel/crates/astrid-native-kernel/src/closure.rs
@@ -10,12 +10,12 @@ use astrid_native_closure::{
     verify_policy_handoff, verify_table,
 };
 use astrid_system_generation::emulator_fixture::{
-    EMULATOR_CLOSURE_ROOT, EMULATOR_COMPONENT_LEN as FIXTURE_COMPONENT_LEN,
-    EMULATOR_GENERATION_FLOOR, EMULATOR_MANIFEST_SIZES, EMULATOR_NOW_UNIX_SECONDS,
-    EMULATOR_OBJECT_ROOT, EMULATOR_PLAN_DIGEST, emulator_components,
+    EMULATOR_CLOSURE_ROOT, EMULATOR_GENERATION_FLOOR, EMULATOR_MANIFEST_SIZES,
+    EMULATOR_NOW_UNIX_SECONDS, EMULATOR_OBJECT_ROOT, EMULATOR_PLAN_DIGEST, emulator_components,
 };
 use astrid_system_generation::{
     ContentId, Generation, GenerationError, MANIFEST_LEN, TrustedInput, TrustedInputData,
+    VerifiedGeneration,
 };
 use bootloader_api::BootInfo;
 use bootloader_api::info::LoaderHandoffVerification;
@@ -43,7 +43,6 @@ const _: () = {
 pub const RAMDISK_BUNDLE_LEN: usize =
     HANDOFF_LEN + TABLE_LEN + MANIFEST_LEN + EMULATOR_COMPONENT_LEN;
 
-const _: () = assert!(EMULATOR_COMPONENT_LEN == FIXTURE_COMPONENT_LEN);
 const _: () = assert!(EMULATOR_COMPONENT_LEN == 517);
 
 /// Emulator fixture root public key corresponding to the explicit root seed
@@ -76,6 +75,35 @@ pub struct AcceptedClosure {
     component_payload: [u8; EMULATOR_COMPONENT_LEN],
 }
 
+/// A verified generation and the one component admitted from its component
+/// set. This is the only ring-0 bridge between manifest verification and
+/// native-domain admission; its fields stay private so a handle can never be
+/// relabeled after admission.
+#[derive(Clone, Copy)]
+pub struct AdmittedGeneration {
+    verified: VerifiedGeneration,
+    component: ComponentBytes,
+    component_id: ContentId,
+}
+
+impl AdmittedGeneration {
+    pub const fn verified_generation(&self) -> VerifiedGeneration {
+        self.verified
+    }
+
+    pub const fn manifest_identity(&self) -> astrid_system_generation::ManifestIdentity {
+        self.verified.manifest_identity()
+    }
+
+    pub const fn component(&self) -> &ComponentBytes {
+        &self.component
+    }
+
+    pub const fn component_id(&self) -> ContentId {
+        self.component_id
+    }
+}
+
 impl AcceptedClosure {
     pub const fn handoff(&self) -> AuthenticatedPolicyHandoff {
         self.handoff
@@ -98,14 +126,21 @@ impl AcceptedClosure {
     }
 }
 
-pub fn bind_component(bytes: &[u8; EMULATOR_COMPONENT_LEN]) -> bool {
+pub fn admit_component(
+    verified: VerifiedGeneration,
+    bytes: &[u8; EMULATOR_COMPONENT_LEN],
+) -> Result<AdmittedGeneration, ClosureError> {
     let identity = ContentId::from_payload(bytes);
-    let components = emulator_components();
+    let components = verified.manifest().components();
     if components.count() != 1 || components.digest(0) != Some(identity) {
-        return false;
+        return Err(ClosureError::BindingMismatch);
     }
     *AUTHENTICATED_COMPONENT.lock() = Some(*bytes);
-    true
+    Ok(AdmittedGeneration {
+        verified,
+        component: *bytes,
+        component_id: identity,
+    })
 }
 
 pub fn authenticated_component() -> ComponentBytes {

--- a/kernel/crates/astrid-native-kernel/src/domains/admission.rs
+++ b/kernel/crates/astrid-native-kernel/src/domains/admission.rs
@@ -1,0 +1,169 @@
+//! Private binding from verified generation identity to native domains.
+
+use spin::Mutex;
+
+use astrid_system_generation::{ContentId, ManifestIdentity};
+
+use super::manager;
+#[cfg(not(test))]
+use super::types::Scenario;
+use super::types::{DomainHandle, SLOT_CAPACITY};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum AdmissionError {
+    Unverified,
+    AlreadyInstalled,
+    ComponentMismatch,
+    UnknownDomain,
+    SubstitutedIdentity,
+    StaleDomain,
+}
+
+impl AdmissionError {
+    pub(crate) const fn as_reason(self) -> &'static str {
+        match self {
+            Self::Unverified => "unverified_generation",
+            Self::AlreadyInstalled => "generation_already_installed",
+            Self::ComponentMismatch => "admission_component_mismatch",
+            Self::UnknownDomain => "unknown_admitted_domain",
+            Self::SubstitutedIdentity => "substituted_generation_identity",
+            Self::StaleDomain => "stale_admitted_domain",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct AdmittedIdentity {
+    manifest_identity: ManifestIdentity,
+    component_id: ContentId,
+}
+
+#[derive(Clone, Copy)]
+struct AdmissionRecord {
+    handle: DomainHandle,
+    identity: AdmittedIdentity,
+}
+
+#[derive(Clone, Copy)]
+struct AdmissionState {
+    identity: Option<AdmittedIdentity>,
+    records: [Option<AdmissionRecord>; SLOT_CAPACITY],
+}
+
+impl AdmissionState {
+    const fn new() -> Self {
+        Self {
+            identity: None,
+            records: [None; SLOT_CAPACITY],
+        }
+    }
+
+    fn install(
+        &mut self,
+        manifest_identity: ManifestIdentity,
+        component_id: ContentId,
+    ) -> Result<(), AdmissionError> {
+        if self.identity.is_some() {
+            return Err(AdmissionError::AlreadyInstalled);
+        }
+        self.identity = Some(AdmittedIdentity {
+            manifest_identity,
+            component_id,
+        });
+        Ok(())
+    }
+
+    fn expected(&self, component_id: ContentId) -> Result<AdmittedIdentity, AdmissionError> {
+        let identity = self.identity.ok_or(AdmissionError::Unverified)?;
+        if identity.component_id != component_id {
+            return Err(AdmissionError::ComponentMismatch);
+        }
+        Ok(identity)
+    }
+
+    fn record(&mut self, handle: DomainHandle, expected: AdmittedIdentity) {
+        let slot = handle.id().0 as usize;
+        if slot < SLOT_CAPACITY {
+            self.records[slot] = Some(AdmissionRecord {
+                handle,
+                identity: expected,
+            });
+        }
+    }
+
+    fn bound_identity(
+        &self,
+        handle: DomainHandle,
+        component_id: ContentId,
+    ) -> Result<ManifestIdentity, AdmissionError> {
+        let expected = self.expected(component_id)?;
+        let slot = handle.id().0 as usize;
+        if slot >= SLOT_CAPACITY {
+            return Err(AdmissionError::UnknownDomain);
+        }
+        let Some(record) = self.records[slot] else {
+            return Err(AdmissionError::UnknownDomain);
+        };
+        if record.handle != handle || record.identity != expected {
+            return Err(AdmissionError::SubstitutedIdentity);
+        }
+        Ok(record.identity.manifest_identity)
+    }
+}
+
+static ADMISSIONS: Mutex<AdmissionState> = Mutex::new(AdmissionState::new());
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum PrepareError {
+    Admission(AdmissionError),
+    Domain(manager::PrepareError),
+}
+
+impl PrepareError {
+    pub(crate) const fn as_reason(self) -> &'static str {
+        match self {
+            Self::Admission(error) => error.as_reason(),
+            Self::Domain(error) => error.as_reason(),
+        }
+    }
+}
+
+#[cfg(not(test))]
+pub(crate) fn install(
+    manifest_identity: ManifestIdentity,
+    component_id: ContentId,
+) -> Result<(), AdmissionError> {
+    let mut state = ADMISSIONS.lock();
+    state.records = [None; SLOT_CAPACITY];
+    state.install(manifest_identity, component_id)
+}
+
+#[cfg(not(test))]
+pub(crate) fn prepare(
+    raw: &[u8],
+    expected_identity: ContentId,
+    scenario: Scenario,
+) -> Result<DomainHandle, PrepareError> {
+    let expected = ADMISSIONS
+        .lock()
+        .expected(expected_identity)
+        .map_err(PrepareError::Admission)?;
+    let handle =
+        manager::prepare(raw, expected_identity, scenario).map_err(PrepareError::Domain)?;
+    ADMISSIONS.lock().record(handle, expected);
+    Ok(handle)
+}
+
+#[cfg(not(test))]
+pub(crate) fn confirm_start(
+    handle: DomainHandle,
+    expected_identity: ContentId,
+) -> Result<ManifestIdentity, AdmissionError> {
+    let manifest_identity = ADMISSIONS
+        .lock()
+        .bound_identity(handle, expected_identity)?;
+    if manager::is_stale(handle) {
+        return Err(AdmissionError::StaleDomain);
+    }
+    Ok(manifest_identity)
+}

--- a/kernel/crates/astrid-native-kernel/src/domains/admission.rs
+++ b/kernel/crates/astrid-native-kernel/src/domains/admission.rs
@@ -5,9 +5,13 @@ use spin::Mutex;
 use astrid_system_generation::{ContentId, ManifestIdentity};
 
 use super::manager;
+use super::types::{DomainHandle, SLOT_CAPACITY};
+
+#[cfg(not(test))]
+use crate::closure::AdmittedGeneration;
+
 #[cfg(not(test))]
 use super::types::Scenario;
-use super::types::{DomainHandle, SLOT_CAPACITY};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum AdmissionError {
@@ -33,24 +37,29 @@ impl AdmissionError {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) struct AdmittedIdentity {
-    manifest_identity: ManifestIdentity,
-    component_id: ContentId,
+pub(crate) struct AdmittedIdentity<G, C> {
+    manifest_identity: G,
+    component_id: C,
 }
 
 #[derive(Clone, Copy)]
-struct AdmissionRecord {
+struct AdmissionRecord<G, C> {
     handle: DomainHandle,
-    identity: AdmittedIdentity,
+    identity: AdmittedIdentity<G, C>,
+    live: bool,
 }
 
 #[derive(Clone, Copy)]
-struct AdmissionState {
-    identity: Option<AdmittedIdentity>,
-    records: [Option<AdmissionRecord>; SLOT_CAPACITY],
+struct AdmissionState<G, C> {
+    identity: Option<AdmittedIdentity<G, C>>,
+    records: [Option<AdmissionRecord<G, C>>; SLOT_CAPACITY],
 }
 
-impl AdmissionState {
+impl<G, C> AdmissionState<G, C>
+where
+    G: Copy + PartialEq,
+    C: Copy + PartialEq,
+{
     const fn new() -> Self {
         Self {
             identity: None,
@@ -58,11 +67,7 @@ impl AdmissionState {
         }
     }
 
-    fn install(
-        &mut self,
-        manifest_identity: ManifestIdentity,
-        component_id: ContentId,
-    ) -> Result<(), AdmissionError> {
+    fn install(&mut self, manifest_identity: G, component_id: C) -> Result<(), AdmissionError> {
         if self.identity.is_some() {
             return Err(AdmissionError::AlreadyInstalled);
         }
@@ -73,7 +78,7 @@ impl AdmissionState {
         Ok(())
     }
 
-    fn expected(&self, component_id: ContentId) -> Result<AdmittedIdentity, AdmissionError> {
+    fn expected(&self, component_id: C) -> Result<AdmittedIdentity<G, C>, AdmissionError> {
         let identity = self.identity.ok_or(AdmissionError::Unverified)?;
         if identity.component_id != component_id {
             return Err(AdmissionError::ComponentMismatch);
@@ -81,21 +86,18 @@ impl AdmissionState {
         Ok(identity)
     }
 
-    fn record(&mut self, handle: DomainHandle, expected: AdmittedIdentity) {
+    fn record(&mut self, handle: DomainHandle, expected: AdmittedIdentity<G, C>) {
         let slot = handle.id().0 as usize;
         if slot < SLOT_CAPACITY {
             self.records[slot] = Some(AdmissionRecord {
                 handle,
                 identity: expected,
+                live: true,
             });
         }
     }
 
-    fn bound_identity(
-        &self,
-        handle: DomainHandle,
-        component_id: ContentId,
-    ) -> Result<ManifestIdentity, AdmissionError> {
+    fn bound_identity(&self, handle: DomainHandle, component_id: C) -> Result<G, AdmissionError> {
         let expected = self.expected(component_id)?;
         let slot = handle.id().0 as usize;
         if slot >= SLOT_CAPACITY {
@@ -107,11 +109,25 @@ impl AdmissionState {
         if record.handle != handle || record.identity != expected {
             return Err(AdmissionError::SubstitutedIdentity);
         }
+        if !record.live {
+            return Err(AdmissionError::StaleDomain);
+        }
         Ok(record.identity.manifest_identity)
+    }
+
+    fn release(&mut self, handle: DomainHandle) {
+        let slot = handle.id().0 as usize;
+        if let Some(record) = self.records.get_mut(slot).and_then(Option::as_mut)
+            && record.handle == handle
+            && record.live
+        {
+            record.live = false;
+        }
     }
 }
 
-static ADMISSIONS: Mutex<AdmissionState> = Mutex::new(AdmissionState::new());
+static ADMISSIONS: Mutex<AdmissionState<ManifestIdentity, ContentId>> =
+    Mutex::new(AdmissionState::new());
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum PrepareError {
@@ -129,10 +145,9 @@ impl PrepareError {
 }
 
 #[cfg(not(test))]
-pub(crate) fn install(
-    manifest_identity: ManifestIdentity,
-    component_id: ContentId,
-) -> Result<(), AdmissionError> {
+pub(crate) fn install(admitted: &AdmittedGeneration) -> Result<(), AdmissionError> {
+    let manifest_identity = admitted.manifest_identity();
+    let component_id = admitted.component_id();
     let mut state = ADMISSIONS.lock();
     state.records = [None; SLOT_CAPACITY];
     state.install(manifest_identity, component_id)
@@ -166,4 +181,119 @@ pub(crate) fn confirm_start(
         return Err(AdmissionError::StaleDomain);
     }
     Ok(manifest_identity)
+}
+
+#[cfg(not(test))]
+pub(crate) fn release(handle: DomainHandle) {
+    ADMISSIONS.lock().release(handle);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::types::{DomainGeneration, DomainHandle, DomainId, SLOT_CAPACITY};
+    use super::{AdmissionError, AdmissionState, AdmittedIdentity};
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    struct TestGeneration(u8);
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    struct TestComponent(u8);
+
+    const GENERATION_A: TestGeneration = TestGeneration(1);
+    const GENERATION_B: TestGeneration = TestGeneration(2);
+    const COMPONENT_A: TestComponent = TestComponent(3);
+    const COMPONENT_B: TestComponent = TestComponent(4);
+
+    fn handle(slot: u64, generation: u64) -> DomainHandle {
+        DomainHandle::new(DomainId(slot), DomainGeneration(generation))
+    }
+
+    fn installed() -> AdmissionState<TestGeneration, TestComponent> {
+        let mut state = AdmissionState::new();
+        state.install(GENERATION_A, COMPONENT_A).unwrap();
+        state
+    }
+
+    #[test]
+    fn unverified_component_and_reinstall_are_rejected() {
+        let mut state = AdmissionState::new();
+        assert_eq!(state.expected(COMPONENT_A), Err(AdmissionError::Unverified));
+        state.install(GENERATION_A, COMPONENT_A).unwrap();
+        assert_eq!(
+            state.install(GENERATION_B, COMPONENT_B),
+            Err(AdmissionError::AlreadyInstalled)
+        );
+    }
+
+    #[test]
+    fn cross_generation_component_is_rejected() {
+        let state = installed();
+        assert_eq!(
+            state.expected(COMPONENT_B),
+            Err(AdmissionError::ComponentMismatch)
+        );
+    }
+
+    #[test]
+    fn unknown_or_substituted_handle_is_rejected() {
+        let mut state = installed();
+        assert_eq!(
+            state.bound_identity(handle(0, 1), COMPONENT_A),
+            Err(AdmissionError::UnknownDomain)
+        );
+        state.record(handle(0, 1), state.expected(COMPONENT_A).unwrap());
+        assert_eq!(
+            state.bound_identity(handle(0, 2), COMPONENT_A),
+            Err(AdmissionError::SubstitutedIdentity)
+        );
+        assert_eq!(
+            state.bound_identity(handle(1, 1), COMPONENT_A),
+            Err(AdmissionError::UnknownDomain)
+        );
+    }
+
+    #[test]
+    fn split_record_tuple_is_rejected() {
+        let mut state = installed();
+        state.record(
+            handle(0, 1),
+            AdmittedIdentity {
+                manifest_identity: GENERATION_B,
+                component_id: COMPONENT_A,
+            },
+        );
+        assert_eq!(
+            state.bound_identity(handle(0, 1), COMPONENT_A),
+            Err(AdmissionError::SubstitutedIdentity)
+        );
+    }
+
+    #[test]
+    fn released_handle_is_stale() {
+        let mut state = installed();
+        state.record(handle(0, 1), state.expected(COMPONENT_A).unwrap());
+        state.release(handle(0, 1));
+        assert_eq!(
+            state.bound_identity(handle(0, 1), COMPONENT_A),
+            Err(AdmissionError::StaleDomain)
+        );
+    }
+
+    #[test]
+    fn release_preserves_other_slots_and_ignores_substitutes() {
+        let mut state = AdmissionState::new();
+        state.install(GENERATION_A, COMPONENT_A).unwrap();
+        state.record(handle(0, 1), state.expected(COMPONENT_A).unwrap());
+        state.record(handle(1, 2), state.expected(COMPONENT_A).unwrap());
+        state.release(handle(0, 2));
+        assert_eq!(
+            state.bound_identity(handle(0, 1), COMPONENT_A),
+            Ok(GENERATION_A)
+        );
+        assert_eq!(
+            state.bound_identity(handle(1, 2), COMPONENT_A),
+            Ok(GENERATION_A)
+        );
+        assert!(SLOT_CAPACITY >= 2);
+    }
 }

--- a/kernel/crates/astrid-native-kernel/src/domains/harness.rs
+++ b/kernel/crates/astrid-native-kernel/src/domains/harness.rs
@@ -5,6 +5,7 @@ use core::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use astrid_system_generation::ContentId;
 use astrid_system_generation::emulator_fixture::EMULATOR_COMPONENT_LEN;
 
+use super::admission;
 use super::manager::{self, CancelError, DomainIdentity, PrepareError};
 use super::types::{BindError, ComponentImage, DomainGeneration, DomainHandle, DomainId};
 use super::types::{Outcome, Scenario};
@@ -101,6 +102,8 @@ fn fail(reason: &'static str) -> ! {
 }
 
 fn start_domain(handle: DomainHandle, scenario: Scenario) -> ! {
+    admission::confirm_start(handle, authenticated_component_id())
+        .unwrap_or_else(|error| fail(error.as_reason()));
     if let Err(error) = manager::start(handle, scenario) {
         fail(error.as_reason());
     }
@@ -108,7 +111,7 @@ fn start_domain(handle: DomainHandle, scenario: Scenario) -> ! {
 }
 
 fn prepare_domain(raw: &[u8], expected: ContentId, scenario: Scenario) -> DomainHandle {
-    match manager::prepare(raw, expected, scenario) {
+    match admission::prepare(raw, expected, scenario) {
         Ok(handle) => handle,
         Err(error) => fail(error.as_reason()),
     }

--- a/kernel/crates/astrid-native-kernel/src/domains/manager.rs
+++ b/kernel/crates/astrid-native-kernel/src/domains/manager.rs
@@ -906,6 +906,7 @@ impl Manager {
                     freed,
                     expected - freed,
                 );
+                super::admission::release(handle);
                 true
             }
         };

--- a/kernel/crates/astrid-native-kernel/src/domains/mod.rs
+++ b/kernel/crates/astrid-native-kernel/src/domains/mod.rs
@@ -3,6 +3,7 @@
 #[cfg(not(test))]
 use x86_64::registers::control::Cr3;
 
+mod admission;
 #[cfg(not(test))]
 mod harness;
 mod manager;
@@ -21,7 +22,17 @@ pub fn bind_kernel_cr3() {
 }
 
 #[cfg(not(test))]
-pub fn start_harness(raw: &[u8], expected: astrid_system_generation::ContentId) -> ! {
+pub fn start_harness(
+    raw: &[u8],
+    manifest_identity: astrid_system_generation::ManifestIdentity,
+    expected: astrid_system_generation::ContentId,
+) -> ! {
+    admission::install(manifest_identity, expected).unwrap_or_else(|error| {
+        crate::serial::ev_domain_auth_reject(error.as_reason());
+        crate::serial::ev_domain_harness(false);
+        crate::serial::ev_halt(false);
+        crate::serial::exit_qemu(false);
+    });
     manager::init_resume_stack();
     harness::start(raw, expected)
 }

--- a/kernel/crates/astrid-native-kernel/src/domains/mod.rs
+++ b/kernel/crates/astrid-native-kernel/src/domains/mod.rs
@@ -22,19 +22,23 @@ pub fn bind_kernel_cr3() {
 }
 
 #[cfg(not(test))]
-pub fn start_harness(
-    raw: &[u8],
-    manifest_identity: astrid_system_generation::ManifestIdentity,
-    expected: astrid_system_generation::ContentId,
-) -> ! {
-    admission::install(manifest_identity, expected).unwrap_or_else(|error| {
+pub fn start_harness(raw: &[u8], admitted: &crate::closure::AdmittedGeneration) -> ! {
+    if astrid_system_generation::ContentId::from_payload(raw) != admitted.component_id() {
+        crate::serial::ev_domain_auth_reject(
+            crate::domains::admission::AdmissionError::ComponentMismatch.as_reason(),
+        );
+        crate::serial::ev_domain_harness(false);
+        crate::serial::ev_halt(false);
+        crate::serial::exit_qemu(false);
+    }
+    admission::install(admitted).unwrap_or_else(|error| {
         crate::serial::ev_domain_auth_reject(error.as_reason());
         crate::serial::ev_domain_harness(false);
         crate::serial::ev_halt(false);
         crate::serial::exit_qemu(false);
     });
     manager::init_resume_stack();
-    harness::start(raw, expected)
+    harness::start(raw, admitted.component_id())
 }
 
 #[cfg(not(test))]

--- a/kernel/crates/astrid-native-kernel/src/main.rs
+++ b/kernel/crates/astrid-native-kernel/src/main.rs
@@ -162,9 +162,7 @@ fn kernel_main(boot_info: &'static mut BootInfo) -> ! {
         memory::reserve_live_page_tables();
         domains::bind_kernel_cr3();
         let component = *admitted.component();
-        let component_id = admitted.component_id();
-        let manifest_identity = admitted.manifest_identity();
-        domains::start_harness(&component, manifest_identity, component_id);
+        domains::start_harness(&component, &admitted);
     }
     serial::ev_halt(wx_ok && tests_ok);
     serial::exit_qemu(wx_ok && tests_ok);

--- a/kernel/crates/astrid-native-kernel/src/main.rs
+++ b/kernel/crates/astrid-native-kernel/src/main.rs
@@ -70,6 +70,7 @@ fn kernel_main(boot_info: &'static mut BootInfo) -> ! {
     interrupts::init_idt();
     serial::ev_idt_ready(interrupts::EXCEPTION_VECTORS);
 
+    let admitted;
     match closure::accept(boot_info) {
         Ok(accepted) => {
             // Keep descriptor bytes independent of the loader-owned mapping;
@@ -93,15 +94,27 @@ fn kernel_main(boot_info: &'static mut BootInfo) -> ! {
                     serial::exit_qemu(false);
                 },
             };
-            if let Err(err) = verify_manifest(&descriptor, &trusted) {
-                serial::ev_closure_reject(err.as_reason());
-                serial::ev_halt(false);
-                serial::exit_qemu(false);
-            }
-            // The executable component is admitted only after its kernel copy
-            // matches the authenticated component set. Keep this gate ahead of
-            // every success-bound closure event.
-            if !closure::bind_component(accepted.component()) {
+            let verified = match verify_manifest(&descriptor, &trusted) {
+                Ok(verified) => verified,
+                Err(err) => {
+                    serial::ev_closure_reject(err.as_reason());
+                    serial::ev_halt(false);
+                    serial::exit_qemu(false)
+                },
+            };
+            // Admission consumes the verifier-owned generation, not fixture
+            // constants. Keep this gate ahead of every success-bound event.
+            admitted = match closure::admit_component(verified, accepted.component()) {
+                Ok(admitted) => admitted,
+                Err(err) => {
+                    serial::ev_closure_reject(err.as_reason());
+                    serial::ev_halt(false);
+                    serial::exit_qemu(false)
+                },
+            };
+            if admitted.verified_generation().signer()
+                != accepted.handoff().policy().sysgen_verify()
+            {
                 serial::ev_closure_reject(
                     astrid_native_closure::ClosureError::BindingMismatch.as_reason(),
                 );
@@ -148,9 +161,10 @@ fn kernel_main(boot_info: &'static mut BootInfo) -> ! {
     if wx_ok && tests_ok {
         memory::reserve_live_page_tables();
         domains::bind_kernel_cr3();
-        let component = closure::authenticated_component();
-        let component_id = closure::authenticated_component_id();
-        domains::start_harness(&component, component_id);
+        let component = *admitted.component();
+        let component_id = admitted.component_id();
+        let manifest_identity = admitted.manifest_identity();
+        domains::start_harness(&component, manifest_identity, component_id);
     }
     serial::ev_halt(wx_ok && tests_ok);
     serial::exit_qemu(wx_ok && tests_ok);


### PR DESCRIPTION
## Summary

Ring 0 now retains `VerifiedGeneration` and its opaque `ManifestIdentity` after canonical manifest verification. Native start consumes one verifier-owned admitted generation, derives component admission from that same verified component set, and privately binds the manifest/component tuple to each admitted domain handle and generation.

The start boundary also checks the component payload against the admitted tuple before adapter installation. Reclamation marks the adapter record stale, and stale, substituted, or component-mismatched admission identities fail closed before domain start or user entry. Ring 0 remains outside `astrid-init-plan`.

This is identity-retention and admission evidence only. It is not evidence of a returning lifecycle, publication, retirement, reboot reconstruction, selector persistence, or a production publication oracle.

## Verification

- `cargo fmt -p astrid-native-kernel -- --check`
- `cargo clippy -p astrid-native-kernel --target x86_64-unknown-none --locked -- -D warnings`
- `cargo test -p astrid-native-kernel --lib --locked`
- Focused QEMU run passed deterministic image comparison, full serial assertions, tampered-descriptor fail-before-entry, and plan-mismatch rejection with exit 35.
- QEMU used explicit TCG; KVM, virtio, and IOMMU were not selected.

## Test Plan

- Verify the canonical manifest and retain its verifier-owned generation.
- Derive and admit the sole native component from that same verified tuple.
- Check the start payload against the admitted component before adapter installation.
- Reconfirm the admitted identity before every domain start.
- Reject missing, duplicate, mismatched, substituted, and stale admission state.
- Keep existing descriptor tamper and plan-mismatch negative paths green.

Tracking #1766