### PR TITLE
feat(package-service): add registry-neutral lifecycle contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -775,6 +775,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "astrid-package-service"
+version = "0.10.4"
+dependencies = [
+ "blake3",
+ "thiserror 2.0.20",
+]
+
+[[package]]
 name = "astrid-prelude"
 version = "0.10.4"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "crates/astrid-emit",
     "crates/astrid-crypto",
     "crates/astrid-events",
+    "crates/astrid-package-service",
     "crates/astrid-types",
     "crates/astrid-gateway",
     "crates/astrid-hooks",

--- a/changes/1750.added.md
+++ b/changes/1750.added.md
@@ -22,3 +22,14 @@ tombstone semantics.
 Lifecycle contexts and drain plans are bound to the exact canonical state, zero
 binding digests are rejected at construction boundaries, and the shared
 identity, receipt, and lifecycle types are available to internal consumers.
+
+Each slot now retains a durable package-generation high-watermark beside its
+canonical state and journal. Every accepted lifecycle transition advances the
+watermark with overflow-checked arithmetic, including drain, terminal, expiry,
+recovery, and collection outcomes, so removal never resets the slot and
+reinstall cannot reuse or skip a generation.
+
+Install and update now use one authority-bound commit plan that binds the exact
+content root, provenance, artifact, manifest, lifecycle plan, expected state,
+and drain plan. Staging and commit require the same immutable plan, while
+activate, deactivate, and remove retain exact canonical-state binding.

--- a/changes/1750.added.md
+++ b/changes/1750.added.md
@@ -3,3 +3,12 @@ state model. Canonical state and its authoritative operation journal share one
 slot value, with full authority-context binding, expected-state transitions,
 bounded drain and recovery behavior, replayable receipts, finite retention and
 capacity policy, and domain-separated deterministic digests. Closes #1750
+
+Update success now requires structural proof of the new canonical state,
+including its completing operation, post-commit lifecycle, artifact and
+manifest bindings, authority record, and resulting generation. Abort, expiry,
+and old-state recovery preserve prior content while forcing an inactive
+lifecycle and monotonic package generation. Lifecycle contexts and drain plans
+are bound to the exact canonical state, zero binding digests are rejected at
+construction boundaries, and the shared identity, receipt, and lifecycle types
+are available to internal consumers.

--- a/changes/1750.added.md
+++ b/changes/1750.added.md
@@ -8,10 +8,11 @@ Update success now requires structural proof of the new canonical state,
 including its completing operation, post-commit lifecycle, artifact and
 manifest bindings, authority record, and resulting generation. Abort, expiry,
 and old-state recovery preserve prior content while forcing an inactive
-lifecycle and the exact next package generation. The recorded drain deadline
-blocks proof, completion, and late replacement recovery; explicit expiry or
-recovery may restore old content or prove absence. An observed-state recovery
-boundary validates every retained binding and accepts only the exact successor.
+lifecycle and the exact successor of the current drain boundary. Each proof
+advances that boundary monotonically. The recorded drain deadline blocks
+proof, completion, and late replacement recovery; explicit expiry or recovery
+may restore old content or prove absence. An observed-state recovery boundary
+validates every retained binding and accepts only the exact successor.
 Lifecycle contexts and drain plans are bound to the exact canonical state, zero
 binding digests are rejected at construction boundaries, and the shared
 identity, receipt, and lifecycle types are available to internal consumers.

--- a/changes/1750.added.md
+++ b/changes/1750.added.md
@@ -1,0 +1,5 @@
+Add a private package-lifecycle contract and pure executable owner/package
+state model. Canonical state and its authoritative operation journal share one
+slot value, with full authority-context binding, expected-state transitions,
+bounded drain and recovery behavior, replayable receipts, finite retention and
+capacity policy, and domain-separated deterministic digests. Closes #1750

--- a/changes/1750.added.md
+++ b/changes/1750.added.md
@@ -13,6 +13,12 @@ advances that boundary monotonically. The recorded drain deadline blocks
 proof, completion, and late replacement recovery; explicit expiry or recovery
 may restore old content or prove absence. An observed-state recovery boundary
 validates every retained binding and accepts only the exact successor.
+Install and update recovery is bound to the exact staged content and
+provenance before the uncertain boundary. Removal absence recovery requires
+the recorded removal drain and exact successor-generation proof. Outcome
+evidence outside the selected terminal shape fails closed, and successful
+recovery clears stale drain lineage while retaining its terminal receipt or
+tombstone semantics.
 Lifecycle contexts and drain plans are bound to the exact canonical state, zero
 binding digests are rejected at construction boundaries, and the shared
 identity, receipt, and lifecycle types are available to internal consumers.

--- a/changes/1750.added.md
+++ b/changes/1750.added.md
@@ -8,7 +8,10 @@ Update success now requires structural proof of the new canonical state,
 including its completing operation, post-commit lifecycle, artifact and
 manifest bindings, authority record, and resulting generation. Abort, expiry,
 and old-state recovery preserve prior content while forcing an inactive
-lifecycle and monotonic package generation. Lifecycle contexts and drain plans
-are bound to the exact canonical state, zero binding digests are rejected at
-construction boundaries, and the shared identity, receipt, and lifecycle types
-are available to internal consumers.
+lifecycle and the exact next package generation. The recorded drain deadline
+blocks proof, completion, and late replacement recovery; explicit expiry or
+recovery may restore old content or prove absence. An observed-state recovery
+boundary validates every retained binding and accepts only the exact successor.
+Lifecycle contexts and drain plans are bound to the exact canonical state, zero
+binding digests are rejected at construction boundaries, and the shared
+identity, receipt, and lifecycle types are available to internal consumers.

--- a/crates/astrid-package-service/Cargo.toml
+++ b/crates/astrid-package-service/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "astrid-package-service"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+publish = false
+
+[dependencies]
+blake3.workspace = true
+thiserror.workspace = true

--- a/crates/astrid-package-service/Cargo.toml
+++ b/crates/astrid-package-service/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 rust-version.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 blake3.workspace = true
 thiserror.workspace = true

--- a/crates/astrid-package-service/src/authority.rs
+++ b/crates/astrid-package-service/src/authority.rs
@@ -98,17 +98,19 @@ pub struct AuthenticatedAuthority(AuthorityDecision);
 
 impl AuthenticatedAuthority {
     /// Binds issuer evidence to the canonical context digest.
-    #[must_use]
     pub fn bind(
         context: &OperationContext,
         issuer: AuthorityIssuer,
         evidence: Blake3Digest,
-    ) -> Self {
-        Self(AuthorityDecision {
+    ) -> PackageServiceResult<Self> {
+        if evidence.as_bytes() == &[0; 32] {
+            return Err(PackageServiceError::AuthorityIssuerRejected);
+        }
+        Ok(Self(AuthorityDecision {
             issuer,
             context_digest: *context.digest(),
             evidence,
-        })
+        }))
     }
 
     pub(crate) fn decision_digest(&self) -> AuthorityDecisionDigest {

--- a/crates/astrid-package-service/src/authority.rs
+++ b/crates/astrid-package-service/src/authority.rs
@@ -1,0 +1,157 @@
+use crate::context::{
+    AdmittedService, ApproverIdentity, AuthenticatedIngress, Operation, OperationContext,
+};
+use crate::digest::{AuthorityDecisionDigest, Blake3Digest, ContextDigest, DigestWriter};
+use crate::error::{PackageServiceError, PackageServiceResult};
+use crate::identity::AuthorityIssuerIdentity;
+
+/// Verified issuer class of an authority decision.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AuthorityIssuerClass {
+    /// Automatic authority limited to this runtime's build identity.
+    RuntimeBuildPolicy,
+    /// An authenticated principal's explicit approval.
+    ExplicitApproval,
+    /// An authenticated operator distribution channel.
+    OperatorDistribution,
+    /// One-way preservation bridge for an already verified installed state.
+    VerifiedLegacyMigration,
+}
+
+/// Verified issuer and channel evidence.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct AuthorityIssuer {
+    class: AuthorityIssuerClass,
+    identity: AuthorityIssuerIdentity,
+    channel: AuthorityIssuerIdentity,
+    channel_evidence: Blake3Digest,
+}
+
+impl AuthorityIssuer {
+    /// Constructs a verified issuer from the authority boundary.
+    pub fn new(
+        class: AuthorityIssuerClass,
+        identity: AuthorityIssuerIdentity,
+        channel: AuthorityIssuerIdentity,
+        channel_evidence: Blake3Digest,
+    ) -> PackageServiceResult<Self> {
+        if identity.as_bytes() == &[0; 32]
+            || channel.as_bytes() == &[0; 32]
+            || channel_evidence.as_bytes() == &[0; 32]
+        {
+            return Err(PackageServiceError::AuthorityIssuerRejected);
+        }
+        Ok(Self {
+            class,
+            identity,
+            channel,
+            channel_evidence,
+        })
+    }
+
+    pub(crate) const fn class(&self) -> AuthorityIssuerClass {
+        self.class
+    }
+
+    pub(crate) fn write(&self, writer: &mut DigestWriter) {
+        writer.tag(match self.class {
+            AuthorityIssuerClass::RuntimeBuildPolicy => 1,
+            AuthorityIssuerClass::ExplicitApproval => 2,
+            AuthorityIssuerClass::OperatorDistribution => 3,
+            AuthorityIssuerClass::VerifiedLegacyMigration => 4,
+        });
+        writer.bytes(self.identity.as_bytes());
+        writer.bytes(self.channel.as_bytes());
+        writer.digest(&self.channel_evidence);
+    }
+}
+
+/// Authority evidence bound to one complete canonical context.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct AuthorityDecision {
+    issuer: AuthorityIssuer,
+    context_digest: ContextDigest,
+    evidence: Blake3Digest,
+}
+
+impl AuthorityDecision {
+    /// Returns the exact context digest covered by this decision.
+    #[must_use]
+    pub const fn context_digest(&self) -> &ContextDigest {
+        &self.context_digest
+    }
+
+    /// Computes the canonical decision digest retained by installed state.
+    #[must_use]
+    pub fn digest(&self) -> AuthorityDecisionDigest {
+        let mut writer = DigestWriter::new();
+        self.issuer.write(&mut writer);
+        writer.digest(&self.context_digest);
+        writer.digest(&self.evidence);
+        writer.finish("astrid.package.authority-decision.v1")
+    }
+}
+
+/// A decision that has passed this model's exact-binding checks.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct AuthenticatedAuthority(AuthorityDecision);
+
+impl AuthenticatedAuthority {
+    /// Binds issuer evidence to the canonical context digest.
+    #[must_use]
+    pub fn bind(
+        context: &OperationContext,
+        issuer: AuthorityIssuer,
+        evidence: Blake3Digest,
+    ) -> Self {
+        Self(AuthorityDecision {
+            issuer,
+            context_digest: *context.digest(),
+            evidence,
+        })
+    }
+
+    pub(crate) fn decision_digest(&self) -> AuthorityDecisionDigest {
+        self.0.digest()
+    }
+
+    pub(crate) fn verify(
+        &self,
+        context: &OperationContext,
+        ingress: &AuthenticatedIngress,
+        service: &AdmittedService,
+        now: crate::context::Timestamp,
+    ) -> PackageServiceResult<()> {
+        if context.expiry() <= now {
+            return Err(PackageServiceError::AuthorityExpired);
+        }
+        if self.0.context_digest != *context.digest() {
+            return Err(PackageServiceError::AuthorityContextMismatch);
+        }
+        if self.0.evidence.as_bytes() == &[0; 32] {
+            return Err(PackageServiceError::AuthorityIssuerRejected);
+        }
+        match self.0.issuer.class() {
+            AuthorityIssuerClass::VerifiedLegacyMigration
+                if context.operation() != Operation::Recover =>
+            {
+                return Err(PackageServiceError::AuthorityIssuerRejected);
+            },
+            AuthorityIssuerClass::ExplicitApproval
+                if !matches!(context.approver_identity(), ApproverIdentity::Principal(_)) =>
+            {
+                return Err(PackageServiceError::AuthorityIssuerRejected);
+            },
+            _ => {},
+        }
+        if ingress.caller() != context.effective_caller()
+            || service.component() != context.service_component()
+            || service.generation() != context.service_generation()
+            || ingress.evidence().as_bytes() == &[0; 32]
+            || service.evidence().as_bytes() == &[0; 32]
+        {
+            return Err(PackageServiceError::StampedIdentityMismatch);
+        }
+        Ok(())
+    }
+}

--- a/crates/astrid-package-service/src/authority.rs
+++ b/crates/astrid-package-service/src/authority.rs
@@ -29,6 +29,9 @@ pub struct AuthorityIssuer {
 
 impl AuthorityIssuer {
     /// Constructs a verified issuer from the authority boundary.
+    ///
+    /// # Errors
+    /// Returns [`PackageServiceError::AuthorityIssuerRejected`] for zero identity or evidence.
     pub fn new(
         class: AuthorityIssuerClass,
         identity: AuthorityIssuerIdentity,
@@ -98,6 +101,9 @@ pub struct AuthenticatedAuthority(AuthorityDecision);
 
 impl AuthenticatedAuthority {
     /// Binds issuer evidence to the canonical context digest.
+    ///
+    /// # Errors
+    /// Returns [`PackageServiceError::AuthorityIssuerRejected`] for zero evidence.
     pub fn bind(
         context: &OperationContext,
         issuer: AuthorityIssuer,

--- a/crates/astrid-package-service/src/bytes.rs
+++ b/crates/astrid-package-service/src/bytes.rs
@@ -1,0 +1,36 @@
+macro_rules! opaque32 {
+    ($name:ident, $doc:literal) => {
+        #[doc = $doc]
+        #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+        pub struct $name([u8; 32]);
+
+        impl $name {
+            /// Creates an identifier from exactly 32 canonical bytes.
+            #[must_use]
+            pub const fn from_bytes(bytes: [u8; 32]) -> Self {
+                Self(bytes)
+            }
+
+            /// Returns the immutable canonical bytes.
+            #[must_use]
+            pub const fn as_bytes(&self) -> &[u8; 32] {
+                &self.0
+            }
+
+            /// Returns ownership of the immutable canonical bytes.
+            #[must_use]
+            pub const fn into_bytes(self) -> [u8; 32] {
+                self.0
+            }
+        }
+    };
+}
+
+opaque32!(
+    PrincipalUid,
+    "Immutable effective principal identity stamped by authenticated ingress."
+);
+opaque32!(
+    RecoveryToken,
+    "Opaque token used to locate recovery evidence without granting authority."
+);

--- a/crates/astrid-package-service/src/context.rs
+++ b/crates/astrid-package-service/src/context.rs
@@ -1,5 +1,7 @@
 use crate::bytes::PrincipalUid;
-use crate::digest::{Blake3Digest, BudgetDigest, ContextDigest, DigestWriter, PlanDigest};
+use crate::digest::{
+    Blake3Digest, BudgetDigest, ContextDigest, DigestWriter, PlanDigest, ProvenanceDigest,
+};
 use crate::error::{PackageServiceError, PackageServiceResult};
 use crate::identity::{
     ArtifactIdentity, ComponentIdentity, ManifestIdentity, Nonce, PROTOCOL_VERSION, PackageObject,
@@ -65,7 +67,7 @@ pub enum Operation {
 }
 
 impl Operation {
-    pub(crate) const fn tag(&self) -> u8 {
+    pub(crate) const fn tag(self) -> u8 {
         match self {
             Self::Install => 1,
             Self::Update => 2,
@@ -89,7 +91,7 @@ pub enum IngressChannel {
 }
 
 impl IngressChannel {
-    const fn tag(&self) -> u8 {
+    const fn tag(self) -> u8 {
         match self {
             Self::AuthenticatedIpc => 1,
             Self::HostedService => 2,
@@ -108,6 +110,7 @@ pub struct AuthenticatedIngress {
 
 impl AuthenticatedIngress {
     /// Constructs ingress from trusted transport data.
+    #[must_use]
     pub fn new(caller: PrincipalUid, channel: IngressChannel, evidence: Blake3Digest) -> Self {
         Self {
             caller,
@@ -181,7 +184,7 @@ pub enum ApproverIdentity {
 }
 
 impl ApproverIdentity {
-    pub(crate) fn write(&self, writer: &mut DigestWriter) {
+    pub(crate) fn write(self, writer: &mut DigestWriter) {
         match self {
             Self::Principal(uid) => {
                 writer.tag(1);
@@ -189,7 +192,7 @@ impl ApproverIdentity {
             },
             Self::Policy(policy) => {
                 writer.tag(2);
-                writer.digest(policy);
+                writer.digest(&policy);
             },
         }
     }
@@ -198,45 +201,31 @@ impl ApproverIdentity {
 /// Resource classes admitted by the kernel/resource authority.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct ResourceClasses {
-    artifact_storage: bool,
-    lifecycle: bool,
-    activation: bool,
-    audit: bool,
+    classes: [bool; 4],
 }
 
 impl ResourceClasses {
-    /// Constructs all-or-nothing admitted classes from authoritative flags.
+    /// Constructs admitted classes in canonical `ResourceClass` order.
     #[must_use]
-    pub const fn new(
-        artifact_storage: bool,
-        lifecycle: bool,
-        activation: bool,
-        audit: bool,
-    ) -> Self {
-        Self {
-            artifact_storage,
-            lifecycle,
-            activation,
-            audit,
-        }
+    pub const fn new(classes: [bool; 4]) -> Self {
+        Self { classes }
     }
 
     /// Returns whether a class is admitted.
     #[must_use]
     pub const fn contains(&self, class: ResourceClass) -> bool {
         match class {
-            ResourceClass::ArtifactStorage => self.artifact_storage,
-            ResourceClass::Lifecycle => self.lifecycle,
-            ResourceClass::Activation => self.activation,
-            ResourceClass::Audit => self.audit,
+            ResourceClass::ArtifactStorage => self.classes[0],
+            ResourceClass::Lifecycle => self.classes[1],
+            ResourceClass::Activation => self.classes[2],
+            ResourceClass::Audit => self.classes[3],
         }
     }
 
-    fn write(&self, writer: &mut DigestWriter) {
-        writer.bool(self.artifact_storage);
-        writer.bool(self.lifecycle);
-        writer.bool(self.activation);
-        writer.bool(self.audit);
+    fn write(self, writer: &mut DigestWriter) {
+        for admitted in self.classes {
+            writer.bool(admitted);
+        }
     }
 }
 
@@ -306,7 +295,10 @@ pub struct OperationContext {
     package_object: PackageObject,
     artifact: ArtifactIdentity,
     manifest: ManifestIdentity,
+    content_root: Blake3Digest,
+    provenance: ProvenanceDigest,
     plan_digest: PlanDigest,
+    commit_plan_digest: PlanDigest,
     budget: ResourceBudget,
     service_component: ComponentIdentity,
     service_generation: ServiceGeneration,
@@ -335,8 +327,14 @@ pub struct OperationContextSpec {
     pub artifact: ArtifactIdentity,
     /// Exact manifest identity.
     pub manifest: ManifestIdentity,
+    /// Exact content root admitted for replacement or retained-state work.
+    pub content_root: Blake3Digest,
+    /// Exact provenance digest admitted for replacement or retained-state work.
+    pub provenance: ProvenanceDigest,
     /// Activation, replacement, or removal plan digest.
     pub plan_digest: PlanDigest,
+    /// Exact staged-and-committed plan bound by authority.
+    pub commit_plan_digest: PlanDigest,
     /// Canonical resource budget.
     pub budget: ResourceBudget,
     /// Authority-owned expiry.
@@ -345,6 +343,9 @@ pub struct OperationContextSpec {
 
 impl OperationContext {
     /// Validates and binds a complete operation context.
+    ///
+    /// # Errors
+    /// Returns typed binding, expiry, identity, resource, and expectation failures.
     pub fn new(
         spec: OperationContextSpec,
         service: &AdmittedService,
@@ -360,7 +361,10 @@ impl OperationContext {
             package_object,
             artifact,
             manifest,
+            content_root,
+            provenance,
             plan_digest,
+            commit_plan_digest,
             budget,
             expiry,
         } = spec;
@@ -371,72 +375,50 @@ impl OperationContext {
             || package_object.as_bytes() == &[0; 32]
             || service.component.as_bytes() == &[0; 32]
             || plan_digest.as_bytes() == &[0; 32]
+            || content_root.as_bytes() == &[0; 32]
+            || provenance.as_bytes() == &[0; 32]
         {
             return Err(PackageServiceError::InvalidValue("operation identity"));
         }
-        match approver {
-            ApproverIdentity::Principal(uid) if uid.as_bytes() == &[0; 32] => {
-                return Err(PackageServiceError::InvalidValue("approver"));
-            },
-            ApproverIdentity::Policy(policy) if policy.as_bytes() == &[0; 32] => {
-                return Err(PackageServiceError::InvalidValue("approver"));
-            },
-            _ => {},
-        }
-        if effective_caller.as_bytes() == &[0; 32] || target_owner.as_bytes() == &[0; 32] {
-            return Err(PackageServiceError::InvalidValue("principal"));
-        }
-        if operation == Operation::Install
-            && !matches!(expected_state, crate::state::ExpectedPackageState::Absent)
-        {
-            return Err(PackageServiceError::ExpectedStateMismatch);
-        }
-        if operation == Operation::Update
-            && !matches!(expected_state, crate::state::ExpectedPackageState::Exact(_))
-        {
-            return Err(PackageServiceError::ExpectedStateMismatch);
-        }
-        if (operation == Operation::Install || operation == Operation::Update)
-            && !budget.classes().contains(ResourceClass::ArtifactStorage)
-        {
+        Self::validate_participants(&approver, &effective_caller, &target_owner)?;
+        let expected_commit_plan = if matches!(operation, Operation::Install | Operation::Update) {
+            operation_commit_plan_digest(
+                operation,
+                &artifact,
+                &manifest,
+                &content_root,
+                &provenance,
+                (operation == Operation::Update).then_some(plan_digest),
+            )
+        } else {
+            plan_digest
+        };
+        let plan_kind_matches = matches!(operation, Operation::Install | Operation::Update)
+            || commit_plan_digest == plan_digest;
+        if commit_plan_digest != expected_commit_plan || !plan_kind_matches {
             return Err(PackageServiceError::BindingMismatch);
         }
-        if !budget.classes().contains(ResourceClass::Lifecycle)
-            || ((operation == Operation::Activate)
-                && !budget.classes().contains(ResourceClass::Activation))
-        {
-            return Err(PackageServiceError::BindingMismatch);
-        }
+        Self::validate_expectations_and_budget(operation, &expected_state, &budget)?;
 
-        let mut writer = DigestWriter::new();
-        writer.u64(u64::from(PROTOCOL_VERSION.get()));
-        writer.bytes(nonce.as_bytes());
-        writer.tag(operation.tag());
-        match &expected_state {
-            crate::state::ExpectedPackageState::Absent => writer.tag(0),
-            crate::state::ExpectedPackageState::Exact(state_digest) => {
-                writer.tag(1);
-                writer.digest(state_digest);
-            },
+        let digest = ContextDigestParts {
+            nonce: &nonce,
+            operation,
+            expected_state: &expected_state,
+            effective_caller: &effective_caller,
+            approver: &approver,
+            target_owner: &target_owner,
+            package_object: &package_object,
+            artifact: &artifact,
+            manifest: &manifest,
+            content_root: &content_root,
+            provenance: &provenance,
+            plan_digest: &plan_digest,
+            commit_plan_digest: &commit_plan_digest,
+            budget: &budget,
+            service,
+            expiry,
         }
-        writer.bytes(effective_caller.as_bytes());
-        approver.write(&mut writer);
-        writer.bytes(target_owner.as_bytes());
-        writer.bytes(package_object.as_bytes());
-        writer.u64(u64::from(artifact.format_version()));
-        writer.u64(artifact.size_bytes());
-        writer.digest(artifact.sha256());
-        writer.digest(artifact.blake3());
-        writer.u64(u64::from(manifest.format_version()));
-        writer.bytes(manifest.package_name().as_str().as_bytes());
-        writer.bytes(manifest.package_version().as_str().as_bytes());
-        writer.digest(manifest.manifest_digest());
-        writer.digest(&plan_digest);
-        writer.digest(budget.digest());
-        writer.bytes(service.component.as_bytes());
-        writer.u64(service.generation.get());
-        writer.u64(expiry.get());
-        let digest = writer.finish("astrid.package.operation-context.v1");
+        .digest();
 
         Ok(Self {
             protocol_version: PROTOCOL_VERSION,
@@ -449,7 +431,10 @@ impl OperationContext {
             package_object,
             artifact,
             manifest,
+            content_root,
+            provenance,
             plan_digest,
+            commit_plan_digest,
             budget,
             service_component: *service.component(),
             service_generation: service.generation(),
@@ -458,6 +443,115 @@ impl OperationContext {
         })
     }
 
+    fn validate_expectations_and_budget(
+        operation: Operation,
+        expected_state: &crate::state::ExpectedPackageState,
+        budget: &ResourceBudget,
+    ) -> PackageServiceResult<()> {
+        let expected_matches = match operation {
+            Operation::Install => {
+                matches!(expected_state, crate::state::ExpectedPackageState::Absent)
+            },
+            Operation::Update => {
+                matches!(expected_state, crate::state::ExpectedPackageState::Exact(_))
+            },
+            _ => true,
+        };
+        if !expected_matches {
+            return Err(PackageServiceError::ExpectedStateMismatch);
+        }
+        let storage_required = matches!(operation, Operation::Install | Operation::Update);
+        if storage_required && !budget.classes().contains(ResourceClass::ArtifactStorage) {
+            return Err(PackageServiceError::BindingMismatch);
+        }
+        if !budget.classes().contains(ResourceClass::Lifecycle)
+            || (operation == Operation::Activate
+                && !budget.classes().contains(ResourceClass::Activation))
+        {
+            return Err(PackageServiceError::BindingMismatch);
+        }
+        Ok(())
+    }
+
+    fn validate_participants(
+        approver: &ApproverIdentity,
+        effective_caller: &PrincipalUid,
+        target_owner: &PrincipalUid,
+    ) -> PackageServiceResult<()> {
+        let zero_approver = matches!(
+            approver,
+            ApproverIdentity::Principal(uid) if uid.as_bytes() == &[0; 32]
+        ) || matches!(
+            approver,
+            ApproverIdentity::Policy(policy) if policy.as_bytes() == &[0; 32]
+        );
+        if zero_approver {
+            return Err(PackageServiceError::InvalidValue("approver"));
+        }
+        if effective_caller.as_bytes() == &[0; 32] || target_owner.as_bytes() == &[0; 32] {
+            return Err(PackageServiceError::InvalidValue("principal"));
+        }
+        Ok(())
+    }
+}
+
+struct ContextDigestParts<'a> {
+    nonce: &'a Nonce,
+    operation: Operation,
+    expected_state: &'a crate::state::ExpectedPackageState,
+    effective_caller: &'a PrincipalUid,
+    approver: &'a ApproverIdentity,
+    target_owner: &'a PrincipalUid,
+    package_object: &'a PackageObject,
+    artifact: &'a ArtifactIdentity,
+    manifest: &'a ManifestIdentity,
+    content_root: &'a Blake3Digest,
+    provenance: &'a ProvenanceDigest,
+    plan_digest: &'a PlanDigest,
+    commit_plan_digest: &'a PlanDigest,
+    budget: &'a ResourceBudget,
+    service: &'a AdmittedService,
+    expiry: Timestamp,
+}
+
+impl ContextDigestParts<'_> {
+    fn digest(self) -> ContextDigest {
+        let mut writer = DigestWriter::new();
+        writer.u64(u64::from(PROTOCOL_VERSION.get()));
+        writer.bytes(self.nonce.as_bytes());
+        writer.tag(self.operation.tag());
+        match self.expected_state {
+            crate::state::ExpectedPackageState::Absent => writer.tag(0),
+            crate::state::ExpectedPackageState::Exact(state_digest) => {
+                writer.tag(1);
+                writer.digest(state_digest);
+            },
+        }
+        writer.bytes(self.effective_caller.as_bytes());
+        self.approver.write(&mut writer);
+        writer.bytes(self.target_owner.as_bytes());
+        writer.bytes(self.package_object.as_bytes());
+        writer.u64(u64::from(self.artifact.format_version()));
+        writer.u64(self.artifact.size_bytes());
+        writer.digest(self.artifact.sha256());
+        writer.digest(self.artifact.blake3());
+        writer.u64(u64::from(self.manifest.format_version()));
+        writer.bytes(self.manifest.package_name().as_str().as_bytes());
+        writer.bytes(self.manifest.package_version().as_str().as_bytes());
+        writer.digest(self.manifest.manifest_digest());
+        writer.digest(self.content_root);
+        writer.digest(self.provenance);
+        writer.digest(self.plan_digest);
+        writer.digest(self.commit_plan_digest);
+        writer.digest(self.budget.digest());
+        writer.bytes(self.service.component.as_bytes());
+        writer.u64(self.service.generation.get());
+        writer.u64(self.expiry.get());
+        writer.finish("astrid.package.operation-context.v1")
+    }
+}
+
+impl OperationContext {
     /// Returns the canonical context digest covered by authority.
     #[must_use]
     pub const fn digest(&self) -> &ContextDigest {
@@ -502,10 +596,28 @@ impl OperationContext {
         &self.manifest
     }
 
+    /// Returns the exact committed content root.
+    #[must_use]
+    pub const fn content_root(&self) -> &Blake3Digest {
+        &self.content_root
+    }
+
+    /// Returns the exact committed provenance digest.
+    #[must_use]
+    pub const fn provenance(&self) -> &ProvenanceDigest {
+        &self.provenance
+    }
+
     /// Returns the activation or removal plan digest.
     #[must_use]
     pub const fn plan_digest(&self) -> &PlanDigest {
         &self.plan_digest
+    }
+
+    /// Returns the unified content and lifecycle plan admitted by authority.
+    #[must_use]
+    pub const fn commit_plan_digest(&self) -> &PlanDigest {
+        &self.commit_plan_digest
     }
 
     /// Returns the expiry owned by the canonical context.
@@ -541,4 +653,34 @@ impl OperationContext {
     pub(crate) const fn service_generation(&self) -> ServiceGeneration {
         self.service_generation
     }
+}
+
+/// Derives the exact committed plan admitted by an Install or Update context.
+#[must_use]
+pub fn operation_commit_plan_digest(
+    operation: Operation,
+    artifact: &ArtifactIdentity,
+    manifest: &ManifestIdentity,
+    content_root: &Blake3Digest,
+    provenance: &ProvenanceDigest,
+    lifecycle_plan: Option<PlanDigest>,
+) -> PlanDigest {
+    let mut writer = DigestWriter::new();
+    writer.u64(u64::from(artifact.format_version()));
+    writer.u64(artifact.size_bytes());
+    writer.digest(artifact.sha256());
+    writer.digest(artifact.blake3());
+    writer.u64(u64::from(manifest.format_version()));
+    writer.bytes(manifest.package_name().as_str().as_bytes());
+    writer.bytes(manifest.package_version().as_str().as_bytes());
+    writer.digest(manifest.manifest_digest());
+    writer.digest(content_root);
+    writer.digest(provenance);
+    writer.tag(operation.tag());
+    if operation == Operation::Update
+        && let Some(plan) = lifecycle_plan
+    {
+        writer.digest(&plan);
+    }
+    writer.finish("astrid.package.commit-plan.v1")
 }

--- a/crates/astrid-package-service/src/context.rs
+++ b/crates/astrid-package-service/src/context.rs
@@ -1,0 +1,544 @@
+use crate::bytes::PrincipalUid;
+use crate::digest::{Blake3Digest, BudgetDigest, ContextDigest, DigestWriter, PlanDigest};
+use crate::error::{PackageServiceError, PackageServiceResult};
+use crate::identity::{
+    ArtifactIdentity, ComponentIdentity, ManifestIdentity, Nonce, PROTOCOL_VERSION, PackageObject,
+    ProtocolVersion, ServiceGeneration,
+};
+use std::num::NonZeroU64;
+use std::time::Duration as StdDuration;
+
+/// Finite monotonic duration used by policy and leases.
+pub type Duration = StdDuration;
+
+/// Finite monotonic timestamp in seconds.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct Timestamp(u64);
+
+impl Timestamp {
+    /// The beginning of the monotonic domain.
+    pub const ZERO: Self = Self(0);
+
+    /// Constructs a timestamp.
+    #[must_use]
+    pub const fn new(seconds: u64) -> Self {
+        Self(seconds)
+    }
+
+    /// Returns the timestamp seconds.
+    #[must_use]
+    pub const fn get(&self) -> u64 {
+        self.0
+    }
+
+    /// Adds finite seconds, refusing overflow.
+    #[must_use]
+    pub const fn checked_add(&self, seconds: u64) -> Option<Self> {
+        match self.0.checked_add(seconds) {
+            Some(value) => Some(Self(value)),
+            None => None,
+        }
+    }
+
+    /// Returns the elapsed whole seconds, refusing time inversion.
+    #[must_use]
+    pub const fn seconds_since(&self, earlier: Self) -> Option<u64> {
+        self.0.checked_sub(earlier.0)
+    }
+}
+
+/// Neutral operation class in the private contract.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Operation {
+    /// Create the absent owner/package slot.
+    Install,
+    /// Replace the exact prior owner/package state.
+    Update,
+    /// Publish the exact installed state to the runtime.
+    Activate,
+    /// Stop publication of the exact installed state.
+    Deactivate,
+    /// Drain and retire the exact installed state.
+    Remove,
+    /// Reconcile an existing operation record.
+    Recover,
+}
+
+impl Operation {
+    pub(crate) const fn tag(&self) -> u8 {
+        match self {
+            Self::Install => 1,
+            Self::Update => 2,
+            Self::Activate => 3,
+            Self::Deactivate => 4,
+            Self::Remove => 5,
+            Self::Recover => 6,
+        }
+    }
+}
+
+/// Authenticated ingress channel class.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum IngressChannel {
+    /// Authenticated local IPC.
+    AuthenticatedIpc,
+    /// Authenticated hosted-service transport.
+    HostedService,
+    /// Authenticated system-generation transport.
+    SystemGeneration,
+}
+
+impl IngressChannel {
+    const fn tag(&self) -> u8 {
+        match self {
+            Self::AuthenticatedIpc => 1,
+            Self::HostedService => 2,
+            Self::SystemGeneration => 3,
+        }
+    }
+}
+
+/// Identity stamped by authenticated transport.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct AuthenticatedIngress {
+    caller: PrincipalUid,
+    channel: IngressChannel,
+    evidence: Blake3Digest,
+}
+
+impl AuthenticatedIngress {
+    /// Constructs ingress from trusted transport data.
+    pub fn new(caller: PrincipalUid, channel: IngressChannel, evidence: Blake3Digest) -> Self {
+        Self {
+            caller,
+            channel,
+            evidence,
+        }
+    }
+
+    /// Returns the stamped effective caller.
+    #[must_use]
+    pub const fn caller(&self) -> PrincipalUid {
+        self.caller
+    }
+
+    pub(crate) const fn channel_tag(&self) -> u8 {
+        self.channel.tag()
+    }
+
+    pub(crate) const fn evidence(&self) -> &Blake3Digest {
+        &self.evidence
+    }
+}
+
+/// Identity and evidence stamped by the admitted-service lifecycle.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct AdmittedService {
+    component: ComponentIdentity,
+    generation: ServiceGeneration,
+    evidence: Blake3Digest,
+}
+
+impl AdmittedService {
+    /// Constructs service admission from trusted lifecycle data.
+    #[must_use]
+    pub const fn new(
+        component: ComponentIdentity,
+        generation: ServiceGeneration,
+        evidence: Blake3Digest,
+    ) -> Self {
+        Self {
+            component,
+            generation,
+            evidence,
+        }
+    }
+
+    /// Returns the admitted component identity.
+    #[must_use]
+    pub const fn component(&self) -> &ComponentIdentity {
+        &self.component
+    }
+
+    /// Returns the admitted immutable generation.
+    #[must_use]
+    pub const fn generation(&self) -> ServiceGeneration {
+        self.generation
+    }
+
+    pub(crate) const fn evidence(&self) -> &Blake3Digest {
+        &self.evidence
+    }
+}
+
+/// Principal or authenticated policy approver identity.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ApproverIdentity {
+    /// An immutable authenticated principal.
+    Principal(PrincipalUid),
+    /// A digest naming an authenticated policy.
+    Policy(Blake3Digest),
+}
+
+impl ApproverIdentity {
+    pub(crate) fn write(&self, writer: &mut DigestWriter) {
+        match self {
+            Self::Principal(uid) => {
+                writer.tag(1);
+                writer.bytes(uid.as_bytes());
+            },
+            Self::Policy(policy) => {
+                writer.tag(2);
+                writer.digest(policy);
+            },
+        }
+    }
+}
+
+/// Resource classes admitted by the kernel/resource authority.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ResourceClasses {
+    artifact_storage: bool,
+    lifecycle: bool,
+    activation: bool,
+    audit: bool,
+}
+
+impl ResourceClasses {
+    /// Constructs all-or-nothing admitted classes from authoritative flags.
+    #[must_use]
+    pub const fn new(
+        artifact_storage: bool,
+        lifecycle: bool,
+        activation: bool,
+        audit: bool,
+    ) -> Self {
+        Self {
+            artifact_storage,
+            lifecycle,
+            activation,
+            audit,
+        }
+    }
+
+    /// Returns whether a class is admitted.
+    #[must_use]
+    pub const fn contains(&self, class: ResourceClass) -> bool {
+        match class {
+            ResourceClass::ArtifactStorage => self.artifact_storage,
+            ResourceClass::Lifecycle => self.lifecycle,
+            ResourceClass::Activation => self.activation,
+            ResourceClass::Audit => self.audit,
+        }
+    }
+
+    fn write(&self, writer: &mut DigestWriter) {
+        writer.bool(self.artifact_storage);
+        writer.bool(self.lifecycle);
+        writer.bool(self.activation);
+        writer.bool(self.audit);
+    }
+}
+
+/// Neutral resource class.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ResourceClass {
+    /// Immutable artifact retention.
+    ArtifactStorage,
+    /// Journal and lifecycle execution.
+    Lifecycle,
+    /// Runtime activation work.
+    Activation,
+    /// Audit emission.
+    Audit,
+}
+
+/// Canonical resource budget with its semantic digest.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ResourceBudget {
+    reservation_bytes: NonZeroU64,
+    classes: ResourceClasses,
+    digest: BudgetDigest,
+}
+
+impl ResourceBudget {
+    /// Computes the canonical budget and its domain-separated digest.
+    #[must_use]
+    pub fn new(reservation_bytes: NonZeroU64, classes: ResourceClasses) -> Self {
+        let mut writer = DigestWriter::new();
+        writer.u64(reservation_bytes.get());
+        classes.write(&mut writer);
+        let digest = writer.finish("astrid.package.budget.v1");
+        Self {
+            reservation_bytes,
+            classes,
+            digest,
+        }
+    }
+
+    /// Returns the reserved byte count.
+    #[must_use]
+    pub const fn reservation_bytes(&self) -> u64 {
+        self.reservation_bytes.get()
+    }
+
+    /// Returns the canonical budget digest.
+    #[must_use]
+    pub const fn digest(&self) -> &BudgetDigest {
+        &self.digest
+    }
+
+    pub(crate) const fn classes(&self) -> &ResourceClasses {
+        &self.classes
+    }
+}
+
+/// Complete authority-bearing context for one mutating operation.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OperationContext {
+    protocol_version: ProtocolVersion,
+    nonce: Nonce,
+    operation: Operation,
+    expected_state: crate::state::ExpectedPackageState,
+    effective_caller: PrincipalUid,
+    approver: ApproverIdentity,
+    target_owner: PrincipalUid,
+    package_object: PackageObject,
+    artifact: ArtifactIdentity,
+    manifest: ManifestIdentity,
+    plan_digest: PlanDigest,
+    budget: ResourceBudget,
+    service_component: ComponentIdentity,
+    service_generation: ServiceGeneration,
+    expiry: Timestamp,
+    digest: ContextDigest,
+}
+
+/// Validated input needed to construct one canonical operation context.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OperationContextSpec {
+    /// Global operation nonce.
+    pub nonce: Nonce,
+    /// Mutation class.
+    pub operation: Operation,
+    /// Exact current state accepted by the operation.
+    pub expected_state: crate::state::ExpectedPackageState,
+    /// Effective stamped caller.
+    pub effective_caller: PrincipalUid,
+    /// Authenticated approver or policy.
+    pub approver: ApproverIdentity,
+    /// Effective target owner.
+    pub target_owner: PrincipalUid,
+    /// Immutable owner-neutral package object.
+    pub package_object: PackageObject,
+    /// Exact-byte artifact identity.
+    pub artifact: ArtifactIdentity,
+    /// Exact manifest identity.
+    pub manifest: ManifestIdentity,
+    /// Activation, replacement, or removal plan digest.
+    pub plan_digest: PlanDigest,
+    /// Canonical resource budget.
+    pub budget: ResourceBudget,
+    /// Authority-owned expiry.
+    pub expiry: Timestamp,
+}
+
+impl OperationContext {
+    /// Validates and binds a complete operation context.
+    pub fn new(
+        spec: OperationContextSpec,
+        service: &AdmittedService,
+        now: Timestamp,
+    ) -> PackageServiceResult<Self> {
+        let OperationContextSpec {
+            nonce,
+            operation,
+            expected_state,
+            effective_caller,
+            approver,
+            target_owner,
+            package_object,
+            artifact,
+            manifest,
+            plan_digest,
+            budget,
+            expiry,
+        } = spec;
+        if expiry <= now {
+            return Err(PackageServiceError::AuthorityExpired);
+        }
+        if nonce.as_bytes() == &[0; 32]
+            || package_object.as_bytes() == &[0; 32]
+            || service.component.as_bytes() == &[0; 32]
+            || plan_digest.as_bytes() == &[0; 32]
+        {
+            return Err(PackageServiceError::InvalidValue("operation identity"));
+        }
+        match approver {
+            ApproverIdentity::Principal(uid) if uid.as_bytes() == &[0; 32] => {
+                return Err(PackageServiceError::InvalidValue("approver"));
+            },
+            ApproverIdentity::Policy(policy) if policy.as_bytes() == &[0; 32] => {
+                return Err(PackageServiceError::InvalidValue("approver"));
+            },
+            _ => {},
+        }
+        if effective_caller.as_bytes() == &[0; 32] || target_owner.as_bytes() == &[0; 32] {
+            return Err(PackageServiceError::InvalidValue("principal"));
+        }
+        if operation == Operation::Install
+            && !matches!(expected_state, crate::state::ExpectedPackageState::Absent)
+        {
+            return Err(PackageServiceError::ExpectedStateMismatch);
+        }
+        if operation == Operation::Update
+            && !matches!(expected_state, crate::state::ExpectedPackageState::Exact(_))
+        {
+            return Err(PackageServiceError::ExpectedStateMismatch);
+        }
+        if (operation == Operation::Install || operation == Operation::Update)
+            && !budget.classes().contains(ResourceClass::ArtifactStorage)
+        {
+            return Err(PackageServiceError::BindingMismatch);
+        }
+        if !budget.classes().contains(ResourceClass::Lifecycle)
+            || ((operation == Operation::Activate)
+                && !budget.classes().contains(ResourceClass::Activation))
+        {
+            return Err(PackageServiceError::BindingMismatch);
+        }
+
+        let mut writer = DigestWriter::new();
+        writer.u64(u64::from(PROTOCOL_VERSION.get()));
+        writer.bytes(nonce.as_bytes());
+        writer.tag(operation.tag());
+        match &expected_state {
+            crate::state::ExpectedPackageState::Absent => writer.tag(0),
+            crate::state::ExpectedPackageState::Exact(state_digest) => {
+                writer.tag(1);
+                writer.digest(state_digest);
+            },
+        }
+        writer.bytes(effective_caller.as_bytes());
+        approver.write(&mut writer);
+        writer.bytes(target_owner.as_bytes());
+        writer.bytes(package_object.as_bytes());
+        writer.u64(u64::from(artifact.format_version()));
+        writer.u64(artifact.size_bytes());
+        writer.digest(artifact.sha256());
+        writer.digest(artifact.blake3());
+        writer.u64(u64::from(manifest.format_version()));
+        writer.bytes(manifest.package_name().as_str().as_bytes());
+        writer.bytes(manifest.package_version().as_str().as_bytes());
+        writer.digest(manifest.manifest_digest());
+        writer.digest(&plan_digest);
+        writer.digest(budget.digest());
+        writer.bytes(service.component.as_bytes());
+        writer.u64(service.generation.get());
+        writer.u64(expiry.get());
+        let digest = writer.finish("astrid.package.operation-context.v1");
+
+        Ok(Self {
+            protocol_version: PROTOCOL_VERSION,
+            nonce,
+            operation,
+            expected_state,
+            effective_caller,
+            approver,
+            target_owner,
+            package_object,
+            artifact,
+            manifest,
+            plan_digest,
+            budget,
+            service_component: *service.component(),
+            service_generation: service.generation(),
+            expiry,
+            digest,
+        })
+    }
+
+    /// Returns the canonical context digest covered by authority.
+    #[must_use]
+    pub const fn digest(&self) -> &ContextDigest {
+        &self.digest
+    }
+
+    pub(crate) const fn budget_digest(&self) -> &crate::digest::BudgetDigest {
+        self.budget.digest()
+    }
+
+    pub(crate) const fn reservation_bytes(&self) -> u64 {
+        self.budget.reservation_bytes()
+    }
+
+    /// Returns the operation nonce.
+    #[must_use]
+    pub const fn nonce(&self) -> Nonce {
+        self.nonce
+    }
+
+    /// Returns the operation class.
+    #[must_use]
+    pub const fn operation(&self) -> Operation {
+        self.operation
+    }
+
+    /// Returns the expected canonical state.
+    #[must_use]
+    pub const fn expected_state(&self) -> &crate::state::ExpectedPackageState {
+        &self.expected_state
+    }
+
+    /// Returns the exact artifact identity.
+    #[must_use]
+    pub const fn artifact(&self) -> &ArtifactIdentity {
+        &self.artifact
+    }
+
+    /// Returns the exact manifest identity.
+    #[must_use]
+    pub const fn manifest(&self) -> &ManifestIdentity {
+        &self.manifest
+    }
+
+    /// Returns the activation or removal plan digest.
+    #[must_use]
+    pub const fn plan_digest(&self) -> &PlanDigest {
+        &self.plan_digest
+    }
+
+    /// Returns the expiry owned by the canonical context.
+    #[must_use]
+    pub const fn expiry(&self) -> Timestamp {
+        self.expiry
+    }
+
+    pub(crate) const fn approver_identity(&self) -> &ApproverIdentity {
+        &self.approver
+    }
+
+    pub(crate) const fn protocol_version(&self) -> ProtocolVersion {
+        self.protocol_version
+    }
+
+    pub(crate) const fn effective_caller(&self) -> PrincipalUid {
+        self.effective_caller
+    }
+
+    pub(crate) const fn target_owner(&self) -> PrincipalUid {
+        self.target_owner
+    }
+
+    pub(crate) const fn package_object(&self) -> PackageObject {
+        self.package_object
+    }
+
+    pub(crate) const fn service_component(&self) -> &ComponentIdentity {
+        &self.service_component
+    }
+
+    pub(crate) const fn service_generation(&self) -> ServiceGeneration {
+        self.service_generation
+    }
+}

--- a/crates/astrid-package-service/src/digest.rs
+++ b/crates/astrid-package-service/src/digest.rs
@@ -117,7 +117,11 @@ impl Display for Blake3Digest {
 }
 
 fn hex_lower(bytes: &[u8]) -> String {
-    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+    bytes.iter().fold(String::new(), |mut output, byte| {
+        use std::fmt::Write as _;
+        let _ = write!(output, "{byte:02x}");
+        output
+    })
 }
 
 fn cast_length(length: usize) -> u64 {

--- a/crates/astrid-package-service/src/digest.rs
+++ b/crates/astrid-package-service/src/digest.rs
@@ -1,0 +1,125 @@
+use blake3::Hasher;
+use std::fmt::{Display, Formatter};
+
+macro_rules! digest_alias {
+    ($name:ident, $doc:literal, $kind:literal) => {
+        #[doc = $doc]
+        pub type $name = TypedDigest<$kind>;
+    };
+}
+
+/// A fixed-size digest tagged by its semantic type.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct TypedDigest<const KIND: u8>([u8; 32]);
+
+impl<const KIND: u8> TypedDigest<KIND> {
+    /// Creates a digest from exactly 32 bytes.
+    #[must_use]
+    pub const fn from_bytes(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+
+    /// Returns the digest bytes.
+    #[must_use]
+    pub const fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+
+    /// Returns ownership of the digest bytes.
+    #[must_use]
+    pub const fn into_bytes(self) -> [u8; 32] {
+        self.0
+    }
+}
+
+digest_alias!(ContextDigest, "Canonical operation-context digest.", 1);
+digest_alias!(StateDigest, "Canonical installed-state digest.", 2);
+digest_alias!(PlanDigest, "Canonical lifecycle-plan digest.", 3);
+digest_alias!(BudgetDigest, "Canonical resource-budget digest.", 4);
+digest_alias!(RequestDigest, "Canonical authenticated-request digest.", 5);
+digest_alias!(
+    ProvenanceDigest,
+    "Canonical attribution-evidence digest.",
+    6
+);
+digest_alias!(Sha256Digest, "Exact SHA-256 artifact digest.", 7);
+digest_alias!(Blake3Digest, "Exact BLAKE3 evidence digest.", 8);
+digest_alias!(
+    AuthorityDecisionDigest,
+    "Canonical authenticated-authority decision digest.",
+    9
+);
+digest_alias!(ReceiptDigest, "Canonical operation-receipt digest.", 12);
+
+/// Canonical, field-length-delimited digest input.
+#[derive(Default)]
+pub struct DigestWriter {
+    bytes: Vec<u8>,
+}
+
+impl DigestWriter {
+    /// Creates empty canonical input.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Writes a fixed variant or field tag.
+    pub fn tag(&mut self, value: u8) {
+        self.bytes.push(value);
+    }
+
+    /// Writes a bounded unsigned integer.
+    pub fn u64(&mut self, value: u64) {
+        self.bytes.extend_from_slice(&value.to_le_bytes());
+    }
+
+    /// Writes a boolean as exactly one canonical byte.
+    pub fn bool(&mut self, value: bool) {
+        self.bytes.push(u8::from(value));
+    }
+
+    /// Writes a digest as its exact bytes.
+    pub fn digest<const KIND: u8>(&mut self, value: &TypedDigest<KIND>) {
+        self.bytes.extend_from_slice(value.as_bytes());
+    }
+
+    /// Length-prefixes canonical bytes.
+    pub fn bytes(&mut self, value: &[u8]) {
+        self.u64(cast_length(value.len()));
+        self.bytes.extend_from_slice(value);
+    }
+
+    fn digest_bytes(&self, domain: &'static str) -> [u8; 32] {
+        let mut hasher = Hasher::new();
+        hasher.update(&(domain.len() as u64).to_le_bytes());
+        hasher.update(domain.as_bytes());
+        hasher.update(&(self.bytes.len() as u64).to_le_bytes());
+        hasher.update(&self.bytes);
+        *hasher.finalize().as_bytes()
+    }
+
+    pub(crate) fn finish<const KIND: u8>(&self, domain: &'static str) -> TypedDigest<KIND> {
+        TypedDigest::from_bytes(self.digest_bytes(domain))
+    }
+}
+
+impl Display for Sha256Digest {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "sha256:{}", hex_lower(self.as_bytes()))
+    }
+}
+
+impl Display for Blake3Digest {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "blake3:{}", hex_lower(self.as_bytes()))
+    }
+}
+
+fn hex_lower(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+fn cast_length(length: usize) -> u64 {
+    u64::try_from(length).unwrap_or(u64::MAX)
+}

--- a/crates/astrid-package-service/src/error.rs
+++ b/crates/astrid-package-service/src/error.rs
@@ -1,0 +1,66 @@
+use std::num::TryFromIntError;
+
+/// Typed failures for the pure package-lifecycle model.
+#[derive(Debug, thiserror::Error)]
+pub enum PackageServiceError {
+    /// The request uses a protocol version this model does not understand.
+    #[error("unsupported package protocol version")]
+    ProtocolVersion,
+    /// An identifier or bounded text failed validation.
+    #[error("invalid package value: {0}")]
+    InvalidValue(&'static str),
+    /// An integer did not fit its bounded contract representation.
+    #[error("package value is outside its bounded representation")]
+    IntegerBounds(#[from] TryFromIntError),
+    /// A canonical generation counter refused overflow.
+    #[error("canonical generation overflow")]
+    GenerationOverflow,
+    /// Authenticated ingress and the canonical context disagree.
+    #[error("authenticated ingress does not match the operation context")]
+    StampedIdentityMismatch,
+    /// Admitted service identity or generation does not match the context.
+    #[error("admitted service does not match the operation context")]
+    ServiceAdmissionMismatch,
+    /// An authority decision was not bound to the exact context.
+    #[error("authority decision is not bound to this operation context")]
+    AuthorityContextMismatch,
+    /// An authority issuer or channel is not permitted for its decision class.
+    #[error("authority issuer is not permitted for this decision class")]
+    AuthorityIssuerRejected,
+    /// A nonce or authority decision was replayed for a different effect.
+    #[error("authority or nonce replay detected")]
+    ReplayRejected,
+    /// The operation context expired before admission or work.
+    #[error("operation authority has expired")]
+    AuthorityExpired,
+    /// The operation is not valid for the expected canonical state.
+    #[error("canonical state expectation was not met")]
+    ExpectedStateMismatch,
+    /// The lifecycle state cannot make the requested transition.
+    #[error("package lifecycle transition is invalid")]
+    LifecycleTransition,
+    /// Exact artifact, manifest, plan, or budget bindings disagree.
+    #[error("validated operation binding does not match the canonical context")]
+    BindingMismatch,
+    /// A bounded drain still has live leases at its deadline.
+    #[error("drain is blocked because live leases remain")]
+    DrainBlocked,
+    /// Recovery evidence did not prove an exact old or new outcome.
+    #[error("recovery evidence does not resolve the unknown outcome")]
+    RecoveryUnresolved,
+    /// The requested nonce has no authoritative owner/package record.
+    #[error("operation record is absent")]
+    RecordMissing,
+    /// Recovery addressed a record that is not currently unknown.
+    #[error("operation record is not available for reconciliation")]
+    RecordNotReconcilable,
+    /// Capacity policy refused work before any budgeted effect.
+    #[error("journal capacity or retention policy refused the operation")]
+    QuotaExhausted,
+    /// Canonical slot occupancy is inconsistent.
+    #[error("package slot occupancy invariant failed")]
+    OccupancyCorruption,
+}
+
+/// Convenient result alias for this private crate.
+pub type PackageServiceResult<T> = Result<T, PackageServiceError>;

--- a/crates/astrid-package-service/src/identity.rs
+++ b/crates/astrid-package-service/src/identity.rs
@@ -1,0 +1,478 @@
+use crate::digest::{Blake3Digest, Sha256Digest};
+use crate::error::{PackageServiceError, PackageServiceResult};
+use std::num::{NonZeroU32, NonZeroU64};
+
+macro_rules! opaque32 {
+    ($name:ident, $doc:literal) => {
+        #[doc = $doc]
+        #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+        pub struct $name([u8; 32]);
+
+        impl $name {
+            #[doc = concat!("Creates a validated ", stringify!($name), " from 32 bytes.")]
+            #[must_use]
+            pub const fn from_bytes(bytes: [u8; 32]) -> Self {
+                Self(bytes)
+            }
+
+            #[doc = "Returns the immutable canonical bytes."]
+            #[must_use]
+            pub const fn as_bytes(&self) -> &[u8; 32] {
+                &self.0
+            }
+        }
+    };
+}
+
+opaque32!(
+    Nonce,
+    "Cryptographically random, globally unique operation nonce."
+);
+opaque32!(
+    ComponentIdentity,
+    "Authenticated admitted-service component identity."
+);
+opaque32!(
+    PackageObject,
+    "Immutable owner-neutral package object identity."
+);
+opaque32!(
+    AuthorityIssuerIdentity,
+    "Immutable authority issuer or issuer-policy identity."
+);
+
+/// Private protocol version.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct ProtocolVersion(NonZeroU32);
+
+/// Canonical installed-state schema version.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct StateSchemaVersion(NonZeroU32);
+
+/// Canonical operation-journal schema version.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct JournalSchemaVersion(NonZeroU32);
+
+/// Immutable admitted-service generation.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct ServiceGeneration(NonZeroU64);
+
+impl ProtocolVersion {
+    /// Constructs a protocol version.
+    #[must_use]
+    pub const fn new(value: NonZeroU32) -> Self {
+        Self(value)
+    }
+
+    /// Returns the numeric protocol version.
+    #[must_use]
+    pub const fn get(&self) -> u32 {
+        self.0.get()
+    }
+}
+
+impl StateSchemaVersion {
+    /// Constructs a state schema version.
+    #[must_use]
+    pub const fn new(value: NonZeroU32) -> Self {
+        Self(value)
+    }
+
+    /// Returns the numeric schema version.
+    #[must_use]
+    pub const fn get(&self) -> u32 {
+        self.0.get()
+    }
+}
+
+impl JournalSchemaVersion {
+    /// Constructs a journal schema version.
+    #[must_use]
+    pub const fn new(value: NonZeroU32) -> Self {
+        Self(value)
+    }
+
+    /// Returns the numeric journal schema version.
+    #[must_use]
+    pub const fn get(&self) -> u32 {
+        self.0.get()
+    }
+}
+
+impl ServiceGeneration {
+    /// Constructs a positive service generation.
+    #[must_use]
+    pub const fn new(value: NonZeroU64) -> Self {
+        Self(value)
+    }
+
+    /// Returns the numeric generation.
+    #[must_use]
+    pub const fn get(&self) -> u64 {
+        self.0.get()
+    }
+
+    /// Returns the underlying nonzero generation.
+    #[must_use]
+    pub const fn as_non_zero(&self) -> NonZeroU64 {
+        self.0
+    }
+}
+
+/// Artifact format identity.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct ArtifactFormatVersion(NonZeroU32);
+
+/// Manifest format identity.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct ManifestFormatVersion(NonZeroU32);
+
+impl ArtifactFormatVersion {
+    /// Constructs a positive format version.
+    #[must_use]
+    pub const fn new(value: NonZeroU32) -> Self {
+        Self(value)
+    }
+
+    /// Returns the numeric format version.
+    #[must_use]
+    pub const fn get(&self) -> u32 {
+        self.0.get()
+    }
+}
+
+impl ManifestFormatVersion {
+    /// Constructs a positive format version.
+    #[must_use]
+    pub const fn new(value: NonZeroU32) -> Self {
+        Self(value)
+    }
+
+    /// Returns the numeric format version.
+    #[must_use]
+    pub const fn get(&self) -> u32 {
+        self.0.get()
+    }
+}
+
+/// Exact-byte artifact identity produced by the trusted staging boundary.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ArtifactIdentity {
+    format_version: ArtifactFormatVersion,
+    size_bytes: NonZeroU64,
+    sha256: Sha256Digest,
+    blake3: Blake3Digest,
+}
+
+impl ArtifactIdentity {
+    /// Binds both mandatory exact-byte digests and the exact size.
+    pub fn new(
+        format_version: ArtifactFormatVersion,
+        size_bytes: NonZeroU64,
+        sha256: Sha256Digest,
+        blake3: Blake3Digest,
+    ) -> PackageServiceResult<Self> {
+        if sha256.as_bytes() == &[0; 32] || blake3.as_bytes() == &[0; 32] {
+            return Err(PackageServiceError::InvalidValue("artifact identity"));
+        }
+        Ok(Self {
+            format_version,
+            size_bytes,
+            sha256,
+            blake3,
+        })
+    }
+
+    /// Returns the exact artifact size in bytes.
+    #[must_use]
+    pub const fn size_bytes(&self) -> u64 {
+        self.size_bytes.get()
+    }
+
+    /// Returns the SHA-256 identity.
+    #[must_use]
+    pub const fn sha256(&self) -> &Sha256Digest {
+        &self.sha256
+    }
+
+    /// Returns the BLAKE3 identity.
+    #[must_use]
+    pub const fn blake3(&self) -> &Blake3Digest {
+        &self.blake3
+    }
+
+    pub(crate) const fn format_version(&self) -> u32 {
+        self.format_version.get()
+    }
+}
+
+/// Validated manifest identity bound to exact manifest bytes.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ManifestIdentity {
+    format_version: ManifestFormatVersion,
+    package_name: PackageName,
+    package_version: PackageVersion,
+    manifest_digest: Blake3Digest,
+}
+
+impl ManifestIdentity {
+    /// Constructs a bounded, validated manifest identity.
+    pub fn new(
+        format_version: ManifestFormatVersion,
+        package_name: PackageName,
+        package_version: PackageVersion,
+        manifest_digest: Blake3Digest,
+    ) -> PackageServiceResult<Self> {
+        if manifest_digest.as_bytes() == &[0; 32] {
+            return Err(PackageServiceError::InvalidValue("manifest identity"));
+        }
+        Ok(Self {
+            format_version,
+            package_name,
+            package_version,
+            manifest_digest,
+        })
+    }
+
+    /// Returns the validated package name.
+    #[must_use]
+    pub const fn package_name(&self) -> &PackageName {
+        &self.package_name
+    }
+
+    /// Returns the validated package version.
+    #[must_use]
+    pub const fn package_version(&self) -> &PackageVersion {
+        &self.package_version
+    }
+
+    pub(crate) const fn format_version(&self) -> u32 {
+        self.format_version.get()
+    }
+
+    pub(crate) const fn manifest_digest(&self) -> &Blake3Digest {
+        &self.manifest_digest
+    }
+}
+
+/// Artifact identities and immutable content root after full validation.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ValidatedArtifact {
+    artifact: ArtifactIdentity,
+    manifest: ManifestIdentity,
+    content_root: Blake3Digest,
+    provenance: ProvenanceEvidence,
+}
+
+/// Bounded provenance evidence used for attribution only.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProvenanceEvidence {
+    class: ProvenanceClass,
+    evidence: Blake3Digest,
+    bounded_evidence: BoundedEvidence,
+}
+
+/// Neutral provenance class used only for attribution.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ProvenanceClass {
+    /// Artifact already resident in trusted service storage.
+    LocalArtifact,
+    /// Artifact produced by an authenticated build boundary.
+    BuildOutput,
+    /// Artifact admitted by an authenticated publication boundary.
+    PublishedArtifact,
+    /// Artifact admitted by an authenticated distribution boundary.
+    DistributionArtifact,
+}
+
+impl ProvenanceClass {
+    pub(crate) const fn tag(&self) -> u8 {
+        match self {
+            Self::LocalArtifact => 1,
+            Self::BuildOutput => 2,
+            Self::PublishedArtifact => 3,
+            Self::DistributionArtifact => 4,
+        }
+    }
+}
+
+impl ProvenanceEvidence {
+    /// Constructs attribution evidence without interpreting its bounded bytes.
+    pub fn new(
+        class: ProvenanceClass,
+        evidence: Blake3Digest,
+        bounded_evidence: BoundedEvidence,
+    ) -> PackageServiceResult<Self> {
+        if evidence.as_bytes() == &[0; 32] {
+            return Err(PackageServiceError::InvalidValue("provenance evidence"));
+        }
+        Ok(Self {
+            class,
+            evidence,
+            bounded_evidence,
+        })
+    }
+
+    pub(crate) const fn class(&self) -> ProvenanceClass {
+        self.class
+    }
+
+    pub(crate) const fn evidence(&self) -> &Blake3Digest {
+        &self.evidence
+    }
+
+    pub(crate) const fn bounded_evidence(&self) -> &BoundedEvidence {
+        &self.bounded_evidence
+    }
+}
+
+/// Bounded opaque bytes preserved by the trusted validation boundary.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BoundedEvidence(Vec<u8>);
+
+impl BoundedEvidence {
+    /// Maximum protocol ceiling for attribution evidence retained in state.
+    ///
+    /// This is a format boundary, not an operator tuning knob. A deployment may
+    /// supply fewer bytes; larger evidence remains outside this contract.
+    pub const MAX_BYTES: usize = 4_096;
+
+    /// Validates and owns an evidence byte vector.
+    pub fn new(bytes: Vec<u8>) -> PackageServiceResult<Self> {
+        if bytes.len() > Self::MAX_BYTES {
+            return Err(PackageServiceError::InvalidValue("bounded evidence"));
+        }
+        Ok(Self(bytes))
+    }
+
+    /// Returns the preserved evidence bytes.
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl ValidatedArtifact {
+    /// Binds an already validated artifact to immutable content and provenance.
+    pub fn new(
+        artifact: ArtifactIdentity,
+        manifest: ManifestIdentity,
+        content_root: Blake3Digest,
+        provenance: ProvenanceEvidence,
+    ) -> PackageServiceResult<Self> {
+        if content_root.as_bytes() == &[0; 32] {
+            return Err(PackageServiceError::InvalidValue("content root"));
+        }
+        Ok(Self {
+            artifact,
+            manifest,
+            content_root,
+            provenance,
+        })
+    }
+
+    /// Returns the exact-byte artifact identity.
+    #[must_use]
+    pub const fn artifact(&self) -> &ArtifactIdentity {
+        &self.artifact
+    }
+
+    /// Returns the exact manifest identity.
+    #[must_use]
+    pub const fn manifest(&self) -> &ManifestIdentity {
+        &self.manifest
+    }
+
+    /// Returns the immutable content root.
+    #[must_use]
+    pub const fn content_root(&self) -> &Blake3Digest {
+        &self.content_root
+    }
+
+    /// Returns attribution-only provenance evidence.
+    #[must_use]
+    pub const fn provenance(&self) -> &ProvenanceEvidence {
+        &self.provenance
+    }
+}
+
+/// Bounded package-name syntax used only by manifest identity.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct PackageName(String);
+
+/// Bounded package-version text used only by manifest identity.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct PackageVersion(String);
+
+impl PackageName {
+    /// Validates a lowercase ASCII package name of at most 64 bytes.
+    pub fn new(value: &str) -> PackageServiceResult<Self> {
+        validate_bounded_ascii(value, 64, false)?;
+        if !value.bytes().all(|byte| {
+            byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'-' | b'_' | b'.')
+        }) {
+            return Err(PackageServiceError::InvalidValue("package name"));
+        }
+        Ok(Self(value.to_owned()))
+    }
+
+    /// Returns the validated value.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl PackageVersion {
+    /// Validates printable, non-whitespace ASCII of at most 64 bytes.
+    pub fn new(value: &str) -> PackageServiceResult<Self> {
+        validate_bounded_ascii(value, 64, false)?;
+        if value
+            .bytes()
+            .any(|byte| byte.is_ascii_whitespace() || byte.is_ascii_control())
+        {
+            return Err(PackageServiceError::InvalidValue("package version"));
+        }
+        Ok(Self(value.to_owned()))
+    }
+
+    /// Returns the validated value.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+fn validate_bounded_ascii(
+    value: &str,
+    maximum: usize,
+    allow_empty: bool,
+) -> PackageServiceResult<()> {
+    if value.len() > maximum
+        || (value.is_empty() && !allow_empty)
+        || !value.bytes().all(|byte| byte.is_ascii())
+    {
+        return Err(PackageServiceError::InvalidValue("bounded ASCII"));
+    }
+    Ok(())
+}
+
+/// The protocol version understood by this model.
+pub const PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::new(match NonZeroU32::new(1) {
+    Some(value) => value,
+    None => panic!("protocol one is non-zero"),
+});
+
+/// Canonical installed-state schema version understood by this model.
+pub const STATE_SCHEMA_VERSION: StateSchemaVersion =
+    StateSchemaVersion::new(match NonZeroU32::new(1) {
+        Some(value) => value,
+        None => panic!("schema one is non-zero"),
+    });
+
+/// Canonical operation-journal schema version understood by this model.
+pub const JOURNAL_SCHEMA_VERSION: JournalSchemaVersion =
+    JournalSchemaVersion::new(match NonZeroU32::new(1) {
+        Some(value) => value,
+        None => panic!("journal schema one is non-zero"),
+    });

--- a/crates/astrid-package-service/src/identity.rs
+++ b/crates/astrid-package-service/src/identity.rs
@@ -166,6 +166,9 @@ pub struct ArtifactIdentity {
 
 impl ArtifactIdentity {
     /// Binds both mandatory exact-byte digests and the exact size.
+    ///
+    /// # Errors
+    /// Returns [`PackageServiceError::InvalidValue`] for a zero digest.
     pub fn new(
         format_version: ArtifactFormatVersion,
         size_bytes: NonZeroU64,
@@ -217,6 +220,9 @@ pub struct ManifestIdentity {
 
 impl ManifestIdentity {
     /// Constructs a bounded, validated manifest identity.
+    ///
+    /// # Errors
+    /// Returns [`PackageServiceError::InvalidValue`] for a zero manifest digest.
     pub fn new(
         format_version: ManifestFormatVersion,
         package_name: PackageName,
@@ -286,7 +292,7 @@ pub enum ProvenanceClass {
 }
 
 impl ProvenanceClass {
-    pub(crate) const fn tag(&self) -> u8 {
+    pub(crate) const fn tag(self) -> u8 {
         match self {
             Self::LocalArtifact => 1,
             Self::BuildOutput => 2,
@@ -298,6 +304,9 @@ impl ProvenanceClass {
 
 impl ProvenanceEvidence {
     /// Constructs attribution evidence without interpreting its bounded bytes.
+    ///
+    /// # Errors
+    /// Returns [`PackageServiceError::InvalidValue`] for zero evidence.
     pub fn new(
         class: ProvenanceClass,
         evidence: Blake3Digest,
@@ -338,6 +347,9 @@ impl BoundedEvidence {
     pub const MAX_BYTES: usize = 4_096;
 
     /// Validates and owns an evidence byte vector.
+    ///
+    /// # Errors
+    /// Returns [`PackageServiceError::InvalidValue`] when bytes exceed the protocol ceiling.
     pub fn new(bytes: Vec<u8>) -> PackageServiceResult<Self> {
         if bytes.len() > Self::MAX_BYTES {
             return Err(PackageServiceError::InvalidValue("bounded evidence"));
@@ -354,6 +366,9 @@ impl BoundedEvidence {
 
 impl ValidatedArtifact {
     /// Binds an already validated artifact to immutable content and provenance.
+    ///
+    /// # Errors
+    /// Returns [`PackageServiceError::InvalidValue`] for a zero content root.
     pub fn new(
         artifact: ArtifactIdentity,
         manifest: ManifestIdentity,
@@ -406,6 +421,9 @@ pub struct PackageVersion(String);
 
 impl PackageName {
     /// Validates a lowercase ASCII package name of at most 64 bytes.
+    ///
+    /// # Errors
+    /// Returns [`PackageServiceError::InvalidValue`] for malformed or oversized names.
     pub fn new(value: &str) -> PackageServiceResult<Self> {
         validate_bounded_ascii(value, 64, false)?;
         if !value.bytes().all(|byte| {
@@ -425,6 +443,9 @@ impl PackageName {
 
 impl PackageVersion {
     /// Validates printable, non-whitespace ASCII of at most 64 bytes.
+    ///
+    /// # Errors
+    /// Returns [`PackageServiceError::InvalidValue`] for malformed or oversized versions.
     pub fn new(value: &str) -> PackageServiceResult<Self> {
         validate_bounded_ascii(value, 64, false)?;
         if value

--- a/crates/astrid-package-service/src/journal.rs
+++ b/crates/astrid-package-service/src/journal.rs
@@ -32,7 +32,7 @@ pub enum JournalStatus {
 }
 
 impl JournalStatus {
-    const fn tag(&self) -> u8 {
+    const fn tag(self) -> u8 {
         match self {
             Self::Intent => 1,
             Self::Executing => 2,
@@ -44,7 +44,7 @@ impl JournalStatus {
         }
     }
 
-    pub(crate) const fn is_unresolved(&self) -> bool {
+    pub(crate) const fn is_unresolved(self) -> bool {
         matches!(self, Self::Intent | Self::Executing | Self::Unknown)
     }
 }
@@ -65,7 +65,7 @@ pub enum ReceiptOutcome {
 }
 
 impl ReceiptOutcome {
-    const fn tag(&self) -> u8 {
+    const fn tag(self) -> u8 {
         match self {
             Self::Installed => 1,
             Self::Updated => 2,
@@ -215,6 +215,9 @@ pub struct DrainPlan {
 
 impl DrainPlan {
     /// Validates a drain against the exact canonical state it may alter.
+    ///
+    /// # Errors
+    /// Returns typed invalid-value failures when the plan is not state-bound.
     pub fn new(
         destination: DrainDestination,
         expected_state: crate::state::ExpectedPackageState,
@@ -311,6 +314,9 @@ impl RecoveryEvidence {
     }
 
     /// Constructs recovery evidence from independently read state/runtime values.
+    ///
+    /// # Errors
+    /// Returns [`PackageServiceError::InvalidValue`] for zero evidence.
     pub fn new(
         token: RecoveryToken,
         observed_state: StateDigest,
@@ -602,6 +608,7 @@ pub enum ReplayOutcome {
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct PackageSlotRecord {
     state: Option<CanonicalInstalledState>,
+    generation_high_watermark: Option<NonZeroU64>,
     journal: BTreeMap<Nonce, OperationJournalRecord>,
 }
 
@@ -646,19 +653,47 @@ impl PackageSlotRecord {
         self.journal.values()
     }
 
+    /// Returns the durable generation high-watermark retained across absence.
+    #[must_use]
+    pub const fn generation_high_watermark(&self) -> Option<NonZeroU64> {
+        self.generation_high_watermark
+    }
+
+    #[cfg(test)]
+    pub(crate) fn force_generation_high_watermark_for_test(&mut self, generation: NonZeroU64) {
+        self.generation_high_watermark = Some(generation);
+    }
+
+    /// Replaces state and advances the high-watermark to one exact transition.
+    pub(crate) fn replace_state_with_generation(
+        &mut self,
+        state: Option<CanonicalInstalledState>,
+        generation: NonZeroU64,
+    ) -> PackageServiceResult<()> {
+        if let Some(existing) = self.generation_high_watermark {
+            let successor = existing
+                .get()
+                .checked_add(1)
+                .ok_or(PackageServiceError::GenerationOverflow)?;
+            if successor != generation.get() {
+                return Err(PackageServiceError::BindingMismatch);
+            }
+        } else if generation.get() != 1 {
+            return Err(PackageServiceError::InvalidValue("initial generation"));
+        }
+        self.generation_high_watermark = Some(generation);
+        self.state = state;
+        Ok(())
+    }
+
     pub(crate) fn remove_journal(&mut self, nonce: &Nonce) -> Option<Tombstone> {
         let record = self.journal.remove(nonce)?;
         Some(Tombstone {
             nonce: *nonce,
             terminal_status: record.status(),
             context_digest: *record.context().digest(),
-            outcome: record.receipt().map(|receipt| receipt.outcome()),
+            outcome: record.receipt().map(OperationReceipt::outcome),
             record_digest: record.record_digest(),
         })
-    }
-
-    /// Replaces canonical state and journal as one logical value.
-    pub(crate) fn replace_state(&mut self, state: Option<CanonicalInstalledState>) {
-        self.state = state;
     }
 }

--- a/crates/astrid-package-service/src/journal.rs
+++ b/crates/astrid-package-service/src/journal.rs
@@ -311,21 +311,26 @@ impl RecoveryEvidence {
     }
 
     /// Constructs recovery evidence from independently read state/runtime values.
-    #[must_use]
-    pub const fn new(
+    pub fn new(
         token: RecoveryToken,
         observed_state: StateDigest,
         runtime_generation: NonZeroU64,
         activation_receipt: Option<Blake3Digest>,
         zero_leases_proved: bool,
-    ) -> Self {
-        Self {
+    ) -> PackageServiceResult<Self> {
+        if token.into_bytes() == [0; 32] {
+            return Err(PackageServiceError::InvalidValue("recovery token"));
+        }
+        if activation_receipt.is_some_and(|receipt| receipt.as_bytes() == &[0; 32]) {
+            return Err(PackageServiceError::InvalidValue("activation receipt"));
+        }
+        Ok(Self {
             token,
             observed_state,
             runtime_generation,
             activation_receipt,
             zero_leases_proved,
-        }
+        })
     }
 }
 
@@ -466,6 +471,10 @@ impl OperationJournalRecord {
 
     pub(crate) fn set_drain_base_state(&mut self, state: CanonicalInstalledState) {
         self.drain_base_state = Some(state);
+    }
+
+    pub(crate) const fn drain_base_state(&self) -> Option<&CanonicalInstalledState> {
+        self.drain_base_state.as_ref()
     }
 
     pub(crate) fn take_drain_base_state(&mut self) -> Option<CanonicalInstalledState> {

--- a/crates/astrid-package-service/src/journal.rs
+++ b/crates/astrid-package-service/src/journal.rs
@@ -350,6 +350,7 @@ pub struct OperationJournalRecord {
     recovery_token: RecoveryToken,
     state_generation: Option<NonZeroU64>,
     drain_lineage: Option<DrainLineage>,
+    staged_commit_plan: Option<PlanDigest>,
 }
 
 impl OperationJournalRecord {
@@ -403,6 +404,7 @@ impl OperationJournalRecord {
             recovery_token,
             state_generation,
             drain_lineage: None,
+            staged_commit_plan: None,
         }
     }
 
@@ -458,6 +460,13 @@ impl OperationJournalRecord {
             },
             None => writer.tag(0),
         }
+        match &self.staged_commit_plan {
+            Some(plan) => {
+                writer.tag(1);
+                writer.digest(plan);
+            },
+            None => writer.tag(0),
+        }
         writer.finish("astrid.package.journal-record.v1")
     }
 
@@ -491,6 +500,18 @@ impl OperationJournalRecord {
 
     pub(crate) fn take_drain_lineage(&mut self) -> Option<DrainLineage> {
         self.drain_lineage.take()
+    }
+
+    pub(crate) const fn staged_commit_plan(&self) -> Option<&PlanDigest> {
+        self.staged_commit_plan.as_ref()
+    }
+
+    pub(crate) fn set_staged_commit_plan(&mut self, plan: PlanDigest) {
+        self.staged_commit_plan = Some(plan);
+    }
+
+    pub(crate) fn take_staged_commit_plan(&mut self) -> Option<PlanDigest> {
+        self.staged_commit_plan.take()
     }
 
     pub(crate) const fn before_state(&self) -> StateDigest {

--- a/crates/astrid-package-service/src/journal.rs
+++ b/crates/astrid-package-service/src/journal.rs
@@ -1,0 +1,599 @@
+use crate::bytes::RecoveryToken;
+use crate::context::{Operation, OperationContext, Timestamp};
+use crate::digest::{
+    AuthorityDecisionDigest, Blake3Digest, DigestWriter, PlanDigest, ReceiptDigest, RequestDigest,
+    StateDigest, TypedDigest,
+};
+use crate::error::{PackageServiceError, PackageServiceResult};
+use crate::identity::{JOURNAL_SCHEMA_VERSION, JournalSchemaVersion, Nonce, ProtocolVersion};
+use crate::state::{CanonicalInstalledState, DrainDestination, PackageSlot};
+use std::collections::BTreeMap;
+use std::num::NonZeroU64;
+
+pub(crate) type ReservationDigest = RequestDigest;
+
+/// Status of the authoritative operation journal record.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum JournalStatus {
+    /// Durable before any budgeted effect.
+    Intent,
+    /// A bounded budgeted effect is in progress.
+    Executing,
+    /// The outcome cannot yet be proved.
+    Unknown,
+    /// A successful receipt is retained.
+    Committed,
+    /// A typed failure is terminal.
+    Failed,
+    /// Authority or lease expiry is terminal.
+    Expired,
+    /// Cancellation before the commit boundary is terminal.
+    Aborted,
+}
+
+impl JournalStatus {
+    const fn tag(&self) -> u8 {
+        match self {
+            Self::Intent => 1,
+            Self::Executing => 2,
+            Self::Unknown => 3,
+            Self::Committed => 4,
+            Self::Failed => 5,
+            Self::Expired => 6,
+            Self::Aborted => 7,
+        }
+    }
+
+    pub(crate) const fn is_unresolved(&self) -> bool {
+        matches!(self, Self::Intent | Self::Executing | Self::Unknown)
+    }
+}
+
+/// Success or typed retirement outcome carried by a receipt.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ReceiptOutcome {
+    /// Exact new state became installed and inactive.
+    Installed,
+    /// Exact new state replaced the prior state.
+    Updated,
+    /// Runtime publication succeeded.
+    Activated,
+    /// Runtime publication stopped.
+    Deactivated,
+    /// Canonical state became absent; retirement exists only here.
+    Retired,
+}
+
+impl ReceiptOutcome {
+    const fn tag(&self) -> u8 {
+        match self {
+            Self::Installed => 1,
+            Self::Updated => 2,
+            Self::Activated => 3,
+            Self::Deactivated => 4,
+            Self::Retired => 5,
+        }
+    }
+}
+
+/// At-most-once success evidence.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OperationReceipt {
+    protocol_version: ProtocolVersion,
+    operation: Operation,
+    slot: PackageSlot,
+    nonce: Nonce,
+    outcome: ReceiptOutcome,
+    before_state: StateDigest,
+    after_state: StateDigest,
+    state_generation: NonZeroU64,
+    service_generation: NonZeroU64,
+    activation_receipt: Option<Blake3Digest>,
+    expiry: Timestamp,
+    digest: ReceiptDigest,
+}
+
+impl OperationReceipt {
+    pub(crate) fn new(
+        context: &OperationContext,
+        outcome: ReceiptOutcome,
+        before_state: StateDigest,
+        after_state: StateDigest,
+        state_generation: NonZeroU64,
+        activation_receipt: Option<Blake3Digest>,
+    ) -> Self {
+        let value = Self {
+            protocol_version: context.protocol_version(),
+            operation: context.operation(),
+            slot: PackageSlot::new(context.target_owner(), context.package_object()),
+            nonce: context.nonce(),
+            outcome,
+            before_state,
+            after_state,
+            state_generation,
+            service_generation: context.service_generation().as_non_zero(),
+            activation_receipt,
+            expiry: context.expiry(),
+            digest: TypedDigest::from_bytes([0; 32]),
+        };
+        let mut writer = DigestWriter::new();
+        value.write(&mut writer);
+        let digest = writer.finish("astrid.package.receipt.v1");
+        Self { digest, ..value }
+    }
+
+    fn write(&self, writer: &mut DigestWriter) {
+        writer.u64(u64::from(self.protocol_version.get()));
+        writer.tag(self.operation.tag());
+        writer.bytes(self.slot.owner().as_bytes());
+        writer.bytes(self.slot.package_object().as_bytes());
+        writer.bytes(self.nonce.as_bytes());
+        writer.tag(self.outcome.tag());
+        writer.digest(&self.before_state);
+        writer.digest(&self.after_state);
+        writer.u64(self.state_generation.get());
+        writer.u64(self.service_generation.get());
+        match &self.activation_receipt {
+            Some(receipt) => {
+                writer.tag(1);
+                writer.digest(receipt);
+            },
+            None => writer.tag(0),
+        }
+        writer.u64(self.expiry.get());
+    }
+
+    /// Returns the exact receipt digest.
+    #[must_use]
+    pub const fn digest(&self) -> ReceiptDigest {
+        self.digest
+    }
+
+    /// Returns the receipt protocol version.
+    #[must_use]
+    pub const fn protocol_version(&self) -> ProtocolVersion {
+        self.protocol_version
+    }
+
+    /// Returns the operation class.
+    #[must_use]
+    pub const fn operation(&self) -> Operation {
+        self.operation
+    }
+
+    /// Returns the immutable owner/package slot.
+    #[must_use]
+    pub const fn slot(&self) -> PackageSlot {
+        self.slot
+    }
+
+    /// Returns the operation nonce.
+    #[must_use]
+    pub const fn nonce(&self) -> Nonce {
+        self.nonce
+    }
+
+    /// Returns the outcome.
+    #[must_use]
+    pub const fn outcome(&self) -> ReceiptOutcome {
+        self.outcome
+    }
+
+    /// Returns the canonical state before the operation.
+    #[must_use]
+    pub const fn before_state(&self) -> StateDigest {
+        self.before_state
+    }
+
+    /// Returns the canonical state after the operation.
+    #[must_use]
+    pub const fn after_state(&self) -> StateDigest {
+        self.after_state
+    }
+}
+
+/// Durable intent for a bounded drain.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DrainPlan {
+    destination: DrainDestination,
+    deadline: Timestamp,
+    nonce: Nonce,
+}
+
+impl DrainPlan {
+    pub(crate) const fn new(
+        destination: DrainDestination,
+        deadline: Timestamp,
+        nonce: Nonce,
+    ) -> Self {
+        Self {
+            destination,
+            deadline,
+            nonce,
+        }
+    }
+
+    /// Returns the destination.
+    #[must_use]
+    pub const fn destination(&self) -> DrainDestination {
+        self.destination
+    }
+
+    /// Returns the bounded deadline.
+    #[must_use]
+    pub const fn deadline(&self) -> Timestamp {
+        self.deadline
+    }
+
+    /// Returns the owning nonce.
+    #[must_use]
+    pub const fn nonce(&self) -> Nonce {
+        self.nonce
+    }
+
+    /// Returns the canonical plan digest bound into the operation context.
+    #[must_use]
+    pub fn digest(&self) -> PlanDigest {
+        let mut writer = DigestWriter::new();
+        writer.tag(match self.destination {
+            DrainDestination::Replacement => 1,
+            DrainDestination::Removal => 2,
+        });
+        writer.u64(self.deadline.get());
+        writer.bytes(self.nonce.as_bytes());
+        writer.finish("astrid.package.plan.v1")
+    }
+}
+
+/// Result of advancing a drain.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DrainResult {
+    /// The drain remains durable and activation is refused.
+    Draining,
+    /// The deadline passed with live leases; recovery remains blocked.
+    Blocked,
+    /// The destination proved zero leases and completed.
+    Completed,
+}
+
+/// Exact evidence used to reconcile an unknown result.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RecoveryEvidence {
+    token: RecoveryToken,
+    observed_state: StateDigest,
+    runtime_generation: NonZeroU64,
+    activation_receipt: Option<Blake3Digest>,
+    zero_leases_proved: bool,
+}
+
+impl RecoveryEvidence {
+    pub(crate) const fn token_bytes(&self) -> [u8; 32] {
+        self.token.into_bytes()
+    }
+
+    pub(crate) const fn observed_state(&self) -> StateDigest {
+        self.observed_state
+    }
+
+    pub(crate) const fn runtime_generation(&self) -> NonZeroU64 {
+        self.runtime_generation
+    }
+
+    pub(crate) const fn activation_receipt(&self) -> Option<Blake3Digest> {
+        self.activation_receipt
+    }
+
+    pub(crate) const fn zero_leases_proved(&self) -> bool {
+        self.zero_leases_proved
+    }
+
+    /// Constructs recovery evidence from independently read state/runtime values.
+    #[must_use]
+    pub const fn new(
+        token: RecoveryToken,
+        observed_state: StateDigest,
+        runtime_generation: NonZeroU64,
+        activation_receipt: Option<Blake3Digest>,
+        zero_leases_proved: bool,
+    ) -> Self {
+        Self {
+            token,
+            observed_state,
+            runtime_generation,
+            activation_receipt,
+            zero_leases_proved,
+        }
+    }
+}
+
+/// The authoritative co-located operation record.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OperationJournalRecord {
+    schema_version: JournalSchemaVersion,
+    context: OperationContext,
+    authority_digest: AuthorityDecisionDigest,
+    request_digest: RequestDigest,
+    intent_digest: TypedDigest<10>,
+    reservation_digest: ReservationDigest,
+    status: JournalStatus,
+    started_at: Timestamp,
+    terminal_at: Timestamp,
+    receipt: Option<OperationReceipt>,
+    recovery_token: RecoveryToken,
+    state_generation: Option<NonZeroU64>,
+    drain_base_state: Option<CanonicalInstalledState>,
+}
+
+impl OperationJournalRecord {
+    pub(crate) fn new_intent(
+        context: OperationContext,
+        authority_digest: AuthorityDecisionDigest,
+        ingress: &crate::context::AuthenticatedIngress,
+        service: &crate::context::AdmittedService,
+        now: Timestamp,
+        state_generation: Option<NonZeroU64>,
+    ) -> Self {
+        let request_digest = {
+            let mut writer = DigestWriter::new();
+            writer.digest(context.digest());
+            writer.digest(&authority_digest);
+            writer.tag(ingress.channel_tag());
+            writer.digest(ingress.evidence());
+            writer.digest(service.evidence());
+            writer.finish("astrid.package.request.v1")
+        };
+        let intent_digest = {
+            let mut writer = DigestWriter::new();
+            writer.digest(&request_digest);
+            writer.tag(JournalStatus::Intent.tag());
+            writer.finish("astrid.package.journal-intent.v1")
+        };
+        let reservation_digest = {
+            let mut writer = DigestWriter::new();
+            writer.digest(context.budget_digest());
+            writer.u64(context.reservation_bytes());
+            writer.finish("astrid.package.reservation.v1")
+        };
+        let recovery_token = {
+            let mut writer = DigestWriter::new();
+            writer.bytes(context.nonce().as_bytes());
+            writer.digest(&intent_digest);
+            let bytes: crate::digest::RequestDigest = writer.finish("astrid.package.recovery.v1");
+            RecoveryToken::from_bytes(bytes.into_bytes())
+        };
+        Self {
+            schema_version: JOURNAL_SCHEMA_VERSION,
+            context,
+            authority_digest,
+            request_digest,
+            intent_digest,
+            reservation_digest,
+            status: JournalStatus::Intent,
+            started_at: now,
+            terminal_at: now,
+            receipt: None,
+            recovery_token,
+            state_generation,
+            drain_base_state: None,
+        }
+    }
+
+    /// Stable approximate encoded size charged against bounded capacity.
+    #[must_use]
+    pub const fn encoded_len(&self) -> u64 {
+        1024
+    }
+
+    /// Returns the nonce-scoped recovery token.
+    #[must_use]
+    pub const fn recovery_token(&self) -> RecoveryToken {
+        self.recovery_token
+    }
+
+    /// Returns the current journal status.
+    #[must_use]
+    pub const fn status(&self) -> JournalStatus {
+        self.status
+    }
+
+    /// Returns the terminal timestamp when status is terminal.
+    #[must_use]
+    pub const fn terminal_at(&self) -> Timestamp {
+        self.terminal_at
+    }
+
+    /// Returns the retained receipt when committed.
+    #[must_use]
+    pub const fn receipt(&self) -> Option<&OperationReceipt> {
+        self.receipt.as_ref()
+    }
+
+    pub(crate) const fn context(&self) -> &OperationContext {
+        &self.context
+    }
+
+    pub(crate) const fn authority_digest(&self) -> &AuthorityDecisionDigest {
+        &self.authority_digest
+    }
+
+    pub(crate) fn record_digest(&self) -> TypedDigest<11> {
+        let mut writer = DigestWriter::new();
+        writer.u64(u64::from(self.schema_version.get()));
+        writer.digest(&self.intent_digest);
+        writer.tag(self.status.tag());
+        writer.u64(self.started_at.get());
+        writer.u64(self.terminal_at.get());
+        match &self.receipt {
+            Some(receipt) => {
+                writer.tag(1);
+                writer.digest(&receipt.digest);
+            },
+            None => writer.tag(0),
+        }
+        writer.finish("astrid.package.journal-record.v1")
+    }
+
+    pub(crate) const fn state_generation(&self) -> Option<NonZeroU64> {
+        self.state_generation
+    }
+
+    pub(crate) const fn set_state_generation(&mut self, generation: NonZeroU64) {
+        self.state_generation = Some(generation);
+    }
+
+    pub(crate) fn set_drain_base_state(&mut self, state: CanonicalInstalledState) {
+        self.drain_base_state = Some(state);
+    }
+
+    pub(crate) fn take_drain_base_state(&mut self) -> Option<CanonicalInstalledState> {
+        self.drain_base_state.take()
+    }
+
+    pub(crate) const fn before_state(&self) -> StateDigest {
+        self.context.expected_state().digest()
+    }
+
+    pub(crate) fn set_executing(&mut self, now: Timestamp) {
+        self.status = JournalStatus::Executing;
+        self.started_at = now;
+    }
+
+    pub(crate) fn mark_unknown(&mut self, now: Timestamp) {
+        self.status = JournalStatus::Unknown;
+        self.terminal_at = now;
+    }
+
+    pub(crate) fn terminal_failure(&mut self, status: JournalStatus, now: Timestamp) {
+        self.status = status;
+        self.terminal_at = now;
+    }
+
+    pub(crate) fn commit(&mut self, receipt: OperationReceipt, now: Timestamp) {
+        self.status = JournalStatus::Committed;
+        self.terminal_at = now;
+        self.receipt = Some(receipt);
+    }
+
+    pub(crate) fn resolve_recovery(
+        &mut self,
+        receipt: Option<OperationReceipt>,
+        status: JournalStatus,
+        now: Timestamp,
+    ) {
+        self.status = status;
+        self.terminal_at = now;
+        self.receipt = receipt;
+    }
+}
+
+/// Bounded replay evidence retained even after record collection.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Tombstone {
+    nonce: Nonce,
+    terminal_status: JournalStatus,
+    context_digest: crate::digest::ContextDigest,
+    outcome: Option<ReceiptOutcome>,
+    record_digest: TypedDigest<11>,
+}
+
+impl Tombstone {
+    /// Returns the collected nonce.
+    #[must_use]
+    pub const fn nonce(&self) -> Nonce {
+        self.nonce
+    }
+
+    /// Returns the terminal record class retained by the tombstone.
+    #[must_use]
+    pub const fn terminal_status(&self) -> JournalStatus {
+        self.terminal_status
+    }
+
+    /// Returns the operation context originally covered by the record.
+    #[must_use]
+    pub const fn context_digest(&self) -> crate::digest::ContextDigest {
+        self.context_digest
+    }
+
+    /// Returns the outcome class when a receipt had committed.
+    #[must_use]
+    pub const fn outcome(&self) -> Option<ReceiptOutcome> {
+        self.outcome
+    }
+}
+
+/// Outcome of replaying a nonce.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ReplayOutcome {
+    /// The exact terminal receipt was retained.
+    Receipt(OperationReceipt),
+    /// The operation is still unresolved and may only resume or recover.
+    Unresolved,
+    /// The record was collected, but a bounded tombstone proves later replay.
+    Tombstoned(Tombstone),
+}
+
+/// One owner/package slot holding canonical state and its authoritative journal.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct PackageSlotRecord {
+    state: Option<CanonicalInstalledState>,
+    journal: BTreeMap<Nonce, OperationJournalRecord>,
+}
+
+impl PackageSlotRecord {
+    /// Returns the canonical state digest, with a fixed digest for absence.
+    #[must_use]
+    pub const fn expected_state_digest(&self) -> StateDigest {
+        match &self.state {
+            Some(state) => state.digest(),
+            None => StateDigest::from_bytes([0; 32]),
+        }
+    }
+
+    /// Returns canonical installed state.
+    #[must_use]
+    pub const fn state(&self) -> Option<&CanonicalInstalledState> {
+        self.state.as_ref()
+    }
+
+    /// Returns a journal record by nonce.
+    #[must_use]
+    pub fn journal_record(&self, nonce: &Nonce) -> Option<&OperationJournalRecord> {
+        self.journal.get(nonce)
+    }
+
+    pub(crate) fn journal_mut(&mut self, nonce: &Nonce) -> Option<&mut OperationJournalRecord> {
+        self.journal.get_mut(nonce)
+    }
+
+    pub(crate) fn insert_intent(
+        &mut self,
+        record: OperationJournalRecord,
+    ) -> PackageServiceResult<()> {
+        if self.journal.contains_key(&record.context().nonce()) {
+            return Err(PackageServiceError::ReplayRejected);
+        }
+        self.journal.insert(record.context().nonce(), record);
+        Ok(())
+    }
+
+    pub(crate) fn journal_values(&self) -> impl Iterator<Item = &OperationJournalRecord> {
+        self.journal.values()
+    }
+
+    pub(crate) fn remove_journal(&mut self, nonce: &Nonce) -> Option<Tombstone> {
+        let record = self.journal.remove(nonce)?;
+        Some(Tombstone {
+            nonce: *nonce,
+            terminal_status: record.status(),
+            context_digest: *record.context().digest(),
+            outcome: record.receipt().map(|receipt| receipt.outcome()),
+            record_digest: record.record_digest(),
+        })
+    }
+
+    /// Replaces canonical state and journal as one logical value.
+    pub(crate) fn replace_state(&mut self, state: Option<CanonicalInstalledState>) {
+        self.state = state;
+    }
+}

--- a/crates/astrid-package-service/src/journal.rs
+++ b/crates/astrid-package-service/src/journal.rs
@@ -6,7 +6,7 @@ use crate::digest::{
 };
 use crate::error::{PackageServiceError, PackageServiceResult};
 use crate::identity::{JOURNAL_SCHEMA_VERSION, JournalSchemaVersion, Nonce, ProtocolVersion};
-use crate::state::{CanonicalInstalledState, DrainDestination, PackageSlot};
+use crate::state::{CanonicalInstalledState, DrainDestination, DrainLineage, PackageSlot};
 use std::collections::BTreeMap;
 use std::num::NonZeroU64;
 
@@ -349,7 +349,7 @@ pub struct OperationJournalRecord {
     receipt: Option<OperationReceipt>,
     recovery_token: RecoveryToken,
     state_generation: Option<NonZeroU64>,
-    drain_base_state: Option<CanonicalInstalledState>,
+    drain_lineage: Option<DrainLineage>,
 }
 
 impl OperationJournalRecord {
@@ -402,7 +402,7 @@ impl OperationJournalRecord {
             receipt: None,
             recovery_token,
             state_generation,
-            drain_base_state: None,
+            drain_lineage: None,
         }
     }
 
@@ -469,16 +469,28 @@ impl OperationJournalRecord {
         self.state_generation = Some(generation);
     }
 
-    pub(crate) fn set_drain_base_state(&mut self, state: CanonicalInstalledState) {
-        self.drain_base_state = Some(state);
+    pub(crate) fn set_drain_lineage(&mut self, lineage: DrainLineage) {
+        self.drain_lineage = Some(lineage);
     }
 
-    pub(crate) const fn drain_base_state(&self) -> Option<&CanonicalInstalledState> {
-        self.drain_base_state.as_ref()
+    pub(crate) const fn drain_lineage(&self) -> Option<&DrainLineage> {
+        self.drain_lineage.as_ref()
     }
 
-    pub(crate) fn take_drain_base_state(&mut self) -> Option<CanonicalInstalledState> {
-        self.drain_base_state.take()
+    pub(crate) fn advance_drain_boundary(&mut self) -> PackageServiceResult<()> {
+        let lineage = self
+            .drain_lineage
+            .as_ref()
+            .ok_or(PackageServiceError::OccupancyCorruption)?
+            .advanced()?;
+        let generation = lineage.boundary_generation();
+        self.drain_lineage = Some(lineage);
+        self.state_generation = Some(generation);
+        Ok(())
+    }
+
+    pub(crate) fn take_drain_lineage(&mut self) -> Option<DrainLineage> {
+        self.drain_lineage.take()
     }
 
     pub(crate) const fn before_state(&self) -> StateDigest {

--- a/crates/astrid-package-service/src/journal.rs
+++ b/crates/astrid-package-service/src/journal.rs
@@ -190,27 +190,49 @@ impl OperationReceipt {
     pub const fn after_state(&self) -> StateDigest {
         self.after_state
     }
+
+    /// Returns the canonical package-state generation produced by the receipt.
+    #[must_use]
+    pub const fn state_generation(&self) -> NonZeroU64 {
+        self.state_generation
+    }
+
+    /// Returns the admitted-service generation covered by the receipt.
+    #[must_use]
+    pub const fn service_generation(&self) -> NonZeroU64 {
+        self.service_generation
+    }
 }
 
 /// Durable intent for a bounded drain.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct DrainPlan {
     destination: DrainDestination,
+    state_digest: StateDigest,
     deadline: Timestamp,
     nonce: Nonce,
 }
 
 impl DrainPlan {
-    pub(crate) const fn new(
+    /// Validates a drain against the exact canonical state it may alter.
+    pub fn new(
         destination: DrainDestination,
+        expected_state: crate::state::ExpectedPackageState,
         deadline: Timestamp,
         nonce: Nonce,
-    ) -> Self {
-        Self {
+    ) -> PackageServiceResult<Self> {
+        let crate::state::ExpectedPackageState::Exact(state_digest) = expected_state else {
+            return Err(PackageServiceError::InvalidValue("drain expected state"));
+        };
+        if nonce.as_bytes() == &[0; 32] || deadline.get() == 0 {
+            return Err(PackageServiceError::InvalidValue("drain plan"));
+        }
+        Ok(Self {
             destination,
+            state_digest,
             deadline,
             nonce,
-        }
+        })
     }
 
     /// Returns the destination.
@@ -239,6 +261,7 @@ impl DrainPlan {
             DrainDestination::Replacement => 1,
             DrainDestination::Removal => 2,
         });
+        writer.digest(&self.state_digest);
         writer.u64(self.deadline.get());
         writer.bytes(self.nonce.as_bytes());
         writer.finish("astrid.package.plan.v1")

--- a/crates/astrid-package-service/src/lib.rs
+++ b/crates/astrid-package-service/src/lib.rs
@@ -30,7 +30,7 @@ pub use context::Duration;
 pub use context::{
     AdmittedService, ApproverIdentity, AuthenticatedIngress, IngressChannel, Operation,
     OperationContext, OperationContextSpec, ResourceBudget, ResourceClass, ResourceClasses,
-    Timestamp,
+    Timestamp, operation_commit_plan_digest,
 };
 pub use digest::{
     AuthorityDecisionDigest, Blake3Digest, BudgetDigest, ContextDigest, DigestWriter, PlanDigest,

--- a/crates/astrid-package-service/src/lib.rs
+++ b/crates/astrid-package-service/src/lib.rs
@@ -30,6 +30,7 @@ pub use context::Duration;
 pub use context::{
     AdmittedService, ApproverIdentity, AuthenticatedIngress, IngressChannel, Operation,
     OperationContext, OperationContextSpec, ResourceBudget, ResourceClass, ResourceClasses,
+    Timestamp,
 };
 pub use digest::{
     AuthorityDecisionDigest, Blake3Digest, BudgetDigest, ContextDigest, DigestWriter, PlanDigest,
@@ -39,14 +40,17 @@ pub use error::{PackageServiceError, PackageServiceResult};
 pub use identity::{
     ArtifactFormatVersion, ArtifactIdentity, AuthorityIssuerIdentity, BoundedEvidence,
     ComponentIdentity, JOURNAL_SCHEMA_VERSION, JournalSchemaVersion, ManifestFormatVersion,
-    ManifestIdentity, Nonce, PROTOCOL_VERSION, PackageObject, PackageVersion, ProtocolVersion,
-    ProvenanceClass, ProvenanceEvidence, STATE_SCHEMA_VERSION, ServiceGeneration,
+    ManifestIdentity, Nonce, PROTOCOL_VERSION, PackageName, PackageObject, PackageVersion,
+    ProtocolVersion, ProvenanceClass, ProvenanceEvidence, STATE_SCHEMA_VERSION, ServiceGeneration,
     StateSchemaVersion, ValidatedArtifact,
 };
 pub use journal::{
-    DrainPlan, DrainResult, JournalStatus, OperationJournalRecord, PackageSlotRecord,
-    ReceiptOutcome, RecoveryEvidence, ReplayOutcome, Tombstone,
+    DrainPlan, DrainResult, JournalStatus, OperationJournalRecord, OperationReceipt,
+    PackageSlotRecord, ReceiptOutcome, RecoveryEvidence, ReplayOutcome, Tombstone,
 };
 pub use lifecycle::PackageServiceModel;
 pub use policy::{JournalPolicy, JournalRetention, Occupancy, RetentionWindow};
-pub use state::{CanonicalInstalledState, ExpectedPackageState, InstalledStateSpec, PackageSlot};
+pub use state::{
+    CanonicalInstalledState, DrainDestination, ExpectedPackageState, InstalledStateSpec,
+    LifecycleState, PackageSlot,
+};

--- a/crates/astrid-package-service/src/lib.rs
+++ b/crates/astrid-package-service/src/lib.rs
@@ -1,0 +1,52 @@
+//! Private package-lifecycle contract and executable state model.
+//!
+//! This crate intentionally has no transport, durable-storage, or package
+//! parsing implementation. Its values are suitable for an authenticated host
+//! to persist as one owner/package value and later reconcile using runtime
+//! evidence. The contract is private and makes no compatibility commitment.
+
+#![deny(unsafe_code)]
+#![deny(missing_docs)]
+#![deny(clippy::unwrap_used)]
+#![deny(clippy::expect_used)]
+#![deny(unreachable_pub)]
+
+mod authority;
+mod bytes;
+mod context;
+mod digest;
+mod error;
+mod identity;
+mod journal;
+mod lifecycle;
+mod policy;
+mod state;
+
+pub use authority::{
+    AuthenticatedAuthority, AuthorityDecision, AuthorityIssuer, AuthorityIssuerClass,
+};
+pub use bytes::{PrincipalUid, RecoveryToken};
+pub use context::Duration;
+pub use context::{
+    AdmittedService, ApproverIdentity, AuthenticatedIngress, IngressChannel, Operation,
+    OperationContext, OperationContextSpec, ResourceBudget, ResourceClass, ResourceClasses,
+};
+pub use digest::{
+    AuthorityDecisionDigest, Blake3Digest, BudgetDigest, ContextDigest, DigestWriter, PlanDigest,
+    ProvenanceDigest, ReceiptDigest, RequestDigest, Sha256Digest, StateDigest, TypedDigest,
+};
+pub use error::{PackageServiceError, PackageServiceResult};
+pub use identity::{
+    ArtifactFormatVersion, ArtifactIdentity, AuthorityIssuerIdentity, BoundedEvidence,
+    ComponentIdentity, JOURNAL_SCHEMA_VERSION, JournalSchemaVersion, ManifestFormatVersion,
+    ManifestIdentity, Nonce, PROTOCOL_VERSION, PackageObject, PackageVersion, ProtocolVersion,
+    ProvenanceClass, ProvenanceEvidence, STATE_SCHEMA_VERSION, ServiceGeneration,
+    StateSchemaVersion, ValidatedArtifact,
+};
+pub use journal::{
+    DrainPlan, DrainResult, JournalStatus, OperationJournalRecord, PackageSlotRecord,
+    ReceiptOutcome, RecoveryEvidence, ReplayOutcome, Tombstone,
+};
+pub use lifecycle::PackageServiceModel;
+pub use policy::{JournalPolicy, JournalRetention, Occupancy, RetentionWindow};
+pub use state::{CanonicalInstalledState, ExpectedPackageState, InstalledStateSpec, PackageSlot};

--- a/crates/astrid-package-service/src/lifecycle.rs
+++ b/crates/astrid-package-service/src/lifecycle.rs
@@ -83,6 +83,9 @@ impl PackageServiceModel {
         }) {
             return Err(PackageServiceError::RecordNotReconcilable);
         }
+        if let Some(state) = self.slot_record(&slot).and_then(PackageSlotRecord::state) {
+            self.validate_context_bindings(&context, state)?;
+        }
 
         let current_generation = self
             .slot_record(&slot)
@@ -150,6 +153,31 @@ impl PackageServiceModel {
         }
     }
 
+    fn validate_context_bindings(
+        &self,
+        context: &OperationContext,
+        state: &CanonicalInstalledState,
+    ) -> PackageServiceResult<()> {
+        if !matches!(
+            context.operation(),
+            Operation::Activate | Operation::Deactivate | Operation::Remove
+        ) {
+            return Ok(());
+        }
+        if context.artifact() != state.artifact() || context.manifest() != state.manifest() {
+            return Err(PackageServiceError::BindingMismatch);
+        }
+        if context.operation() != Operation::Remove {
+            let expected_plan = context
+                .expected_state()
+                .lifecycle_plan_digest(context.operation())?;
+            if context.plan_digest() != &expected_plan {
+                return Err(PackageServiceError::BindingMismatch);
+            }
+        }
+        Ok(())
+    }
+
     fn record_mut(&mut self, nonce: &Nonce) -> PackageServiceResult<&mut OperationJournalRecord> {
         let slot = self
             .nonce_locations
@@ -206,7 +234,24 @@ impl PackageServiceModel {
         if context.operation() != required || deadline > context.expiry() || deadline <= now {
             return Err(PackageServiceError::BindingMismatch);
         }
-        let plan = DrainPlan::new(destination, deadline, *nonce);
+        let slot_for_plan = self
+            .nonce_locations
+            .get(nonce)
+            .copied()
+            .ok_or(PackageServiceError::RecordMissing)?;
+        let current_digest = self
+            .slots
+            .get(&slot_for_plan)
+            .and_then(PackageSlotRecord::state)
+            .map(CanonicalInstalledState::digest)
+            .ok_or(PackageServiceError::LifecycleTransition)?;
+        let plan = DrainPlan::new(
+            destination,
+            ExpectedPackageState::Exact(current_digest),
+            deadline,
+            *nonce,
+        )
+        .map_err(|_| PackageServiceError::BindingMismatch)?;
         if *context.plan_digest() != plan.digest() {
             return Err(PackageServiceError::BindingMismatch);
         }
@@ -350,6 +395,7 @@ impl PackageServiceModel {
                     authority_digest,
                     artifact,
                     LifecycleState::Inactive,
+                    first_state_generation()?,
                 )?;
                 let generation = state.generation_value();
                 record_slot.replace_state(Some(state));
@@ -374,6 +420,7 @@ impl PackageServiceModel {
                     authority_digest,
                     artifact,
                     LifecycleState::Inactive,
+                    next_generation(&state)?,
                 )?;
                 let generation = replacement.generation_value();
                 record_slot.replace_state(Some(replacement));
@@ -483,6 +530,10 @@ impl PackageServiceModel {
             .map(|record| record.before_state())
             .ok_or(PackageServiceError::RecordMissing)?;
         let observed_state = record_slot.state().cloned();
+        let expected_authority = record_slot
+            .journal_record(nonce)
+            .map(|record| *record.authority_digest())
+            .ok_or(PackageServiceError::RecordMissing)?;
         if status != JournalStatus::Unknown {
             return Err(PackageServiceError::RecordNotReconcilable);
         }
@@ -495,7 +546,8 @@ impl PackageServiceModel {
                 .journal_mut(nonce)
                 .and_then(OperationJournalRecord::take_drain_base_state)
             {
-                record_slot.replace_state(Some(base_state));
+                let restored = restore_prior_content(base_state)?;
+                record_slot.replace_state(Some(restored));
             }
             let journal = record_slot
                 .journal_mut(nonce)
@@ -506,16 +558,18 @@ impl PackageServiceModel {
         let proven_outcome = match observed_state {
             Some(state)
                 if state.digest().as_bytes() == observed.as_bytes()
-                    && state.generation_value() == evidence.runtime_generation() =>
+                    && state.generation_value() == evidence.runtime_generation()
+                    && validate_committed_state(&context, &state, &expected_authority) =>
             {
                 match context.operation() {
                     Operation::Install => {
                         Some((ReceiptOutcome::Installed, state.generation_value()))
                     },
                     Operation::Update => Some((ReceiptOutcome::Updated, state.generation_value())),
-                    Operation::Activate => {
-                        Some((ReceiptOutcome::Activated, state.generation_value()))
-                    },
+                    Operation::Activate => evidence
+                        .activation_receipt()
+                        .filter(|receipt| receipt.as_bytes() != &[0; 32])
+                        .map(|_| (ReceiptOutcome::Activated, state.generation_value())),
                     Operation::Deactivate => {
                         Some((ReceiptOutcome::Deactivated, state.generation_value()))
                     },
@@ -588,7 +642,8 @@ impl PackageServiceModel {
                 .journal_mut(nonce)
                 .and_then(OperationJournalRecord::take_drain_base_state)
                 .ok_or(PackageServiceError::OccupancyCorruption)?;
-            record_slot.replace_state(Some(restored));
+            let safe_restored = restore_prior_content(restored)?;
+            record_slot.replace_state(Some(safe_restored));
         }
         let journal = record_slot
             .journal_mut(nonce)
@@ -643,12 +698,33 @@ impl PackageServiceModel {
             .journal_mut(nonce)
             .and_then(OperationJournalRecord::take_drain_base_state)
             .ok_or(PackageServiceError::OccupancyCorruption)?;
-        record_slot.replace_state(Some(restored));
+        let safe_restored = restore_prior_content(restored)?;
+        record_slot.replace_state(Some(safe_restored));
         let journal = record_slot
             .journal_mut(nonce)
             .ok_or(PackageServiceError::RecordMissing)?;
         journal.terminal_failure(JournalStatus::Expired, now);
         Ok(DrainResult::Completed)
+    }
+
+    /// Makes an authority-expired admission explicitly terminal or recoverable.
+    pub fn expire_unresolved(&mut self, nonce: &Nonce, now: Timestamp) -> PackageServiceResult<()> {
+        let context = self.context_for(nonce)?;
+        if now < context.expiry() {
+            return Err(PackageServiceError::AuthorityExpired);
+        }
+        let record = self.record_mut(nonce)?;
+        match record.status() {
+            JournalStatus::Intent => {
+                record.terminal_failure(JournalStatus::Expired, now);
+                Ok(())
+            },
+            JournalStatus::Executing => {
+                record.mark_unknown(now);
+                Ok(())
+            },
+            _ => Err(PackageServiceError::RecordNotReconcilable),
+        }
     }
 
     /// Replays a retained receipt or distinguishes collection from loss.
@@ -763,10 +839,9 @@ fn new_installed_state(
     authority_digest: crate::digest::AuthorityDecisionDigest,
     artifact: &ValidatedArtifact,
     lifecycle: LifecycleState,
+    generation: NonZeroU64,
 ) -> PackageServiceResult<CanonicalInstalledState> {
-    let generation = NonZeroU64::new(context.service_generation().get())
-        .ok_or(PackageServiceError::InvalidValue("service generation"))?;
-    Ok(CanonicalInstalledState::new(InstalledStateSpec {
+    CanonicalInstalledState::new(InstalledStateSpec {
         owner: context.target_owner(),
         package_object: context.package_object(),
         artifact: *context.artifact(),
@@ -778,7 +853,11 @@ fn new_installed_state(
         lifecycle_plan: *context.plan_digest(),
         generation,
         completing_nonce: context.nonce(),
-    }))
+    })
+}
+
+fn first_state_generation() -> PackageServiceResult<NonZeroU64> {
+    NonZeroU64::new(1).ok_or(PackageServiceError::InvalidValue("package generation"))
 }
 
 fn require_zero_drain(
@@ -802,6 +881,39 @@ fn require_zero_drain(
         return Err(PackageServiceError::DrainBlocked);
     }
     Ok(())
+}
+
+fn restore_prior_content(
+    state: CanonicalInstalledState,
+) -> PackageServiceResult<CanonicalInstalledState> {
+    let plan = *state.lifecycle_plan();
+    let generation = next_generation(&state)?;
+    let mut restored = state;
+    restored.set_lifecycle_state(LifecycleState::Inactive, plan, generation);
+    Ok(restored)
+}
+
+fn validate_committed_state(
+    context: &OperationContext,
+    state: &CanonicalInstalledState,
+    expected_authority: &crate::digest::AuthorityDecisionDigest,
+) -> bool {
+    state.slot() == PackageSlot::new(context.target_owner(), context.package_object())
+        && state.completing_nonce().as_bytes() == context.nonce().as_bytes()
+        && state.artifact() == context.artifact()
+        && state.manifest() == context.manifest()
+        && state.lifecycle_plan() == context.plan_digest()
+        && state.authority_digest() == expected_authority
+        && state.content_root().as_bytes() != &[0; 32]
+        && *state.lifecycle_state() == expected_recovered_lifecycle(context.operation())
+}
+
+const fn expected_recovered_lifecycle(operation: Operation) -> LifecycleState {
+    match operation {
+        Operation::Activate => LifecycleState::Active,
+        Operation::Install | Operation::Update | Operation::Deactivate => LifecycleState::Inactive,
+        Operation::Remove | Operation::Recover => LifecycleState::Inactive,
+    }
 }
 
 fn next_generation(state: &CanonicalInstalledState) -> PackageServiceResult<NonZeroU64> {

--- a/crates/astrid-package-service/src/lifecycle.rs
+++ b/crates/astrid-package-service/src/lifecycle.rs
@@ -1,0 +1,828 @@
+use crate::authority::AuthenticatedAuthority;
+use crate::context::{
+    AdmittedService, AuthenticatedIngress, Operation, OperationContext, Timestamp,
+};
+use crate::digest::{Blake3Digest, DigestWriter, ProvenanceDigest, StateDigest};
+use crate::error::{PackageServiceError, PackageServiceResult};
+use crate::identity::ProvenanceEvidence;
+use crate::identity::{Nonce, ValidatedArtifact};
+use crate::journal::{
+    DrainPlan, DrainResult, JournalStatus, OperationJournalRecord, OperationReceipt,
+    PackageSlotRecord, ReceiptOutcome, RecoveryEvidence, ReplayOutcome, Tombstone,
+};
+use crate::policy::{JournalPolicy, Occupancy};
+use crate::state::{
+    CanonicalInstalledState, DrainDestination, ExpectedPackageState, InstalledStateSpec,
+    LifecycleState, PackageSlot,
+};
+use std::collections::BTreeMap;
+use std::num::NonZeroU64;
+
+/// Pure executable owner/package state model.
+#[derive(Debug)]
+pub struct PackageServiceModel {
+    policy: JournalPolicy,
+    slots: BTreeMap<PackageSlot, PackageSlotRecord>,
+    nonce_locations: BTreeMap<Nonce, PackageSlot>,
+    tombstones: BTreeMap<Nonce, Tombstone>,
+    occupancy: Occupancy,
+}
+
+impl PackageServiceModel {
+    /// Creates a model governed by the supplied bounded policy.
+    #[must_use]
+    pub fn new(policy: JournalPolicy) -> Self {
+        Self {
+            policy,
+            slots: BTreeMap::new(),
+            nonce_locations: BTreeMap::new(),
+            tombstones: BTreeMap::new(),
+            occupancy: Occupancy::default(),
+        }
+    }
+
+    /// Returns the canonical slot value.
+    #[must_use]
+    pub fn slot_record(&self, slot: &PackageSlot) -> Option<&PackageSlotRecord> {
+        self.slots.get(slot)
+    }
+
+    /// Returns current occupancy.
+    #[must_use]
+    pub const fn occupancy(&self) -> Occupancy {
+        self.occupancy
+    }
+
+    /// Durably represents an intent before any budgeted model effect.
+    pub fn begin(
+        &mut self,
+        context: OperationContext,
+        authority: &AuthenticatedAuthority,
+        ingress: AuthenticatedIngress,
+        service: &AdmittedService,
+        now: Timestamp,
+    ) -> PackageServiceResult<Nonce> {
+        if context.protocol_version().get() != crate::identity::PROTOCOL_VERSION.get() {
+            return Err(PackageServiceError::ProtocolVersion);
+        }
+        if now >= context.expiry() {
+            return Err(PackageServiceError::AuthorityExpired);
+        }
+        authority.verify(&context, &ingress, service, now)?;
+        let slot = PackageSlot::new(context.target_owner(), context.package_object());
+        self.validate_current_state(&slot, context.expected_state(), context.operation())?;
+        if self.nonce_locations.contains_key(&context.nonce())
+            || self.tombstones.contains_key(&context.nonce())
+        {
+            return Err(PackageServiceError::ReplayRejected);
+        }
+        if self.slot_record(&slot).is_some_and(|record| {
+            record
+                .journal_values()
+                .any(|entry| entry.status().is_unresolved())
+        }) {
+            return Err(PackageServiceError::RecordNotReconcilable);
+        }
+
+        let current_generation = self
+            .slot_record(&slot)
+            .and_then(|record| record.state())
+            .map(CanonicalInstalledState::generation_value);
+        let record = OperationJournalRecord::new_intent(
+            context,
+            authority.decision_digest(),
+            &ingress,
+            service,
+            now,
+            current_generation,
+        );
+        let record_bytes = record.encoded_len();
+        self.collect(now, self.policy.collection_batch_limit())?;
+        if !self
+            .policy
+            .has_admission_room(&self.occupancy, record_bytes)
+        {
+            return Err(self.policy.admission_error());
+        }
+        let nonce = record.context().nonce();
+        self.slots.entry(slot).or_default().insert_intent(record)?;
+        self.occupancy.add_record(record_bytes);
+        self.nonce_locations.insert(nonce, slot);
+        Ok(nonce)
+    }
+
+    fn validate_current_state(
+        &self,
+        slot: &PackageSlot,
+        expected: &ExpectedPackageState,
+        operation: Operation,
+    ) -> PackageServiceResult<()> {
+        let actual = self.slots.get(slot).map_or_else(
+            || StateDigest::from_bytes([0; 32]),
+            PackageSlotRecord::expected_state_digest,
+        );
+        if !expected.matches_digest(actual) {
+            return Err(PackageServiceError::ExpectedStateMismatch);
+        }
+        let lifecycle = self
+            .slots
+            .get(slot)
+            .and_then(|record| record.state())
+            .map(|state| state.lifecycle_state());
+        let valid = matches!(
+            (operation, lifecycle),
+            (Operation::Install, None)
+                | (
+                    Operation::Update,
+                    Some(LifecycleState::Inactive) | Some(LifecycleState::Active)
+                )
+                | (Operation::Activate, Some(LifecycleState::Inactive))
+                | (Operation::Deactivate, Some(LifecycleState::Active))
+                | (
+                    Operation::Remove,
+                    Some(LifecycleState::Inactive) | Some(LifecycleState::Active)
+                )
+        );
+        if valid {
+            Ok(())
+        } else {
+            Err(PackageServiceError::LifecycleTransition)
+        }
+    }
+
+    fn record_mut(&mut self, nonce: &Nonce) -> PackageServiceResult<&mut OperationJournalRecord> {
+        let slot = self
+            .nonce_locations
+            .get(nonce)
+            .copied()
+            .ok_or(PackageServiceError::RecordMissing)?;
+        self.slots
+            .get_mut(&slot)
+            .and_then(|record| record.journal_mut(nonce))
+            .ok_or(PackageServiceError::RecordMissing)
+    }
+
+    fn context_for(&self, nonce: &Nonce) -> PackageServiceResult<OperationContext> {
+        let slot = self
+            .nonce_locations
+            .get(nonce)
+            .copied()
+            .ok_or(PackageServiceError::RecordMissing)?;
+        self.slots
+            .get(&slot)
+            .and_then(|record| record.journal_record(nonce))
+            .map(|record| record.context().clone())
+            .ok_or(PackageServiceError::RecordMissing)
+    }
+
+    /// Moves an intent to executing after checking authority expiry.
+    pub fn begin_work(&mut self, nonce: &Nonce, now: Timestamp) -> PackageServiceResult<()> {
+        let expiry = self.context_for(nonce)?.expiry();
+        if now >= expiry {
+            return Err(PackageServiceError::AuthorityExpired);
+        }
+        let record = self.record_mut(nonce)?;
+        if record.status() != JournalStatus::Intent {
+            return Err(PackageServiceError::RecordNotReconcilable);
+        }
+        record.set_executing(now);
+        Ok(())
+    }
+
+    /// Durably places the exact state into a bounded drain.
+    pub fn begin_drain(
+        &mut self,
+        nonce: &Nonce,
+        destination: DrainDestination,
+        deadline: Timestamp,
+        live_leases: u32,
+        now: Timestamp,
+    ) -> PackageServiceResult<()> {
+        let context = self.context_for(nonce)?;
+        let required = match destination {
+            DrainDestination::Replacement => Operation::Update,
+            DrainDestination::Removal => Operation::Remove,
+        };
+        if context.operation() != required || deadline > context.expiry() || deadline <= now {
+            return Err(PackageServiceError::BindingMismatch);
+        }
+        let plan = DrainPlan::new(destination, deadline, *nonce);
+        if *context.plan_digest() != plan.digest() {
+            return Err(PackageServiceError::BindingMismatch);
+        }
+        self.begin_work(nonce, now)?;
+        let slot = self
+            .nonce_locations
+            .get(nonce)
+            .copied()
+            .ok_or(PackageServiceError::RecordMissing)?;
+        let Some(record) = self.slots.get_mut(&slot) else {
+            return Err(PackageServiceError::RecordMissing);
+        };
+        let Some(state) = record.state().cloned() else {
+            return Err(PackageServiceError::LifecycleTransition);
+        };
+        let base_state = state.clone();
+        let generation = next_generation(&state)?;
+        let mut replacement = state;
+        replacement.set_lifecycle_state(
+            LifecycleState::Draining {
+                destination,
+                deadline,
+                nonce: *nonce,
+                live_leases,
+            },
+            *context.plan_digest(),
+            generation,
+        );
+        if let Some(journal) = record.journal_mut(nonce) {
+            journal.set_drain_base_state(base_state);
+        }
+        record.replace_state(Some(replacement.clone()));
+        let journal = record
+            .journal_mut(nonce)
+            .ok_or(PackageServiceError::RecordMissing)?;
+        journal.set_state_generation(generation);
+        Ok(())
+    }
+
+    /// Records independently proved runtime lease count without completing the drain.
+    pub fn prove_drain_leases(
+        &mut self,
+        nonce: &Nonce,
+        live_leases: u32,
+        now: Timestamp,
+    ) -> PackageServiceResult<()> {
+        let context = self.context_for(nonce)?;
+        if now >= context.expiry() {
+            return Err(PackageServiceError::AuthorityExpired);
+        }
+        let slot = self
+            .nonce_locations
+            .get(nonce)
+            .copied()
+            .ok_or(PackageServiceError::RecordMissing)?;
+        let record = self
+            .slots
+            .get_mut(&slot)
+            .ok_or(PackageServiceError::RecordMissing)?;
+        let Some(state) = record.state().cloned() else {
+            return Err(PackageServiceError::LifecycleTransition);
+        };
+        let LifecycleState::Draining {
+            deadline,
+            nonce: drain_nonce,
+            live_leases: _,
+            destination,
+        } = state.lifecycle_state()
+        else {
+            return Err(PackageServiceError::LifecycleTransition);
+        };
+        if drain_nonce.as_bytes() != nonce.as_bytes() {
+            return Err(PackageServiceError::LifecycleTransition);
+        }
+        let deadline = *deadline;
+        let destination = *destination;
+        let generation = next_generation(&state)?;
+        let mut replacement = state;
+        replacement.set_lifecycle_state(
+            LifecycleState::Draining {
+                destination,
+                deadline,
+                nonce: *nonce,
+                live_leases,
+            },
+            *context.plan_digest(),
+            generation,
+        );
+        record.replace_state(Some(replacement));
+        let journal = record
+            .journal_mut(nonce)
+            .ok_or(PackageServiceError::RecordMissing)?;
+        journal.set_state_generation(generation);
+        Ok(())
+    }
+
+    /// Commits install, update, activation, deactivation, or final retirement.
+    pub fn complete(
+        &mut self,
+        nonce: &Nonce,
+        artifact: Option<&ValidatedArtifact>,
+        activation_receipt: Option<Blake3Digest>,
+        zero_leases_proved: bool,
+        now: Timestamp,
+    ) -> PackageServiceResult<OperationReceipt> {
+        let context = self.context_for(nonce)?;
+        if now >= context.expiry() {
+            return Err(PackageServiceError::AuthorityExpired);
+        }
+        let slot = self
+            .nonce_locations
+            .get(nonce)
+            .copied()
+            .ok_or(PackageServiceError::RecordMissing)?;
+        let record_slot = self
+            .slots
+            .get_mut(&slot)
+            .ok_or(PackageServiceError::RecordMissing)?;
+        let journal_status = record_slot
+            .journal_record(nonce)
+            .map(|record| record.status())
+            .ok_or(PackageServiceError::RecordMissing)?;
+        let before = record_slot
+            .journal_record(nonce)
+            .map(|record| record.before_state())
+            .ok_or(PackageServiceError::RecordMissing)?;
+        let authority_digest = record_slot
+            .journal_record(nonce)
+            .map(|record| *record.authority_digest())
+            .ok_or(PackageServiceError::RecordMissing)?;
+        if journal_status != JournalStatus::Executing {
+            return Err(PackageServiceError::RecordNotReconcilable);
+        }
+
+        let (after_state, outcome, generation) = match context.operation() {
+            Operation::Install => {
+                let artifact = artifact.ok_or(PackageServiceError::BindingMismatch)?;
+                validate_context_artifact(&context, artifact)?;
+                let state = new_installed_state(
+                    &context,
+                    authority_digest,
+                    artifact,
+                    LifecycleState::Inactive,
+                )?;
+                let generation = state.generation_value();
+                record_slot.replace_state(Some(state));
+                (
+                    record_slot.expected_state_digest(),
+                    ReceiptOutcome::Installed,
+                    generation,
+                )
+            },
+            Operation::Update => {
+                let artifact = artifact.ok_or(PackageServiceError::BindingMismatch)?;
+                validate_context_artifact(&context, artifact)?;
+                let Some(state) = record_slot.state().cloned() else {
+                    return Err(PackageServiceError::LifecycleTransition);
+                };
+                require_zero_drain(&state, *nonce, DrainDestination::Replacement)?;
+                if !zero_leases_proved {
+                    return Err(PackageServiceError::DrainBlocked);
+                }
+                let replacement = new_installed_state(
+                    &context,
+                    authority_digest,
+                    artifact,
+                    LifecycleState::Inactive,
+                )?;
+                let generation = replacement.generation_value();
+                record_slot.replace_state(Some(replacement));
+                (
+                    record_slot.expected_state_digest(),
+                    ReceiptOutcome::Updated,
+                    generation,
+                )
+            },
+            Operation::Activate | Operation::Deactivate => {
+                if context.operation() == Operation::Activate && activation_receipt.is_none() {
+                    return Err(PackageServiceError::BindingMismatch);
+                }
+                let Some(state) = record_slot.state().cloned() else {
+                    return Err(PackageServiceError::LifecycleTransition);
+                };
+                let next_lifecycle = if context.operation() == Operation::Activate {
+                    LifecycleState::Active
+                } else {
+                    LifecycleState::Inactive
+                };
+                let generation = next_generation(&state)?;
+                let mut replacement = state;
+                replacement.set_lifecycle_state(next_lifecycle, *context.plan_digest(), generation);
+                record_slot.replace_state(Some(replacement));
+                (
+                    record_slot.expected_state_digest(),
+                    if context.operation() == Operation::Activate {
+                        ReceiptOutcome::Activated
+                    } else {
+                        ReceiptOutcome::Deactivated
+                    },
+                    generation,
+                )
+            },
+            Operation::Remove => {
+                let Some(state) = record_slot.state().cloned() else {
+                    return Err(PackageServiceError::LifecycleTransition);
+                };
+                require_zero_drain(&state, *nonce, DrainDestination::Removal)?;
+                if !zero_leases_proved {
+                    return Err(PackageServiceError::DrainBlocked);
+                }
+                let generation = next_generation(&state)?;
+                record_slot.replace_state(None);
+                (
+                    record_slot.expected_state_digest(),
+                    ReceiptOutcome::Retired,
+                    generation,
+                )
+            },
+            Operation::Recover => return Err(PackageServiceError::RecordNotReconcilable),
+        };
+        let receipt = OperationReceipt::new(
+            &context,
+            outcome,
+            before,
+            after_state,
+            generation,
+            activation_receipt,
+        );
+        let journal = record_slot
+            .journal_mut(nonce)
+            .ok_or(PackageServiceError::RecordMissing)?;
+        journal.set_state_generation(generation);
+        journal.commit(receipt.clone(), now);
+        Ok(receipt)
+    }
+
+    /// Moves an executing result to unknown after an uncertain boundary.
+    pub fn mark_unknown(&mut self, nonce: &Nonce, now: Timestamp) -> PackageServiceResult<()> {
+        let record = self.record_mut(nonce)?;
+        if record.status() != JournalStatus::Executing {
+            return Err(PackageServiceError::RecordNotReconcilable);
+        }
+        record.mark_unknown(now);
+        Ok(())
+    }
+
+    /// Reconciles an unknown record only with exact old/new evidence.
+    pub fn recover(
+        &mut self,
+        nonce: &Nonce,
+        evidence: &RecoveryEvidence,
+        now: Timestamp,
+    ) -> PackageServiceResult<Option<OperationReceipt>> {
+        let context = self.context_for(nonce)?;
+        let slot = self
+            .nonce_locations
+            .get(nonce)
+            .copied()
+            .ok_or(PackageServiceError::RecordMissing)?;
+        let record_slot = self
+            .slots
+            .get_mut(&slot)
+            .ok_or(PackageServiceError::RecordMissing)?;
+        let status = record_slot
+            .journal_record(nonce)
+            .map(|record| record.status())
+            .ok_or(PackageServiceError::RecordMissing)?;
+        let token = record_slot
+            .journal_record(nonce)
+            .map(|record| record.recovery_token())
+            .ok_or(PackageServiceError::RecordMissing)?;
+        let before = record_slot
+            .journal_record(nonce)
+            .map(|record| record.before_state())
+            .ok_or(PackageServiceError::RecordMissing)?;
+        let observed_state = record_slot.state().cloned();
+        if status != JournalStatus::Unknown {
+            return Err(PackageServiceError::RecordNotReconcilable);
+        }
+        if token.into_bytes() != evidence.token_bytes() {
+            return Err(PackageServiceError::RecoveryUnresolved);
+        }
+        let observed = evidence.observed_state();
+        if observed.as_bytes() == before.as_bytes() {
+            if let Some(base_state) = record_slot
+                .journal_mut(nonce)
+                .and_then(OperationJournalRecord::take_drain_base_state)
+            {
+                record_slot.replace_state(Some(base_state));
+            }
+            let journal = record_slot
+                .journal_mut(nonce)
+                .ok_or(PackageServiceError::RecordMissing)?;
+            journal.resolve_recovery(None, JournalStatus::Failed, now);
+            return Ok(None);
+        }
+        let proven_outcome = match observed_state {
+            Some(state)
+                if state.digest().as_bytes() == observed.as_bytes()
+                    && state.generation_value() == evidence.runtime_generation() =>
+            {
+                match context.operation() {
+                    Operation::Install => {
+                        Some((ReceiptOutcome::Installed, state.generation_value()))
+                    },
+                    Operation::Update => Some((ReceiptOutcome::Updated, state.generation_value())),
+                    Operation::Activate => {
+                        Some((ReceiptOutcome::Activated, state.generation_value()))
+                    },
+                    Operation::Deactivate => {
+                        Some((ReceiptOutcome::Deactivated, state.generation_value()))
+                    },
+                    Operation::Remove | Operation::Recover => None,
+                }
+            },
+            None if context.operation() == Operation::Remove
+                && *observed.as_bytes() == [0; 32]
+                && evidence.zero_leases_proved() =>
+            {
+                let old_generation = record_slot
+                    .journal_record(nonce)
+                    .and_then(|record| record.state_generation());
+                match old_generation.map(next_generation_value) {
+                    Some(Ok(generation)) => Some((ReceiptOutcome::Retired, generation)),
+                    _ => None,
+                }
+            },
+            _ => None,
+        };
+        let Some((outcome, generation)) = proven_outcome else {
+            return Err(PackageServiceError::RecoveryUnresolved);
+        };
+        let receipt = OperationReceipt::new(
+            &context,
+            outcome,
+            before,
+            observed,
+            generation,
+            evidence.activation_receipt(),
+        );
+        let journal = record_slot
+            .journal_mut(nonce)
+            .ok_or(PackageServiceError::RecordMissing)?;
+        journal.resolve_recovery(Some(receipt.clone()), JournalStatus::Committed, now);
+        Ok(Some(receipt))
+    }
+
+    /// Cancels advisory work only before an unknown commit boundary.
+    pub fn cancel(&mut self, nonce: &Nonce, now: Timestamp) -> PackageServiceResult<()> {
+        let context = self.context_for(nonce)?;
+        if now >= context.expiry() {
+            return Err(PackageServiceError::AuthorityExpired);
+        }
+        let slot = self
+            .nonce_locations
+            .get(nonce)
+            .copied()
+            .ok_or(PackageServiceError::RecordMissing)?;
+        let record_slot = self
+            .slots
+            .get_mut(&slot)
+            .ok_or(PackageServiceError::RecordMissing)?;
+        let cancellable = record_slot.journal_record(nonce).is_some_and(|record| {
+            matches!(
+                record.status(),
+                JournalStatus::Intent | JournalStatus::Executing
+            )
+        });
+        if !cancellable {
+            return Err(PackageServiceError::RecordNotReconcilable);
+        }
+        if let Some(state) = record_slot.state().cloned()
+            && let LifecycleState::Draining {
+                nonce: drain_nonce, ..
+            } = state.lifecycle_state()
+            && drain_nonce.as_bytes() == nonce.as_bytes()
+        {
+            let restored = record_slot
+                .journal_mut(nonce)
+                .and_then(OperationJournalRecord::take_drain_base_state)
+                .ok_or(PackageServiceError::OccupancyCorruption)?;
+            record_slot.replace_state(Some(restored));
+        }
+        let journal = record_slot
+            .journal_mut(nonce)
+            .ok_or(PackageServiceError::RecordMissing)?;
+        journal.terminal_failure(JournalStatus::Aborted, now);
+        Ok(())
+    }
+
+    /// Advances a drain at or after its deadline without inventing retirement.
+    pub fn expire_drain(
+        &mut self,
+        nonce: &Nonce,
+        now: Timestamp,
+        zero_leases_proved: bool,
+    ) -> PackageServiceResult<DrainResult> {
+        let _context = self.context_for(nonce)?;
+        let slot = self
+            .nonce_locations
+            .get(nonce)
+            .copied()
+            .ok_or(PackageServiceError::RecordMissing)?;
+        let record_slot = self
+            .slots
+            .get_mut(&slot)
+            .ok_or(PackageServiceError::RecordMissing)?;
+        let Some(state) = record_slot.state().cloned() else {
+            return Err(PackageServiceError::LifecycleTransition);
+        };
+        let LifecycleState::Draining {
+            deadline,
+            nonce: drain_nonce,
+            live_leases,
+            destination,
+        } = state.lifecycle_state()
+        else {
+            return Err(PackageServiceError::LifecycleTransition);
+        };
+        if drain_nonce.as_bytes() != nonce.as_bytes() || now < *deadline {
+            return Err(PackageServiceError::LifecycleTransition);
+        }
+        if *live_leases > 0 || !zero_leases_proved {
+            let journal = record_slot
+                .journal_mut(nonce)
+                .ok_or(PackageServiceError::RecordMissing)?;
+            journal.mark_unknown(now);
+            return Ok(DrainResult::Blocked);
+        }
+        if *destination == DrainDestination::Removal {
+            return Err(PackageServiceError::DrainBlocked);
+        }
+        let restored = record_slot
+            .journal_mut(nonce)
+            .and_then(OperationJournalRecord::take_drain_base_state)
+            .ok_or(PackageServiceError::OccupancyCorruption)?;
+        record_slot.replace_state(Some(restored));
+        let journal = record_slot
+            .journal_mut(nonce)
+            .ok_or(PackageServiceError::RecordMissing)?;
+        journal.terminal_failure(JournalStatus::Expired, now);
+        Ok(DrainResult::Completed)
+    }
+
+    /// Replays a retained receipt or distinguishes collection from loss.
+    pub fn replay(
+        &self,
+        nonce: &Nonce,
+        context_digest: Option<crate::digest::ContextDigest>,
+    ) -> PackageServiceResult<ReplayOutcome> {
+        if let Some(tombstone) = self.tombstones.get(nonce) {
+            if let Some(requested) = context_digest
+                && tombstone.context_digest() != requested
+            {
+                return Err(PackageServiceError::ReplayRejected);
+            }
+            return Ok(ReplayOutcome::Tombstoned(tombstone.clone()));
+        }
+        let slot = self
+            .nonce_locations
+            .get(nonce)
+            .copied()
+            .ok_or(PackageServiceError::RecordMissing)?;
+        let record = self
+            .slots
+            .get(&slot)
+            .and_then(|slot_record| slot_record.journal_record(nonce))
+            .ok_or(PackageServiceError::RecordMissing)?;
+        if let Some(requested) = context_digest
+            && *record.context().digest() != requested
+        {
+            return Err(PackageServiceError::ReplayRejected);
+        }
+        if let Some(receipt) = record.receipt() {
+            return Ok(ReplayOutcome::Receipt(receipt.clone()));
+        }
+        Ok(ReplayOutcome::Unresolved)
+    }
+
+    /// Performs one bounded collection pass; unresolved records are never eligible.
+    pub fn collect(&mut self, now: Timestamp, batch_limit: u64) -> PackageServiceResult<u64> {
+        let (occupied_records, occupied_bytes, tombstones) = self.occupancy.values();
+        let mut actual_records = 0u64;
+        let mut actual_bytes = 0u64;
+        for slot_record in self.slots.values() {
+            for record in slot_record.journal_values() {
+                actual_records = actual_records
+                    .checked_add(1)
+                    .ok_or(PackageServiceError::OccupancyCorruption)?;
+                actual_bytes = actual_bytes
+                    .checked_add(record.encoded_len())
+                    .ok_or(PackageServiceError::OccupancyCorruption)?;
+            }
+        }
+        if actual_records != occupied_records || actual_bytes != occupied_bytes {
+            return Err(PackageServiceError::OccupancyCorruption);
+        }
+
+        let mut selected = Vec::new();
+        for (slot, slot_record) in &self.slots {
+            for record in slot_record.journal_values() {
+                if selected.len() as u64 == batch_limit {
+                    break;
+                }
+                if self.policy.retention_eligible(record, now) {
+                    selected.push((*slot, record.context().nonce()));
+                }
+            }
+        }
+        let selected_count =
+            u64::try_from(selected.len()).map_err(PackageServiceError::IntegerBounds)?;
+        let tombstone_room = self
+            .policy
+            .tombstone_capacity()
+            .checked_sub(tombstones)
+            .ok_or(PackageServiceError::OccupancyCorruption)?;
+        if selected_count > tombstone_room {
+            return Err(PackageServiceError::QuotaExhausted);
+        }
+
+        let mut collected = 0u64;
+        for (slot, nonce) in selected {
+            let slot_record = self
+                .slots
+                .get_mut(&slot)
+                .ok_or(PackageServiceError::OccupancyCorruption)?;
+            let tombstone = slot_record
+                .remove_journal(&nonce)
+                .ok_or(PackageServiceError::OccupancyCorruption)?;
+            self.occupancy.remove_record(1024);
+            self.occupancy.add_tombstone();
+            self.tombstones.insert(nonce, tombstone);
+            self.nonce_locations.remove(&nonce);
+            collected = collected
+                .checked_add(1)
+                .ok_or(PackageServiceError::GenerationOverflow)?;
+        }
+        Ok(collected)
+    }
+}
+
+fn validate_context_artifact(
+    context: &OperationContext,
+    artifact: &ValidatedArtifact,
+) -> PackageServiceResult<()> {
+    if context.artifact() != artifact.artifact() || context.manifest() != artifact.manifest() {
+        return Err(PackageServiceError::BindingMismatch);
+    }
+    Ok(())
+}
+
+fn new_installed_state(
+    context: &OperationContext,
+    authority_digest: crate::digest::AuthorityDecisionDigest,
+    artifact: &ValidatedArtifact,
+    lifecycle: LifecycleState,
+) -> PackageServiceResult<CanonicalInstalledState> {
+    let generation = NonZeroU64::new(context.service_generation().get())
+        .ok_or(PackageServiceError::InvalidValue("service generation"))?;
+    Ok(CanonicalInstalledState::new(InstalledStateSpec {
+        owner: context.target_owner(),
+        package_object: context.package_object(),
+        artifact: *context.artifact(),
+        content_root: *artifact.content_root(),
+        manifest: context.manifest().clone(),
+        authority_digest,
+        provenance: provenance_digest(artifact.provenance()),
+        lifecycle_state: lifecycle,
+        lifecycle_plan: *context.plan_digest(),
+        generation,
+        completing_nonce: context.nonce(),
+    }))
+}
+
+fn require_zero_drain(
+    state: &CanonicalInstalledState,
+    nonce: Nonce,
+    destination: DrainDestination,
+) -> PackageServiceResult<()> {
+    let LifecycleState::Draining {
+        destination: observed_destination,
+        nonce: observed_nonce,
+        live_leases,
+        deadline: _,
+    } = state.lifecycle_state()
+    else {
+        return Err(PackageServiceError::LifecycleTransition);
+    };
+    if observed_destination != &destination
+        || observed_nonce.as_bytes() != nonce.as_bytes()
+        || live_leases != &0
+    {
+        return Err(PackageServiceError::DrainBlocked);
+    }
+    Ok(())
+}
+
+fn next_generation(state: &CanonicalInstalledState) -> PackageServiceResult<NonZeroU64> {
+    next_generation_value(state.generation_value())
+}
+
+fn next_generation_value(generation: NonZeroU64) -> PackageServiceResult<NonZeroU64> {
+    let value = generation
+        .get()
+        .checked_add(1)
+        .ok_or(PackageServiceError::GenerationOverflow)?;
+    NonZeroU64::try_from(value).map_err(PackageServiceError::from)
+}
+
+fn provenance_digest(value: &ProvenanceEvidence) -> ProvenanceDigest {
+    let mut writer = DigestWriter::new();
+    writer.tag(value.class().tag());
+    writer.digest(value.evidence());
+    writer.bytes(value.bounded_evidence().as_bytes());
+    writer.finish("astrid.package.provenance.v1")
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/astrid-package-service/src/lifecycle/commit.rs
+++ b/crates/astrid-package-service/src/lifecycle/commit.rs
@@ -1,0 +1,269 @@
+use super::generation::{next_generation, next_transition_generation};
+use super::lineage::active_drain_lineage;
+use crate::context::{Operation, OperationContext, Timestamp};
+use crate::digest::{
+    AuthorityDecisionDigest, Blake3Digest, DigestWriter, PlanDigest, ProvenanceDigest, StateDigest,
+};
+use crate::error::{PackageServiceError, PackageServiceResult};
+use crate::identity::{Nonce, ProvenanceEvidence, ValidatedArtifact};
+use crate::journal::{JournalStatus, PackageSlotRecord, ReceiptOutcome};
+use crate::state::{CanonicalInstalledState, DrainDestination, InstalledStateSpec, LifecycleState};
+use std::num::NonZeroU64;
+
+pub(super) struct DrainProof<'a> {
+    pub(super) nonce: &'a Nonce,
+    pub(super) now: Timestamp,
+    pub(super) zero_leases: bool,
+}
+
+pub(super) fn validate_context_artifact(
+    context: &OperationContext,
+    artifact: &ValidatedArtifact,
+) -> PackageServiceResult<()> {
+    if context.artifact() != artifact.artifact() || context.manifest() != artifact.manifest() {
+        return Err(PackageServiceError::BindingMismatch);
+    }
+    if context.content_root() != artifact.content_root()
+        || context.provenance() != &provenance_digest(artifact.provenance())
+    {
+        return Err(PackageServiceError::BindingMismatch);
+    }
+    Ok(())
+}
+
+pub(super) fn require_staged_commit(
+    context: &OperationContext,
+    artifact: &ValidatedArtifact,
+    staged_commit_plan: Option<PlanDigest>,
+) -> PackageServiceResult<()> {
+    validate_context_artifact(context, artifact)?;
+    let plan = commit_plan_digest(
+        context,
+        artifact.content_root(),
+        &provenance_digest(artifact.provenance()),
+    );
+    if Some(plan) != staged_commit_plan || context.commit_plan_digest() != &plan {
+        return Err(PackageServiceError::BindingMismatch);
+    }
+    Ok(())
+}
+
+pub(super) fn commit_install(
+    record_slot: &mut PackageSlotRecord,
+    context: &OperationContext,
+    authority_digest: AuthorityDecisionDigest,
+    artifact: &ValidatedArtifact,
+    staged_commit_plan: Option<PlanDigest>,
+) -> PackageServiceResult<(StateDigest, ReceiptOutcome, NonZeroU64)> {
+    require_staged_commit(context, artifact, staged_commit_plan)?;
+    let state = new_installed_state(
+        context,
+        authority_digest,
+        artifact,
+        LifecycleState::Inactive,
+        next_transition_generation(Some(record_slot), Operation::Install)?,
+    )?;
+    let generation = state.generation_value();
+    record_slot.replace_state_with_generation(Some(state), generation)?;
+    Ok((
+        record_slot.expected_state_digest(),
+        ReceiptOutcome::Installed,
+        generation,
+    ))
+}
+
+pub(super) fn commit_retained_state(
+    record_slot: &mut PackageSlotRecord,
+    context: &OperationContext,
+    state: CanonicalInstalledState,
+    nonce: &Nonce,
+) -> PackageServiceResult<(StateDigest, ReceiptOutcome, NonZeroU64)> {
+    let next_lifecycle = if context.operation() == Operation::Activate {
+        LifecycleState::Active
+    } else {
+        LifecycleState::Inactive
+    };
+    let generation = next_generation(&state)?;
+    let mut replacement = state;
+    replacement.set_lifecycle_result(next_lifecycle, *context.plan_digest(), generation, *nonce);
+    record_slot.replace_state_with_generation(Some(replacement), generation)?;
+    let outcome = if context.operation() == Operation::Activate {
+        ReceiptOutcome::Activated
+    } else {
+        ReceiptOutcome::Deactivated
+    };
+    Ok((record_slot.expected_state_digest(), outcome, generation))
+}
+
+pub(super) fn commit_removal(
+    record_slot: &mut PackageSlotRecord,
+    state: &CanonicalInstalledState,
+    nonce: &Nonce,
+    proof: &DrainProof<'_>,
+) -> PackageServiceResult<(StateDigest, ReceiptOutcome, NonZeroU64)> {
+    require_open_drain(state, proof.nonce, proof.now)?;
+    require_zero_drain(state, *nonce, DrainDestination::Removal)?;
+    active_drain_lineage(record_slot, proof.nonce)?;
+    if !proof.zero_leases {
+        return Err(PackageServiceError::DrainBlocked);
+    }
+    let generation = next_generation(state)?;
+    record_slot.replace_state_with_generation(None, generation)?;
+    Ok((
+        record_slot.expected_state_digest(),
+        ReceiptOutcome::Retired,
+        generation,
+    ))
+}
+
+pub(super) fn commit_update(
+    record_slot: &mut PackageSlotRecord,
+    context: &OperationContext,
+    authority_digest: AuthorityDecisionDigest,
+    artifact: &ValidatedArtifact,
+    staged_commit_plan: Option<PlanDigest>,
+    proof: &DrainProof<'_>,
+) -> PackageServiceResult<(StateDigest, ReceiptOutcome, NonZeroU64)> {
+    let Some(state) = record_slot.state().cloned() else {
+        return Err(PackageServiceError::LifecycleTransition);
+    };
+    require_open_drain(&state, proof.nonce, proof.now)?;
+    require_zero_drain(&state, *proof.nonce, DrainDestination::Replacement)?;
+    active_drain_lineage(record_slot, proof.nonce)?;
+    if !proof.zero_leases {
+        return Err(PackageServiceError::DrainBlocked);
+    }
+    require_staged_commit(context, artifact, staged_commit_plan)?;
+    let replacement = new_installed_state(
+        context,
+        authority_digest,
+        artifact,
+        LifecycleState::Inactive,
+        next_generation(&state)?,
+    )?;
+    let generation = replacement.generation_value();
+    record_slot.replace_state_with_generation(Some(replacement), generation)?;
+    Ok((
+        record_slot.expected_state_digest(),
+        ReceiptOutcome::Updated,
+        generation,
+    ))
+}
+
+pub(super) fn commit_record_metadata(
+    record_slot: &PackageSlotRecord,
+    nonce: &Nonce,
+) -> PackageServiceResult<(StateDigest, AuthorityDecisionDigest, Option<PlanDigest>)> {
+    let record = record_slot
+        .journal_record(nonce)
+        .ok_or(PackageServiceError::RecordMissing)?;
+    if record.status() != JournalStatus::Executing {
+        return Err(PackageServiceError::RecordNotReconcilable);
+    }
+    Ok((
+        record.before_state(),
+        *record.authority_digest(),
+        record.staged_commit_plan().copied(),
+    ))
+}
+
+pub(super) fn commit_plan_digest(
+    context: &OperationContext,
+    content_root: &Blake3Digest,
+    provenance: &ProvenanceDigest,
+) -> PlanDigest {
+    crate::context::operation_commit_plan_digest(
+        context.operation(),
+        context.artifact(),
+        context.manifest(),
+        content_root,
+        provenance,
+        (context.operation() == Operation::Update).then_some(*context.plan_digest()),
+    )
+}
+
+pub(super) fn new_installed_state(
+    context: &OperationContext,
+    authority_digest: AuthorityDecisionDigest,
+    artifact: &ValidatedArtifact,
+    lifecycle: LifecycleState,
+    generation: NonZeroU64,
+) -> PackageServiceResult<CanonicalInstalledState> {
+    CanonicalInstalledState::new(InstalledStateSpec {
+        owner: context.target_owner(),
+        package_object: context.package_object(),
+        artifact: *context.artifact(),
+        content_root: *artifact.content_root(),
+        manifest: context.manifest().clone(),
+        authority_digest,
+        provenance: provenance_digest(artifact.provenance()),
+        lifecycle_state: lifecycle,
+        lifecycle_plan: *context.plan_digest(),
+        generation,
+        completing_nonce: context.nonce(),
+    })
+}
+
+pub(super) fn recorded_drain_deadline(
+    state: &CanonicalInstalledState,
+    nonce: &Nonce,
+) -> PackageServiceResult<Option<Timestamp>> {
+    let LifecycleState::Draining {
+        deadline,
+        nonce: drain_nonce,
+        live_leases: _,
+        destination: _,
+    } = state.lifecycle_state()
+    else {
+        return Ok(None);
+    };
+    if drain_nonce.as_bytes() != nonce.as_bytes() {
+        return Err(PackageServiceError::LifecycleTransition);
+    }
+    Ok(Some(*deadline))
+}
+
+fn require_open_drain(
+    state: &CanonicalInstalledState,
+    nonce: &Nonce,
+    now: Timestamp,
+) -> PackageServiceResult<()> {
+    let Some(deadline) = recorded_drain_deadline(state, nonce)? else {
+        return Err(PackageServiceError::LifecycleTransition);
+    };
+    if now >= deadline {
+        return Err(PackageServiceError::AuthorityExpired);
+    }
+    Ok(())
+}
+
+fn require_zero_drain(
+    state: &CanonicalInstalledState,
+    nonce: Nonce,
+    destination: DrainDestination,
+) -> PackageServiceResult<()> {
+    let LifecycleState::Draining {
+        destination: observed_destination,
+        nonce: observed_nonce,
+        live_leases,
+        deadline: _,
+    } = state.lifecycle_state()
+    else {
+        return Err(PackageServiceError::LifecycleTransition);
+    };
+    if observed_destination != &destination
+        || observed_nonce.as_bytes() != nonce.as_bytes()
+        || live_leases != &0
+    {
+        return Err(PackageServiceError::DrainBlocked);
+    }
+    Ok(())
+}
+
+pub(super) fn provenance_digest(value: &ProvenanceEvidence) -> ProvenanceDigest {
+    let mut writer = DigestWriter::new();
+    writer.tag(value.class().tag());
+    writer.digest(value.evidence());
+    writer.bytes(value.bounded_evidence().as_bytes());
+    writer.finish("astrid.package.provenance.v1")
+}

--- a/crates/astrid-package-service/src/lifecycle/generation.rs
+++ b/crates/astrid-package-service/src/lifecycle/generation.rs
@@ -1,0 +1,45 @@
+use crate::context::Operation;
+use crate::error::{PackageServiceError, PackageServiceResult};
+use crate::journal::PackageSlotRecord;
+use crate::state::CanonicalInstalledState;
+use std::num::NonZeroU64;
+
+pub(super) fn next_generation(state: &CanonicalInstalledState) -> PackageServiceResult<NonZeroU64> {
+    next_generation_value(state.generation_value())
+}
+
+pub(super) fn next_generation_from_high_watermark(
+    high_watermark: Option<NonZeroU64>,
+    operation: Operation,
+) -> PackageServiceResult<NonZeroU64> {
+    if operation == Operation::Install {
+        return match high_watermark {
+            None => first_state_generation(),
+            Some(high_watermark) => next_generation_value(high_watermark),
+        };
+    }
+    let high_watermark = high_watermark.ok_or(PackageServiceError::OccupancyCorruption)?;
+    next_generation_value(high_watermark)
+}
+
+pub(super) fn next_transition_generation(
+    slot_record: Option<&PackageSlotRecord>,
+    operation: Operation,
+) -> PackageServiceResult<NonZeroU64> {
+    next_generation_from_high_watermark(
+        slot_record.and_then(PackageSlotRecord::generation_high_watermark),
+        operation,
+    )
+}
+
+pub(super) fn next_generation_value(generation: NonZeroU64) -> PackageServiceResult<NonZeroU64> {
+    let value = generation
+        .get()
+        .checked_add(1)
+        .ok_or(PackageServiceError::GenerationOverflow)?;
+    NonZeroU64::try_from(value).map_err(PackageServiceError::from)
+}
+
+fn first_state_generation() -> PackageServiceResult<NonZeroU64> {
+    NonZeroU64::new(1).ok_or(PackageServiceError::InvalidValue("package generation"))
+}

--- a/crates/astrid-package-service/src/lifecycle/lineage.rs
+++ b/crates/astrid-package-service/src/lifecycle/lineage.rs
@@ -1,0 +1,68 @@
+use super::{next_generation_value, restore_prior_content_to_successor};
+use crate::error::{PackageServiceError, PackageServiceResult};
+use crate::identity::Nonce;
+use crate::journal::{OperationJournalRecord, PackageSlotRecord};
+use crate::state::{CanonicalInstalledState, DrainLineage, LifecycleState};
+use std::num::NonZeroU64;
+
+pub(super) fn active_drain_lineage(
+    slot_record: &PackageSlotRecord,
+    nonce: &Nonce,
+) -> PackageServiceResult<DrainLineage> {
+    let lineage = slot_record
+        .journal_record(nonce)
+        .and_then(OperationJournalRecord::drain_lineage)
+        .cloned()
+        .ok_or(PackageServiceError::OccupancyCorruption)?;
+    let state = slot_record
+        .state()
+        .ok_or(PackageServiceError::LifecycleTransition)?;
+    validate(&lineage, state, nonce)?;
+    Ok(lineage)
+}
+
+pub(super) fn validate(
+    lineage: &DrainLineage,
+    state: &CanonicalInstalledState,
+    nonce: &Nonce,
+) -> PackageServiceResult<()> {
+    let base = lineage.base_state();
+    if !base.has_valid_digest()
+        || base.lifecycle_plan().as_bytes() == &[0; 32]
+        || matches!(base.lifecycle_state(), LifecycleState::Draining { .. })
+    {
+        return Err(PackageServiceError::OccupancyCorruption);
+    }
+
+    let LifecycleState::Draining {
+        deadline: _,
+        nonce: drain_nonce,
+        live_leases: _,
+        destination: _,
+    } = state.lifecycle_state()
+    else {
+        return Err(PackageServiceError::LifecycleTransition);
+    };
+    if !state.has_valid_digest()
+        || drain_nonce.as_bytes() != nonce.as_bytes()
+        || state.generation_value() != lineage.boundary_generation()
+        || state.generation_value().get() <= base.generation_value().get()
+        || base.slot() != state.slot()
+        || base.artifact() != state.artifact()
+        || base.content_root() != state.content_root()
+        || base.manifest() != state.manifest()
+        || base.authority_digest() != state.authority_digest()
+        || base.provenance() != state.provenance()
+    {
+        return Err(PackageServiceError::OccupancyCorruption);
+    }
+    Ok(())
+}
+
+pub(super) fn restore_to_boundary_successor(
+    lineage: &DrainLineage,
+    nonce: &Nonce,
+) -> PackageServiceResult<CanonicalInstalledState> {
+    let generation: NonZeroU64 = next_generation_value(lineage.boundary_generation())?;
+    restore_prior_content_to_successor(lineage.base_state().clone(), *nonce, generation)
+}

--- a/crates/astrid-package-service/src/lifecycle/lineage.rs
+++ b/crates/astrid-package-service/src/lifecycle/lineage.rs
@@ -1,4 +1,4 @@
-use super::{next_generation_value, restore_prior_content_to_successor};
+use super::generation::next_generation_value;
 use crate::error::{PackageServiceError, PackageServiceResult};
 use crate::identity::Nonce;
 use crate::journal::{OperationJournalRecord, PackageSlotRecord};
@@ -19,6 +19,17 @@ pub(super) fn active_drain_lineage(
         .ok_or(PackageServiceError::LifecycleTransition)?;
     validate(&lineage, state, nonce)?;
     Ok(lineage)
+}
+
+fn restore_prior_content_to_successor(
+    state: CanonicalInstalledState,
+    completing_nonce: Nonce,
+    generation: NonZeroU64,
+) -> CanonicalInstalledState {
+    let plan = *state.lifecycle_plan();
+    let mut restored = state;
+    restored.set_lifecycle_result(LifecycleState::Inactive, plan, generation, completing_nonce);
+    restored
 }
 
 pub(super) fn validate(
@@ -64,5 +75,9 @@ pub(super) fn restore_to_boundary_successor(
     nonce: &Nonce,
 ) -> PackageServiceResult<CanonicalInstalledState> {
     let generation: NonZeroU64 = next_generation_value(lineage.boundary_generation())?;
-    restore_prior_content_to_successor(lineage.base_state().clone(), *nonce, generation)
+    Ok(restore_prior_content_to_successor(
+        lineage.base_state().clone(),
+        *nonce,
+        generation,
+    ))
 }

--- a/crates/astrid-package-service/src/lifecycle/mod.rs
+++ b/crates/astrid-package-service/src/lifecycle/mod.rs
@@ -11,13 +11,16 @@ use crate::journal::{
 };
 use crate::policy::{JournalPolicy, Occupancy};
 use crate::state::{
-    CanonicalInstalledState, DrainDestination, ExpectedPackageState, InstalledStateSpec,
-    LifecycleState, PackageSlot,
+    CanonicalInstalledState, DrainDestination, DrainLineage, ExpectedPackageState,
+    InstalledStateSpec, LifecycleState, PackageSlot,
 };
 use std::collections::BTreeMap;
 use std::num::NonZeroU64;
 
+mod lineage;
 mod recovery;
+
+use self::lineage::{active_drain_lineage, restore_to_boundary_successor};
 
 /// Pure executable owner/package state model.
 #[derive(Debug)]
@@ -283,7 +286,7 @@ impl PackageServiceModel {
             *nonce,
         );
         if let Some(journal) = record.journal_mut(nonce) {
-            journal.set_drain_base_state(base_state);
+            journal.set_drain_lineage(DrainLineage::new(base_state, generation)?);
         }
         record.replace_state(Some(replacement.clone()));
         let journal = record
@@ -331,6 +334,7 @@ impl PackageServiceModel {
         if now >= *deadline {
             return Err(PackageServiceError::AuthorityExpired);
         }
+        active_drain_lineage(record, nonce)?;
         let deadline = *deadline;
         let destination = *destination;
         let generation = next_generation(&state)?;
@@ -350,7 +354,7 @@ impl PackageServiceModel {
         let journal = record
             .journal_mut(nonce)
             .ok_or(PackageServiceError::RecordMissing)?;
-        journal.set_state_generation(generation);
+        journal.advance_drain_boundary()?;
         Ok(())
     }
 
@@ -427,6 +431,7 @@ impl PackageServiceModel {
                 };
                 require_open_drain(&state, nonce, now)?;
                 require_zero_drain(&state, *nonce, DrainDestination::Replacement)?;
+                active_drain_lineage(record_slot, nonce)?;
                 if !zero_leases_proved {
                     return Err(PackageServiceError::DrainBlocked);
                 }
@@ -479,6 +484,7 @@ impl PackageServiceModel {
                 };
                 require_open_drain(&state, nonce, now)?;
                 require_zero_drain(&state, *nonce, DrainDestination::Removal)?;
+                active_drain_lineage(record_slot, nonce)?;
                 if !zero_leases_proved {
                     return Err(PackageServiceError::DrainBlocked);
                 }
@@ -503,6 +509,7 @@ impl PackageServiceModel {
         let journal = record_slot
             .journal_mut(nonce)
             .ok_or(PackageServiceError::RecordMissing)?;
+        journal.take_drain_lineage();
         journal.set_state_generation(generation);
         journal.commit(receipt.clone(), now);
         Ok(receipt)
@@ -548,12 +555,15 @@ impl PackageServiceModel {
             if now >= deadline {
                 return Err(PackageServiceError::LifecycleTransition);
             }
-            let restored = record_slot
-                .journal_mut(nonce)
-                .and_then(OperationJournalRecord::take_drain_base_state)
-                .ok_or(PackageServiceError::OccupancyCorruption)?;
-            let safe_restored = restore_prior_content(restored, *nonce)?;
+            let lineage = active_drain_lineage(record_slot, nonce)?;
+            let safe_restored = restore_to_boundary_successor(&lineage, nonce)?;
+            let restored_generation = safe_restored.generation_value();
             record_slot.replace_state(Some(safe_restored));
+            let journal = record_slot
+                .journal_mut(nonce)
+                .ok_or(PackageServiceError::RecordMissing)?;
+            journal.take_drain_lineage();
+            journal.set_state_generation(restored_generation);
         }
         let journal = record_slot
             .journal_mut(nonce)
@@ -585,7 +595,7 @@ impl PackageServiceModel {
         let LifecycleState::Draining {
             deadline,
             nonce: drain_nonce,
-            live_leases,
+            live_leases: _,
             destination,
         } = state.lifecycle_state()
         else {
@@ -594,13 +604,14 @@ impl PackageServiceModel {
         if drain_nonce.as_bytes() != nonce.as_bytes() || now < *deadline {
             return Err(PackageServiceError::LifecycleTransition);
         }
-        if *live_leases > 0 || !zero_leases_proved {
+        if !zero_leases_proved {
             let journal = record_slot
                 .journal_mut(nonce)
                 .ok_or(PackageServiceError::RecordMissing)?;
             journal.mark_unknown(now);
             return Ok(DrainResult::Blocked);
         }
+        let lineage = active_drain_lineage(record_slot, nonce)?;
         if *destination == DrainDestination::Removal {
             let generation = record_slot
                 .journal_record(nonce)
@@ -614,18 +625,18 @@ impl PackageServiceModel {
             if let Some(generation) = generation {
                 journal.set_state_generation(generation);
             }
+            journal.take_drain_lineage();
             journal.terminal_failure(JournalStatus::Expired, now);
             return Ok(DrainResult::Completed);
         }
-        let restored = record_slot
-            .journal_mut(nonce)
-            .and_then(OperationJournalRecord::take_drain_base_state)
-            .ok_or(PackageServiceError::OccupancyCorruption)?;
-        let safe_restored = restore_prior_content(restored, *nonce)?;
+        let safe_restored = restore_to_boundary_successor(&lineage, nonce)?;
+        let restored_generation = safe_restored.generation_value();
         record_slot.replace_state(Some(safe_restored));
         let journal = record_slot
             .journal_mut(nonce)
             .ok_or(PackageServiceError::RecordMissing)?;
+        journal.take_drain_lineage();
+        journal.set_state_generation(restored_generation);
         journal.terminal_failure(JournalStatus::Expired, now);
         Ok(DrainResult::Completed)
     }
@@ -837,14 +848,6 @@ fn require_zero_drain(
         return Err(PackageServiceError::DrainBlocked);
     }
     Ok(())
-}
-
-fn restore_prior_content(
-    state: CanonicalInstalledState,
-    completing_nonce: Nonce,
-) -> PackageServiceResult<CanonicalInstalledState> {
-    let generation = next_generation(&state)?;
-    restore_prior_content_to_successor(state, completing_nonce, generation)
 }
 
 fn restore_prior_content_to_successor(

--- a/crates/astrid-package-service/src/lifecycle/mod.rs
+++ b/crates/astrid-package-service/src/lifecycle/mod.rs
@@ -2,25 +2,37 @@ use crate::authority::AuthenticatedAuthority;
 use crate::context::{
     AdmittedService, AuthenticatedIngress, Operation, OperationContext, Timestamp,
 };
-use crate::digest::{Blake3Digest, DigestWriter, PlanDigest, ProvenanceDigest, StateDigest};
+use crate::digest::{Blake3Digest, StateDigest};
 use crate::error::{PackageServiceError, PackageServiceResult};
-use crate::identity::{Nonce, ProvenanceEvidence, ValidatedArtifact};
+use crate::identity::{Nonce, ValidatedArtifact};
 use crate::journal::{
     DrainPlan, DrainResult, JournalStatus, OperationJournalRecord, OperationReceipt,
-    PackageSlotRecord, ReceiptOutcome, ReplayOutcome, Tombstone,
+    PackageSlotRecord, ReplayOutcome, Tombstone,
 };
 use crate::policy::{JournalPolicy, Occupancy};
 use crate::state::{
-    CanonicalInstalledState, DrainDestination, DrainLineage, ExpectedPackageState,
-    InstalledStateSpec, LifecycleState, PackageSlot,
+    CanonicalInstalledState, DrainDestination, DrainLineage, ExpectedPackageState, LifecycleState,
+    PackageSlot,
 };
 use std::collections::BTreeMap;
-use std::num::NonZeroU64;
 
+mod commit;
+mod generation;
 mod lineage;
 mod recovery;
 
+use self::commit::{
+    DrainProof, commit_install, commit_plan_digest, commit_record_metadata, commit_removal,
+    commit_retained_state, commit_update, provenance_digest, recorded_drain_deadline,
+    validate_context_artifact,
+};
+use self::generation::{next_generation, next_generation_value, next_transition_generation};
 use self::lineage::{active_drain_lineage, restore_to_boundary_successor};
+
+#[cfg(test)]
+use self::commit::new_installed_state;
+#[cfg(test)]
+use self::generation::next_generation_from_high_watermark;
 
 /// Pure executable owner/package state model.
 #[derive(Debug)]
@@ -58,6 +70,9 @@ impl PackageServiceModel {
     }
 
     /// Durably represents an intent before any budgeted model effect.
+    ///
+    /// # Errors
+    /// Returns typed admission failures before any durable intent is inserted.
     pub fn begin(
         &mut self,
         context: OperationContext,
@@ -88,8 +103,9 @@ impl PackageServiceModel {
             return Err(PackageServiceError::RecordNotReconcilable);
         }
         if let Some(state) = self.slot_record(&slot).and_then(PackageSlotRecord::state) {
-            self.validate_context_bindings(&context, state)?;
+            Self::validate_context_bindings(&context, state)?;
         }
+        next_transition_generation(self.slots.get(&slot), context.operation())?;
 
         let current_generation = self
             .slot_record(&slot)
@@ -109,11 +125,11 @@ impl PackageServiceModel {
             .policy
             .has_admission_room(&self.occupancy, record_bytes)
         {
-            return Err(self.policy.admission_error());
+            return Err(JournalPolicy::admission_error());
         }
         let nonce = record.context().nonce();
         self.slots.entry(slot).or_default().insert_intent(record)?;
-        self.occupancy.add_record(record_bytes);
+        self.occupancy.add_record(record_bytes)?;
         self.nonce_locations.insert(nonce, slot);
         Ok(nonce)
     }
@@ -135,20 +151,16 @@ impl PackageServiceModel {
             .slots
             .get(slot)
             .and_then(|record| record.state())
-            .map(|state| state.lifecycle_state());
+            .map(super::state::CanonicalInstalledState::lifecycle_state);
         let valid = matches!(
             (operation, lifecycle),
             (Operation::Install, None)
                 | (
-                    Operation::Update,
-                    Some(LifecycleState::Inactive) | Some(LifecycleState::Active)
+                    Operation::Update | Operation::Remove,
+                    Some(LifecycleState::Inactive | LifecycleState::Active)
                 )
                 | (Operation::Activate, Some(LifecycleState::Inactive))
                 | (Operation::Deactivate, Some(LifecycleState::Active))
-                | (
-                    Operation::Remove,
-                    Some(LifecycleState::Inactive) | Some(LifecycleState::Active)
-                )
         );
         if valid {
             Ok(())
@@ -158,7 +170,6 @@ impl PackageServiceModel {
     }
 
     fn validate_context_bindings(
-        &self,
         context: &OperationContext,
         state: &CanonicalInstalledState,
     ) -> PackageServiceResult<()> {
@@ -169,6 +180,11 @@ impl PackageServiceModel {
             return Ok(());
         }
         if context.artifact() != state.artifact() || context.manifest() != state.manifest() {
+            return Err(PackageServiceError::BindingMismatch);
+        }
+        if context.content_root() != state.content_root()
+            || context.provenance() != state.provenance()
+        {
             return Err(PackageServiceError::BindingMismatch);
         }
         if context.operation() != Operation::Remove {
@@ -208,6 +224,9 @@ impl PackageServiceModel {
     }
 
     /// Moves an intent to executing after checking authority expiry.
+    ///
+    /// # Errors
+    /// Returns expiry or record-state failures without changing status.
     pub fn begin_work(&mut self, nonce: &Nonce, now: Timestamp) -> PackageServiceResult<()> {
         let expiry = self.context_for(nonce)?.expiry();
         if now >= expiry {
@@ -222,6 +241,9 @@ impl PackageServiceModel {
     }
 
     /// Durably places the exact state into a bounded drain.
+    ///
+    /// # Errors
+    /// Returns typed binding or transition failures before recording a drain.
     pub fn begin_drain(
         &mut self,
         nonce: &Nonce,
@@ -235,7 +257,10 @@ impl PackageServiceModel {
             DrainDestination::Replacement => Operation::Update,
             DrainDestination::Removal => Operation::Remove,
         };
-        if context.operation() != required || deadline > context.expiry() || deadline <= now {
+        let required_matches = context.operation() == required;
+        let expiry_allows = deadline <= context.expiry();
+        let now_allows = deadline > now;
+        if !(required_matches && expiry_allows && now_allows) {
             return Err(PackageServiceError::BindingMismatch);
         }
         let slot_for_plan = self
@@ -258,6 +283,13 @@ impl PackageServiceModel {
         .map_err(|_| PackageServiceError::BindingMismatch)?;
         if *context.plan_digest() != plan.digest() {
             return Err(PackageServiceError::BindingMismatch);
+        }
+        if context.operation() == Operation::Update {
+            let unified_plan =
+                commit_plan_digest(&context, context.content_root(), context.provenance());
+            if context.commit_plan_digest() != &unified_plan {
+                return Err(PackageServiceError::BindingMismatch);
+            }
         }
         self.begin_work(nonce, now)?;
         let slot = self
@@ -288,7 +320,7 @@ impl PackageServiceModel {
         if let Some(journal) = record.journal_mut(nonce) {
             journal.set_drain_lineage(DrainLineage::new(base_state, generation)?);
         }
-        record.replace_state(Some(replacement.clone()));
+        record.replace_state_with_generation(Some(replacement.clone()), generation)?;
         let journal = record
             .journal_mut(nonce)
             .ok_or(PackageServiceError::RecordMissing)?;
@@ -297,6 +329,9 @@ impl PackageServiceModel {
     }
 
     /// Binds the exact staged commit content before the uncertain boundary.
+    ///
+    /// # Errors
+    /// Returns binding or record-state failures without replacing an existing stage.
     pub fn stage_commit_artifact(
         &mut self,
         nonce: &Nonce,
@@ -312,6 +347,9 @@ impl PackageServiceModel {
             artifact.content_root(),
             &provenance_digest(artifact.provenance()),
         );
+        if context.commit_plan_digest() != &plan {
+            return Err(PackageServiceError::BindingMismatch);
+        }
         let record = self.record_mut(nonce)?;
         if !matches!(
             record.status(),
@@ -319,11 +357,20 @@ impl PackageServiceModel {
         ) {
             return Err(PackageServiceError::RecordNotReconcilable);
         }
+        if record
+            .staged_commit_plan()
+            .is_some_and(|existing| *existing != plan)
+        {
+            return Err(PackageServiceError::BindingMismatch);
+        }
         record.set_staged_commit_plan(plan);
         Ok(())
     }
 
     /// Records independently proved runtime lease count without completing the drain.
+    ///
+    /// # Errors
+    /// Returns expiry, lineage, or generation failures without a canonical commit.
     pub fn prove_drain_leases(
         &mut self,
         nonce: &Nonce,
@@ -377,7 +424,7 @@ impl PackageServiceModel {
             generation,
             *nonce,
         );
-        record.replace_state(Some(replacement));
+        record.replace_state_with_generation(Some(replacement), generation)?;
         let journal = record
             .journal_mut(nonce)
             .ok_or(PackageServiceError::RecordMissing)?;
@@ -386,6 +433,9 @@ impl PackageServiceModel {
     }
 
     /// Commits install, update, activation, deactivation, or final retirement.
+    ///
+    /// # Errors
+    /// Returns typed binding, expiry, drain, or transition failures before commit.
     pub fn complete(
         &mut self,
         nonce: &Nonce,
@@ -415,133 +465,55 @@ impl PackageServiceModel {
             .slots
             .get_mut(&slot)
             .ok_or(PackageServiceError::RecordMissing)?;
-        let journal_status = record_slot
-            .journal_record(nonce)
-            .map(|record| record.status())
-            .ok_or(PackageServiceError::RecordMissing)?;
-        let before = record_slot
-            .journal_record(nonce)
-            .map(|record| record.before_state())
-            .ok_or(PackageServiceError::RecordMissing)?;
-        let authority_digest = record_slot
-            .journal_record(nonce)
-            .map(|record| *record.authority_digest())
-            .ok_or(PackageServiceError::RecordMissing)?;
-        if journal_status != JournalStatus::Executing {
-            return Err(PackageServiceError::RecordNotReconcilable);
-        }
-        let staged_commit_plan = record_slot
-            .journal_record(nonce)
-            .and_then(OperationJournalRecord::staged_commit_plan)
-            .copied();
+        let (before, authority_digest, staged_commit_plan) =
+            commit_record_metadata(record_slot, nonce)?;
 
         let (after_state, outcome, generation) = match context.operation() {
             Operation::Install => {
                 let artifact = artifact.ok_or(PackageServiceError::BindingMismatch)?;
-                validate_context_artifact(&context, artifact)?;
-                if Some(commit_plan_digest(
-                    &context,
-                    artifact.content_root(),
-                    &provenance_digest(artifact.provenance()),
-                )) != staged_commit_plan
-                {
-                    return Err(PackageServiceError::BindingMismatch);
-                }
-                let state = new_installed_state(
+                commit_install(
+                    record_slot,
                     &context,
                     authority_digest,
                     artifact,
-                    LifecycleState::Inactive,
-                    first_state_generation()?,
-                )?;
-                let generation = state.generation_value();
-                record_slot.replace_state(Some(state));
-                (
-                    record_slot.expected_state_digest(),
-                    ReceiptOutcome::Installed,
-                    generation,
-                )
+                    staged_commit_plan,
+                )?
             },
             Operation::Update => {
                 let artifact = artifact.ok_or(PackageServiceError::BindingMismatch)?;
-                validate_context_artifact(&context, artifact)?;
-                let Some(state) = record_slot.state().cloned() else {
-                    return Err(PackageServiceError::LifecycleTransition);
-                };
-                require_open_drain(&state, nonce, now)?;
-                require_zero_drain(&state, *nonce, DrainDestination::Replacement)?;
-                active_drain_lineage(record_slot, nonce)?;
-                if !zero_leases_proved {
-                    return Err(PackageServiceError::DrainBlocked);
-                }
-                if Some(commit_plan_digest(
-                    &context,
-                    artifact.content_root(),
-                    &provenance_digest(artifact.provenance()),
-                )) != staged_commit_plan
-                {
-                    return Err(PackageServiceError::BindingMismatch);
-                }
-                let replacement = new_installed_state(
+                commit_update(
+                    record_slot,
                     &context,
                     authority_digest,
                     artifact,
-                    LifecycleState::Inactive,
-                    next_generation(&state)?,
-                )?;
-                let generation = replacement.generation_value();
-                record_slot.replace_state(Some(replacement));
-                (
-                    record_slot.expected_state_digest(),
-                    ReceiptOutcome::Updated,
-                    generation,
-                )
+                    staged_commit_plan,
+                    &DrainProof {
+                        nonce,
+                        now,
+                        zero_leases: zero_leases_proved,
+                    },
+                )?
             },
             Operation::Activate | Operation::Deactivate => {
                 let Some(state) = record_slot.state().cloned() else {
                     return Err(PackageServiceError::LifecycleTransition);
                 };
-                let next_lifecycle = if context.operation() == Operation::Activate {
-                    LifecycleState::Active
-                } else {
-                    LifecycleState::Inactive
-                };
-                let generation = next_generation(&state)?;
-                let mut replacement = state;
-                replacement.set_lifecycle_result(
-                    next_lifecycle,
-                    *context.plan_digest(),
-                    generation,
-                    *nonce,
-                );
-                record_slot.replace_state(Some(replacement));
-                (
-                    record_slot.expected_state_digest(),
-                    if context.operation() == Operation::Activate {
-                        ReceiptOutcome::Activated
-                    } else {
-                        ReceiptOutcome::Deactivated
-                    },
-                    generation,
-                )
+                commit_retained_state(record_slot, &context, state, nonce)?
             },
             Operation::Remove => {
                 let Some(state) = record_slot.state().cloned() else {
                     return Err(PackageServiceError::LifecycleTransition);
                 };
-                require_open_drain(&state, nonce, now)?;
-                require_zero_drain(&state, *nonce, DrainDestination::Removal)?;
-                active_drain_lineage(record_slot, nonce)?;
-                if !zero_leases_proved {
-                    return Err(PackageServiceError::DrainBlocked);
-                }
-                let generation = next_generation(&state)?;
-                record_slot.replace_state(None);
-                (
-                    record_slot.expected_state_digest(),
-                    ReceiptOutcome::Retired,
-                    generation,
-                )
+                commit_removal(
+                    record_slot,
+                    &state,
+                    nonce,
+                    &DrainProof {
+                        nonce,
+                        now,
+                        zero_leases: zero_leases_proved,
+                    },
+                )?
             },
             Operation::Recover => return Err(PackageServiceError::RecordNotReconcilable),
         };
@@ -564,6 +536,9 @@ impl PackageServiceModel {
     }
 
     /// Moves an executing result to unknown after an uncertain boundary.
+    ///
+    /// # Errors
+    /// Returns record-state failures unless the record is currently executing.
     pub fn mark_unknown(&mut self, nonce: &Nonce, now: Timestamp) -> PackageServiceResult<()> {
         let record = self.record_mut(nonce)?;
         if record.status() != JournalStatus::Executing {
@@ -574,6 +549,9 @@ impl PackageServiceModel {
     }
 
     /// Cancels advisory work only before an unknown commit boundary.
+    ///
+    /// # Errors
+    /// Returns expiry, transition, or restoration failures before terminal status.
     pub fn cancel(&mut self, nonce: &Nonce, now: Timestamp) -> PackageServiceResult<()> {
         let context = self.context_for(nonce)?;
         if now >= context.expiry() {
@@ -606,7 +584,7 @@ impl PackageServiceModel {
             let lineage = active_drain_lineage(record_slot, nonce)?;
             let safe_restored = restore_to_boundary_successor(&lineage, nonce)?;
             let restored_generation = safe_restored.generation_value();
-            record_slot.replace_state(Some(safe_restored));
+            record_slot.replace_state_with_generation(Some(safe_restored), restored_generation)?;
             let journal = record_slot
                 .journal_mut(nonce)
                 .ok_or(PackageServiceError::RecordMissing)?;
@@ -622,6 +600,9 @@ impl PackageServiceModel {
     }
 
     /// Advances a drain at or after its deadline without inventing retirement.
+    ///
+    /// # Errors
+    /// Returns transition or generation failures without a partial drain resolution.
     pub fn expire_drain(
         &mut self,
         nonce: &Nonce,
@@ -666,14 +647,13 @@ impl PackageServiceModel {
                 .journal_record(nonce)
                 .and_then(OperationJournalRecord::state_generation)
                 .map(next_generation_value)
-                .transpose()?;
-            record_slot.replace_state(None);
+                .transpose()?
+                .ok_or(PackageServiceError::OccupancyCorruption)?;
+            record_slot.replace_state_with_generation(None, generation)?;
             let journal = record_slot
                 .journal_mut(nonce)
                 .ok_or(PackageServiceError::RecordMissing)?;
-            if let Some(generation) = generation {
-                journal.set_state_generation(generation);
-            }
+            journal.set_state_generation(generation);
             journal.take_drain_lineage();
             journal.take_staged_commit_plan();
             journal.terminal_failure(JournalStatus::Expired, now);
@@ -681,7 +661,7 @@ impl PackageServiceModel {
         }
         let safe_restored = restore_to_boundary_successor(&lineage, nonce)?;
         let restored_generation = safe_restored.generation_value();
-        record_slot.replace_state(Some(safe_restored));
+        record_slot.replace_state_with_generation(Some(safe_restored), restored_generation)?;
         let journal = record_slot
             .journal_mut(nonce)
             .ok_or(PackageServiceError::RecordMissing)?;
@@ -693,6 +673,9 @@ impl PackageServiceModel {
     }
 
     /// Makes an authority-expired admission explicitly terminal or recoverable.
+    ///
+    /// # Errors
+    /// Returns record-state failures when the record cannot expire yet.
     pub fn expire_unresolved(&mut self, nonce: &Nonce, now: Timestamp) -> PackageServiceResult<()> {
         let context = self.context_for(nonce)?;
         if now < context.expiry() {
@@ -713,6 +696,9 @@ impl PackageServiceModel {
     }
 
     /// Replays a retained receipt or distinguishes collection from loss.
+    ///
+    /// # Errors
+    /// Returns replay failures for missing records or mismatched context digests.
     pub fn replay(
         &self,
         nonce: &Nonce,
@@ -748,6 +734,9 @@ impl PackageServiceModel {
     }
 
     /// Performs one bounded collection pass; unresolved records are never eligible.
+    ///
+    /// # Errors
+    /// Returns quota and occupancy failures atomically before collecting records.
     pub fn collect(&mut self, now: Timestamp, batch_limit: u64) -> PackageServiceResult<u64> {
         let (occupied_records, occupied_bytes, tombstones) = self.occupancy.values();
         let mut actual_records = 0u64;
@@ -788,7 +777,7 @@ impl PackageServiceModel {
             return Err(PackageServiceError::QuotaExhausted);
         }
 
-        let mut collected = 0u64;
+        let mut collected_records = OccupiedRecords::ZERO;
         for (slot, nonce) in selected {
             let slot_record = self
                 .slots
@@ -797,162 +786,35 @@ impl PackageServiceModel {
             let tombstone = slot_record
                 .remove_journal(&nonce)
                 .ok_or(PackageServiceError::OccupancyCorruption)?;
-            self.occupancy.remove_record(1024);
-            self.occupancy.add_tombstone();
+            self.occupancy.remove_record(1024)?;
+            self.occupancy.add_tombstone()?;
             self.tombstones.insert(nonce, tombstone);
             self.nonce_locations.remove(&nonce);
-            collected = collected
+            collected_records = collected_records
                 .checked_add(1)
                 .ok_or(PackageServiceError::GenerationOverflow)?;
         }
-        Ok(collected)
+        Ok(collected_records.value())
     }
-}
-
-fn validate_context_artifact(
-    context: &OperationContext,
-    artifact: &ValidatedArtifact,
-) -> PackageServiceResult<()> {
-    if context.artifact() != artifact.artifact() || context.manifest() != artifact.manifest() {
-        return Err(PackageServiceError::BindingMismatch);
-    }
-    Ok(())
-}
-
-pub(crate) fn commit_plan_digest(
-    context: &OperationContext,
-    content_root: &Blake3Digest,
-    provenance: &ProvenanceDigest,
-) -> PlanDigest {
-    let artifact_identity = context.artifact();
-    let manifest = context.manifest();
-    let mut writer = DigestWriter::new();
-    writer.u64(u64::from(artifact_identity.format_version()));
-    writer.u64(artifact_identity.size_bytes());
-    writer.digest(artifact_identity.sha256());
-    writer.digest(artifact_identity.blake3());
-    writer.u64(u64::from(manifest.format_version()));
-    writer.bytes(manifest.package_name().as_str().as_bytes());
-    writer.bytes(manifest.package_version().as_str().as_bytes());
-    writer.digest(manifest.manifest_digest());
-    writer.digest(content_root);
-    writer.digest(provenance);
-    writer.tag(context.operation().tag());
-    writer.finish("astrid.package.commit-plan.v1")
-}
-
-fn new_installed_state(
-    context: &OperationContext,
-    authority_digest: crate::digest::AuthorityDecisionDigest,
-    artifact: &ValidatedArtifact,
-    lifecycle: LifecycleState,
-    generation: NonZeroU64,
-) -> PackageServiceResult<CanonicalInstalledState> {
-    CanonicalInstalledState::new(InstalledStateSpec {
-        owner: context.target_owner(),
-        package_object: context.package_object(),
-        artifact: *context.artifact(),
-        content_root: *artifact.content_root(),
-        manifest: context.manifest().clone(),
-        authority_digest,
-        provenance: provenance_digest(artifact.provenance()),
-        lifecycle_state: lifecycle,
-        lifecycle_plan: *context.plan_digest(),
-        generation,
-        completing_nonce: context.nonce(),
-    })
-}
-
-fn first_state_generation() -> PackageServiceResult<NonZeroU64> {
-    NonZeroU64::new(1).ok_or(PackageServiceError::InvalidValue("package generation"))
-}
-
-fn recorded_drain_deadline(
-    state: &CanonicalInstalledState,
-    nonce: &Nonce,
-) -> PackageServiceResult<Option<Timestamp>> {
-    let LifecycleState::Draining {
-        deadline,
-        nonce: drain_nonce,
-        live_leases: _,
-        destination: _,
-    } = state.lifecycle_state()
-    else {
-        return Ok(None);
-    };
-    if drain_nonce.as_bytes() != nonce.as_bytes() {
-        return Err(PackageServiceError::LifecycleTransition);
-    }
-    Ok(Some(*deadline))
-}
-
-fn require_open_drain(
-    state: &CanonicalInstalledState,
-    nonce: &Nonce,
-    now: Timestamp,
-) -> PackageServiceResult<()> {
-    let Some(deadline) = recorded_drain_deadline(state, nonce)? else {
-        return Err(PackageServiceError::LifecycleTransition);
-    };
-    if now >= deadline {
-        return Err(PackageServiceError::AuthorityExpired);
-    }
-    Ok(())
-}
-
-fn require_zero_drain(
-    state: &CanonicalInstalledState,
-    nonce: Nonce,
-    destination: DrainDestination,
-) -> PackageServiceResult<()> {
-    let LifecycleState::Draining {
-        destination: observed_destination,
-        nonce: observed_nonce,
-        live_leases,
-        deadline: _,
-    } = state.lifecycle_state()
-    else {
-        return Err(PackageServiceError::LifecycleTransition);
-    };
-    if observed_destination != &destination
-        || observed_nonce.as_bytes() != nonce.as_bytes()
-        || live_leases != &0
-    {
-        return Err(PackageServiceError::DrainBlocked);
-    }
-    Ok(())
-}
-
-fn restore_prior_content_to_successor(
-    state: CanonicalInstalledState,
-    completing_nonce: Nonce,
-    generation: NonZeroU64,
-) -> PackageServiceResult<CanonicalInstalledState> {
-    let plan = *state.lifecycle_plan();
-    let mut restored = state;
-    restored.set_lifecycle_result(LifecycleState::Inactive, plan, generation, completing_nonce);
-    Ok(restored)
-}
-
-fn next_generation(state: &CanonicalInstalledState) -> PackageServiceResult<NonZeroU64> {
-    next_generation_value(state.generation_value())
-}
-
-fn next_generation_value(generation: NonZeroU64) -> PackageServiceResult<NonZeroU64> {
-    let value = generation
-        .get()
-        .checked_add(1)
-        .ok_or(PackageServiceError::GenerationOverflow)?;
-    NonZeroU64::try_from(value).map_err(PackageServiceError::from)
-}
-
-fn provenance_digest(value: &ProvenanceEvidence) -> ProvenanceDigest {
-    let mut writer = DigestWriter::new();
-    writer.tag(value.class().tag());
-    writer.digest(value.evidence());
-    writer.bytes(value.bounded_evidence().as_bytes());
-    writer.finish("astrid.package.provenance.v1")
 }
 
 #[cfg(test)]
 mod tests;
+
+#[derive(Clone, Copy)]
+struct OccupiedRecords(u64);
+
+impl OccupiedRecords {
+    const ZERO: Self = Self(0);
+
+    const fn checked_add(self, records: u64) -> Option<Self> {
+        match self.0.checked_add(records) {
+            Some(value) => Some(Self(value)),
+            None => None,
+        }
+    }
+
+    const fn value(self) -> u64 {
+        self.0
+    }
+}

--- a/crates/astrid-package-service/src/lifecycle/mod.rs
+++ b/crates/astrid-package-service/src/lifecycle/mod.rs
@@ -2,7 +2,7 @@ use crate::authority::AuthenticatedAuthority;
 use crate::context::{
     AdmittedService, AuthenticatedIngress, Operation, OperationContext, Timestamp,
 };
-use crate::digest::{Blake3Digest, DigestWriter, ProvenanceDigest, StateDigest};
+use crate::digest::{Blake3Digest, DigestWriter, PlanDigest, ProvenanceDigest, StateDigest};
 use crate::error::{PackageServiceError, PackageServiceResult};
 use crate::identity::{Nonce, ProvenanceEvidence, ValidatedArtifact};
 use crate::journal::{
@@ -296,6 +296,33 @@ impl PackageServiceModel {
         Ok(())
     }
 
+    /// Binds the exact staged commit content before the uncertain boundary.
+    pub fn stage_commit_artifact(
+        &mut self,
+        nonce: &Nonce,
+        artifact: &ValidatedArtifact,
+    ) -> PackageServiceResult<()> {
+        let context = self.context_for(nonce)?;
+        if !matches!(context.operation(), Operation::Install | Operation::Update) {
+            return Err(PackageServiceError::LifecycleTransition);
+        }
+        validate_context_artifact(&context, artifact)?;
+        let plan = commit_plan_digest(
+            &context,
+            artifact.content_root(),
+            &provenance_digest(artifact.provenance()),
+        );
+        let record = self.record_mut(nonce)?;
+        if !matches!(
+            record.status(),
+            JournalStatus::Intent | JournalStatus::Executing
+        ) {
+            return Err(PackageServiceError::RecordNotReconcilable);
+        }
+        record.set_staged_commit_plan(plan);
+        Ok(())
+    }
+
     /// Records independently proved runtime lease count without completing the drain.
     pub fn prove_drain_leases(
         &mut self,
@@ -403,11 +430,23 @@ impl PackageServiceModel {
         if journal_status != JournalStatus::Executing {
             return Err(PackageServiceError::RecordNotReconcilable);
         }
+        let staged_commit_plan = record_slot
+            .journal_record(nonce)
+            .and_then(OperationJournalRecord::staged_commit_plan)
+            .copied();
 
         let (after_state, outcome, generation) = match context.operation() {
             Operation::Install => {
                 let artifact = artifact.ok_or(PackageServiceError::BindingMismatch)?;
                 validate_context_artifact(&context, artifact)?;
+                if Some(commit_plan_digest(
+                    &context,
+                    artifact.content_root(),
+                    &provenance_digest(artifact.provenance()),
+                )) != staged_commit_plan
+                {
+                    return Err(PackageServiceError::BindingMismatch);
+                }
                 let state = new_installed_state(
                     &context,
                     authority_digest,
@@ -434,6 +473,14 @@ impl PackageServiceModel {
                 active_drain_lineage(record_slot, nonce)?;
                 if !zero_leases_proved {
                     return Err(PackageServiceError::DrainBlocked);
+                }
+                if Some(commit_plan_digest(
+                    &context,
+                    artifact.content_root(),
+                    &provenance_digest(artifact.provenance()),
+                )) != staged_commit_plan
+                {
+                    return Err(PackageServiceError::BindingMismatch);
                 }
                 let replacement = new_installed_state(
                     &context,
@@ -510,6 +557,7 @@ impl PackageServiceModel {
             .journal_mut(nonce)
             .ok_or(PackageServiceError::RecordMissing)?;
         journal.take_drain_lineage();
+        journal.take_staged_commit_plan();
         journal.set_state_generation(generation);
         journal.commit(receipt.clone(), now);
         Ok(receipt)
@@ -568,6 +616,7 @@ impl PackageServiceModel {
         let journal = record_slot
             .journal_mut(nonce)
             .ok_or(PackageServiceError::RecordMissing)?;
+        journal.take_staged_commit_plan();
         journal.terminal_failure(JournalStatus::Aborted, now);
         Ok(())
     }
@@ -626,6 +675,7 @@ impl PackageServiceModel {
                 journal.set_state_generation(generation);
             }
             journal.take_drain_lineage();
+            journal.take_staged_commit_plan();
             journal.terminal_failure(JournalStatus::Expired, now);
             return Ok(DrainResult::Completed);
         }
@@ -636,6 +686,7 @@ impl PackageServiceModel {
             .journal_mut(nonce)
             .ok_or(PackageServiceError::RecordMissing)?;
         journal.take_drain_lineage();
+        journal.take_staged_commit_plan();
         journal.set_state_generation(restored_generation);
         journal.terminal_failure(JournalStatus::Expired, now);
         Ok(DrainResult::Completed)
@@ -766,6 +817,28 @@ fn validate_context_artifact(
         return Err(PackageServiceError::BindingMismatch);
     }
     Ok(())
+}
+
+pub(crate) fn commit_plan_digest(
+    context: &OperationContext,
+    content_root: &Blake3Digest,
+    provenance: &ProvenanceDigest,
+) -> PlanDigest {
+    let artifact_identity = context.artifact();
+    let manifest = context.manifest();
+    let mut writer = DigestWriter::new();
+    writer.u64(u64::from(artifact_identity.format_version()));
+    writer.u64(artifact_identity.size_bytes());
+    writer.digest(artifact_identity.sha256());
+    writer.digest(artifact_identity.blake3());
+    writer.u64(u64::from(manifest.format_version()));
+    writer.bytes(manifest.package_name().as_str().as_bytes());
+    writer.bytes(manifest.package_version().as_str().as_bytes());
+    writer.digest(manifest.manifest_digest());
+    writer.digest(content_root);
+    writer.digest(provenance);
+    writer.tag(context.operation().tag());
+    writer.finish("astrid.package.commit-plan.v1")
 }
 
 fn new_installed_state(

--- a/crates/astrid-package-service/src/lifecycle/mod.rs
+++ b/crates/astrid-package-service/src/lifecycle/mod.rs
@@ -4,11 +4,10 @@ use crate::context::{
 };
 use crate::digest::{Blake3Digest, DigestWriter, ProvenanceDigest, StateDigest};
 use crate::error::{PackageServiceError, PackageServiceResult};
-use crate::identity::ProvenanceEvidence;
-use crate::identity::{Nonce, ValidatedArtifact};
+use crate::identity::{Nonce, ProvenanceEvidence, ValidatedArtifact};
 use crate::journal::{
     DrainPlan, DrainResult, JournalStatus, OperationJournalRecord, OperationReceipt,
-    PackageSlotRecord, ReceiptOutcome, RecoveryEvidence, ReplayOutcome, Tombstone,
+    PackageSlotRecord, ReceiptOutcome, ReplayOutcome, Tombstone,
 };
 use crate::policy::{JournalPolicy, Occupancy};
 use crate::state::{
@@ -17,6 +16,8 @@ use crate::state::{
 };
 use std::collections::BTreeMap;
 use std::num::NonZeroU64;
+
+mod recovery;
 
 /// Pure executable owner/package state model.
 #[derive(Debug)]
@@ -270,7 +271,7 @@ impl PackageServiceModel {
         let base_state = state.clone();
         let generation = next_generation(&state)?;
         let mut replacement = state;
-        replacement.set_lifecycle_state(
+        replacement.set_lifecycle_result(
             LifecycleState::Draining {
                 destination,
                 deadline,
@@ -279,6 +280,7 @@ impl PackageServiceModel {
             },
             *context.plan_digest(),
             generation,
+            *nonce,
         );
         if let Some(journal) = record.journal_mut(nonce) {
             journal.set_drain_base_state(base_state);
@@ -326,11 +328,14 @@ impl PackageServiceModel {
         if drain_nonce.as_bytes() != nonce.as_bytes() {
             return Err(PackageServiceError::LifecycleTransition);
         }
+        if now >= *deadline {
+            return Err(PackageServiceError::AuthorityExpired);
+        }
         let deadline = *deadline;
         let destination = *destination;
         let generation = next_generation(&state)?;
         let mut replacement = state;
-        replacement.set_lifecycle_state(
+        replacement.set_lifecycle_result(
             LifecycleState::Draining {
                 destination,
                 deadline,
@@ -339,6 +344,7 @@ impl PackageServiceModel {
             },
             *context.plan_digest(),
             generation,
+            *nonce,
         );
         record.replace_state(Some(replacement));
         let journal = record
@@ -360,6 +366,14 @@ impl PackageServiceModel {
         let context = self.context_for(nonce)?;
         if now >= context.expiry() {
             return Err(PackageServiceError::AuthorityExpired);
+        }
+        let receipt_allowed = if context.operation() == Operation::Activate {
+            activation_receipt.is_some_and(|receipt| receipt.as_bytes() != &[0; 32])
+        } else {
+            activation_receipt.is_none()
+        };
+        if !receipt_allowed {
+            return Err(PackageServiceError::BindingMismatch);
         }
         let slot = self
             .nonce_locations
@@ -411,6 +425,7 @@ impl PackageServiceModel {
                 let Some(state) = record_slot.state().cloned() else {
                     return Err(PackageServiceError::LifecycleTransition);
                 };
+                require_open_drain(&state, nonce, now)?;
                 require_zero_drain(&state, *nonce, DrainDestination::Replacement)?;
                 if !zero_leases_proved {
                     return Err(PackageServiceError::DrainBlocked);
@@ -431,9 +446,6 @@ impl PackageServiceModel {
                 )
             },
             Operation::Activate | Operation::Deactivate => {
-                if context.operation() == Operation::Activate && activation_receipt.is_none() {
-                    return Err(PackageServiceError::BindingMismatch);
-                }
                 let Some(state) = record_slot.state().cloned() else {
                     return Err(PackageServiceError::LifecycleTransition);
                 };
@@ -444,7 +456,12 @@ impl PackageServiceModel {
                 };
                 let generation = next_generation(&state)?;
                 let mut replacement = state;
-                replacement.set_lifecycle_state(next_lifecycle, *context.plan_digest(), generation);
+                replacement.set_lifecycle_result(
+                    next_lifecycle,
+                    *context.plan_digest(),
+                    generation,
+                    *nonce,
+                );
                 record_slot.replace_state(Some(replacement));
                 (
                     record_slot.expected_state_digest(),
@@ -460,6 +477,7 @@ impl PackageServiceModel {
                 let Some(state) = record_slot.state().cloned() else {
                     return Err(PackageServiceError::LifecycleTransition);
                 };
+                require_open_drain(&state, nonce, now)?;
                 require_zero_drain(&state, *nonce, DrainDestination::Removal)?;
                 if !zero_leases_proved {
                     return Err(PackageServiceError::DrainBlocked);
@@ -500,114 +518,6 @@ impl PackageServiceModel {
         Ok(())
     }
 
-    /// Reconciles an unknown record only with exact old/new evidence.
-    pub fn recover(
-        &mut self,
-        nonce: &Nonce,
-        evidence: &RecoveryEvidence,
-        now: Timestamp,
-    ) -> PackageServiceResult<Option<OperationReceipt>> {
-        let context = self.context_for(nonce)?;
-        let slot = self
-            .nonce_locations
-            .get(nonce)
-            .copied()
-            .ok_or(PackageServiceError::RecordMissing)?;
-        let record_slot = self
-            .slots
-            .get_mut(&slot)
-            .ok_or(PackageServiceError::RecordMissing)?;
-        let status = record_slot
-            .journal_record(nonce)
-            .map(|record| record.status())
-            .ok_or(PackageServiceError::RecordMissing)?;
-        let token = record_slot
-            .journal_record(nonce)
-            .map(|record| record.recovery_token())
-            .ok_or(PackageServiceError::RecordMissing)?;
-        let before = record_slot
-            .journal_record(nonce)
-            .map(|record| record.before_state())
-            .ok_or(PackageServiceError::RecordMissing)?;
-        let observed_state = record_slot.state().cloned();
-        let expected_authority = record_slot
-            .journal_record(nonce)
-            .map(|record| *record.authority_digest())
-            .ok_or(PackageServiceError::RecordMissing)?;
-        if status != JournalStatus::Unknown {
-            return Err(PackageServiceError::RecordNotReconcilable);
-        }
-        if token.into_bytes() != evidence.token_bytes() {
-            return Err(PackageServiceError::RecoveryUnresolved);
-        }
-        let observed = evidence.observed_state();
-        if observed.as_bytes() == before.as_bytes() {
-            if let Some(base_state) = record_slot
-                .journal_mut(nonce)
-                .and_then(OperationJournalRecord::take_drain_base_state)
-            {
-                let restored = restore_prior_content(base_state)?;
-                record_slot.replace_state(Some(restored));
-            }
-            let journal = record_slot
-                .journal_mut(nonce)
-                .ok_or(PackageServiceError::RecordMissing)?;
-            journal.resolve_recovery(None, JournalStatus::Failed, now);
-            return Ok(None);
-        }
-        let proven_outcome = match observed_state {
-            Some(state)
-                if state.digest().as_bytes() == observed.as_bytes()
-                    && state.generation_value() == evidence.runtime_generation()
-                    && validate_committed_state(&context, &state, &expected_authority) =>
-            {
-                match context.operation() {
-                    Operation::Install => {
-                        Some((ReceiptOutcome::Installed, state.generation_value()))
-                    },
-                    Operation::Update => Some((ReceiptOutcome::Updated, state.generation_value())),
-                    Operation::Activate => evidence
-                        .activation_receipt()
-                        .filter(|receipt| receipt.as_bytes() != &[0; 32])
-                        .map(|_| (ReceiptOutcome::Activated, state.generation_value())),
-                    Operation::Deactivate => {
-                        Some((ReceiptOutcome::Deactivated, state.generation_value()))
-                    },
-                    Operation::Remove | Operation::Recover => None,
-                }
-            },
-            None if context.operation() == Operation::Remove
-                && *observed.as_bytes() == [0; 32]
-                && evidence.zero_leases_proved() =>
-            {
-                let old_generation = record_slot
-                    .journal_record(nonce)
-                    .and_then(|record| record.state_generation());
-                match old_generation.map(next_generation_value) {
-                    Some(Ok(generation)) => Some((ReceiptOutcome::Retired, generation)),
-                    _ => None,
-                }
-            },
-            _ => None,
-        };
-        let Some((outcome, generation)) = proven_outcome else {
-            return Err(PackageServiceError::RecoveryUnresolved);
-        };
-        let receipt = OperationReceipt::new(
-            &context,
-            outcome,
-            before,
-            observed,
-            generation,
-            evidence.activation_receipt(),
-        );
-        let journal = record_slot
-            .journal_mut(nonce)
-            .ok_or(PackageServiceError::RecordMissing)?;
-        journal.resolve_recovery(Some(receipt.clone()), JournalStatus::Committed, now);
-        Ok(Some(receipt))
-    }
-
     /// Cancels advisory work only before an unknown commit boundary.
     pub fn cancel(&mut self, nonce: &Nonce, now: Timestamp) -> PackageServiceResult<()> {
         let context = self.context_for(nonce)?;
@@ -633,16 +543,16 @@ impl PackageServiceModel {
             return Err(PackageServiceError::RecordNotReconcilable);
         }
         if let Some(state) = record_slot.state().cloned()
-            && let LifecycleState::Draining {
-                nonce: drain_nonce, ..
-            } = state.lifecycle_state()
-            && drain_nonce.as_bytes() == nonce.as_bytes()
+            && let Some(deadline) = recorded_drain_deadline(&state, nonce)?
         {
+            if now >= deadline {
+                return Err(PackageServiceError::LifecycleTransition);
+            }
             let restored = record_slot
                 .journal_mut(nonce)
                 .and_then(OperationJournalRecord::take_drain_base_state)
                 .ok_or(PackageServiceError::OccupancyCorruption)?;
-            let safe_restored = restore_prior_content(restored)?;
+            let safe_restored = restore_prior_content(restored, *nonce)?;
             record_slot.replace_state(Some(safe_restored));
         }
         let journal = record_slot
@@ -692,13 +602,26 @@ impl PackageServiceModel {
             return Ok(DrainResult::Blocked);
         }
         if *destination == DrainDestination::Removal {
-            return Err(PackageServiceError::DrainBlocked);
+            let generation = record_slot
+                .journal_record(nonce)
+                .and_then(OperationJournalRecord::state_generation)
+                .map(next_generation_value)
+                .transpose()?;
+            record_slot.replace_state(None);
+            let journal = record_slot
+                .journal_mut(nonce)
+                .ok_or(PackageServiceError::RecordMissing)?;
+            if let Some(generation) = generation {
+                journal.set_state_generation(generation);
+            }
+            journal.terminal_failure(JournalStatus::Expired, now);
+            return Ok(DrainResult::Completed);
         }
         let restored = record_slot
             .journal_mut(nonce)
             .and_then(OperationJournalRecord::take_drain_base_state)
             .ok_or(PackageServiceError::OccupancyCorruption)?;
-        let safe_restored = restore_prior_content(restored)?;
+        let safe_restored = restore_prior_content(restored, *nonce)?;
         record_slot.replace_state(Some(safe_restored));
         let journal = record_slot
             .journal_mut(nonce)
@@ -860,6 +783,39 @@ fn first_state_generation() -> PackageServiceResult<NonZeroU64> {
     NonZeroU64::new(1).ok_or(PackageServiceError::InvalidValue("package generation"))
 }
 
+fn recorded_drain_deadline(
+    state: &CanonicalInstalledState,
+    nonce: &Nonce,
+) -> PackageServiceResult<Option<Timestamp>> {
+    let LifecycleState::Draining {
+        deadline,
+        nonce: drain_nonce,
+        live_leases: _,
+        destination: _,
+    } = state.lifecycle_state()
+    else {
+        return Ok(None);
+    };
+    if drain_nonce.as_bytes() != nonce.as_bytes() {
+        return Err(PackageServiceError::LifecycleTransition);
+    }
+    Ok(Some(*deadline))
+}
+
+fn require_open_drain(
+    state: &CanonicalInstalledState,
+    nonce: &Nonce,
+    now: Timestamp,
+) -> PackageServiceResult<()> {
+    let Some(deadline) = recorded_drain_deadline(state, nonce)? else {
+        return Err(PackageServiceError::LifecycleTransition);
+    };
+    if now >= deadline {
+        return Err(PackageServiceError::AuthorityExpired);
+    }
+    Ok(())
+}
+
 fn require_zero_drain(
     state: &CanonicalInstalledState,
     nonce: Nonce,
@@ -885,35 +841,21 @@ fn require_zero_drain(
 
 fn restore_prior_content(
     state: CanonicalInstalledState,
+    completing_nonce: Nonce,
+) -> PackageServiceResult<CanonicalInstalledState> {
+    let generation = next_generation(&state)?;
+    restore_prior_content_to_successor(state, completing_nonce, generation)
+}
+
+fn restore_prior_content_to_successor(
+    state: CanonicalInstalledState,
+    completing_nonce: Nonce,
+    generation: NonZeroU64,
 ) -> PackageServiceResult<CanonicalInstalledState> {
     let plan = *state.lifecycle_plan();
-    let generation = next_generation(&state)?;
     let mut restored = state;
-    restored.set_lifecycle_state(LifecycleState::Inactive, plan, generation);
+    restored.set_lifecycle_result(LifecycleState::Inactive, plan, generation, completing_nonce);
     Ok(restored)
-}
-
-fn validate_committed_state(
-    context: &OperationContext,
-    state: &CanonicalInstalledState,
-    expected_authority: &crate::digest::AuthorityDecisionDigest,
-) -> bool {
-    state.slot() == PackageSlot::new(context.target_owner(), context.package_object())
-        && state.completing_nonce().as_bytes() == context.nonce().as_bytes()
-        && state.artifact() == context.artifact()
-        && state.manifest() == context.manifest()
-        && state.lifecycle_plan() == context.plan_digest()
-        && state.authority_digest() == expected_authority
-        && state.content_root().as_bytes() != &[0; 32]
-        && *state.lifecycle_state() == expected_recovered_lifecycle(context.operation())
-}
-
-const fn expected_recovered_lifecycle(operation: Operation) -> LifecycleState {
-    match operation {
-        Operation::Activate => LifecycleState::Active,
-        Operation::Install | Operation::Update | Operation::Deactivate => LifecycleState::Inactive,
-        Operation::Remove | Operation::Recover => LifecycleState::Inactive,
-    }
 }
 
 fn next_generation(state: &CanonicalInstalledState) -> PackageServiceResult<NonZeroU64> {

--- a/crates/astrid-package-service/src/lifecycle/recovery.rs
+++ b/crates/astrid-package-service/src/lifecycle/recovery.rs
@@ -1,0 +1,358 @@
+use super::{
+    PackageServiceModel, first_state_generation, next_generation_value, recorded_drain_deadline,
+    restore_prior_content_to_successor,
+};
+use crate::bytes::RecoveryToken;
+use crate::context::{Operation, OperationContext, Timestamp};
+use crate::digest::{AuthorityDecisionDigest, StateDigest};
+use crate::error::{PackageServiceError, PackageServiceResult};
+use crate::identity::{Nonce, STATE_SCHEMA_VERSION};
+use crate::journal::{JournalStatus, OperationReceipt, ReceiptOutcome, RecoveryEvidence};
+use crate::state::{CanonicalInstalledState, LifecycleState, PackageSlot};
+use std::num::NonZeroU64;
+
+#[derive(Clone)]
+struct RecoverySnapshot {
+    context: OperationContext,
+    authority: AuthorityDecisionDigest,
+    token: RecoveryToken,
+    before: StateDigest,
+    boundary_generation: Option<NonZeroU64>,
+    drain_deadline: Option<Timestamp>,
+    base_state: Option<CanonicalInstalledState>,
+}
+
+enum RecoveryEffect {
+    RestoreInactive { generation: NonZeroU64 },
+    Commit(Option<Box<CanonicalInstalledState>>),
+}
+
+impl PackageServiceModel {
+    /// Reconciles an unknown record from retained canonical observations.
+    pub fn recover(
+        &mut self,
+        nonce: &Nonce,
+        evidence: &RecoveryEvidence,
+        now: crate::context::Timestamp,
+    ) -> PackageServiceResult<Option<OperationReceipt>> {
+        let snapshot = self.recovery_snapshot(nonce)?;
+        if snapshot.token.into_bytes() != evidence.token_bytes() {
+            return Err(PackageServiceError::RecoveryUnresolved);
+        }
+        let observed = self.retained_observation(&snapshot, evidence)?;
+        self.resolve_recovery(snapshot, evidence, observed.as_ref(), now)
+    }
+
+    /// Adjudicates a backend-observed canonical value without retaining trust.
+    ///
+    /// A successful commit re-derives or restores the only canonical value
+    /// admitted by the retained operation contract; the caller's value is
+    /// never copied into state merely because its digest was echoed.
+    pub fn recover_observed(
+        &mut self,
+        nonce: &Nonce,
+        evidence: &RecoveryEvidence,
+        observed: Option<&CanonicalInstalledState>,
+        now: crate::context::Timestamp,
+    ) -> PackageServiceResult<Option<OperationReceipt>> {
+        let snapshot = self.recovery_snapshot(nonce)?;
+        if snapshot.token.into_bytes() != evidence.token_bytes() {
+            return Err(PackageServiceError::RecoveryUnresolved);
+        }
+        self.resolve_recovery(snapshot, evidence, observed, now)
+    }
+
+    fn recovery_snapshot(&self, nonce: &Nonce) -> PackageServiceResult<RecoverySnapshot> {
+        let slot = self
+            .nonce_locations
+            .get(nonce)
+            .copied()
+            .ok_or(PackageServiceError::RecordMissing)?;
+        let record = self
+            .slots
+            .get(&slot)
+            .and_then(|slot_record| slot_record.journal_record(nonce))
+            .ok_or(PackageServiceError::RecordMissing)?;
+        if record.status() != JournalStatus::Unknown {
+            return Err(PackageServiceError::RecordNotReconcilable);
+        }
+        let nonce = record.context().nonce();
+        let drain_deadline = match self
+            .slots
+            .get(&slot)
+            .and_then(|slot_record| slot_record.state())
+        {
+            Some(state) => recorded_drain_deadline(state, &nonce)?,
+            None => None,
+        };
+        Ok(RecoverySnapshot {
+            context: record.context().clone(),
+            authority: *record.authority_digest(),
+            token: record.recovery_token(),
+            before: record.before_state(),
+            boundary_generation: record.state_generation(),
+            drain_deadline,
+            base_state: record.drain_base_state().cloned(),
+        })
+    }
+
+    fn retained_observation(
+        &self,
+        snapshot: &RecoverySnapshot,
+        evidence: &RecoveryEvidence,
+    ) -> PackageServiceResult<Option<CanonicalInstalledState>> {
+        let slot = PackageSlot::new(
+            snapshot.context.target_owner(),
+            snapshot.context.package_object(),
+        );
+        let slot_record = self
+            .slots
+            .get(&slot)
+            .ok_or(PackageServiceError::RecordMissing)?;
+        slot_record
+            .journal_record(&snapshot.context.nonce())
+            .ok_or(PackageServiceError::RecordMissing)?;
+        if evidence.observed_state().as_bytes() == snapshot.before.as_bytes() {
+            let record = slot_record
+                .journal_record(&snapshot.context.nonce())
+                .ok_or(PackageServiceError::RecordMissing)?;
+            return Ok(record.drain_base_state().cloned());
+        }
+        Ok(slot_record.state().cloned())
+    }
+
+    fn resolve_recovery(
+        &mut self,
+        snapshot: RecoverySnapshot,
+        evidence: &RecoveryEvidence,
+        observed: Option<&CanonicalInstalledState>,
+        now: crate::context::Timestamp,
+    ) -> PackageServiceResult<Option<OperationReceipt>> {
+        let effect = recovery_effect(&snapshot, evidence, observed, now)?;
+        let slot = PackageSlot::new(
+            snapshot.context.target_owner(),
+            snapshot.context.package_object(),
+        );
+        let nonce = snapshot.context.nonce();
+        let record_slot = self
+            .slots
+            .get_mut(&slot)
+            .ok_or(PackageServiceError::RecordMissing)?;
+        match effect {
+            RecoveryEffect::RestoreInactive { generation } => {
+                let base = record_slot
+                    .journal_mut(&nonce)
+                    .and_then(crate::journal::OperationJournalRecord::take_drain_base_state)
+                    .ok_or(PackageServiceError::OccupancyCorruption)?;
+                let restored = restore_prior_content_to_successor(base, nonce, generation)?;
+                let generation = restored.generation_value();
+                record_slot.replace_state(Some(restored));
+                let journal = record_slot
+                    .journal_mut(&nonce)
+                    .ok_or(PackageServiceError::RecordMissing)?;
+                journal.set_state_generation(generation);
+                journal.resolve_recovery(None, JournalStatus::Failed, now);
+            },
+            RecoveryEffect::Commit(after_state) => {
+                let after = after_state.as_deref().map_or_else(
+                    || StateDigest::from_bytes([0; 32]),
+                    CanonicalInstalledState::digest,
+                );
+                let receipt = OperationReceipt::new(
+                    &snapshot.context,
+                    receipt_outcome(snapshot.context.operation())?,
+                    snapshot.before,
+                    after,
+                    exact_successor_generation(&snapshot)?,
+                    evidence.activation_receipt(),
+                );
+                record_slot.replace_state(after_state.map(|state| *state));
+                let journal = record_slot
+                    .journal_mut(&nonce)
+                    .ok_or(PackageServiceError::RecordMissing)?;
+                journal.set_state_generation(exact_successor_generation(&snapshot)?);
+                journal.resolve_recovery(Some(receipt.clone()), JournalStatus::Committed, now);
+                return Ok(Some(receipt));
+            },
+        }
+        Ok(None)
+    }
+}
+
+fn recovery_effect(
+    snapshot: &RecoverySnapshot,
+    evidence: &RecoveryEvidence,
+    observed: Option<&CanonicalInstalledState>,
+    now: Timestamp,
+) -> PackageServiceResult<RecoveryEffect> {
+    if evidence.observed_state().as_bytes() == snapshot.before.as_bytes() {
+        return restore_effect(snapshot, evidence, observed);
+    }
+    if *evidence.observed_state().as_bytes() == [0; 32] {
+        return absence_effect(snapshot, evidence, observed);
+    }
+    if snapshot.context.operation() == crate::context::Operation::Update {
+        let deadline = snapshot
+            .drain_deadline
+            .ok_or(PackageServiceError::LifecycleTransition)?;
+        if now >= deadline {
+            return Err(PackageServiceError::AuthorityExpired);
+        }
+    }
+    let state = observed.ok_or(PackageServiceError::RecoveryUnresolved)?;
+    validate_observed_state(snapshot, evidence, state)?;
+    match snapshot.context.operation() {
+        crate::context::Operation::Install => {
+            Ok(RecoveryEffect::Commit(Some(Box::new(state.clone()))))
+        },
+        crate::context::Operation::Update => {
+            Ok(RecoveryEffect::Commit(Some(Box::new(state.clone()))))
+        },
+        crate::context::Operation::Activate => {
+            Ok(RecoveryEffect::Commit(Some(Box::new(state.clone()))))
+        },
+        crate::context::Operation::Deactivate => {
+            Ok(RecoveryEffect::Commit(Some(Box::new(state.clone()))))
+        },
+        crate::context::Operation::Remove | crate::context::Operation::Recover => {
+            Err(PackageServiceError::RecoveryUnresolved)
+        },
+    }
+}
+
+fn restore_effect(
+    snapshot: &RecoverySnapshot,
+    evidence: &RecoveryEvidence,
+    observed: Option<&CanonicalInstalledState>,
+) -> PackageServiceResult<RecoveryEffect> {
+    if !matches!(
+        snapshot.context.operation(),
+        crate::context::Operation::Update | crate::context::Operation::Remove
+    ) {
+        return Err(PackageServiceError::RecoveryUnresolved);
+    }
+    let state = observed.ok_or(PackageServiceError::RecoveryUnresolved)?;
+    let expected_base = snapshot
+        .base_state
+        .as_ref()
+        .ok_or(PackageServiceError::RecoveryUnresolved)?;
+    if state != expected_base {
+        return Err(PackageServiceError::RecoveryUnresolved);
+    }
+    let expected_generation = snapshot
+        .boundary_generation
+        .and_then(|generation| generation.get().checked_sub(1))
+        .and_then(NonZeroU64::new)
+        .ok_or(PackageServiceError::RecoveryUnresolved)?;
+    if state.digest() != snapshot.before
+        || !state.has_valid_digest()
+        || state.schema_version() != STATE_SCHEMA_VERSION
+        || state.generation_value() != expected_generation
+        || evidence.runtime_generation() != expected_generation
+        || state.authority_digest().as_bytes() == &[0; 32]
+        || state.lifecycle_plan().as_bytes() == &[0; 32]
+        || matches!(state.lifecycle_state(), LifecycleState::Draining { .. })
+    {
+        return Err(PackageServiceError::RecoveryUnresolved);
+    }
+    let generation = next_generation_value(
+        snapshot
+            .boundary_generation
+            .ok_or(PackageServiceError::RecoveryUnresolved)?,
+    )?;
+    Ok(RecoveryEffect::RestoreInactive { generation })
+}
+
+fn absence_effect(
+    snapshot: &RecoverySnapshot,
+    evidence: &RecoveryEvidence,
+    observed: Option<&CanonicalInstalledState>,
+) -> PackageServiceResult<RecoveryEffect> {
+    if snapshot.context.operation() != crate::context::Operation::Remove
+        || observed.is_some()
+        || !evidence.zero_leases_proved()
+    {
+        return Err(PackageServiceError::RecoveryUnresolved);
+    }
+    let generation = exact_successor_generation(snapshot)?;
+    if evidence.runtime_generation() != generation {
+        return Err(PackageServiceError::RecoveryUnresolved);
+    }
+    Ok(RecoveryEffect::Commit(None))
+}
+
+fn validate_observed_state(
+    snapshot: &RecoverySnapshot,
+    evidence: &RecoveryEvidence,
+    state: &CanonicalInstalledState,
+) -> PackageServiceResult<()> {
+    if state.digest() != evidence.observed_state()
+        || !state.has_valid_digest()
+        || state.schema_version() != STATE_SCHEMA_VERSION
+        || state.generation_value() != exact_successor_generation(snapshot)?
+        || evidence.runtime_generation() != exact_successor_generation(snapshot)?
+        || state.slot()
+            != PackageSlot::new(
+                snapshot.context.target_owner(),
+                snapshot.context.package_object(),
+            )
+        || state.completing_nonce() != snapshot.context.nonce()
+        || state.authority_digest() != &snapshot.authority
+        || state.artifact() != snapshot.context.artifact()
+        || state.manifest() != snapshot.context.manifest()
+        || state.lifecycle_plan() != snapshot.context.plan_digest()
+        || state.content_root().as_bytes() == &[0; 32]
+        || state.provenance().as_bytes() == &[0; 32]
+        || *state.lifecycle_state() != expected_lifecycle(snapshot.context.operation())
+    {
+        return Err(PackageServiceError::RecoveryUnresolved);
+    }
+    if snapshot.context.operation() == crate::context::Operation::Activate {
+        if evidence.activation_receipt().is_none() {
+            return Err(PackageServiceError::BindingMismatch);
+        }
+    } else if evidence.activation_receipt().is_some() {
+        return Err(PackageServiceError::BindingMismatch);
+    }
+    if matches!(
+        snapshot.context.operation(),
+        crate::context::Operation::Update | crate::context::Operation::Remove
+    ) && !evidence.zero_leases_proved()
+    {
+        return Err(PackageServiceError::DrainBlocked);
+    }
+    Ok(())
+}
+
+fn exact_successor_generation(snapshot: &RecoverySnapshot) -> PackageServiceResult<NonZeroU64> {
+    if snapshot.context.operation() == crate::context::Operation::Install {
+        return first_state_generation();
+    }
+    next_generation_value(
+        snapshot
+            .boundary_generation
+            .ok_or(PackageServiceError::RecoveryUnresolved)?,
+    )
+}
+
+fn expected_lifecycle(operation: crate::context::Operation) -> LifecycleState {
+    match operation {
+        crate::context::Operation::Activate => LifecycleState::Active,
+        crate::context::Operation::Install
+        | crate::context::Operation::Update
+        | crate::context::Operation::Deactivate
+        | crate::context::Operation::Remove
+        | crate::context::Operation::Recover => LifecycleState::Inactive,
+    }
+}
+
+fn receipt_outcome(operation: Operation) -> PackageServiceResult<ReceiptOutcome> {
+    match operation {
+        Operation::Install => Ok(ReceiptOutcome::Installed),
+        Operation::Update => Ok(ReceiptOutcome::Updated),
+        Operation::Activate => Ok(ReceiptOutcome::Activated),
+        Operation::Deactivate => Ok(ReceiptOutcome::Deactivated),
+        Operation::Remove => Ok(ReceiptOutcome::Retired),
+        Operation::Recover => Err(PackageServiceError::RecordNotReconcilable),
+    }
+}

--- a/crates/astrid-package-service/src/lifecycle/recovery.rs
+++ b/crates/astrid-package-service/src/lifecycle/recovery.rs
@@ -1,14 +1,16 @@
 use super::{
-    PackageServiceModel, active_drain_lineage, first_state_generation, next_generation_value,
-    recorded_drain_deadline, restore_to_boundary_successor,
+    PackageServiceModel, active_drain_lineage, commit_plan_digest, first_state_generation,
+    next_generation_value, recorded_drain_deadline, restore_to_boundary_successor,
 };
 use crate::bytes::RecoveryToken;
 use crate::context::{Operation, OperationContext, Timestamp};
-use crate::digest::{AuthorityDecisionDigest, StateDigest};
+use crate::digest::{AuthorityDecisionDigest, PlanDigest, StateDigest};
 use crate::error::{PackageServiceError, PackageServiceResult};
 use crate::identity::{Nonce, STATE_SCHEMA_VERSION};
 use crate::journal::{JournalStatus, OperationReceipt, ReceiptOutcome, RecoveryEvidence};
-use crate::state::{CanonicalInstalledState, DrainLineage, LifecycleState, PackageSlot};
+use crate::state::{
+    CanonicalInstalledState, DrainDestination, DrainLineage, LifecycleState, PackageSlot,
+};
 use std::num::NonZeroU64;
 
 #[derive(Clone)]
@@ -20,6 +22,9 @@ struct RecoverySnapshot {
     boundary_generation: Option<NonZeroU64>,
     drain_deadline: Option<Timestamp>,
     drain_lineage: Option<DrainLineage>,
+    drain_destination: Option<DrainDestination>,
+    retained_state: Option<CanonicalInstalledState>,
+    staged_commit_plan: Option<PlanDigest>,
 }
 
 enum RecoveryEffect {
@@ -85,11 +90,15 @@ impl PackageServiceModel {
             Some(state) => recorded_drain_deadline(state, &nonce)?,
             None => None,
         };
-        let drain_lineage = match slot_record.state() {
+        let (drain_lineage, drain_destination) = match slot_record.state() {
             Some(state) if matches!(state.lifecycle_state(), LifecycleState::Draining { .. }) => {
-                Some(active_drain_lineage(slot_record, &nonce)?)
+                let lineage = active_drain_lineage(slot_record, &nonce)?;
+                let LifecycleState::Draining { destination, .. } = state.lifecycle_state() else {
+                    return Err(PackageServiceError::OccupancyCorruption);
+                };
+                (Some(lineage), Some(*destination))
             },
-            _ => None,
+            _ => (None, None),
         };
         Ok(RecoverySnapshot {
             context: record.context().clone(),
@@ -99,6 +108,9 @@ impl PackageServiceModel {
             boundary_generation: record.state_generation(),
             drain_deadline,
             drain_lineage,
+            drain_destination,
+            retained_state: slot_record.state().cloned(),
+            staged_commit_plan: record.staged_commit_plan().copied(),
         })
     }
 
@@ -162,6 +174,7 @@ impl PackageServiceModel {
                     .journal_mut(&nonce)
                     .ok_or(PackageServiceError::RecordMissing)?;
                 journal.take_drain_lineage();
+                journal.take_staged_commit_plan();
                 journal.set_state_generation(generation);
                 journal.resolve_recovery(None, JournalStatus::Failed, now);
             },
@@ -182,6 +195,8 @@ impl PackageServiceModel {
                 let journal = record_slot
                     .journal_mut(&nonce)
                     .ok_or(PackageServiceError::RecordMissing)?;
+                journal.take_drain_lineage();
+                journal.take_staged_commit_plan();
                 journal.set_state_generation(exact_successor_generation(&snapshot)?);
                 journal.resolve_recovery(Some(receipt.clone()), JournalStatus::Committed, now);
                 return Ok(Some(receipt));
@@ -212,6 +227,12 @@ fn recovery_effect(
         }
     }
     let state = observed.ok_or(PackageServiceError::RecoveryUnresolved)?;
+    if snapshot.context.operation() == crate::context::Operation::Update
+        && (snapshot.drain_lineage.is_none()
+            || snapshot.drain_destination != Some(DrainDestination::Replacement))
+    {
+        return Err(PackageServiceError::RecoveryUnresolved);
+    }
     validate_observed_state(snapshot, evidence, state)?;
     match snapshot.context.operation() {
         crate::context::Operation::Install => {
@@ -250,6 +271,9 @@ fn restore_effect(
         .ok_or(PackageServiceError::RecoveryUnresolved)?;
     let base = lineage.base_state();
     let expected_generation = base.generation_value();
+    if evidence.activation_receipt().is_some() {
+        return Err(PackageServiceError::BindingMismatch);
+    }
     if state.digest() != snapshot.before
         || lineage.base_state().digest() != snapshot.before
         || state != base
@@ -272,12 +296,17 @@ fn absence_effect(
     observed: Option<&CanonicalInstalledState>,
 ) -> PackageServiceResult<RecoveryEffect> {
     if snapshot.context.operation() != crate::context::Operation::Remove
+        || snapshot.drain_lineage.is_none()
+        || snapshot.drain_destination != Some(DrainDestination::Removal)
         || observed.is_some()
         || !evidence.zero_leases_proved()
     {
         return Err(PackageServiceError::RecoveryUnresolved);
     }
     let generation = exact_successor_generation(snapshot)?;
+    if evidence.activation_receipt().is_some() {
+        return Err(PackageServiceError::BindingMismatch);
+    }
     if evidence.runtime_generation() != generation {
         return Err(PackageServiceError::RecoveryUnresolved);
     }
@@ -289,6 +318,15 @@ fn validate_observed_state(
     evidence: &RecoveryEvidence,
     state: &CanonicalInstalledState,
 ) -> PackageServiceResult<()> {
+    let expected_commit_plan =
+        commit_plan_digest(&snapshot.context, state.content_root(), state.provenance());
+    if matches!(
+        snapshot.context.operation(),
+        crate::context::Operation::Install | crate::context::Operation::Update
+    ) && snapshot.staged_commit_plan != Some(expected_commit_plan)
+    {
+        return Err(PackageServiceError::RecoveryUnresolved);
+    }
     if state.digest() != evidence.observed_state()
         || !state.has_valid_digest()
         || state.schema_version() != STATE_SCHEMA_VERSION
@@ -309,6 +347,20 @@ fn validate_observed_state(
         || *state.lifecycle_state() != expected_lifecycle(snapshot.context.operation())
     {
         return Err(PackageServiceError::RecoveryUnresolved);
+    }
+    if matches!(
+        snapshot.context.operation(),
+        crate::context::Operation::Activate | crate::context::Operation::Deactivate
+    ) {
+        let baseline = snapshot
+            .retained_state
+            .as_ref()
+            .ok_or(PackageServiceError::RecoveryUnresolved)?;
+        if state.content_root() != baseline.content_root()
+            || state.provenance() != baseline.provenance()
+        {
+            return Err(PackageServiceError::RecoveryUnresolved);
+        }
     }
     if snapshot.context.operation() == crate::context::Operation::Activate {
         if evidence.activation_receipt().is_none() {

--- a/crates/astrid-package-service/src/lifecycle/recovery.rs
+++ b/crates/astrid-package-service/src/lifecycle/recovery.rs
@@ -1,6 +1,6 @@
 use super::{
-    PackageServiceModel, first_state_generation, next_generation_value, recorded_drain_deadline,
-    restore_prior_content_to_successor,
+    PackageServiceModel, active_drain_lineage, first_state_generation, next_generation_value,
+    recorded_drain_deadline, restore_to_boundary_successor,
 };
 use crate::bytes::RecoveryToken;
 use crate::context::{Operation, OperationContext, Timestamp};
@@ -8,7 +8,7 @@ use crate::digest::{AuthorityDecisionDigest, StateDigest};
 use crate::error::{PackageServiceError, PackageServiceResult};
 use crate::identity::{Nonce, STATE_SCHEMA_VERSION};
 use crate::journal::{JournalStatus, OperationReceipt, ReceiptOutcome, RecoveryEvidence};
-use crate::state::{CanonicalInstalledState, LifecycleState, PackageSlot};
+use crate::state::{CanonicalInstalledState, DrainLineage, LifecycleState, PackageSlot};
 use std::num::NonZeroU64;
 
 #[derive(Clone)]
@@ -19,11 +19,11 @@ struct RecoverySnapshot {
     before: StateDigest,
     boundary_generation: Option<NonZeroU64>,
     drain_deadline: Option<Timestamp>,
-    base_state: Option<CanonicalInstalledState>,
+    drain_lineage: Option<DrainLineage>,
 }
 
 enum RecoveryEffect {
-    RestoreInactive { generation: NonZeroU64 },
+    RestoreInactive,
     Commit(Option<Box<CanonicalInstalledState>>),
 }
 
@@ -77,13 +77,19 @@ impl PackageServiceModel {
             return Err(PackageServiceError::RecordNotReconcilable);
         }
         let nonce = record.context().nonce();
-        let drain_deadline = match self
+        let slot_record = self
             .slots
             .get(&slot)
-            .and_then(|slot_record| slot_record.state())
-        {
+            .ok_or(PackageServiceError::RecordMissing)?;
+        let drain_deadline = match slot_record.state() {
             Some(state) => recorded_drain_deadline(state, &nonce)?,
             None => None,
+        };
+        let drain_lineage = match slot_record.state() {
+            Some(state) if matches!(state.lifecycle_state(), LifecycleState::Draining { .. }) => {
+                Some(active_drain_lineage(slot_record, &nonce)?)
+            },
+            _ => None,
         };
         Ok(RecoverySnapshot {
             context: record.context().clone(),
@@ -92,7 +98,7 @@ impl PackageServiceModel {
             before: record.before_state(),
             boundary_generation: record.state_generation(),
             drain_deadline,
-            base_state: record.drain_base_state().cloned(),
+            drain_lineage,
         })
     }
 
@@ -113,10 +119,14 @@ impl PackageServiceModel {
             .journal_record(&snapshot.context.nonce())
             .ok_or(PackageServiceError::RecordMissing)?;
         if evidence.observed_state().as_bytes() == snapshot.before.as_bytes() {
-            let record = slot_record
-                .journal_record(&snapshot.context.nonce())
-                .ok_or(PackageServiceError::RecordMissing)?;
-            return Ok(record.drain_base_state().cloned());
+            let lineage = snapshot
+                .drain_lineage
+                .as_ref()
+                .ok_or(PackageServiceError::RecoveryUnresolved)?;
+            if lineage.base_state().digest() != snapshot.before {
+                return Err(PackageServiceError::RecoveryUnresolved);
+            }
+            return Ok(Some(lineage.base_state().clone()));
         }
         Ok(slot_record.state().cloned())
     }
@@ -139,17 +149,19 @@ impl PackageServiceModel {
             .get_mut(&slot)
             .ok_or(PackageServiceError::RecordMissing)?;
         match effect {
-            RecoveryEffect::RestoreInactive { generation } => {
-                let base = record_slot
-                    .journal_mut(&nonce)
-                    .and_then(crate::journal::OperationJournalRecord::take_drain_base_state)
+            RecoveryEffect::RestoreInactive => {
+                let lineage = record_slot
+                    .journal_record(&nonce)
+                    .and_then(crate::journal::OperationJournalRecord::drain_lineage)
+                    .cloned()
                     .ok_or(PackageServiceError::OccupancyCorruption)?;
-                let restored = restore_prior_content_to_successor(base, nonce, generation)?;
+                let restored = restore_to_boundary_successor(&lineage, &nonce)?;
                 let generation = restored.generation_value();
                 record_slot.replace_state(Some(restored));
                 let journal = record_slot
                     .journal_mut(&nonce)
                     .ok_or(PackageServiceError::RecordMissing)?;
+                journal.take_drain_lineage();
                 journal.set_state_generation(generation);
                 journal.resolve_recovery(None, JournalStatus::Failed, now);
             },
@@ -232,19 +244,15 @@ fn restore_effect(
         return Err(PackageServiceError::RecoveryUnresolved);
     }
     let state = observed.ok_or(PackageServiceError::RecoveryUnresolved)?;
-    let expected_base = snapshot
-        .base_state
+    let lineage = snapshot
+        .drain_lineage
         .as_ref()
         .ok_or(PackageServiceError::RecoveryUnresolved)?;
-    if state != expected_base {
-        return Err(PackageServiceError::RecoveryUnresolved);
-    }
-    let expected_generation = snapshot
-        .boundary_generation
-        .and_then(|generation| generation.get().checked_sub(1))
-        .and_then(NonZeroU64::new)
-        .ok_or(PackageServiceError::RecoveryUnresolved)?;
+    let base = lineage.base_state();
+    let expected_generation = base.generation_value();
     if state.digest() != snapshot.before
+        || lineage.base_state().digest() != snapshot.before
+        || state != base
         || !state.has_valid_digest()
         || state.schema_version() != STATE_SCHEMA_VERSION
         || state.generation_value() != expected_generation
@@ -255,12 +263,7 @@ fn restore_effect(
     {
         return Err(PackageServiceError::RecoveryUnresolved);
     }
-    let generation = next_generation_value(
-        snapshot
-            .boundary_generation
-            .ok_or(PackageServiceError::RecoveryUnresolved)?,
-    )?;
-    Ok(RecoveryEffect::RestoreInactive { generation })
+    Ok(RecoveryEffect::RestoreInactive)
 }
 
 fn absence_effect(
@@ -327,6 +330,9 @@ fn validate_observed_state(
 fn exact_successor_generation(snapshot: &RecoverySnapshot) -> PackageServiceResult<NonZeroU64> {
     if snapshot.context.operation() == crate::context::Operation::Install {
         return first_state_generation();
+    }
+    if let Some(lineage) = snapshot.drain_lineage.as_ref() {
+        return next_generation_value(lineage.boundary_generation());
     }
     next_generation_value(
         snapshot

--- a/crates/astrid-package-service/src/lifecycle/recovery.rs
+++ b/crates/astrid-package-service/src/lifecycle/recovery.rs
@@ -1,6 +1,8 @@
 use super::{
-    PackageServiceModel, active_drain_lineage, commit_plan_digest, first_state_generation,
-    next_generation_value, recorded_drain_deadline, restore_to_boundary_successor,
+    PackageServiceModel,
+    commit::{commit_plan_digest, recorded_drain_deadline},
+    generation::{next_generation_from_high_watermark, next_generation_value},
+    lineage::{active_drain_lineage, restore_to_boundary_successor},
 };
 use crate::bytes::RecoveryToken;
 use crate::context::{Operation, OperationContext, Timestamp};
@@ -20,6 +22,7 @@ struct RecoverySnapshot {
     token: RecoveryToken,
     before: StateDigest,
     boundary_generation: Option<NonZeroU64>,
+    generation_high_watermark: Option<NonZeroU64>,
     drain_deadline: Option<Timestamp>,
     drain_lineage: Option<DrainLineage>,
     drain_destination: Option<DrainDestination>,
@@ -34,6 +37,9 @@ enum RecoveryEffect {
 
 impl PackageServiceModel {
     /// Reconciles an unknown record from retained canonical observations.
+    ///
+    /// # Errors
+    /// Returns typed recovery failures when evidence or state bindings disagree.
     pub fn recover(
         &mut self,
         nonce: &Nonce,
@@ -45,7 +51,7 @@ impl PackageServiceModel {
             return Err(PackageServiceError::RecoveryUnresolved);
         }
         let observed = self.retained_observation(&snapshot, evidence)?;
-        self.resolve_recovery(snapshot, evidence, observed.as_ref(), now)
+        self.resolve_recovery(&snapshot, evidence, observed.as_ref(), now)
     }
 
     /// Adjudicates a backend-observed canonical value without retaining trust.
@@ -53,6 +59,9 @@ impl PackageServiceModel {
     /// A successful commit re-derives or restores the only canonical value
     /// admitted by the retained operation contract; the caller's value is
     /// never copied into state merely because its digest was echoed.
+    ///
+    /// # Errors
+    /// Returns typed recovery failures when observed values cannot prove one effect.
     pub fn recover_observed(
         &mut self,
         nonce: &Nonce,
@@ -64,7 +73,7 @@ impl PackageServiceModel {
         if snapshot.token.into_bytes() != evidence.token_bytes() {
             return Err(PackageServiceError::RecoveryUnresolved);
         }
-        self.resolve_recovery(snapshot, evidence, observed, now)
+        self.resolve_recovery(&snapshot, evidence, observed, now)
     }
 
     fn recovery_snapshot(&self, nonce: &Nonce) -> PackageServiceResult<RecoverySnapshot> {
@@ -106,6 +115,7 @@ impl PackageServiceModel {
             token: record.recovery_token(),
             before: record.before_state(),
             boundary_generation: record.state_generation(),
+            generation_high_watermark: slot_record.generation_high_watermark(),
             drain_deadline,
             drain_lineage,
             drain_destination,
@@ -145,12 +155,12 @@ impl PackageServiceModel {
 
     fn resolve_recovery(
         &mut self,
-        snapshot: RecoverySnapshot,
+        snapshot: &RecoverySnapshot,
         evidence: &RecoveryEvidence,
         observed: Option<&CanonicalInstalledState>,
         now: crate::context::Timestamp,
     ) -> PackageServiceResult<Option<OperationReceipt>> {
-        let effect = recovery_effect(&snapshot, evidence, observed, now)?;
+        let effect = recovery_effect(snapshot, evidence, observed, now)?;
         let slot = PackageSlot::new(
             snapshot.context.target_owner(),
             snapshot.context.package_object(),
@@ -169,7 +179,7 @@ impl PackageServiceModel {
                     .ok_or(PackageServiceError::OccupancyCorruption)?;
                 let restored = restore_to_boundary_successor(&lineage, &nonce)?;
                 let generation = restored.generation_value();
-                record_slot.replace_state(Some(restored));
+                record_slot.replace_state_with_generation(Some(restored), generation)?;
                 let journal = record_slot
                     .journal_mut(&nonce)
                     .ok_or(PackageServiceError::RecordMissing)?;
@@ -183,21 +193,23 @@ impl PackageServiceModel {
                     || StateDigest::from_bytes([0; 32]),
                     CanonicalInstalledState::digest,
                 );
+                let generation = exact_successor_generation(snapshot)?;
                 let receipt = OperationReceipt::new(
                     &snapshot.context,
                     receipt_outcome(snapshot.context.operation())?,
                     snapshot.before,
                     after,
-                    exact_successor_generation(&snapshot)?,
+                    generation,
                     evidence.activation_receipt(),
                 );
-                record_slot.replace_state(after_state.map(|state| *state));
+                record_slot
+                    .replace_state_with_generation(after_state.map(|state| *state), generation)?;
                 let journal = record_slot
                     .journal_mut(&nonce)
                     .ok_or(PackageServiceError::RecordMissing)?;
                 journal.take_drain_lineage();
                 journal.take_staged_commit_plan();
-                journal.set_state_generation(exact_successor_generation(&snapshot)?);
+                journal.set_state_generation(generation);
                 journal.resolve_recovery(Some(receipt.clone()), JournalStatus::Committed, now);
                 return Ok(Some(receipt));
             },
@@ -235,16 +247,10 @@ fn recovery_effect(
     }
     validate_observed_state(snapshot, evidence, state)?;
     match snapshot.context.operation() {
-        crate::context::Operation::Install => {
-            Ok(RecoveryEffect::Commit(Some(Box::new(state.clone()))))
-        },
-        crate::context::Operation::Update => {
-            Ok(RecoveryEffect::Commit(Some(Box::new(state.clone()))))
-        },
-        crate::context::Operation::Activate => {
-            Ok(RecoveryEffect::Commit(Some(Box::new(state.clone()))))
-        },
-        crate::context::Operation::Deactivate => {
+        crate::context::Operation::Install
+        | crate::context::Operation::Update
+        | crate::context::Operation::Activate
+        | crate::context::Operation::Deactivate => {
             Ok(RecoveryEffect::Commit(Some(Box::new(state.clone()))))
         },
         crate::context::Operation::Remove | crate::context::Operation::Recover => {
@@ -381,7 +387,10 @@ fn validate_observed_state(
 
 fn exact_successor_generation(snapshot: &RecoverySnapshot) -> PackageServiceResult<NonZeroU64> {
     if snapshot.context.operation() == crate::context::Operation::Install {
-        return first_state_generation();
+        return next_generation_from_high_watermark(
+            snapshot.generation_high_watermark,
+            crate::context::Operation::Install,
+        );
     }
     if let Some(lineage) = snapshot.drain_lineage.as_ref() {
         return next_generation_value(lineage.boundary_generation());

--- a/crates/astrid-package-service/src/lifecycle/tests.rs
+++ b/crates/astrid-package-service/src/lifecycle/tests.rs
@@ -1,0 +1,870 @@
+use super::*;
+use crate::authority::{AuthorityIssuer, AuthorityIssuerClass};
+use crate::bytes::PrincipalUid;
+use crate::context::{
+    ApproverIdentity, IngressChannel, OperationContextSpec, ResourceBudget, ResourceClasses,
+};
+use crate::digest::{Blake3Digest, DigestWriter, PlanDigest, Sha256Digest, TypedDigest};
+use crate::identity::{
+    ArtifactFormatVersion, ArtifactIdentity, AuthorityIssuerIdentity, BoundedEvidence,
+    ComponentIdentity, ManifestFormatVersion, ManifestIdentity, Nonce, PackageName, PackageObject,
+    PackageVersion, ProvenanceClass, ServiceGeneration,
+};
+use crate::policy::{JournalPolicy, JournalRetention, RetentionWindow};
+use crate::state::PackageSlot;
+use std::num::{NonZeroU32, NonZeroU64};
+use std::time::Duration;
+
+fn non_zero(value: u64) -> NonZeroU64 {
+    match NonZeroU64::new(value) {
+        Some(value) => value,
+        None => panic!("test value is non-zero"),
+    }
+}
+
+fn format(value: u32) -> ArtifactFormatVersion {
+    ArtifactFormatVersion::new(match NonZeroU32::new(value) {
+        Some(value) => value,
+        None => panic!("test format is non-zero"),
+    })
+}
+
+fn manifest_format(value: u32) -> ManifestFormatVersion {
+    ManifestFormatVersion::new(match NonZeroU32::new(value) {
+        Some(value) => value,
+        None => panic!("test format is non-zero"),
+    })
+}
+
+fn digest(byte: u8) -> Blake3Digest {
+    Blake3Digest::from_bytes([byte; 32])
+}
+
+fn sha(byte: u8) -> Sha256Digest {
+    Sha256Digest::from_bytes([byte; 32])
+}
+
+fn plan_digest(byte: u8) -> PlanDigest {
+    PlanDigest::from_bytes([byte; 32])
+}
+
+fn artifact() -> ArtifactIdentity {
+    match ArtifactIdentity::new(format(1), non_zero(128), sha(2), digest(3)) {
+        Ok(value) => value,
+        Err(_) => panic!("fixed artifact identity is valid"),
+    }
+}
+
+fn manifest() -> ManifestIdentity {
+    let name = match PackageName::new("example-package") {
+        Ok(value) => value,
+        Err(_) => panic!("fixed test name is valid"),
+    };
+    let version = match PackageVersion::new("1.2.3") {
+        Ok(value) => value,
+        Err(_) => panic!("fixed test version is valid"),
+    };
+    match ManifestIdentity::new(manifest_format(1), name, version, digest(4)) {
+        Ok(value) => value,
+        Err(_) => panic!("fixed manifest identity is valid"),
+    }
+}
+
+fn validated_artifact(content: u8) -> ValidatedArtifact {
+    let bounded = match BoundedEvidence::new(vec![1, 2, 3]) {
+        Ok(value) => value,
+        Err(_) => panic!("fixed evidence is valid"),
+    };
+    let provenance =
+        match ProvenanceEvidence::new(ProvenanceClass::LocalArtifact, digest(5), bounded) {
+            Ok(value) => value,
+            Err(_) => panic!("fixed provenance is valid"),
+        };
+    match ValidatedArtifact::new(artifact(), manifest(), digest(content), provenance) {
+        Ok(value) => value,
+        Err(_) => panic!("fixed validated artifact is valid"),
+    }
+}
+
+struct Fixture {
+    caller: PrincipalUid,
+    owner: PrincipalUid,
+    other_owner: PrincipalUid,
+    object: PackageObject,
+    service: AdmittedService,
+    ingress: AuthenticatedIngress,
+    issuer: AuthorityIssuer,
+    evidence: Blake3Digest,
+    budget: ResourceBudget,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        Self {
+            caller: PrincipalUid::from_bytes([1; 32]),
+            owner: PrincipalUid::from_bytes([2; 32]),
+            other_owner: PrincipalUid::from_bytes([3; 32]),
+            object: PackageObject::from_bytes([4; 32]),
+            service: AdmittedService::new(
+                ComponentIdentity::from_bytes([5; 32]),
+                ServiceGeneration::new(non_zero(1)),
+                digest(6),
+            ),
+            ingress: AuthenticatedIngress::new(
+                PrincipalUid::from_bytes([1; 32]),
+                IngressChannel::AuthenticatedIpc,
+                digest(7),
+            ),
+            issuer: match AuthorityIssuer::new(
+                AuthorityIssuerClass::ExplicitApproval,
+                AuthorityIssuerIdentity::from_bytes([8; 32]),
+                AuthorityIssuerIdentity::from_bytes([9; 32]),
+                digest(10),
+            ) {
+                Ok(value) => value,
+                Err(_) => panic!("fixed issuer is valid"),
+            },
+            evidence: digest(11),
+            budget: ResourceBudget::new(
+                non_zero(4_096),
+                ResourceClasses::new(true, true, true, true),
+            ),
+        }
+    }
+
+    fn context(
+        &self,
+        operation: Operation,
+        expected: ExpectedPackageState,
+        plan: PlanDigest,
+        participants: (PrincipalUid, PrincipalUid),
+        generation: u64,
+        nonce: Nonce,
+    ) -> OperationContext {
+        match OperationContext::new(
+            OperationContextSpec {
+                nonce,
+                operation,
+                expected_state: expected,
+                effective_caller: participants.1,
+                approver: ApproverIdentity::Principal(participants.1),
+                target_owner: participants.0,
+                package_object: self.object,
+                artifact: artifact(),
+                manifest: manifest(),
+                plan_digest: plan,
+                budget: self.budget,
+                expiry: Timestamp::new(1_000),
+            },
+            &self.service_at(generation),
+            Timestamp::new(100),
+        ) {
+            Ok(value) => value,
+            Err(_) => panic!("fixed operation context is valid"),
+        }
+    }
+
+    fn service_at(&self, generation: u64) -> AdmittedService {
+        AdmittedService::new(
+            *self.service.component(),
+            ServiceGeneration::new(non_zero(generation)),
+            digest(6),
+        )
+    }
+
+    fn authority(&self, context: &OperationContext) -> AuthenticatedAuthority {
+        AuthenticatedAuthority::bind(context, self.issuer, self.evidence)
+    }
+
+    fn begin(
+        &self,
+        model: &mut PackageServiceModel,
+        context: OperationContext,
+        now: u64,
+    ) -> PackageServiceResult<Nonce> {
+        let authority = self.authority_for(&context);
+        model.begin(
+            context,
+            &authority,
+            self.ingress,
+            &self.service_at(1),
+            Timestamp::new(now),
+        )
+    }
+
+    fn authority_for(&self, context: &OperationContext) -> AuthenticatedAuthority {
+        AuthenticatedAuthority::bind(context, self.issuer, self.evidence)
+    }
+
+    fn slot(&self, owner: PrincipalUid) -> PackageSlot {
+        PackageSlot::new(owner, self.object)
+    }
+}
+
+fn policy(capacity: u64) -> JournalPolicy {
+    policy_with_tombstone_capacity(capacity, 128)
+}
+
+fn policy_with_tombstone_capacity(capacity: u64, tombstone_capacity: u64) -> JournalPolicy {
+    let receipts = match RetentionWindow::new(Duration::from_hours(1), Duration::from_hours(2)) {
+        Ok(value) => value,
+        Err(_) => panic!("test retention is valid"),
+    };
+    let failures = match RetentionWindow::new(Duration::from_hours(1), Duration::from_hours(2)) {
+        Ok(value) => value,
+        Err(_) => panic!("test retention is valid"),
+    };
+    JournalPolicy::new(
+        non_zero(capacity),
+        non_zero(1_048_576),
+        non_zero(tombstone_capacity),
+        non_zero(8),
+        JournalRetention::new(receipts, failures),
+    )
+}
+
+fn policy_short_retention(capacity: u64, tombstone_capacity: u64) -> JournalPolicy {
+    let receipts = match RetentionWindow::new(Duration::from_secs(50), Duration::from_secs(100)) {
+        Ok(value) => value,
+        Err(_) => panic!("short test retention is valid"),
+    };
+    let failures = match RetentionWindow::new(Duration::from_secs(50), Duration::from_secs(100)) {
+        Ok(value) => value,
+        Err(_) => panic!("short test retention is valid"),
+    };
+    JournalPolicy::new(
+        non_zero(capacity),
+        non_zero(1_048_576),
+        non_zero(tombstone_capacity),
+        non_zero(8),
+        JournalRetention::new(receipts, failures),
+    )
+}
+
+fn install(model: &mut PackageServiceModel, fixture: &Fixture, nonce_byte: u8) -> OperationReceipt {
+    let context = fixture.context(
+        Operation::Install,
+        ExpectedPackageState::Absent,
+        plan_digest(20),
+        (fixture.owner, fixture.caller),
+        1,
+        Nonce::from_bytes([nonce_byte; 32]),
+    );
+    let nonce = match fixture.begin(model, context, 100) {
+        Ok(value) => value,
+        Err(_) => panic!("install admission should succeed"),
+    };
+    model
+        .begin_work(&nonce, Timestamp::new(110))
+        .unwrap_or_else(|_| panic!("work should start"));
+    model
+        .complete(
+            &nonce,
+            Some(&validated_artifact(12)),
+            None,
+            true,
+            Timestamp::new(120),
+        )
+        .unwrap_or_else(|_| panic!("install should commit"))
+}
+
+fn begin_update(model: &mut PackageServiceModel, fixture: &Fixture) -> Nonce {
+    let state = match model
+        .slot_record(&fixture.slot(fixture.owner))
+        .and_then(|record| record.state())
+    {
+        Some(state) => state.digest(),
+        None => panic!("installed state should exist"),
+    };
+    let replacement_plan = DrainPlan::new(
+        DrainDestination::Replacement,
+        Timestamp::new(200),
+        Nonce::from_bytes([2; 32]),
+    );
+    let context = fixture.context(
+        Operation::Update,
+        ExpectedPackageState::Exact(state),
+        replacement_plan.digest(),
+        (fixture.owner, fixture.caller),
+        1,
+        Nonce::from_bytes([2; 32]),
+    );
+    let nonce = match fixture.begin(model, context, 130) {
+        Ok(value) => value,
+        Err(_) => panic!("update admission should succeed"),
+    };
+    model
+        .begin_drain(
+            &nonce,
+            DrainDestination::Replacement,
+            Timestamp::new(200),
+            1,
+            Timestamp::new(140),
+        )
+        .unwrap_or_else(|_| panic!("replacement drain should start"));
+    nonce
+}
+
+fn begin_remove(model: &mut PackageServiceModel, fixture: &Fixture) -> Nonce {
+    let state = match model
+        .slot_record(&fixture.slot(fixture.owner))
+        .and_then(|record| record.state())
+    {
+        Some(state) => state.digest(),
+        None => panic!("installed state should exist"),
+    };
+    let removal_plan = DrainPlan::new(
+        DrainDestination::Removal,
+        Timestamp::new(400),
+        Nonce::from_bytes([3; 32]),
+    );
+    let context = fixture.context(
+        Operation::Remove,
+        ExpectedPackageState::Exact(state),
+        removal_plan.digest(),
+        (fixture.owner, fixture.caller),
+        1,
+        Nonce::from_bytes([3; 32]),
+    );
+    let nonce = match fixture.begin(model, context, 300) {
+        Ok(value) => value,
+        Err(_) => panic!("remove admission should succeed"),
+    };
+    model
+        .begin_drain(
+            &nonce,
+            DrainDestination::Removal,
+            Timestamp::new(400),
+            1,
+            Timestamp::new(310),
+        )
+        .unwrap_or_else(|_| panic!("removal drain should start"));
+    nonce
+}
+
+#[test]
+fn authority_replay_rejects_changed_context_fields() {
+    let fixture = Fixture::new();
+    let mut model = PackageServiceModel::new(policy(8));
+    let base = fixture.context(
+        Operation::Install,
+        ExpectedPackageState::Absent,
+        plan_digest(20),
+        (fixture.owner, fixture.caller),
+        1,
+        Nonce::from_bytes([7; 32]),
+    );
+    let authority = fixture.authority(&base);
+    let changed = [
+        fixture.context(
+            Operation::Install,
+            ExpectedPackageState::Absent,
+            plan_digest(21),
+            (fixture.owner, fixture.caller),
+            1,
+            Nonce::from_bytes([7; 32]),
+        ),
+        fixture.context(
+            Operation::Install,
+            ExpectedPackageState::Absent,
+            plan_digest(20),
+            (fixture.other_owner, fixture.caller),
+            1,
+            Nonce::from_bytes([7; 32]),
+        ),
+        fixture.context(
+            Operation::Install,
+            ExpectedPackageState::Absent,
+            plan_digest(20),
+            (fixture.owner, fixture.other_owner),
+            1,
+            Nonce::from_bytes([7; 32]),
+        ),
+        fixture.context(
+            Operation::Install,
+            ExpectedPackageState::Absent,
+            plan_digest(20),
+            (fixture.owner, fixture.caller),
+            2,
+            Nonce::from_bytes([7; 32]),
+        ),
+    ];
+    for context in changed {
+        let error = model
+            .begin(
+                context,
+                &authority,
+                fixture.ingress,
+                &fixture.service_at(1),
+                Timestamp::new(100),
+            )
+            .err()
+            .unwrap_or_else(|| panic!("changed authority context must fail"));
+        assert!(matches!(
+            error,
+            PackageServiceError::AuthorityContextMismatch
+        ));
+    }
+    assert!(model.slot_record(&fixture.slot(fixture.owner)).is_none());
+}
+
+#[test]
+fn terminal_receipt_replays_after_update_and_removal() {
+    let fixture = Fixture::new();
+    let mut model = PackageServiceModel::new(policy(8));
+    install(&mut model, &fixture, 1);
+    let update_nonce = begin_update(&mut model, &fixture);
+    model
+        .prove_drain_leases(&update_nonce, 0, Timestamp::new(200))
+        .unwrap_or_else(|_| panic!("zero leases should be provable"));
+    model
+        .complete(
+            &update_nonce,
+            Some(&validated_artifact(13)),
+            None,
+            true,
+            Timestamp::new(220),
+        )
+        .unwrap_or_else(|_| panic!("update should commit"));
+    let remove_nonce = begin_remove(&mut model, &fixture);
+    model
+        .prove_drain_leases(&remove_nonce, 0, Timestamp::new(400))
+        .unwrap_or_else(|_| panic!("zero leases should be provable"));
+    let retired = model
+        .complete(&remove_nonce, None, None, true, Timestamp::new(420))
+        .unwrap_or_else(|_| panic!("removal should commit"));
+    assert_eq!(retired.outcome(), ReceiptOutcome::Retired);
+    assert_eq!(retired.protocol_version().get(), 1);
+    assert_eq!(retired.operation(), Operation::Remove);
+    assert_eq!(retired.slot(), fixture.slot(fixture.owner));
+    assert!(
+        model
+            .slot_record(&fixture.slot(fixture.owner))
+            .and_then(|record| record.state())
+            .is_none()
+    );
+
+    let original = fixture.context(
+        Operation::Install,
+        ExpectedPackageState::Absent,
+        plan_digest(20),
+        (fixture.owner, fixture.caller),
+        1,
+        Nonce::from_bytes([1; 32]),
+    );
+    match model.replay(&original.nonce(), Some(*original.digest())) {
+        Ok(ReplayOutcome::Receipt(receipt)) => {
+            assert_eq!(receipt.outcome(), ReceiptOutcome::Installed)
+        },
+        _ => panic!("original receipt must remain replayable"),
+    }
+}
+
+#[test]
+fn cross_owner_nonce_use_is_isolated() {
+    let fixture = Fixture::new();
+    let mut model = PackageServiceModel::new(policy(8));
+    let first = fixture.context(
+        Operation::Install,
+        ExpectedPackageState::Absent,
+        plan_digest(20),
+        (fixture.owner, fixture.caller),
+        1,
+        Nonce::from_bytes([9; 32]),
+    );
+    fixture
+        .begin(&mut model, first, 100)
+        .unwrap_or_else(|_| panic!("first owner admission should succeed"));
+    let second = fixture.context(
+        Operation::Install,
+        ExpectedPackageState::Absent,
+        plan_digest(20),
+        (fixture.other_owner, fixture.caller),
+        1,
+        Nonce::from_bytes([9; 32]),
+    );
+    let error = fixture
+        .begin(&mut model, second, 100)
+        .err()
+        .unwrap_or_else(|| panic!("cross-owner nonce must fail"));
+    assert!(matches!(error, PackageServiceError::ReplayRejected));
+    assert!(
+        model
+            .slot_record(&fixture.slot(fixture.other_owner))
+            .is_none()
+    );
+}
+
+#[test]
+fn nonce_replay_after_later_commits_is_rejected_and_bound() {
+    let fixture = Fixture::new();
+    let mut model = PackageServiceModel::new(policy_short_retention(8, 128));
+    install(&mut model, &fixture, 1);
+    let update_nonce = begin_update(&mut model, &fixture);
+    model
+        .prove_drain_leases(&update_nonce, 0, Timestamp::new(200))
+        .unwrap_or_else(|_| panic!("zero leases should be provable"));
+    model
+        .complete(
+            &update_nonce,
+            Some(&validated_artifact(13)),
+            None,
+            true,
+            Timestamp::new(220),
+        )
+        .unwrap_or_else(|_| panic!("update should commit"));
+
+    let collected = model
+        .collect(Timestamp::new(900), 8)
+        .unwrap_or_else(|_| panic!("eligible terminal records should collect"));
+    assert_eq!(collected, 2);
+
+    let original = fixture.context(
+        Operation::Install,
+        ExpectedPackageState::Absent,
+        plan_digest(20),
+        (fixture.owner, fixture.caller),
+        1,
+        Nonce::from_bytes([1; 32]),
+    );
+    let current_state = model
+        .slot_record(&fixture.slot(fixture.owner))
+        .and_then(|record| record.state().map(CanonicalInstalledState::digest))
+        .unwrap_or_else(|| panic!("updated state should exist"));
+    let replay_context = fixture.context(
+        Operation::Update,
+        ExpectedPackageState::Exact(current_state),
+        plan_digest(22),
+        (fixture.owner, fixture.caller),
+        1,
+        Nonce::from_bytes([1; 32]),
+    );
+    let replay_error = fixture
+        .begin(&mut model, replay_context, 910)
+        .err()
+        .unwrap_or_else(|| panic!("collected nonce must not execute again"));
+    assert!(
+        matches!(replay_error, PackageServiceError::ReplayRejected),
+        "unexpected replay error: {replay_error:?}"
+    );
+    match model.replay(&original.nonce(), Some(*original.digest())) {
+        Ok(ReplayOutcome::Tombstoned(tombstone)) => {
+            assert_eq!(tombstone.terminal_status(), JournalStatus::Committed);
+            assert_eq!(tombstone.outcome(), Some(ReceiptOutcome::Installed));
+            assert_eq!(tombstone.context_digest(), *original.digest());
+        },
+        _ => panic!("collected receipt must remain distinguishable from loss"),
+    }
+
+    let other_context = fixture.context(
+        Operation::Install,
+        ExpectedPackageState::Absent,
+        plan_digest(21),
+        (fixture.owner, fixture.caller),
+        1,
+        Nonce::from_bytes([1; 32]),
+    );
+    let error = model
+        .replay(&other_context.nonce(), Some(*other_context.digest()))
+        .err()
+        .unwrap_or_else(|| panic!("tombstone must reject a different context"));
+    assert!(matches!(error, PackageServiceError::ReplayRejected));
+}
+
+#[test]
+fn stale_expected_state_is_rejected() {
+    let fixture = Fixture::new();
+    let mut model = PackageServiceModel::new(policy(8));
+    install(&mut model, &fixture, 1);
+    let stale = fixture.context(
+        Operation::Update,
+        ExpectedPackageState::Exact(StateDigest::from_bytes([99; 32])),
+        plan_digest(21),
+        (fixture.owner, fixture.caller),
+        1,
+        Nonce::from_bytes([2; 32]),
+    );
+    let error = fixture
+        .begin(&mut model, stale, 130)
+        .err()
+        .unwrap_or_else(|| panic!("stale expectation must fail"));
+    assert!(matches!(error, PackageServiceError::ExpectedStateMismatch));
+}
+
+#[test]
+fn unresolved_records_never_expire() {
+    let fixture = Fixture::new();
+    let mut model = PackageServiceModel::new(policy(1));
+    let context = fixture.context(
+        Operation::Install,
+        ExpectedPackageState::Absent,
+        plan_digest(20),
+        (fixture.owner, fixture.caller),
+        1,
+        Nonce::from_bytes([1; 32]),
+    );
+    let nonce = fixture
+        .begin(&mut model, context, 100)
+        .unwrap_or_else(|_| panic!("intent should be admitted"));
+    let collected = model
+        .collect(Timestamp::new(u64::MAX), 64)
+        .unwrap_or_else(|_| panic!("collection should not fail"));
+    assert_eq!(collected, 0);
+    let record = model
+        .slot_record(&fixture.slot(fixture.owner))
+        .and_then(|record| record.journal_record(&nonce))
+        .unwrap_or_else(|| panic!("record should remain"));
+    assert_eq!(record.status(), JournalStatus::Intent);
+}
+
+#[test]
+fn drain_expiry_blocks_and_abort_is_coherent() {
+    let fixture = Fixture::new();
+    let mut model = PackageServiceModel::new(policy(8));
+    install(&mut model, &fixture, 1);
+    let original = model
+        .slot_record(&fixture.slot(fixture.owner))
+        .and_then(|record| record.state().map(CanonicalInstalledState::digest))
+        .unwrap_or_else(|| panic!("installed state should exist"));
+    let nonce = begin_update(&mut model, &fixture);
+    let blocked = model
+        .expire_drain(&nonce, Timestamp::new(250), false)
+        .unwrap_or_else(|_| panic!("expired drain should be observable"));
+    assert_eq!(blocked, DrainResult::Blocked);
+    assert!(matches!(
+        model.slot_record(&fixture.slot(fixture.owner)).and_then(|record| record.state()),
+        Some(state) if matches!(state.lifecycle_state(), LifecycleState::Draining { live_leases: 1, .. })
+    ));
+
+    let abort_fixture = Fixture::new();
+    let mut abort_model = PackageServiceModel::new(policy(8));
+    install(&mut abort_model, &abort_fixture, 1);
+    let remove_nonce = begin_remove(&mut abort_model, &abort_fixture);
+    abort_model
+        .cancel(&remove_nonce, Timestamp::new(320))
+        .unwrap_or_else(|_| panic!("pre-commit cancellation should succeed"));
+    assert!(matches!(
+        abort_model.slot_record(&abort_fixture.slot(abort_fixture.owner)).and_then(|record| record.state()),
+        Some(state) if *state.lifecycle_state() == LifecycleState::Inactive
+    ));
+    assert_eq!(
+        abort_model
+            .slot_record(&abort_fixture.slot(abort_fixture.owner))
+            .and_then(|record| record.state().map(CanonicalInstalledState::digest)),
+        Some(original)
+    );
+}
+
+#[test]
+fn retired_receipt_keeps_absent_canonical_state() {
+    let fixture = Fixture::new();
+    let mut model = PackageServiceModel::new(policy(8));
+    install(&mut model, &fixture, 1);
+    let nonce = begin_remove(&mut model, &fixture);
+    model
+        .prove_drain_leases(&nonce, 0, Timestamp::new(400))
+        .unwrap_or_else(|_| panic!("zero leases should be provable"));
+    let receipt = model
+        .complete(&nonce, None, None, true, Timestamp::new(420))
+        .unwrap_or_else(|_| panic!("zero-lease removal should commit"));
+    assert_eq!(receipt.outcome(), ReceiptOutcome::Retired);
+    assert!(
+        model
+            .slot_record(&fixture.slot(fixture.owner))
+            .and_then(|record| record.state())
+            .is_none()
+    );
+}
+
+#[test]
+fn canonical_state_digests_are_deterministic_and_domain_separated() {
+    let fixture = Fixture::new();
+    let context = fixture.context(
+        Operation::Install,
+        ExpectedPackageState::Absent,
+        plan_digest(20),
+        (fixture.owner, fixture.caller),
+        1,
+        Nonce::from_bytes([1; 32]),
+    );
+    let authority_digest = fixture.authority(&context).decision_digest();
+    let first = new_installed_state(
+        &context,
+        authority_digest,
+        &validated_artifact(12),
+        LifecycleState::Inactive,
+    )
+    .unwrap_or_else(|_| panic!("state should construct"));
+    let second = new_installed_state(
+        &context,
+        authority_digest,
+        &validated_artifact(12),
+        LifecycleState::Inactive,
+    )
+    .unwrap_or_else(|_| panic!("state should construct"));
+    assert_eq!(first.digest(), second.digest());
+    let different_owner_context = fixture.context(
+        Operation::Install,
+        ExpectedPackageState::Absent,
+        plan_digest(20),
+        (fixture.other_owner, fixture.caller),
+        1,
+        Nonce::from_bytes([1; 32]),
+    );
+    let different = new_installed_state(
+        &different_owner_context,
+        fixture
+            .authority(&different_owner_context)
+            .decision_digest(),
+        &validated_artifact(12),
+        LifecycleState::Inactive,
+    )
+    .unwrap_or_else(|_| panic!("state should construct"));
+    assert_ne!(first.digest(), different.digest());
+
+    let mut writer = DigestWriter::new();
+    writer.u64(1);
+    let left: TypedDigest<100> = writer.finish("astrid.test.left");
+    let right: TypedDigest<101> = writer.finish("astrid.test.right");
+    assert_ne!(left.as_bytes(), right.as_bytes());
+}
+
+#[test]
+fn quota_fails_closed_without_evicting_live_or_terminal_records() {
+    let fixture = Fixture::new();
+    let mut model = PackageServiceModel::new(policy(1));
+    install(&mut model, &fixture, 1);
+    let state = match model
+        .slot_record(&fixture.slot(fixture.owner))
+        .and_then(|record| record.state())
+    {
+        Some(state) => state.digest(),
+        None => panic!("installed state should exist"),
+    };
+    let update = fixture.context(
+        Operation::Update,
+        ExpectedPackageState::Exact(state),
+        plan_digest(21),
+        (fixture.owner, fixture.caller),
+        1,
+        Nonce::from_bytes([2; 32]),
+    );
+    let error = fixture
+        .begin(&mut model, update, 130)
+        .err()
+        .unwrap_or_else(|| panic!("full journal must fail closed"));
+    assert!(matches!(error, PackageServiceError::QuotaExhausted));
+
+    let unknown_fixture = Fixture::new();
+    let mut unknown_model = PackageServiceModel::new(policy(1));
+    let context = unknown_fixture.context(
+        Operation::Install,
+        ExpectedPackageState::Absent,
+        plan_digest(20),
+        (unknown_fixture.owner, unknown_fixture.caller),
+        1,
+        Nonce::from_bytes([1; 32]),
+    );
+    let nonce = unknown_fixture
+        .begin(&mut unknown_model, context, 100)
+        .unwrap_or_else(|_| panic!("unknown fixture should start"));
+    unknown_model
+        .begin_work(&nonce, Timestamp::new(110))
+        .unwrap_or_else(|_| panic!("work should start"));
+    unknown_model
+        .mark_unknown(&nonce, Timestamp::new(120))
+        .unwrap_or_else(|_| panic!("unknown should mark"));
+    let collected = unknown_model
+        .collect(Timestamp::new(u64::MAX), 64)
+        .unwrap_or_else(|_| panic!("collection should not fail"));
+    assert_eq!(collected, 0);
+}
+
+#[test]
+fn quota_collection_is_atomic_when_tombstone_capacity_is_short() {
+    let fixture = Fixture::new();
+    let mut model = PackageServiceModel::new(policy_short_retention(8, 1));
+    install(&mut model, &fixture, 1);
+    let update_nonce = begin_update(&mut model, &fixture);
+    model
+        .prove_drain_leases(&update_nonce, 0, Timestamp::new(200))
+        .unwrap_or_else(|_| panic!("zero leases should be provable"));
+    model
+        .complete(
+            &update_nonce,
+            Some(&validated_artifact(13)),
+            None,
+            true,
+            Timestamp::new(220),
+        )
+        .unwrap_or_else(|_| panic!("update should commit"));
+    let before = model.occupancy();
+
+    let error = model
+        .collect(Timestamp::new(900), 8)
+        .err()
+        .unwrap_or_else(|| panic!("short tombstone capacity must fail closed"));
+    assert!(matches!(error, PackageServiceError::QuotaExhausted));
+    assert_eq!(model.occupancy(), before);
+    let slot_record = model
+        .slot_record(&fixture.slot(fixture.owner))
+        .unwrap_or_else(|| panic!("slot should remain intact"));
+    assert!(
+        slot_record
+            .journal_record(&Nonce::from_bytes([1; 32]))
+            .is_some()
+    );
+    assert!(
+        slot_record
+            .journal_record(&Nonce::from_bytes([2; 32]))
+            .is_some()
+    );
+}
+
+#[test]
+fn activation_requires_exact_installed_state_and_produces_active_generation() {
+    let fixture = Fixture::new();
+    let mut model = PackageServiceModel::new(policy(8));
+    install(&mut model, &fixture, 1);
+    let state = match model
+        .slot_record(&fixture.slot(fixture.owner))
+        .and_then(|record| record.state())
+    {
+        Some(state) => state.digest(),
+        None => panic!("installed state should exist"),
+    };
+    let context = fixture.context(
+        Operation::Activate,
+        ExpectedPackageState::Exact(state),
+        plan_digest(30),
+        (fixture.owner, fixture.caller),
+        1,
+        Nonce::from_bytes([4; 32]),
+    );
+    let nonce = fixture
+        .begin(&mut model, context, 130)
+        .unwrap_or_else(|_| panic!("activation should be admitted"));
+    model
+        .begin_work(&nonce, Timestamp::new(140))
+        .unwrap_or_else(|_| panic!("activation should start"));
+    let missing_receipt = model
+        .complete(&nonce, None, None, true, Timestamp::new(145))
+        .err()
+        .unwrap_or_else(|| panic!("activation without runtime receipt must fail"));
+    assert!(matches!(
+        missing_receipt,
+        PackageServiceError::BindingMismatch
+    ));
+    assert!(matches!(
+        model.slot_record(&fixture.slot(fixture.owner)).and_then(|record| record.state()),
+        Some(state) if *state.lifecycle_state() == LifecycleState::Inactive
+    ));
+    let receipt = model
+        .complete(&nonce, None, Some(digest(31)), true, Timestamp::new(150))
+        .unwrap_or_else(|_| panic!("activation should commit"));
+    assert_eq!(receipt.outcome(), ReceiptOutcome::Activated);
+    assert!(matches!(
+        model.slot_record(&fixture.slot(fixture.owner)).and_then(|record| record.state()),
+        Some(state) if *state.lifecycle_state() == LifecycleState::Active
+    ));
+}

--- a/crates/astrid-package-service/src/lifecycle/tests.rs
+++ b/crates/astrid-package-service/src/lifecycle/tests.rs
@@ -16,6 +16,7 @@ use std::num::{NonZeroU32, NonZeroU64};
 use std::time::Duration;
 
 mod cure_tests;
+mod successor_tests;
 
 fn non_zero(value: u64) -> NonZeroU64 {
     match NonZeroU64::new(value) {
@@ -469,10 +470,10 @@ fn retired_receipt_keeps_absent_canonical_state() {
     install(&mut model, &fixture, 1);
     let nonce = begin_remove(&mut model, &fixture);
     model
-        .prove_drain_leases(&nonce, 0, Timestamp::new(400))
+        .prove_drain_leases(&nonce, 0, Timestamp::new(399))
         .unwrap_or_else(|_| panic!("zero leases should be provable"));
     let receipt = model
-        .complete(&nonce, None, None, true, Timestamp::new(420))
+        .complete(&nonce, None, None, true, Timestamp::new(399))
         .unwrap_or_else(|_| panic!("zero-lease removal should commit"));
     assert_eq!(receipt.outcome(), ReceiptOutcome::Retired);
     assert!(
@@ -597,7 +598,7 @@ fn quota_collection_is_atomic_when_tombstone_capacity_is_short() {
     install(&mut model, &fixture, 1);
     let update_nonce = begin_update(&mut model, &fixture);
     model
-        .prove_drain_leases(&update_nonce, 0, Timestamp::new(200))
+        .prove_drain_leases(&update_nonce, 0, Timestamp::new(199))
         .unwrap_or_else(|_| panic!("zero leases should be provable"));
     model
         .complete(
@@ -605,7 +606,7 @@ fn quota_collection_is_atomic_when_tombstone_capacity_is_short() {
             Some(&validated_artifact(13)),
             None,
             true,
-            Timestamp::new(220),
+            Timestamp::new(199),
         )
         .unwrap_or_else(|_| panic!("update should commit"));
     let before = model.occupancy();

--- a/crates/astrid-package-service/src/lifecycle/tests.rs
+++ b/crates/astrid-package-service/src/lifecycle/tests.rs
@@ -4,18 +4,23 @@ use crate::bytes::{PrincipalUid, RecoveryToken};
 use crate::context::{
     ApproverIdentity, IngressChannel, OperationContextSpec, ResourceBudget, ResourceClasses,
 };
-use crate::digest::{Blake3Digest, DigestWriter, PlanDigest, Sha256Digest, TypedDigest};
+use crate::digest::{
+    Blake3Digest, DigestWriter, PlanDigest, ProvenanceDigest, Sha256Digest, TypedDigest,
+};
 use crate::identity::{
     ArtifactFormatVersion, ArtifactIdentity, AuthorityIssuerIdentity, BoundedEvidence,
     ComponentIdentity, ManifestFormatVersion, ManifestIdentity, Nonce, PackageName, PackageObject,
-    PackageVersion, ProvenanceClass, ServiceGeneration,
+    PackageVersion, ProvenanceClass, ProvenanceEvidence, ServiceGeneration, ValidatedArtifact,
 };
+use crate::journal::{OperationJournalRecord, ReceiptOutcome};
 use crate::policy::{JournalPolicy, JournalRetention, RetentionWindow};
-use crate::state::PackageSlot;
+use crate::state::{InstalledStateSpec, PackageSlot};
 use std::num::{NonZeroU32, NonZeroU64};
 use std::time::Duration;
 
+mod binding_tests;
 mod cure_tests;
+mod highwater_tests;
 mod lineage_tests;
 mod successor_tests;
 
@@ -55,38 +60,38 @@ fn plan_digest(byte: u8) -> PlanDigest {
 fn artifact() -> ArtifactIdentity {
     match ArtifactIdentity::new(format(1), non_zero(128), sha(2), digest(3)) {
         Ok(value) => value,
-        Err(_) => panic!("fixed artifact identity is valid"),
+        Err(error) => panic!("fixed artifact identity is valid: {error:?}"),
     }
 }
 
 fn manifest() -> ManifestIdentity {
     let name = match PackageName::new("example-package") {
         Ok(value) => value,
-        Err(_) => panic!("fixed test name is valid"),
+        Err(error) => panic!("fixed test name is valid: {error:?}"),
     };
     let version = match PackageVersion::new("1.2.3") {
         Ok(value) => value,
-        Err(_) => panic!("fixed test version is valid"),
+        Err(error) => panic!("fixed test version is valid: {error:?}"),
     };
     match ManifestIdentity::new(manifest_format(1), name, version, digest(4)) {
         Ok(value) => value,
-        Err(_) => panic!("fixed manifest identity is valid"),
+        Err(error) => panic!("fixed manifest identity is valid: {error:?}"),
     }
 }
 
 fn validated_artifact(content: u8) -> ValidatedArtifact {
     let bounded = match BoundedEvidence::new(vec![1, 2, 3]) {
         Ok(value) => value,
-        Err(_) => panic!("fixed evidence is valid"),
+        Err(error) => panic!("fixed evidence is valid: {error:?}"),
     };
     let provenance =
         match ProvenanceEvidence::new(ProvenanceClass::LocalArtifact, digest(5), bounded) {
             Ok(value) => value,
-            Err(_) => panic!("fixed provenance is valid"),
+            Err(error) => panic!("fixed provenance is valid: {error:?}"),
         };
     match ValidatedArtifact::new(artifact(), manifest(), digest(content), provenance) {
         Ok(value) => value,
-        Err(_) => panic!("fixed validated artifact is valid"),
+        Err(error) => panic!("fixed validated artifact is valid: {error:?}"),
     }
 }
 
@@ -99,6 +104,25 @@ fn commit_plan_for_artifact(
         artifact.content_root(),
         &provenance_digest(artifact.provenance()),
     )
+}
+
+fn commit_plan_for_artifact_parts(
+    operation: Operation,
+    artifact: &ValidatedArtifact,
+    lifecycle_plan: Option<PlanDigest>,
+) -> PlanDigest {
+    crate::context::operation_commit_plan_digest(
+        operation,
+        artifact.artifact(),
+        artifact.manifest(),
+        artifact.content_root(),
+        &provenance_digest(artifact.provenance()),
+        lifecycle_plan,
+    )
+}
+
+fn provenance_for_content(content: u8) -> crate::digest::ProvenanceDigest {
+    provenance_digest(validated_artifact(content).provenance())
 }
 
 struct Fixture {
@@ -146,12 +170,12 @@ impl Fixture {
                 digest(10),
             ) {
                 Ok(value) => value,
-                Err(_) => panic!("fixed issuer is valid"),
+                Err(error) => panic!("fixed issuer is valid: {error:?}"),
             },
             evidence: digest(11),
             budget: ResourceBudget::new(
                 non_zero(4_096),
-                ResourceClasses::new(true, true, true, true),
+                ResourceClasses::new([true, true, true, true]),
             ),
         }
     }
@@ -165,7 +189,7 @@ impl Fixture {
         generation: u64,
         nonce: Nonce,
     ) -> OperationContext {
-        self.context_with_expiry(ContextOptions {
+        self.context_with_expiry(&ContextOptions {
             operation,
             expected,
             plan,
@@ -176,7 +200,7 @@ impl Fixture {
         })
     }
 
-    fn context_with_expiry(&self, options: ContextOptions) -> OperationContext {
+    fn context_with_expiry(&self, options: &ContextOptions) -> OperationContext {
         match OperationContext::new(
             OperationContextSpec {
                 nonce: options.nonce,
@@ -188,7 +212,34 @@ impl Fixture {
                 package_object: self.object,
                 artifact: artifact(),
                 manifest: manifest(),
+                content_root: *validated_artifact(if options.operation == Operation::Update {
+                    13
+                } else {
+                    12
+                })
+                .content_root(),
+                provenance: provenance_for_content(if options.operation == Operation::Update {
+                    13
+                } else {
+                    12
+                }),
                 plan_digest: options.plan,
+                commit_plan_digest: if matches!(
+                    options.operation,
+                    Operation::Install | Operation::Update
+                ) {
+                    commit_plan_for_artifact_parts(
+                        options.operation,
+                        &validated_artifact(if options.operation == Operation::Update {
+                            13
+                        } else {
+                            12
+                        }),
+                        matches!(options.operation, Operation::Update).then_some(options.plan),
+                    )
+                } else {
+                    options.plan
+                },
                 budget: self.budget,
                 expiry: options.expiry,
             },
@@ -196,7 +247,7 @@ impl Fixture {
             Timestamp::new(100),
         ) {
             Ok(value) => value,
-            Err(_) => panic!("fixed operation context is valid"),
+            Err(error) => panic!("fixed operation context is valid: {error:?}"),
         }
     }
 
@@ -208,10 +259,45 @@ impl Fixture {
         )
     }
 
+    fn context_for_state(
+        &self,
+        operation: Operation,
+        expected: ExpectedPackageState,
+        plan: PlanDigest,
+        participants: (PrincipalUid, PrincipalUid),
+        state: &CanonicalInstalledState,
+        nonce: Nonce,
+    ) -> OperationContext {
+        match OperationContext::new(
+            OperationContextSpec {
+                nonce,
+                operation,
+                expected_state: expected,
+                effective_caller: participants.1,
+                approver: ApproverIdentity::Principal(participants.1),
+                target_owner: participants.0,
+                package_object: self.object,
+                artifact: *state.artifact(),
+                manifest: state.manifest().clone(),
+                content_root: *state.content_root(),
+                provenance: *state.provenance(),
+                plan_digest: plan,
+                commit_plan_digest: plan,
+                budget: self.budget,
+                expiry: Timestamp::new(1_000),
+            },
+            &self.service_at(1),
+            Timestamp::new(100),
+        ) {
+            Ok(value) => value,
+            Err(error) => panic!("state-bound context is valid: {error:?}"),
+        }
+    }
+
     fn authority(&self, context: &OperationContext) -> AuthenticatedAuthority {
         match AuthenticatedAuthority::bind(context, self.issuer, self.evidence) {
             Ok(value) => value,
-            Err(_) => panic!("fixed authority is valid"),
+            Err(error) => panic!("fixed authority is valid: {error:?}"),
         }
     }
 
@@ -234,7 +320,7 @@ impl Fixture {
     fn authority_for(&self, context: &OperationContext) -> AuthenticatedAuthority {
         match AuthenticatedAuthority::bind(context, self.issuer, self.evidence) {
             Ok(value) => value,
-            Err(_) => panic!("fixed authority is valid"),
+            Err(error) => panic!("fixed authority is valid: {error:?}"),
         }
     }
 
@@ -250,11 +336,11 @@ fn policy(capacity: u64) -> JournalPolicy {
 fn policy_with_tombstone_capacity(capacity: u64, tombstone_capacity: u64) -> JournalPolicy {
     let receipts = match RetentionWindow::new(Duration::from_hours(1), Duration::from_hours(2)) {
         Ok(value) => value,
-        Err(_) => panic!("test retention is valid"),
+        Err(error) => panic!("test retention is valid: {error:?}"),
     };
     let failures = match RetentionWindow::new(Duration::from_hours(1), Duration::from_hours(2)) {
         Ok(value) => value,
-        Err(_) => panic!("test retention is valid"),
+        Err(error) => panic!("test retention is valid: {error:?}"),
     };
     JournalPolicy::new(
         non_zero(capacity),
@@ -268,11 +354,11 @@ fn policy_with_tombstone_capacity(capacity: u64, tombstone_capacity: u64) -> Jou
 fn policy_short_retention(capacity: u64, tombstone_capacity: u64) -> JournalPolicy {
     let receipts = match RetentionWindow::new(Duration::from_secs(50), Duration::from_secs(100)) {
         Ok(value) => value,
-        Err(_) => panic!("short test retention is valid"),
+        Err(error) => panic!("short test retention is valid: {error:?}"),
     };
     let failures = match RetentionWindow::new(Duration::from_secs(50), Duration::from_secs(100)) {
         Ok(value) => value,
-        Err(_) => panic!("short test retention is valid"),
+        Err(error) => panic!("short test retention is valid: {error:?}"),
     };
     JournalPolicy::new(
         non_zero(capacity),
@@ -303,7 +389,7 @@ fn install(model: &mut PackageServiceModel, fixture: &Fixture, nonce_byte: u8) -
     );
     let nonce = match fixture.begin(model, context, 100) {
         Ok(value) => value,
-        Err(_) => panic!("install admission should succeed"),
+        Err(error) => panic!("install admission should succeed: {error:?}"),
     };
     model
         .begin_work(&nonce, Timestamp::new(110))
@@ -331,7 +417,7 @@ fn begin_update_with_deadline(
     fixture: &Fixture,
     deadline: Timestamp,
 ) -> Nonce {
-    let state = match model
+    let state_digest = match model
         .slot_record(&fixture.slot(fixture.owner))
         .and_then(|record| record.state())
     {
@@ -341,16 +427,16 @@ fn begin_update_with_deadline(
     let staged_artifact = validated_artifact(13);
     let replacement_plan = match DrainPlan::new(
         DrainDestination::Replacement,
-        ExpectedPackageState::Exact(state),
+        ExpectedPackageState::Exact(state_digest),
         deadline,
         Nonce::from_bytes([2; 32]),
     ) {
         Ok(value) => value,
-        Err(_) => panic!("replacement plan is valid"),
+        Err(error) => panic!("replacement plan is valid: {error:?}"),
     };
     let context = fixture.context(
         Operation::Update,
-        ExpectedPackageState::Exact(state),
+        ExpectedPackageState::Exact(state_digest),
         replacement_plan.digest(),
         (fixture.owner, fixture.caller),
         1,
@@ -358,7 +444,7 @@ fn begin_update_with_deadline(
     );
     let nonce = match fixture.begin(model, context, 130) {
         Ok(value) => value,
-        Err(_) => panic!("update admission should succeed"),
+        Err(error) => panic!("update admission should succeed: {error:?}"),
     };
     model
         .begin_drain(
@@ -376,7 +462,7 @@ fn begin_update_with_deadline(
 }
 
 fn begin_remove(model: &mut PackageServiceModel, fixture: &Fixture) -> Nonce {
-    let state = match model
+    let state_digest = match model
         .slot_record(&fixture.slot(fixture.owner))
         .and_then(|record| record.state())
     {
@@ -385,24 +471,30 @@ fn begin_remove(model: &mut PackageServiceModel, fixture: &Fixture) -> Nonce {
     };
     let removal_plan = match DrainPlan::new(
         DrainDestination::Removal,
-        ExpectedPackageState::Exact(state),
+        ExpectedPackageState::Exact(state_digest),
         Timestamp::new(400),
         Nonce::from_bytes([3; 32]),
     ) {
         Ok(value) => value,
-        Err(_) => panic!("removal plan is valid"),
+        Err(error) => panic!("removal plan is valid: {error:?}"),
     };
-    let context = fixture.context(
+    let Some(state_value) = model
+        .slot_record(&fixture.slot(fixture.owner))
+        .and_then(|record| record.state().cloned())
+    else {
+        panic!("installed state should exist")
+    };
+    let context = fixture.context_for_state(
         Operation::Remove,
-        ExpectedPackageState::Exact(state),
+        ExpectedPackageState::Exact(state_value.digest()),
         removal_plan.digest(),
         (fixture.owner, fixture.caller),
-        1,
+        &state_value,
         Nonce::from_bytes([3; 32]),
     );
     let nonce = match fixture.begin(model, context, 300) {
         Ok(value) => value,
-        Err(_) => panic!("remove admission should succeed"),
+        Err(error) => panic!("remove admission should succeed: {error:?}"),
     };
     model
         .begin_drain(

--- a/crates/astrid-package-service/src/lifecycle/tests.rs
+++ b/crates/astrid-package-service/src/lifecycle/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::authority::{AuthorityIssuer, AuthorityIssuerClass};
-use crate::bytes::PrincipalUid;
+use crate::bytes::{PrincipalUid, RecoveryToken};
 use crate::context::{
     ApproverIdentity, IngressChannel, OperationContextSpec, ResourceBudget, ResourceClasses,
 };
@@ -14,6 +14,8 @@ use crate::policy::{JournalPolicy, JournalRetention, RetentionWindow};
 use crate::state::PackageSlot;
 use std::num::{NonZeroU32, NonZeroU64};
 use std::time::Duration;
+
+mod cure_tests;
 
 fn non_zero(value: u64) -> NonZeroU64 {
     match NonZeroU64::new(value) {
@@ -98,6 +100,15 @@ struct Fixture {
     budget: ResourceBudget,
 }
 
+struct ContextOptions {
+    operation: Operation,
+    expected: ExpectedPackageState,
+    plan: PlanDigest,
+    participants: (PrincipalUid, PrincipalUid),
+    generation: u64,
+    nonce: Nonce,
+    expiry: Timestamp,
+}
 impl Fixture {
     fn new() -> Self {
         Self {
@@ -141,22 +152,34 @@ impl Fixture {
         generation: u64,
         nonce: Nonce,
     ) -> OperationContext {
+        self.context_with_expiry(ContextOptions {
+            operation,
+            expected,
+            plan,
+            participants,
+            generation,
+            nonce,
+            expiry: Timestamp::new(1_000),
+        })
+    }
+
+    fn context_with_expiry(&self, options: ContextOptions) -> OperationContext {
         match OperationContext::new(
             OperationContextSpec {
-                nonce,
-                operation,
-                expected_state: expected,
-                effective_caller: participants.1,
-                approver: ApproverIdentity::Principal(participants.1),
-                target_owner: participants.0,
+                nonce: options.nonce,
+                operation: options.operation,
+                expected_state: options.expected,
+                effective_caller: options.participants.1,
+                approver: ApproverIdentity::Principal(options.participants.1),
+                target_owner: options.participants.0,
                 package_object: self.object,
                 artifact: artifact(),
                 manifest: manifest(),
-                plan_digest: plan,
+                plan_digest: options.plan,
                 budget: self.budget,
-                expiry: Timestamp::new(1_000),
+                expiry: options.expiry,
             },
-            &self.service_at(generation),
+            &self.service_at(options.generation),
             Timestamp::new(100),
         ) {
             Ok(value) => value,
@@ -173,7 +196,10 @@ impl Fixture {
     }
 
     fn authority(&self, context: &OperationContext) -> AuthenticatedAuthority {
-        AuthenticatedAuthority::bind(context, self.issuer, self.evidence)
+        match AuthenticatedAuthority::bind(context, self.issuer, self.evidence) {
+            Ok(value) => value,
+            Err(_) => panic!("fixed authority is valid"),
+        }
     }
 
     fn begin(
@@ -193,7 +219,10 @@ impl Fixture {
     }
 
     fn authority_for(&self, context: &OperationContext) -> AuthenticatedAuthority {
-        AuthenticatedAuthority::bind(context, self.issuer, self.evidence)
+        match AuthenticatedAuthority::bind(context, self.issuer, self.evidence) {
+            Ok(value) => value,
+            Err(_) => panic!("fixed authority is valid"),
+        }
     }
 
     fn slot(&self, owner: PrincipalUid) -> PackageSlot {
@@ -276,11 +305,15 @@ fn begin_update(model: &mut PackageServiceModel, fixture: &Fixture) -> Nonce {
         Some(state) => state.digest(),
         None => panic!("installed state should exist"),
     };
-    let replacement_plan = DrainPlan::new(
+    let replacement_plan = match DrainPlan::new(
         DrainDestination::Replacement,
+        ExpectedPackageState::Exact(state),
         Timestamp::new(200),
         Nonce::from_bytes([2; 32]),
-    );
+    ) {
+        Ok(value) => value,
+        Err(_) => panic!("replacement plan is valid"),
+    };
     let context = fixture.context(
         Operation::Update,
         ExpectedPackageState::Exact(state),
@@ -313,11 +346,15 @@ fn begin_remove(model: &mut PackageServiceModel, fixture: &Fixture) -> Nonce {
         Some(state) => state.digest(),
         None => panic!("installed state should exist"),
     };
-    let removal_plan = DrainPlan::new(
+    let removal_plan = match DrainPlan::new(
         DrainDestination::Removal,
+        ExpectedPackageState::Exact(state),
         Timestamp::new(400),
         Nonce::from_bytes([3; 32]),
-    );
+    ) {
+        Ok(value) => value,
+        Err(_) => panic!("removal plan is valid"),
+    };
     let context = fixture.context(
         Operation::Remove,
         ExpectedPackageState::Exact(state),
@@ -340,235 +377,6 @@ fn begin_remove(model: &mut PackageServiceModel, fixture: &Fixture) -> Nonce {
         )
         .unwrap_or_else(|_| panic!("removal drain should start"));
     nonce
-}
-
-#[test]
-fn authority_replay_rejects_changed_context_fields() {
-    let fixture = Fixture::new();
-    let mut model = PackageServiceModel::new(policy(8));
-    let base = fixture.context(
-        Operation::Install,
-        ExpectedPackageState::Absent,
-        plan_digest(20),
-        (fixture.owner, fixture.caller),
-        1,
-        Nonce::from_bytes([7; 32]),
-    );
-    let authority = fixture.authority(&base);
-    let changed = [
-        fixture.context(
-            Operation::Install,
-            ExpectedPackageState::Absent,
-            plan_digest(21),
-            (fixture.owner, fixture.caller),
-            1,
-            Nonce::from_bytes([7; 32]),
-        ),
-        fixture.context(
-            Operation::Install,
-            ExpectedPackageState::Absent,
-            plan_digest(20),
-            (fixture.other_owner, fixture.caller),
-            1,
-            Nonce::from_bytes([7; 32]),
-        ),
-        fixture.context(
-            Operation::Install,
-            ExpectedPackageState::Absent,
-            plan_digest(20),
-            (fixture.owner, fixture.other_owner),
-            1,
-            Nonce::from_bytes([7; 32]),
-        ),
-        fixture.context(
-            Operation::Install,
-            ExpectedPackageState::Absent,
-            plan_digest(20),
-            (fixture.owner, fixture.caller),
-            2,
-            Nonce::from_bytes([7; 32]),
-        ),
-    ];
-    for context in changed {
-        let error = model
-            .begin(
-                context,
-                &authority,
-                fixture.ingress,
-                &fixture.service_at(1),
-                Timestamp::new(100),
-            )
-            .err()
-            .unwrap_or_else(|| panic!("changed authority context must fail"));
-        assert!(matches!(
-            error,
-            PackageServiceError::AuthorityContextMismatch
-        ));
-    }
-    assert!(model.slot_record(&fixture.slot(fixture.owner)).is_none());
-}
-
-#[test]
-fn terminal_receipt_replays_after_update_and_removal() {
-    let fixture = Fixture::new();
-    let mut model = PackageServiceModel::new(policy(8));
-    install(&mut model, &fixture, 1);
-    let update_nonce = begin_update(&mut model, &fixture);
-    model
-        .prove_drain_leases(&update_nonce, 0, Timestamp::new(200))
-        .unwrap_or_else(|_| panic!("zero leases should be provable"));
-    model
-        .complete(
-            &update_nonce,
-            Some(&validated_artifact(13)),
-            None,
-            true,
-            Timestamp::new(220),
-        )
-        .unwrap_or_else(|_| panic!("update should commit"));
-    let remove_nonce = begin_remove(&mut model, &fixture);
-    model
-        .prove_drain_leases(&remove_nonce, 0, Timestamp::new(400))
-        .unwrap_or_else(|_| panic!("zero leases should be provable"));
-    let retired = model
-        .complete(&remove_nonce, None, None, true, Timestamp::new(420))
-        .unwrap_or_else(|_| panic!("removal should commit"));
-    assert_eq!(retired.outcome(), ReceiptOutcome::Retired);
-    assert_eq!(retired.protocol_version().get(), 1);
-    assert_eq!(retired.operation(), Operation::Remove);
-    assert_eq!(retired.slot(), fixture.slot(fixture.owner));
-    assert!(
-        model
-            .slot_record(&fixture.slot(fixture.owner))
-            .and_then(|record| record.state())
-            .is_none()
-    );
-
-    let original = fixture.context(
-        Operation::Install,
-        ExpectedPackageState::Absent,
-        plan_digest(20),
-        (fixture.owner, fixture.caller),
-        1,
-        Nonce::from_bytes([1; 32]),
-    );
-    match model.replay(&original.nonce(), Some(*original.digest())) {
-        Ok(ReplayOutcome::Receipt(receipt)) => {
-            assert_eq!(receipt.outcome(), ReceiptOutcome::Installed)
-        },
-        _ => panic!("original receipt must remain replayable"),
-    }
-}
-
-#[test]
-fn cross_owner_nonce_use_is_isolated() {
-    let fixture = Fixture::new();
-    let mut model = PackageServiceModel::new(policy(8));
-    let first = fixture.context(
-        Operation::Install,
-        ExpectedPackageState::Absent,
-        plan_digest(20),
-        (fixture.owner, fixture.caller),
-        1,
-        Nonce::from_bytes([9; 32]),
-    );
-    fixture
-        .begin(&mut model, first, 100)
-        .unwrap_or_else(|_| panic!("first owner admission should succeed"));
-    let second = fixture.context(
-        Operation::Install,
-        ExpectedPackageState::Absent,
-        plan_digest(20),
-        (fixture.other_owner, fixture.caller),
-        1,
-        Nonce::from_bytes([9; 32]),
-    );
-    let error = fixture
-        .begin(&mut model, second, 100)
-        .err()
-        .unwrap_or_else(|| panic!("cross-owner nonce must fail"));
-    assert!(matches!(error, PackageServiceError::ReplayRejected));
-    assert!(
-        model
-            .slot_record(&fixture.slot(fixture.other_owner))
-            .is_none()
-    );
-}
-
-#[test]
-fn nonce_replay_after_later_commits_is_rejected_and_bound() {
-    let fixture = Fixture::new();
-    let mut model = PackageServiceModel::new(policy_short_retention(8, 128));
-    install(&mut model, &fixture, 1);
-    let update_nonce = begin_update(&mut model, &fixture);
-    model
-        .prove_drain_leases(&update_nonce, 0, Timestamp::new(200))
-        .unwrap_or_else(|_| panic!("zero leases should be provable"));
-    model
-        .complete(
-            &update_nonce,
-            Some(&validated_artifact(13)),
-            None,
-            true,
-            Timestamp::new(220),
-        )
-        .unwrap_or_else(|_| panic!("update should commit"));
-
-    let collected = model
-        .collect(Timestamp::new(900), 8)
-        .unwrap_or_else(|_| panic!("eligible terminal records should collect"));
-    assert_eq!(collected, 2);
-
-    let original = fixture.context(
-        Operation::Install,
-        ExpectedPackageState::Absent,
-        plan_digest(20),
-        (fixture.owner, fixture.caller),
-        1,
-        Nonce::from_bytes([1; 32]),
-    );
-    let current_state = model
-        .slot_record(&fixture.slot(fixture.owner))
-        .and_then(|record| record.state().map(CanonicalInstalledState::digest))
-        .unwrap_or_else(|| panic!("updated state should exist"));
-    let replay_context = fixture.context(
-        Operation::Update,
-        ExpectedPackageState::Exact(current_state),
-        plan_digest(22),
-        (fixture.owner, fixture.caller),
-        1,
-        Nonce::from_bytes([1; 32]),
-    );
-    let replay_error = fixture
-        .begin(&mut model, replay_context, 910)
-        .err()
-        .unwrap_or_else(|| panic!("collected nonce must not execute again"));
-    assert!(
-        matches!(replay_error, PackageServiceError::ReplayRejected),
-        "unexpected replay error: {replay_error:?}"
-    );
-    match model.replay(&original.nonce(), Some(*original.digest())) {
-        Ok(ReplayOutcome::Tombstoned(tombstone)) => {
-            assert_eq!(tombstone.terminal_status(), JournalStatus::Committed);
-            assert_eq!(tombstone.outcome(), Some(ReceiptOutcome::Installed));
-            assert_eq!(tombstone.context_digest(), *original.digest());
-        },
-        _ => panic!("collected receipt must remain distinguishable from loss"),
-    }
-
-    let other_context = fixture.context(
-        Operation::Install,
-        ExpectedPackageState::Absent,
-        plan_digest(21),
-        (fixture.owner, fixture.caller),
-        1,
-        Nonce::from_bytes([1; 32]),
-    );
-    let error = model
-        .replay(&other_context.nonce(), Some(*other_context.digest()))
-        .err()
-        .unwrap_or_else(|| panic!("tombstone must reject a different context"));
-    assert!(matches!(error, PackageServiceError::ReplayRejected));
 }
 
 #[test]
@@ -647,12 +455,11 @@ fn drain_expiry_blocks_and_abort_is_coherent() {
         abort_model.slot_record(&abort_fixture.slot(abort_fixture.owner)).and_then(|record| record.state()),
         Some(state) if *state.lifecycle_state() == LifecycleState::Inactive
     ));
-    assert_eq!(
-        abort_model
-            .slot_record(&abort_fixture.slot(abort_fixture.owner))
-            .and_then(|record| record.state().map(CanonicalInstalledState::digest)),
-        Some(original)
-    );
+    let cancelled_digest = abort_model
+        .slot_record(&abort_fixture.slot(abort_fixture.owner))
+        .and_then(|record| record.state().map(CanonicalInstalledState::digest))
+        .unwrap_or_else(|| panic!("cancelled state should remain"));
+    assert_ne!(cancelled_digest, original);
 }
 
 #[test]
@@ -693,6 +500,7 @@ fn canonical_state_digests_are_deterministic_and_domain_separated() {
         authority_digest,
         &validated_artifact(12),
         LifecycleState::Inactive,
+        non_zero(1),
     )
     .unwrap_or_else(|_| panic!("state should construct"));
     let second = new_installed_state(
@@ -700,6 +508,7 @@ fn canonical_state_digests_are_deterministic_and_domain_separated() {
         authority_digest,
         &validated_artifact(12),
         LifecycleState::Inactive,
+        non_zero(1),
     )
     .unwrap_or_else(|_| panic!("state should construct"));
     assert_eq!(first.digest(), second.digest());
@@ -718,6 +527,7 @@ fn canonical_state_digests_are_deterministic_and_domain_separated() {
             .decision_digest(),
         &validated_artifact(12),
         LifecycleState::Inactive,
+        non_zero(1),
     )
     .unwrap_or_else(|_| panic!("state should construct"));
     assert_ne!(first.digest(), different.digest());
@@ -836,7 +646,9 @@ fn activation_requires_exact_installed_state_and_produces_active_generation() {
     let context = fixture.context(
         Operation::Activate,
         ExpectedPackageState::Exact(state),
-        plan_digest(30),
+        ExpectedPackageState::Exact(state)
+            .lifecycle_plan_digest(Operation::Activate)
+            .unwrap_or_else(|_| panic!("activation plan is valid")),
         (fixture.owner, fixture.caller),
         1,
         Nonce::from_bytes([4; 32]),

--- a/crates/astrid-package-service/src/lifecycle/tests.rs
+++ b/crates/astrid-package-service/src/lifecycle/tests.rs
@@ -90,6 +90,17 @@ fn validated_artifact(content: u8) -> ValidatedArtifact {
     }
 }
 
+fn commit_plan_for_artifact(
+    context: &OperationContext,
+    artifact: &ValidatedArtifact,
+) -> PlanDigest {
+    commit_plan_digest(
+        context,
+        artifact.content_root(),
+        &provenance_digest(artifact.provenance()),
+    )
+}
+
 struct Fixture {
     caller: PrincipalUid,
     owner: PrincipalUid,
@@ -273,10 +284,19 @@ fn policy_short_retention(capacity: u64, tombstone_capacity: u64) -> JournalPoli
 }
 
 fn install(model: &mut PackageServiceModel, fixture: &Fixture, nonce_byte: u8) -> OperationReceipt {
-    let context = fixture.context(
+    let staged_artifact = validated_artifact(12);
+    let binding_context = fixture.context(
         Operation::Install,
         ExpectedPackageState::Absent,
         plan_digest(20),
+        (fixture.owner, fixture.caller),
+        1,
+        Nonce::from_bytes([nonce_byte; 32]),
+    );
+    let context = fixture.context(
+        Operation::Install,
+        ExpectedPackageState::Absent,
+        commit_plan_for_artifact(&binding_context, &staged_artifact),
         (fixture.owner, fixture.caller),
         1,
         Nonce::from_bytes([nonce_byte; 32]),
@@ -289,6 +309,9 @@ fn install(model: &mut PackageServiceModel, fixture: &Fixture, nonce_byte: u8) -
         .begin_work(&nonce, Timestamp::new(110))
         .unwrap_or_else(|_| panic!("work should start"));
     model
+        .stage_commit_artifact(&nonce, &staged_artifact)
+        .unwrap_or_else(|_| panic!("install artifact should stage"));
+    model
         .complete(
             &nonce,
             Some(&validated_artifact(12)),
@@ -300,6 +323,14 @@ fn install(model: &mut PackageServiceModel, fixture: &Fixture, nonce_byte: u8) -
 }
 
 fn begin_update(model: &mut PackageServiceModel, fixture: &Fixture) -> Nonce {
+    begin_update_with_deadline(model, fixture, Timestamp::new(200))
+}
+
+fn begin_update_with_deadline(
+    model: &mut PackageServiceModel,
+    fixture: &Fixture,
+    deadline: Timestamp,
+) -> Nonce {
     let state = match model
         .slot_record(&fixture.slot(fixture.owner))
         .and_then(|record| record.state())
@@ -307,10 +338,11 @@ fn begin_update(model: &mut PackageServiceModel, fixture: &Fixture) -> Nonce {
         Some(state) => state.digest(),
         None => panic!("installed state should exist"),
     };
+    let staged_artifact = validated_artifact(13);
     let replacement_plan = match DrainPlan::new(
         DrainDestination::Replacement,
         ExpectedPackageState::Exact(state),
-        Timestamp::new(200),
+        deadline,
         Nonce::from_bytes([2; 32]),
     ) {
         Ok(value) => value,
@@ -332,11 +364,14 @@ fn begin_update(model: &mut PackageServiceModel, fixture: &Fixture) -> Nonce {
         .begin_drain(
             &nonce,
             DrainDestination::Replacement,
-            Timestamp::new(200),
+            deadline,
             1,
             Timestamp::new(140),
         )
         .unwrap_or_else(|_| panic!("replacement drain should start"));
+    model
+        .stage_commit_artifact(&nonce, &staged_artifact)
+        .unwrap_or_else(|_| panic!("replacement artifact should stage"));
     nonce
 }
 

--- a/crates/astrid-package-service/src/lifecycle/tests.rs
+++ b/crates/astrid-package-service/src/lifecycle/tests.rs
@@ -16,6 +16,7 @@ use std::num::{NonZeroU32, NonZeroU64};
 use std::time::Duration;
 
 mod cure_tests;
+mod lineage_tests;
 mod successor_tests;
 
 fn non_zero(value: u64) -> NonZeroU64 {

--- a/crates/astrid-package-service/src/lifecycle/tests/binding_tests.rs
+++ b/crates/astrid-package-service/src/lifecycle/tests/binding_tests.rs
@@ -1,0 +1,341 @@
+use super::*;
+use crate::identity::{BoundedEvidence, ProvenanceClass};
+
+fn validated_artifact_with(
+    artifact_identity: ArtifactIdentity,
+    manifest_identity: ManifestIdentity,
+    content: u8,
+    evidence: Blake3Digest,
+) -> ValidatedArtifact {
+    let bounded = BoundedEvidence::new(vec![1, 2, 3])
+        .unwrap_or_else(|error| panic!("test evidence is valid: {error:?}"));
+    let provenance = ProvenanceEvidence::new(ProvenanceClass::LocalArtifact, evidence, bounded)
+        .unwrap_or_else(|error| panic!("test provenance is valid: {error:?}"));
+    ValidatedArtifact::new(
+        artifact_identity,
+        manifest_identity,
+        digest(content),
+        provenance,
+    )
+    .unwrap_or_else(|error| panic!("test artifact is valid: {error:?}"))
+}
+
+#[test]
+fn changed_authority_or_content_cannot_stage_or_mutate_a_record() {
+    let fixture = Fixture::new();
+    let mut model = PackageServiceModel::new(policy(8));
+    let artifact = validated_artifact(12);
+    let binding_context = fixture.context(
+        Operation::Install,
+        ExpectedPackageState::Absent,
+        plan_digest(20),
+        (fixture.owner, fixture.caller),
+        1,
+        Nonce::from_bytes([1; 32]),
+    );
+    let unified_plan = crate::context::operation_commit_plan_digest(
+        Operation::Install,
+        binding_context.artifact(),
+        binding_context.manifest(),
+        artifact.content_root(),
+        &provenance_digest(artifact.provenance()),
+        None,
+    );
+    let context = fixture.context_with_expiry(&ContextOptions {
+        operation: Operation::Install,
+        expected: ExpectedPackageState::Absent,
+        plan: unified_plan,
+        participants: (fixture.owner, fixture.caller),
+        generation: 1,
+        nonce: Nonce::from_bytes([1; 32]),
+        expiry: Timestamp::new(1_000),
+    });
+    let unbound_context = fixture.context(
+        Operation::Install,
+        ExpectedPackageState::Absent,
+        unified_plan,
+        (fixture.other_owner, fixture.caller),
+        1,
+        Nonce::from_bytes([2; 32]),
+    );
+    let wrong_authority = fixture.authority(&unbound_context);
+    let error = model
+        .begin(
+            context.clone(),
+            &wrong_authority,
+            fixture.ingress,
+            &fixture.service_at(1),
+            Timestamp::new(100),
+        )
+        .err()
+        .unwrap_or_else(|| panic!("unbound authority must not admit"));
+    assert!(matches!(
+        error,
+        PackageServiceError::AuthorityContextMismatch
+    ));
+
+    let nonce = fixture
+        .begin(&mut model, context.clone(), 100)
+        .unwrap_or_else(|error| panic!("bound install should admit: {error:?}"));
+    model
+        .begin_work(&nonce, Timestamp::new(110))
+        .unwrap_or_else(|error| panic!("install should start: {error:?}"));
+    let wrong_content = validated_artifact_with(
+        *context.artifact(),
+        context.manifest().clone(),
+        13,
+        digest(5),
+    );
+    assert_changed_content_is_rejected(
+        &mut model,
+        &fixture,
+        &nonce,
+        &context,
+        &wrong_content,
+        &artifact,
+    );
+}
+
+fn assert_changed_content_is_rejected(
+    model: &mut PackageServiceModel,
+    fixture: &Fixture,
+    nonce: &Nonce,
+    context: &OperationContext,
+    wrong_content: &ValidatedArtifact,
+    artifact: &ValidatedArtifact,
+) {
+    let staged_before = model
+        .slot_record(&fixture.slot(fixture.owner))
+        .and_then(|record| record.journal_record(nonce))
+        .and_then(OperationJournalRecord::staged_commit_plan)
+        .copied();
+    assert_eq!(staged_before, None);
+    let error = model
+        .stage_commit_artifact(nonce, wrong_content)
+        .err()
+        .unwrap_or_else(|| panic!("changed content must not stage"));
+    assert!(matches!(error, PackageServiceError::BindingMismatch));
+    let staged_after = model
+        .slot_record(&fixture.slot(fixture.owner))
+        .and_then(|record| record.journal_record(nonce))
+        .and_then(OperationJournalRecord::staged_commit_plan)
+        .copied();
+    assert_eq!(staged_before, staged_after);
+
+    model
+        .stage_commit_artifact(nonce, artifact)
+        .unwrap_or_else(|error| panic!("authoritative content should stage: {error:?}"));
+    let committed = model
+        .slot_record(&fixture.slot(fixture.owner))
+        .and_then(|record| record.journal_record(nonce))
+        .map_or_else(
+            || panic!("journal should exist"),
+            OperationJournalRecord::staged_commit_plan,
+        );
+    assert_eq!(committed, Some(*context.commit_plan_digest()).as_ref());
+    let error = model
+        .complete(nonce, Some(wrong_content), None, true, Timestamp::new(120))
+        .err()
+        .unwrap_or_else(|| panic!("changed content must not commit"));
+    assert!(matches!(error, PackageServiceError::BindingMismatch));
+}
+
+#[test]
+fn changed_lifecycle_plans_and_expectations_fail_before_transition() {
+    let fixture = Fixture::new();
+    let mut model = PackageServiceModel::new(policy(8));
+    install(&mut model, &fixture, 1);
+    let state = model
+        .slot_record(&fixture.slot(fixture.owner))
+        .and_then(|record| record.state())
+        .map_or_else(
+            || panic!("installed state should exist"),
+            CanonicalInstalledState::digest,
+        );
+
+    let wrong_deadline_plan = DrainPlan::new(
+        DrainDestination::Replacement,
+        ExpectedPackageState::Exact(state),
+        Timestamp::new(250),
+        Nonce::from_bytes([2; 32]),
+    )
+    .unwrap_or_else(|error| panic!("wrong deadline plan is valid: {error:?}"));
+    let wrong_deadline_context = fixture.context(
+        Operation::Update,
+        ExpectedPackageState::Exact(state),
+        wrong_deadline_plan.digest(),
+        (fixture.owner, fixture.caller),
+        1,
+        Nonce::from_bytes([2; 32]),
+    );
+    let nonce = fixture
+        .begin(&mut model, wrong_deadline_context, 130)
+        .unwrap_or_else(|error| panic!("update with its exact plan should admit: {error:?}"));
+    let error = model
+        .begin_drain(
+            &nonce,
+            DrainDestination::Replacement,
+            Timestamp::new(300),
+            1,
+            Timestamp::new(140),
+        )
+        .err()
+        .unwrap_or_else(|| panic!("changed drain deadline must fail"));
+    assert!(matches!(error, PackageServiceError::BindingMismatch));
+
+    model
+        .cancel(&nonce, Timestamp::new(150))
+        .unwrap_or_else(|error| panic!("rejected deadline work should cancel: {error:?}"));
+    let current_digest = model
+        .slot_record(&fixture.slot(fixture.owner))
+        .and_then(|record| record.state())
+        .map_or_else(
+            || panic!("state should remain after cancellation"),
+            CanonicalInstalledState::digest,
+        );
+    let replacement_plan = DrainPlan::new(
+        DrainDestination::Replacement,
+        ExpectedPackageState::Exact(current_digest),
+        Timestamp::new(300),
+        Nonce::from_bytes([6; 32]),
+    )
+    .unwrap_or_else(|error| panic!("replacement plan is valid: {error:?}"));
+    let replacement_context = fixture.context(
+        Operation::Update,
+        ExpectedPackageState::Exact(current_digest),
+        replacement_plan.digest(),
+        (fixture.owner, fixture.caller),
+        1,
+        Nonce::from_bytes([6; 32]),
+    );
+    let replacement_nonce = fixture
+        .begin(&mut model, replacement_context, 130)
+        .unwrap_or_else(|error| panic!("exact update should admit: {error:?}"));
+    model
+        .begin_drain(
+            &replacement_nonce,
+            DrainDestination::Replacement,
+            Timestamp::new(300),
+            1,
+            Timestamp::new(140),
+        )
+        .unwrap_or_else(|error| panic!("exact replacement should drain: {error:?}"));
+
+    let wrong_destination = model
+        .context_for(&replacement_nonce)
+        .unwrap_or_else(|error| panic!("{error:?}"));
+    let error = model
+        .begin_drain(
+            &replacement_nonce,
+            DrainDestination::Removal,
+            Timestamp::new(300),
+            0,
+            Timestamp::new(140),
+        )
+        .err()
+        .unwrap_or_else(|| panic!("changed drain destination must fail"));
+    assert!(matches!(error, PackageServiceError::BindingMismatch));
+    drop(wrong_destination);
+}
+
+#[test]
+fn changed_expected_state_is_refused_before_admission() {
+    let fixture = Fixture::new();
+    let mut model = PackageServiceModel::new(policy(8));
+    install(&mut model, &fixture, 1);
+    let state = model
+        .slot_record(&fixture.slot(fixture.owner))
+        .and_then(|record| record.state())
+        .map_or_else(
+            || panic!("installed state should exist"),
+            CanonicalInstalledState::digest,
+        );
+    let plan = DrainPlan::new(
+        DrainDestination::Replacement,
+        ExpectedPackageState::Exact(state),
+        Timestamp::new(300),
+        Nonce::from_bytes([2; 32]),
+    )
+    .unwrap_or_else(|error| panic!("replacement plan is valid: {error:?}"));
+    let stale_update = fixture.context(
+        Operation::Update,
+        ExpectedPackageState::Exact(StateDigest::from_bytes([90; 32])),
+        plan.digest(),
+        (fixture.owner, fixture.caller),
+        1,
+        Nonce::from_bytes([5; 32]),
+    );
+    let error = fixture
+        .begin(&mut model, stale_update, 140)
+        .err()
+        .unwrap_or_else(|| panic!("stale expected state must fail"));
+    assert!(matches!(error, PackageServiceError::ExpectedStateMismatch));
+}
+
+#[test]
+fn changed_removal_and_activation_plans_fail_before_effect() {
+    let fixture = Fixture::new();
+    let mut model = PackageServiceModel::new(policy(8));
+    install(&mut model, &fixture, 1);
+    let state_value = model
+        .slot_record(&fixture.slot(fixture.owner))
+        .and_then(|record| record.state().cloned())
+        .unwrap_or_else(|| panic!("state should remain"));
+    let state = state_value.digest();
+    let wrong_removal_plan = DrainPlan::new(
+        DrainDestination::Removal,
+        ExpectedPackageState::Exact(state),
+        Timestamp::new(500),
+        Nonce::from_bytes([3; 32]),
+    )
+    .unwrap_or_else(|error| panic!("removal plan is valid: {error:?}"));
+    let removal_context = fixture.context_for_state(
+        Operation::Remove,
+        ExpectedPackageState::Exact(state),
+        wrong_removal_plan.digest(),
+        (fixture.owner, fixture.caller),
+        &state_value,
+        Nonce::from_bytes([3; 32]),
+    );
+    let removal_nonce = fixture
+        .begin(&mut model, removal_context, 140)
+        .unwrap_or_else(|error| panic!("removal may admit before drain authorization: {error:?}"));
+    let error = model
+        .begin_drain(
+            &removal_nonce,
+            DrainDestination::Removal,
+            Timestamp::new(400),
+            1,
+            Timestamp::new(140),
+        )
+        .err()
+        .unwrap_or_else(|| panic!("changed removal deadline must fail"));
+    assert!(matches!(error, PackageServiceError::BindingMismatch));
+    let status = model
+        .slot_record(&fixture.slot(fixture.owner))
+        .and_then(|record| record.journal_record(&removal_nonce))
+        .map_or_else(
+            || panic!("removal record should remain"),
+            OperationJournalRecord::status,
+        );
+    assert_eq!(status, JournalStatus::Intent);
+
+    model
+        .cancel(&removal_nonce, Timestamp::new(150))
+        .unwrap_or_else(|error| panic!("rejected removal should cancel: {error:?}"));
+
+    let wrong_activation_plan = plan_digest(31);
+    let activation_context = fixture.context(
+        Operation::Activate,
+        ExpectedPackageState::Exact(state),
+        wrong_activation_plan,
+        (fixture.owner, fixture.caller),
+        1,
+        Nonce::from_bytes([6; 32]),
+    );
+    let error = fixture
+        .begin(&mut model, activation_context, 140)
+        .err()
+        .unwrap_or_else(|| panic!("changed activation plan must fail"));
+    assert!(matches!(error, PackageServiceError::BindingMismatch));
+}

--- a/crates/astrid-package-service/src/lifecycle/tests/cure_tests.rs
+++ b/crates/astrid-package-service/src/lifecycle/tests/cure_tests.rs
@@ -349,19 +349,20 @@ fn repeated_updates_monotonically_bump_package_generation() {
         .slot_record(&fixture.slot(fixture.owner))
         .and_then(|record| record.state().map(CanonicalInstalledState::digest))
         .unwrap_or_else(|| panic!("updated state should exist"));
-    let replacement_plan = match DrainPlan::new(
+    let second_artifact = validated_artifact(14);
+    let second_plan = match DrainPlan::new(
         DrainDestination::Replacement,
         ExpectedPackageState::Exact(second_state),
         Timestamp::new(350),
         Nonce::from_bytes([6; 32]),
     ) {
         Ok(value) => value,
-        Err(_) => panic!("replacement plan is valid"),
+        Err(_) => panic!("second replacement plan is valid"),
     };
     let second_context = fixture.context(
         Operation::Update,
         ExpectedPackageState::Exact(second_state),
-        replacement_plan.digest(),
+        second_plan.digest(),
         (fixture.owner, fixture.caller),
         1,
         Nonce::from_bytes([6; 32]),
@@ -379,9 +380,12 @@ fn repeated_updates_monotonically_bump_package_generation() {
         )
         .unwrap_or_else(|_| panic!("second drain should start"));
     model
+        .stage_commit_artifact(&second, &second_artifact)
+        .unwrap_or_else(|_| panic!("second replacement should stage"));
+    model
         .complete(
             &second,
-            Some(&validated_artifact(14)),
+            Some(&second_artifact),
             None,
             true,
             Timestamp::new(320),
@@ -393,6 +397,97 @@ fn repeated_updates_monotonically_bump_package_generation() {
         .map(|state| state.generation_value().get())
         .unwrap_or_else(|| panic!("second updated state should exist"));
     assert!(second_generation > first_generation);
+}
+
+#[test]
+fn install_recovery_rejects_arbitrary_content_and_provenance() {
+    let fixture = Fixture::new();
+    let mut model = PackageServiceModel::new(policy(8));
+    let nonce = Nonce::from_bytes([11; 32]);
+    let staged_artifact = validated_artifact(12);
+    let binding_context = fixture.context(
+        Operation::Install,
+        ExpectedPackageState::Absent,
+        plan_digest(20),
+        (fixture.owner, fixture.caller),
+        1,
+        nonce,
+    );
+    let context = fixture.context(
+        Operation::Install,
+        ExpectedPackageState::Absent,
+        commit_plan_for_artifact(&binding_context, &staged_artifact),
+        (fixture.owner, fixture.caller),
+        1,
+        nonce,
+    );
+    let operation = fixture
+        .begin(&mut model, context, 100)
+        .unwrap_or_else(|error| panic!("{error:?}"));
+    model
+        .begin_work(&operation, Timestamp::new(110))
+        .unwrap_or_else(|error| panic!("{error:?}"));
+    model
+        .stage_commit_artifact(&operation, &staged_artifact)
+        .unwrap_or_else(|error| panic!("{error:?}"));
+    model
+        .mark_unknown(&operation, Timestamp::new(120))
+        .unwrap_or_else(|error| panic!("{error:?}"));
+
+    let slot = fixture.slot(fixture.owner);
+    let authority = model
+        .slot_record(&slot)
+        .and_then(|record| record.journal_record(&operation))
+        .map(|record| *record.authority_digest())
+        .unwrap_or_else(|| panic!("install authority should remain"));
+    let token = model
+        .slot_record(&slot)
+        .and_then(|record| record.journal_record(&operation))
+        .map(OperationJournalRecord::recovery_token)
+        .unwrap_or_else(|| panic!("install token should remain"));
+    let operation_context = model
+        .context_for(&operation)
+        .unwrap_or_else(|error| panic!("{error:?}"));
+    let valid = new_installed_state(
+        &operation_context,
+        authority,
+        &staged_artifact,
+        LifecycleState::Inactive,
+        non_zero(1),
+    )
+    .unwrap_or_else(|error| panic!("{error:?}"));
+
+    for provenance in [valid.provenance(), &ProvenanceDigest::from_bytes([99; 32])] {
+        for content_root in [*valid.content_root(), digest(99)] {
+            if *provenance == *valid.provenance() && content_root == *valid.content_root() {
+                continue;
+            }
+            let spoof = CanonicalInstalledState::new(InstalledStateSpec {
+                owner: fixture.owner,
+                package_object: fixture.object,
+                artifact: *operation_context.artifact(),
+                content_root,
+                manifest: operation_context.manifest().clone(),
+                authority_digest: authority,
+                provenance: *provenance,
+                lifecycle_state: LifecycleState::Inactive,
+                lifecycle_plan: *operation_context.plan_digest(),
+                generation: non_zero(1),
+                completing_nonce: nonce,
+            })
+            .unwrap_or_else(|error| panic!("{error:?}"));
+            let evidence =
+                match RecoveryEvidence::new(token, spoof.digest(), non_zero(1), None, false) {
+                    Ok(value) => value,
+                    Err(error) => panic!("{error:?}"),
+                };
+            let error = model
+                .recover_observed(&operation, &evidence, Some(&spoof), Timestamp::new(130))
+                .err()
+                .unwrap_or_else(|| panic!("arbitrary install evidence must fail"));
+            assert!(matches!(error, PackageServiceError::RecoveryUnresolved));
+        }
+    }
 }
 
 #[test]

--- a/crates/astrid-package-service/src/lifecycle/tests/cure_tests.rs
+++ b/crates/astrid-package-service/src/lifecycle/tests/cure_tests.rs
@@ -1,0 +1,396 @@
+use super::*;
+
+fn recovery_evidence(
+    token: RecoveryToken,
+    observed: StateDigest,
+    generation: u64,
+) -> RecoveryEvidence {
+    RecoveryEvidence::new(token, observed, non_zero(generation), None, false)
+}
+
+fn begin_activation(model: &mut PackageServiceModel, fixture: &Fixture, nonce_byte: u8) -> Nonce {
+    let state = model
+        .slot_record(&fixture.slot(fixture.owner))
+        .and_then(|record| record.state().map(CanonicalInstalledState::digest))
+        .unwrap_or_else(|| panic!("installed state should exist"));
+    let activation_plan = ExpectedPackageState::Exact(state)
+        .lifecycle_plan_digest(Operation::Activate)
+        .unwrap_or_else(|_| panic!("activation plan is valid"));
+    let context = fixture.context(
+        Operation::Activate,
+        ExpectedPackageState::Exact(state),
+        activation_plan,
+        (fixture.owner, fixture.caller),
+        1,
+        Nonce::from_bytes([nonce_byte; 32]),
+    );
+    let nonce = fixture
+        .begin(model, context, 130)
+        .unwrap_or_else(|error| panic!("activation should be admitted: {error:?}"));
+    model
+        .begin_work(&nonce, Timestamp::new(140))
+        .unwrap_or_else(|_| panic!("activation should start"));
+    model
+        .complete(&nonce, None, Some(digest(31)), true, Timestamp::new(150))
+        .unwrap_or_else(|_| panic!("activation should commit"));
+    nonce
+}
+
+#[test]
+fn mid_drain_recovery_does_not_infer_update_success() {
+    let fixture = Fixture::new();
+    let mut model = PackageServiceModel::new(policy(8));
+    install(&mut model, &fixture, 1);
+    let prior = model
+        .slot_record(&fixture.slot(fixture.owner))
+        .and_then(|record| record.state())
+        .cloned()
+        .unwrap_or_else(|| panic!("prior state should exist"));
+    let nonce = begin_update(&mut model, &fixture);
+    model
+        .mark_unknown(&nonce, Timestamp::new(180))
+        .unwrap_or_else(|_| panic!("mid-drain boundary should become unknown"));
+    let draining = model
+        .slot_record(&fixture.slot(fixture.owner))
+        .and_then(|record| record.state().map(CanonicalInstalledState::digest))
+        .unwrap_or_else(|| panic!("draining state should exist"));
+    let draining_generation = model
+        .slot_record(&fixture.slot(fixture.owner))
+        .and_then(|record| record.state())
+        .map(|state| state.generation_value())
+        .unwrap_or_else(|| panic!("draining generation should exist"));
+    let token = model
+        .slot_record(&fixture.slot(fixture.owner))
+        .and_then(|record| record.journal_record(&nonce))
+        .map(OperationJournalRecord::recovery_token)
+        .unwrap_or_else(|| panic!("recovery record should exist"));
+    let false_success = recovery_evidence(token, draining, draining_generation.get());
+    let error = model
+        .recover(&nonce, &false_success, Timestamp::new(190))
+        .err()
+        .unwrap_or_else(|| panic!("mid-drain evidence must not prove an update"));
+    assert!(matches!(error, PackageServiceError::RecoveryUnresolved));
+    assert_eq!(
+        model
+            .slot_record(&fixture.slot(fixture.owner))
+            .and_then(|record| record.journal_record(&nonce))
+            .map(OperationJournalRecord::status),
+        Some(JournalStatus::Unknown)
+    );
+
+    let old_evidence = recovery_evidence(token, prior.digest(), 1);
+    model
+        .recover(&nonce, &old_evidence, Timestamp::new(200))
+        .unwrap_or_else(|_| panic!("exact old-state evidence should resolve"));
+    let restored = model
+        .slot_record(&fixture.slot(fixture.owner))
+        .and_then(|record| record.state())
+        .cloned()
+        .unwrap_or_else(|| panic!("restored state should exist"));
+    assert_eq!(restored.lifecycle_state(), &LifecycleState::Inactive,);
+    assert!(restored.generation_value().get() > prior.generation_value().get());
+}
+
+#[test]
+fn recovery_rejects_a_token_mismatch() {
+    let fixture = Fixture::new();
+    let mut model = PackageServiceModel::new(policy(8));
+    install(&mut model, &fixture, 1);
+    let prior = model
+        .slot_record(&fixture.slot(fixture.owner))
+        .and_then(|record| record.state())
+        .cloned()
+        .unwrap_or_else(|| panic!("prior state should exist"));
+    let nonce = begin_update(&mut model, &fixture);
+    model
+        .mark_unknown(&nonce, Timestamp::new(180))
+        .unwrap_or_else(|_| panic!("unknown boundary should be recorded"));
+    let evidence = RecoveryEvidence::new(
+        RecoveryToken::from_bytes([0; 32]),
+        prior.digest(),
+        non_zero(1),
+        None,
+        false,
+    );
+    let error = model
+        .recover(&nonce, &evidence, Timestamp::new(190))
+        .err()
+        .unwrap_or_else(|| panic!("token mismatch must not resolve recovery"));
+    assert!(matches!(error, PackageServiceError::RecoveryUnresolved));
+    assert_eq!(
+        model
+            .slot_record(&fixture.slot(fixture.owner))
+            .and_then(|record| record.journal_record(&nonce))
+            .map(OperationJournalRecord::status),
+        Some(JournalStatus::Unknown)
+    );
+}
+
+#[test]
+fn recovery_accepts_structurally_proven_new_update_state() {
+    let fixture = Fixture::new();
+    let mut model = PackageServiceModel::new(policy(8));
+    install(&mut model, &fixture, 1);
+    let nonce = begin_update(&mut model, &fixture);
+    let slot = fixture.slot(fixture.owner);
+    model
+        .mark_unknown(&nonce, Timestamp::new(180))
+        .unwrap_or_else(|_| panic!("unknown boundary should be recorded"));
+    let context = model
+        .context_for(&nonce)
+        .unwrap_or_else(|_| panic!("unknown context should remain"));
+    let authority_digest = model
+        .slot_record(&slot)
+        .and_then(|record| record.journal_record(&nonce))
+        .map(|record| *record.authority_digest())
+        .unwrap_or_else(|| panic!("unknown authority should remain"));
+    let new_state = new_installed_state(
+        &context,
+        authority_digest,
+        &validated_artifact(13),
+        LifecycleState::Inactive,
+        non_zero(3),
+    )
+    .unwrap_or_else(|_| panic!("new update state should construct"));
+    model
+        .slots
+        .get_mut(&slot)
+        .unwrap_or_else(|| panic!("owner slot should remain"))
+        .replace_state(Some(new_state.clone()));
+    let token = model
+        .slot_record(&slot)
+        .and_then(|record| record.journal_record(&nonce))
+        .map(OperationJournalRecord::recovery_token)
+        .unwrap_or_else(|| panic!("recovery token should remain"));
+    let evidence = RecoveryEvidence::new(
+        token,
+        new_state.digest(),
+        new_state.generation_value(),
+        None,
+        true,
+    );
+    let receipt = model
+        .recover(&nonce, &evidence, Timestamp::new(200))
+        .unwrap_or_else(|_| panic!("structural new-state proof should recover"))
+        .unwrap_or_else(|| panic!("new-state proof should produce a receipt"));
+    assert_eq!(receipt.outcome(), ReceiptOutcome::Updated);
+    assert_eq!(receipt.after_state(), new_state.digest());
+    assert_eq!(receipt.state_generation().get(), 3);
+}
+
+#[test]
+fn active_drain_abort_and_expiry_restore_inactive_content() {
+    let fixture = Fixture::new();
+    let mut model = PackageServiceModel::new(policy(8));
+    install(&mut model, &fixture, 1);
+    begin_activation(&mut model, &fixture, 8);
+    let active_before = model
+        .slot_record(&fixture.slot(fixture.owner))
+        .and_then(|record| record.state())
+        .cloned()
+        .unwrap_or_else(|| panic!("active state should exist"));
+
+    let update_nonce = begin_update(&mut model, &fixture);
+    model
+        .expire_drain(&update_nonce, Timestamp::new(250), false)
+        .unwrap_or_else(|_| panic!("drain expiry should be observable"));
+    model
+        .prove_drain_leases(&update_nonce, 0, Timestamp::new(260))
+        .unwrap_or_else(|_| panic!("zero leases should become provable"));
+    model
+        .expire_drain(&update_nonce, Timestamp::new(270), true)
+        .unwrap_or_else(|_| panic!("proved drain should restore safely"));
+    let expired = model
+        .slot_record(&fixture.slot(fixture.owner))
+        .and_then(|record| record.state())
+        .cloned()
+        .unwrap_or_else(|| panic!("cancelled state should remain"));
+    assert_eq!(expired.artifact(), active_before.artifact());
+    assert_eq!(expired.manifest(), active_before.manifest());
+    assert_eq!(expired.content_root(), active_before.content_root());
+    assert_eq!(expired.lifecycle_state(), &LifecycleState::Inactive);
+    assert!(expired.generation_value().get() > active_before.generation_value().get());
+
+    let remove_nonce = begin_remove(&mut model, &fixture);
+    model
+        .cancel(&remove_nonce, Timestamp::new(320))
+        .unwrap_or_else(|_| panic!("drain cancellation should succeed"));
+    let cancelled = model
+        .slot_record(&fixture.slot(fixture.owner))
+        .and_then(|record| record.state())
+        .cloned()
+        .unwrap_or_else(|| panic!("cancelled state should remain"));
+    assert_eq!(cancelled.content_root(), expired.content_root());
+    assert_eq!(cancelled.lifecycle_state(), &LifecycleState::Inactive);
+    assert!(cancelled.generation_value().get() > expired.generation_value().get());
+}
+
+#[test]
+fn lifecycle_contexts_must_match_canonical_state() {
+    let fixture = Fixture::new();
+    let mut model = PackageServiceModel::new(policy(8));
+    install(&mut model, &fixture, 1);
+    let state = model
+        .slot_record(&fixture.slot(fixture.owner))
+        .and_then(|record| record.state().map(CanonicalInstalledState::digest))
+        .unwrap_or_else(|| panic!("installed state should exist"));
+    let unrelated_activation = fixture.context(
+        Operation::Activate,
+        ExpectedPackageState::Exact(state),
+        plan_digest(30),
+        (fixture.owner, fixture.caller),
+        1,
+        Nonce::from_bytes([4; 32]),
+    );
+    let error = fixture
+        .begin(&mut model, unrelated_activation, 130)
+        .err()
+        .unwrap_or_else(|| panic!("unrelated activation bindings must fail"));
+    assert!(matches!(error, PackageServiceError::BindingMismatch));
+
+    let unrelated_removal = fixture.context(
+        Operation::Remove,
+        ExpectedPackageState::Exact(state),
+        plan_digest(31),
+        (fixture.owner, fixture.caller),
+        1,
+        Nonce::from_bytes([5; 32]),
+    );
+    let removal_nonce = fixture
+        .begin(&mut model, unrelated_removal, 130)
+        .unwrap_or_else(|_| panic!("removal admission is separate from drain authorization"));
+    let error = model
+        .begin_drain(
+            &removal_nonce,
+            DrainDestination::Removal,
+            Timestamp::new(200),
+            0,
+            Timestamp::new(140),
+        )
+        .err()
+        .unwrap_or_else(|| panic!("unrelated removal plan must not authorize a drain"));
+    assert!(matches!(error, PackageServiceError::BindingMismatch));
+}
+
+#[test]
+fn repeated_updates_monotonically_bump_package_generation() {
+    let fixture = Fixture::new();
+    let mut model = PackageServiceModel::new(policy(8));
+    install(&mut model, &fixture, 1);
+    let installed_generation = model
+        .slot_record(&fixture.slot(fixture.owner))
+        .and_then(|record| record.state())
+        .map(|state| state.generation_value().get())
+        .unwrap_or_else(|| panic!("installed state should exist"));
+    assert_eq!(installed_generation, 1);
+
+    let first = begin_update(&mut model, &fixture);
+    model
+        .prove_drain_leases(&first, 0, Timestamp::new(200))
+        .unwrap_or_else(|_| panic!("first drain should complete"));
+    model
+        .complete(
+            &first,
+            Some(&validated_artifact(13)),
+            None,
+            true,
+            Timestamp::new(220),
+        )
+        .unwrap_or_else(|_| panic!("first update should commit"));
+    let first_generation = model
+        .slot_record(&fixture.slot(fixture.owner))
+        .and_then(|record| record.state())
+        .map(|state| state.generation_value().get())
+        .unwrap_or_else(|| panic!("first updated state should exist"));
+    assert!(first_generation > installed_generation);
+
+    let second_state = model
+        .slot_record(&fixture.slot(fixture.owner))
+        .and_then(|record| record.state().map(CanonicalInstalledState::digest))
+        .unwrap_or_else(|| panic!("updated state should exist"));
+    let replacement_plan = match DrainPlan::new(
+        DrainDestination::Replacement,
+        ExpectedPackageState::Exact(second_state),
+        Timestamp::new(350),
+        Nonce::from_bytes([6; 32]),
+    ) {
+        Ok(value) => value,
+        Err(_) => panic!("replacement plan is valid"),
+    };
+    let second_context = fixture.context(
+        Operation::Update,
+        ExpectedPackageState::Exact(second_state),
+        replacement_plan.digest(),
+        (fixture.owner, fixture.caller),
+        1,
+        Nonce::from_bytes([6; 32]),
+    );
+    let second = fixture
+        .begin(&mut model, second_context, 300)
+        .unwrap_or_else(|_| panic!("second update should be admitted"));
+    model
+        .begin_drain(
+            &second,
+            DrainDestination::Replacement,
+            Timestamp::new(350),
+            0,
+            Timestamp::new(310),
+        )
+        .unwrap_or_else(|_| panic!("second drain should start"));
+    model
+        .complete(
+            &second,
+            Some(&validated_artifact(14)),
+            None,
+            true,
+            Timestamp::new(320),
+        )
+        .unwrap_or_else(|_| panic!("second update should commit"));
+    let second_generation = model
+        .slot_record(&fixture.slot(fixture.owner))
+        .and_then(|record| record.state())
+        .map(|state| state.generation_value().get())
+        .unwrap_or_else(|| panic!("second updated state should exist"));
+    assert!(second_generation > first_generation);
+}
+
+#[test]
+fn expired_intent_reaches_terminal_and_releases_slot() {
+    let fixture = Fixture::new();
+    let mut model = PackageServiceModel::new(policy_short_retention(1, 128));
+    let context = fixture.context_with_expiry(ContextOptions {
+        operation: Operation::Install,
+        expected: ExpectedPackageState::Absent,
+        plan: plan_digest(20),
+        participants: (fixture.owner, fixture.caller),
+        generation: 1,
+        nonce: Nonce::from_bytes([1; 32]),
+        expiry: Timestamp::new(400),
+    });
+    let nonce = fixture
+        .begin(&mut model, context, 100)
+        .unwrap_or_else(|_| panic!("intent should be admitted"));
+    model
+        .expire_unresolved(&nonce, Timestamp::new(500))
+        .unwrap_or_else(|_| panic!("expired intent should be terminal"));
+    assert_eq!(
+        model
+            .slot_record(&fixture.slot(fixture.owner))
+            .and_then(|record| record.journal_record(&nonce))
+            .map(OperationJournalRecord::status),
+        Some(JournalStatus::Expired)
+    );
+
+    let replacement = fixture.context_with_expiry(ContextOptions {
+        operation: Operation::Install,
+        expected: ExpectedPackageState::Absent,
+        plan: plan_digest(21),
+        participants: (fixture.owner, fixture.caller),
+        generation: 1,
+        nonce: Nonce::from_bytes([2; 32]),
+        expiry: Timestamp::new(1_400),
+    });
+    fixture
+        .begin(&mut model, replacement, 700)
+        .unwrap_or_else(|_| panic!("terminal expiry must not fence admission"));
+}

--- a/crates/astrid-package-service/src/lifecycle/tests/cure_tests.rs
+++ b/crates/astrid-package-service/src/lifecycle/tests/cure_tests.rs
@@ -1,14 +1,22 @@
 use super::*;
+use crate::journal::RecoveryEvidence;
 
 fn recovery_evidence(
     token: RecoveryToken,
     observed: StateDigest,
     generation: u64,
 ) -> RecoveryEvidence {
-    RecoveryEvidence::new(token, observed, non_zero(generation), None, false)
+    match RecoveryEvidence::new(token, observed, non_zero(generation), None, false) {
+        Ok(value) => value,
+        Err(error) => panic!("test recovery evidence is valid: {error:?}"),
+    }
 }
 
-fn begin_activation(model: &mut PackageServiceModel, fixture: &Fixture, nonce_byte: u8) -> Nonce {
+pub(super) fn begin_activation(
+    model: &mut PackageServiceModel,
+    fixture: &Fixture,
+    nonce_byte: u8,
+) -> Nonce {
     let state = model
         .slot_record(&fixture.slot(fixture.owner))
         .and_then(|record| record.state().map(CanonicalInstalledState::digest))
@@ -81,14 +89,15 @@ fn mid_drain_recovery_does_not_infer_update_success() {
     let old_evidence = recovery_evidence(token, prior.digest(), 1);
     model
         .recover(&nonce, &old_evidence, Timestamp::new(200))
-        .unwrap_or_else(|_| panic!("exact old-state evidence should resolve"));
+        .unwrap_or_else(|error| panic!("exact old-state evidence should resolve: {error:?}"));
     let restored = model
         .slot_record(&fixture.slot(fixture.owner))
         .and_then(|record| record.state())
         .cloned()
         .unwrap_or_else(|| panic!("restored state should exist"));
     assert_eq!(restored.lifecycle_state(), &LifecycleState::Inactive,);
-    assert!(restored.generation_value().get() > prior.generation_value().get());
+    assert_eq!(restored.generation_value().get(), 3);
+    assert_eq!(restored.completing_nonce(), nonce);
 }
 
 #[test]
@@ -105,13 +114,17 @@ fn recovery_rejects_a_token_mismatch() {
     model
         .mark_unknown(&nonce, Timestamp::new(180))
         .unwrap_or_else(|_| panic!("unknown boundary should be recorded"));
-    let evidence = RecoveryEvidence::new(
-        RecoveryToken::from_bytes([0; 32]),
-        prior.digest(),
-        non_zero(1),
-        None,
-        false,
+    assert!(
+        RecoveryEvidence::new(
+            RecoveryToken::from_bytes([0; 32]),
+            prior.digest(),
+            non_zero(1),
+            None,
+            false,
+        )
+        .is_err()
     );
+    let evidence = recovery_evidence(RecoveryToken::from_bytes([8; 32]), prior.digest(), 1);
     let error = model
         .recover(&nonce, &evidence, Timestamp::new(190))
         .err()
@@ -152,25 +165,39 @@ fn recovery_accepts_structurally_proven_new_update_state() {
         non_zero(3),
     )
     .unwrap_or_else(|_| panic!("new update state should construct"));
-    model
-        .slots
-        .get_mut(&slot)
-        .unwrap_or_else(|| panic!("owner slot should remain"))
-        .replace_state(Some(new_state.clone()));
     let token = model
         .slot_record(&slot)
         .and_then(|record| record.journal_record(&nonce))
         .map(OperationJournalRecord::recovery_token)
         .unwrap_or_else(|| panic!("recovery token should remain"));
-    let evidence = RecoveryEvidence::new(
+    let evidence = match RecoveryEvidence::new(
         token,
         new_state.digest(),
         new_state.generation_value(),
         None,
         true,
-    );
+    ) {
+        Ok(value) => value,
+        Err(error) => panic!("new-state recovery evidence is valid: {error:?}"),
+    };
+    let state_before_recovery = model
+        .slot_record(&slot)
+        .and_then(|record| record.state())
+        .cloned()
+        .unwrap_or_else(|| panic!("draining state should remain"));
+    for now in [200, 201] {
+        let error = model
+            .recover_observed(&nonce, &evidence, Some(&new_state), Timestamp::new(now))
+            .err()
+            .unwrap_or_else(|| panic!("late replacement recovery must fail"));
+        assert!(matches!(error, PackageServiceError::AuthorityExpired));
+        assert_eq!(
+            model.slot_record(&slot).and_then(|record| record.state()),
+            Some(&state_before_recovery)
+        );
+    }
     let receipt = model
-        .recover(&nonce, &evidence, Timestamp::new(200))
+        .recover_observed(&nonce, &evidence, Some(&new_state), Timestamp::new(199))
         .unwrap_or_else(|_| panic!("structural new-state proof should recover"))
         .unwrap_or_else(|| panic!("new-state proof should produce a receipt"));
     assert_eq!(receipt.outcome(), ReceiptOutcome::Updated);
@@ -191,15 +218,29 @@ fn active_drain_abort_and_expiry_restore_inactive_content() {
         .unwrap_or_else(|| panic!("active state should exist"));
 
     let update_nonce = begin_update(&mut model, &fixture);
+    let recovery_token = model
+        .slot_record(&fixture.slot(fixture.owner))
+        .and_then(|record| record.journal_record(&update_nonce))
+        .map(OperationJournalRecord::recovery_token)
+        .unwrap_or_else(|| panic!("recovery record should exist"));
     model
         .expire_drain(&update_nonce, Timestamp::new(250), false)
         .unwrap_or_else(|_| panic!("drain expiry should be observable"));
+    assert!(matches!(
+        model
+            .slot_record(&fixture.slot(fixture.owner))
+            .and_then(|record| record.state())
+            .map(CanonicalInstalledState::lifecycle_state),
+        Some(LifecycleState::Draining { live_leases: 1, .. })
+    ));
+    let blocked_evidence = recovery_evidence(
+        recovery_token,
+        active_before.digest(),
+        active_before.generation_value().get(),
+    );
     model
-        .prove_drain_leases(&update_nonce, 0, Timestamp::new(260))
-        .unwrap_or_else(|_| panic!("zero leases should become provable"));
-    model
-        .expire_drain(&update_nonce, Timestamp::new(270), true)
-        .unwrap_or_else(|_| panic!("proved drain should restore safely"));
+        .recover(&update_nonce, &blocked_evidence, Timestamp::new(260))
+        .unwrap_or_else(|error| panic!("blocked drain should recover old content: {error:?}"));
     let expired = model
         .slot_record(&fixture.slot(fixture.owner))
         .and_then(|record| record.state())
@@ -286,7 +327,7 @@ fn repeated_updates_monotonically_bump_package_generation() {
 
     let first = begin_update(&mut model, &fixture);
     model
-        .prove_drain_leases(&first, 0, Timestamp::new(200))
+        .prove_drain_leases(&first, 0, Timestamp::new(199))
         .unwrap_or_else(|_| panic!("first drain should complete"));
     model
         .complete(
@@ -294,7 +335,7 @@ fn repeated_updates_monotonically_bump_package_generation() {
             Some(&validated_artifact(13)),
             None,
             true,
-            Timestamp::new(220),
+            Timestamp::new(199),
         )
         .unwrap_or_else(|_| panic!("first update should commit"));
     let first_generation = model

--- a/crates/astrid-package-service/src/lifecycle/tests/cure_tests.rs
+++ b/crates/astrid-package-service/src/lifecycle/tests/cure_tests.rs
@@ -65,13 +65,17 @@ fn mid_drain_recovery_does_not_infer_update_success() {
     let draining_generation = model
         .slot_record(&fixture.slot(fixture.owner))
         .and_then(|record| record.state())
-        .map(|state| state.generation_value())
-        .unwrap_or_else(|| panic!("draining generation should exist"));
+        .map_or_else(
+            || panic!("draining generation should exist"),
+            crate::state::CanonicalInstalledState::generation_value,
+        );
     let token = model
         .slot_record(&fixture.slot(fixture.owner))
         .and_then(|record| record.journal_record(&nonce))
-        .map(OperationJournalRecord::recovery_token)
-        .unwrap_or_else(|| panic!("recovery record should exist"));
+        .map_or_else(
+            || panic!("recovery record should exist"),
+            OperationJournalRecord::recovery_token,
+        );
     let false_success = recovery_evidence(token, draining, draining_generation.get());
     let error = model
         .recover(&nonce, &false_success, Timestamp::new(190))
@@ -155,8 +159,10 @@ fn recovery_accepts_structurally_proven_new_update_state() {
     let authority_digest = model
         .slot_record(&slot)
         .and_then(|record| record.journal_record(&nonce))
-        .map(|record| *record.authority_digest())
-        .unwrap_or_else(|| panic!("unknown authority should remain"));
+        .map_or_else(
+            || panic!("unknown authority should remain"),
+            |record| *record.authority_digest(),
+        );
     let new_state = new_installed_state(
         &context,
         authority_digest,
@@ -168,8 +174,10 @@ fn recovery_accepts_structurally_proven_new_update_state() {
     let token = model
         .slot_record(&slot)
         .and_then(|record| record.journal_record(&nonce))
-        .map(OperationJournalRecord::recovery_token)
-        .unwrap_or_else(|| panic!("recovery token should remain"));
+        .map_or_else(
+            || panic!("recovery token should remain"),
+            OperationJournalRecord::recovery_token,
+        );
     let evidence = match RecoveryEvidence::new(
         token,
         new_state.digest(),
@@ -221,8 +229,10 @@ fn active_drain_abort_and_expiry_restore_inactive_content() {
     let recovery_token = model
         .slot_record(&fixture.slot(fixture.owner))
         .and_then(|record| record.journal_record(&update_nonce))
-        .map(OperationJournalRecord::recovery_token)
-        .unwrap_or_else(|| panic!("recovery record should exist"));
+        .map_or_else(
+            || panic!("recovery record should exist"),
+            OperationJournalRecord::recovery_token,
+        );
     model
         .expire_drain(&update_nonce, Timestamp::new(250), false)
         .unwrap_or_else(|_| panic!("drain expiry should be observable"));
@@ -321,8 +331,10 @@ fn repeated_updates_monotonically_bump_package_generation() {
     let installed_generation = model
         .slot_record(&fixture.slot(fixture.owner))
         .and_then(|record| record.state())
-        .map(|state| state.generation_value().get())
-        .unwrap_or_else(|| panic!("installed state should exist"));
+        .map_or_else(
+            || panic!("installed state should exist"),
+            |state| state.generation_value().get(),
+        );
     assert_eq!(installed_generation, 1);
 
     let first = begin_update(&mut model, &fixture);
@@ -341,15 +353,17 @@ fn repeated_updates_monotonically_bump_package_generation() {
     let first_generation = model
         .slot_record(&fixture.slot(fixture.owner))
         .and_then(|record| record.state())
-        .map(|state| state.generation_value().get())
-        .unwrap_or_else(|| panic!("first updated state should exist"));
+        .map_or_else(
+            || panic!("first updated state should exist"),
+            |state| state.generation_value().get(),
+        );
     assert!(first_generation > installed_generation);
 
     let second_state = model
         .slot_record(&fixture.slot(fixture.owner))
         .and_then(|record| record.state().map(CanonicalInstalledState::digest))
         .unwrap_or_else(|| panic!("updated state should exist"));
-    let second_artifact = validated_artifact(14);
+    let second_artifact = validated_artifact(13);
     let second_plan = match DrainPlan::new(
         DrainDestination::Replacement,
         ExpectedPackageState::Exact(second_state),
@@ -357,7 +371,7 @@ fn repeated_updates_monotonically_bump_package_generation() {
         Nonce::from_bytes([6; 32]),
     ) {
         Ok(value) => value,
-        Err(_) => panic!("second replacement plan is valid"),
+        Err(error) => panic!("second replacement plan is valid: {error:?}"),
     };
     let second_context = fixture.context(
         Operation::Update,
@@ -394,8 +408,10 @@ fn repeated_updates_monotonically_bump_package_generation() {
     let second_generation = model
         .slot_record(&fixture.slot(fixture.owner))
         .and_then(|record| record.state())
-        .map(|state| state.generation_value().get())
-        .unwrap_or_else(|| panic!("second updated state should exist"));
+        .map_or_else(
+            || panic!("second updated state should exist"),
+            |state| state.generation_value().get(),
+        );
     assert!(second_generation > first_generation);
 }
 
@@ -438,13 +454,17 @@ fn install_recovery_rejects_arbitrary_content_and_provenance() {
     let authority = model
         .slot_record(&slot)
         .and_then(|record| record.journal_record(&operation))
-        .map(|record| *record.authority_digest())
-        .unwrap_or_else(|| panic!("install authority should remain"));
+        .map_or_else(
+            || panic!("install authority should remain"),
+            |record| *record.authority_digest(),
+        );
     let token = model
         .slot_record(&slot)
         .and_then(|record| record.journal_record(&operation))
-        .map(OperationJournalRecord::recovery_token)
-        .unwrap_or_else(|| panic!("install token should remain"));
+        .map_or_else(
+            || panic!("install token should remain"),
+            OperationJournalRecord::recovery_token,
+        );
     let operation_context = model
         .context_for(&operation)
         .unwrap_or_else(|error| panic!("{error:?}"));
@@ -494,7 +514,7 @@ fn install_recovery_rejects_arbitrary_content_and_provenance() {
 fn expired_intent_reaches_terminal_and_releases_slot() {
     let fixture = Fixture::new();
     let mut model = PackageServiceModel::new(policy_short_retention(1, 128));
-    let context = fixture.context_with_expiry(ContextOptions {
+    let context = fixture.context_with_expiry(&ContextOptions {
         operation: Operation::Install,
         expected: ExpectedPackageState::Absent,
         plan: plan_digest(20),
@@ -517,7 +537,7 @@ fn expired_intent_reaches_terminal_and_releases_slot() {
         Some(JournalStatus::Expired)
     );
 
-    let replacement = fixture.context_with_expiry(ContextOptions {
+    let replacement = fixture.context_with_expiry(&ContextOptions {
         operation: Operation::Install,
         expected: ExpectedPackageState::Absent,
         plan: plan_digest(21),

--- a/crates/astrid-package-service/src/lifecycle/tests/highwater_tests.rs
+++ b/crates/astrid-package-service/src/lifecycle/tests/highwater_tests.rs
@@ -1,0 +1,207 @@
+use super::*;
+use crate::journal::RecoveryEvidence;
+
+fn high_watermark(model: &PackageServiceModel, fixture: &Fixture) -> NonZeroU64 {
+    model
+        .slot_record(&fixture.slot(fixture.owner))
+        .and_then(PackageSlotRecord::generation_high_watermark)
+        .unwrap_or_else(|| panic!("absence must retain the slot high-watermark"))
+}
+
+fn install_after_removal(model: &mut PackageServiceModel, fixture: &Fixture) -> OperationReceipt {
+    install(model, fixture, 4)
+}
+
+#[test]
+fn direct_removal_then_reinstall_uses_the_high_watermark_successor() {
+    let fixture = Fixture::new();
+    let mut model = PackageServiceModel::new(policy(8));
+    install(&mut model, &fixture, 1);
+    assert_eq!(high_watermark(&model, &fixture).get(), 1);
+
+    let nonce = begin_remove(&mut model, &fixture);
+    model
+        .prove_drain_leases(&nonce, 0, Timestamp::new(399))
+        .unwrap_or_else(|error| panic!("zero leases should prove: {error:?}"));
+    assert_eq!(high_watermark(&model, &fixture).get(), 3);
+    model
+        .complete(&nonce, None, None, true, Timestamp::new(399))
+        .unwrap_or_else(|error| panic!("direct removal should commit: {error:?}"));
+    assert!(model.slot_record(&fixture.slot(fixture.owner)).is_some());
+    assert!(
+        model
+            .slot_record(&fixture.slot(fixture.owner))
+            .and_then(PackageSlotRecord::state)
+            .is_none()
+    );
+    assert_eq!(high_watermark(&model, &fixture).get(), 4);
+
+    install_after_removal(&mut model, &fixture);
+    let reinstalled = model
+        .slot_record(&fixture.slot(fixture.owner))
+        .and_then(PackageSlotRecord::state)
+        .unwrap_or_else(|| panic!("reinstalled state should exist"));
+    assert_eq!(reinstalled.generation_value().get(), 5);
+    assert_eq!(high_watermark(&model, &fixture).get(), 5);
+}
+
+#[test]
+fn removal_deadline_expiry_then_reinstall_uses_the_high_watermark_successor() {
+    let fixture = Fixture::new();
+    let mut model = PackageServiceModel::new(policy(8));
+    install(&mut model, &fixture, 1);
+    let nonce = begin_remove(&mut model, &fixture);
+    model
+        .prove_drain_leases(&nonce, 0, Timestamp::new(399))
+        .unwrap_or_else(|error| panic!("zero leases should prove: {error:?}"));
+    let result = model
+        .expire_drain(&nonce, Timestamp::new(400), true)
+        .unwrap_or_else(|error| panic!("removal deadline should expire: {error:?}"));
+    assert_eq!(result, DrainResult::Completed);
+    assert_eq!(high_watermark(&model, &fixture).get(), 4);
+
+    install_after_removal(&mut model, &fixture);
+    let reinstalled = model
+        .slot_record(&fixture.slot(fixture.owner))
+        .and_then(PackageSlotRecord::state)
+        .unwrap_or_else(|| panic!("reinstalled state should exist"));
+    assert_eq!(reinstalled.generation_value().get(), 5);
+    assert_eq!(high_watermark(&model, &fixture).get(), 5);
+}
+
+#[test]
+fn unknown_removal_recovery_then_reinstall_uses_the_high_watermark_successor() {
+    let fixture = Fixture::new();
+    let mut model = PackageServiceModel::new(policy(8));
+    install(&mut model, &fixture, 1);
+    let nonce = begin_remove(&mut model, &fixture);
+    model
+        .prove_drain_leases(&nonce, 0, Timestamp::new(399))
+        .unwrap_or_else(|error| panic!("zero leases should prove: {error:?}"));
+    model
+        .mark_unknown(&nonce, Timestamp::new(399))
+        .unwrap_or_else(|error| panic!("removal should become unknown: {error:?}"));
+    let token = model
+        .slot_record(&fixture.slot(fixture.owner))
+        .and_then(|record| record.journal_record(&nonce))
+        .map_or_else(
+            || panic!("unknown removal should retain its token"),
+            OperationJournalRecord::recovery_token,
+        );
+    let evidence = RecoveryEvidence::new(
+        token,
+        StateDigest::from_bytes([0; 32]),
+        non_zero(4),
+        None,
+        true,
+    )
+    .unwrap_or_else(|error| panic!("absence evidence should construct: {error:?}"));
+    let receipt = model
+        .recover_observed(&nonce, &evidence, None, Timestamp::new(399))
+        .unwrap_or_else(|error| panic!("unknown removal should recover: {error:?}"))
+        .unwrap_or_else(|| panic!("absence recovery should produce a receipt"));
+    assert_eq!(receipt.state_generation().get(), 4);
+    assert_eq!(high_watermark(&model, &fixture).get(), 4);
+
+    install_after_removal(&mut model, &fixture);
+    let reinstalled = model
+        .slot_record(&fixture.slot(fixture.owner))
+        .and_then(PackageSlotRecord::state)
+        .unwrap_or_else(|| panic!("reinstalled state should exist"));
+    assert_eq!(reinstalled.generation_value().get(), 5);
+    assert_eq!(high_watermark(&model, &fixture).get(), 5);
+}
+
+#[test]
+fn collection_retains_the_high_watermark_for_reinstall() {
+    let fixture = Fixture::new();
+    let mut model = PackageServiceModel::new(policy_short_retention(8, 128));
+    install(&mut model, &fixture, 1);
+    let nonce = begin_remove(&mut model, &fixture);
+    model
+        .prove_drain_leases(&nonce, 0, Timestamp::new(399))
+        .unwrap_or_else(|error| panic!("zero leases should prove: {error:?}"));
+    model
+        .complete(&nonce, None, None, true, Timestamp::new(399))
+        .unwrap_or_else(|error| panic!("removal should commit: {error:?}"));
+    assert_eq!(high_watermark(&model, &fixture).get(), 4);
+
+    let collected = model
+        .collect(Timestamp::new(600), 8)
+        .unwrap_or_else(|error| panic!("terminal records should collect: {error:?}"));
+    assert_eq!(collected, 1);
+    assert!(
+        model
+            .slot_record(&fixture.slot(fixture.owner))
+            .and_then(|record| record.journal_values().next())
+            .is_none()
+    );
+    assert_eq!(high_watermark(&model, &fixture).get(), 4);
+
+    install_after_removal(&mut model, &fixture);
+    let reinstalled = model
+        .slot_record(&fixture.slot(fixture.owner))
+        .and_then(PackageSlotRecord::state)
+        .unwrap_or_else(|| panic!("reinstalled state should exist"));
+    assert_eq!(reinstalled.generation_value().get(), 5);
+    assert_eq!(high_watermark(&model, &fixture).get(), 5);
+}
+
+#[test]
+fn max_high_watermark_refuses_every_successor_before_transition() {
+    let max = non_zero(u64::MAX);
+    let install_error = next_generation_from_high_watermark(Some(max), Operation::Install)
+        .err()
+        .unwrap_or_else(|| panic!("install successor must overflow"));
+    let lifecycle_error = next_generation_from_high_watermark(Some(max), Operation::Remove)
+        .err()
+        .unwrap_or_else(|| panic!("lifecycle successor must overflow"));
+    assert!(matches!(
+        install_error,
+        PackageServiceError::GenerationOverflow
+    ));
+    assert!(matches!(
+        lifecycle_error,
+        PackageServiceError::GenerationOverflow
+    ));
+}
+
+#[test]
+fn max_watermark_admission_fails_without_state_or_journal_effect() {
+    let fixture = Fixture::new();
+    let mut model = PackageServiceModel::new(policy(8));
+    let slot = fixture.slot(fixture.owner);
+    let mut record = PackageSlotRecord::default();
+    record.force_generation_high_watermark_for_test(non_zero(u64::MAX));
+    model.slots.insert(slot, record);
+    let context = fixture.context(
+        Operation::Install,
+        ExpectedPackageState::Absent,
+        plan_digest(20),
+        (fixture.owner, fixture.caller),
+        1,
+        Nonce::from_bytes([1; 32]),
+    );
+    let authority = fixture.authority(&context);
+
+    let error = model
+        .begin(
+            context,
+            &authority,
+            fixture.ingress,
+            &fixture.service_at(1),
+            Timestamp::new(100),
+        )
+        .err()
+        .unwrap_or_else(|| panic!("maximum watermark must refuse a successor"));
+    assert!(matches!(error, PackageServiceError::GenerationOverflow));
+    let Some(record) = model.slots.get(&slot) else {
+        panic!("failed admission must retain the slot record");
+    };
+    assert_eq!(record.generation_high_watermark(), Some(non_zero(u64::MAX)));
+    assert!(record.state().is_none());
+    assert!(record.journal_values().next().is_none());
+    assert!(model.nonce_locations.is_empty());
+    assert!(model.tombstones.is_empty());
+    assert_eq!(model.occupancy(), Occupancy::default());
+}

--- a/crates/astrid-package-service/src/lifecycle/tests/lineage_tests.rs
+++ b/crates/astrid-package-service/src/lifecycle/tests/lineage_tests.rs
@@ -34,6 +34,7 @@ fn drain_to_boundary(
     let mut model = PackageServiceModel::new(policy(8));
     install(&mut model, &fixture, 1);
     let base = current_state(&model, &fixture);
+    assert_eq!(base.generation_value().get(), 1);
     let nonce = begin_update(&mut model, &fixture);
     for proof in 0..proof_count {
         model
@@ -43,6 +44,15 @@ fn drain_to_boundary(
                 Timestamp::new(150),
             )
             .unwrap_or_else(|error| panic!("drain proof should advance: {error:?}"));
+        let expected_boundary = 2 + proof as u64 + 1;
+        let proved = current_state(&model, &fixture);
+        assert_eq!(proved.generation_value().get(), expected_boundary);
+        let lineage = model
+            .slot_record(&fixture.slot(fixture.owner))
+            .and_then(|record| record.journal_record(&nonce))
+            .and_then(OperationJournalRecord::drain_lineage)
+            .unwrap_or_else(|| panic!("drain lineage should remain"));
+        assert_eq!(lineage.boundary_generation().get(), expected_boundary);
     }
     (fixture, model, base, nonce)
 }
@@ -73,8 +83,7 @@ fn drain_resolution_restores_the_exact_successor_of_the_boundary() {
             DrainResolution::Recover,
         ] {
             let (fixture, mut model, base, nonce) = drain_to_boundary(proof_count);
-            let boundary = current_state(&model, &fixture).generation_value().get();
-            let expected_generation = boundary + 1;
+            let expected_generation = 2 + proof_count as u64 + 1;
             let token = model
                 .slot_record(&fixture.slot(fixture.owner))
                 .and_then(|record| record.journal_record(&nonce))
@@ -119,6 +128,18 @@ fn drain_resolution_restores_the_exact_successor_of_the_boundary() {
             );
         }
     }
+}
+
+#[test]
+fn proof_oracle_refuses_a_reset_on_each_proof() {
+    let (fixture, model, _base, nonce) = drain_to_boundary(2);
+    let lineage = model
+        .slot_record(&fixture.slot(fixture.owner))
+        .and_then(|record| record.journal_record(&nonce))
+        .and_then(OperationJournalRecord::drain_lineage)
+        .unwrap_or_else(|| panic!("drain lineage should remain"));
+    assert_eq!(lineage.boundary_generation().get(), 4);
+    assert_ne!(lineage.boundary_generation().get(), 3);
 }
 
 fn reject_old_evidence(
@@ -202,30 +223,150 @@ fn old_state_recovery_rejects_every_noncanonical_generation_claim() {
     model
         .mark_unknown(&nonce, Timestamp::new(160))
         .unwrap_or_else(|error| panic!("{error:?}"));
-    let boundary = current_state(&model, &fixture).generation_value().get();
+    let boundary = 1 + 2 + 1 + 2;
     assert_eq!(boundary, 6);
+    assert_eq!(
+        current_state(&model, &fixture).generation_value().get(),
+        boundary
+    );
     let service_generation = model
         .slot_record(&fixture.slot(fixture.owner))
         .and_then(|record| record.journal_record(&nonce))
         .map(|record| non_zero(record.context().service_generation().get()))
         .unwrap_or_else(|| panic!("service generation should remain"));
 
-    reject_old_evidence(
-        &mut model,
-        &fixture,
-        &nonce,
-        None,
-        non_zero(base.generation_value().get() - 1),
-    );
-    reject_old_evidence(
-        &mut model,
-        &fixture,
-        &nonce,
-        None,
-        non_zero(base.generation_value().get() + 1),
-    );
+    reject_old_evidence(&mut model, &fixture, &nonce, None, non_zero(2));
+    reject_old_evidence(&mut model, &fixture, &nonce, None, non_zero(4));
     reject_old_evidence(&mut model, &fixture, &nonce, None, non_zero(boundary + 2));
     reject_old_evidence(&mut model, &fixture, &nonce, None, service_generation);
+}
+
+#[test]
+fn absence_recovery_requires_the_recorded_removal_lineage() {
+    let fixture = Fixture::new();
+    let mut model = PackageServiceModel::new(policy(8));
+    install(&mut model, &fixture, 1);
+    let state = current_state(&model, &fixture).digest();
+    let plan = match DrainPlan::new(
+        DrainDestination::Removal,
+        ExpectedPackageState::Exact(state),
+        Timestamp::new(400),
+        Nonce::from_bytes([3; 32]),
+    ) {
+        Ok(value) => value,
+        Err(error) => panic!("{error:?}"),
+    };
+    let context = fixture.context(
+        Operation::Remove,
+        ExpectedPackageState::Exact(state),
+        plan.digest(),
+        (fixture.owner, fixture.caller),
+        1,
+        Nonce::from_bytes([3; 32]),
+    );
+    let nonce = fixture
+        .begin(&mut model, context, 300)
+        .unwrap_or_else(|error| panic!("{error:?}"));
+    model
+        .begin_work(&nonce, Timestamp::new(310))
+        .unwrap_or_else(|error| panic!("{error:?}"));
+    model
+        .mark_unknown(&nonce, Timestamp::new(320))
+        .unwrap_or_else(|error| panic!("{error:?}"));
+    let token = model
+        .slot_record(&fixture.slot(fixture.owner))
+        .and_then(|record| record.journal_record(&nonce))
+        .map(OperationJournalRecord::recovery_token)
+        .unwrap_or_else(|| panic!("no-drain token should remain"));
+    let evidence = match RecoveryEvidence::new(
+        token,
+        StateDigest::from_bytes([0; 32]),
+        non_zero(2),
+        None,
+        true,
+    ) {
+        Ok(value) => value,
+        Err(error) => panic!("{error:?}"),
+    };
+    let error = model
+        .recover_observed(&nonce, &evidence, None, Timestamp::new(330))
+        .err()
+        .unwrap_or_else(|| panic!("absence without drain lineage must fail"));
+    assert!(matches!(error, PackageServiceError::RecoveryUnresolved));
+}
+
+#[test]
+fn exact_removal_recovery_clears_lineage_and_retains_terminal_receipt() {
+    let fixture = Fixture::new();
+    let mut model = PackageServiceModel::new(policy(8));
+    install(&mut model, &fixture, 1);
+    let base = current_state(&model, &fixture);
+    let nonce = begin_remove(&mut model, &fixture);
+    model
+        .prove_drain_leases(&nonce, 0, Timestamp::new(399))
+        .unwrap_or_else(|error| panic!("{error:?}"));
+    model
+        .mark_unknown(&nonce, Timestamp::new(399))
+        .unwrap_or_else(|error| panic!("{error:?}"));
+    let token = model
+        .slot_record(&fixture.slot(fixture.owner))
+        .and_then(|record| record.journal_record(&nonce))
+        .map(OperationJournalRecord::recovery_token)
+        .unwrap_or_else(|| panic!("removal token should remain"));
+    let old_receipt = match RecoveryEvidence::new(
+        token,
+        base.digest(),
+        base.generation_value(),
+        Some(digest(31)),
+        true,
+    ) {
+        Ok(value) => value,
+        Err(error) => panic!("{error:?}"),
+    };
+    let error = model
+        .recover_observed(&nonce, &old_receipt, Some(&base), Timestamp::new(399))
+        .err()
+        .unwrap_or_else(|| panic!("unexpected old-state receipt must fail"));
+    assert!(matches!(error, PackageServiceError::BindingMismatch));
+
+    let receipt_evidence = match RecoveryEvidence::new(
+        token,
+        StateDigest::from_bytes([0; 32]),
+        non_zero(4),
+        Some(digest(31)),
+        true,
+    ) {
+        Ok(value) => value,
+        Err(error) => panic!("{error:?}"),
+    };
+    let error = model
+        .recover_observed(&nonce, &receipt_evidence, None, Timestamp::new(399))
+        .err()
+        .unwrap_or_else(|| panic!("unexpected absence receipt must fail"));
+    assert!(matches!(error, PackageServiceError::BindingMismatch));
+
+    let evidence = match RecoveryEvidence::new(
+        token,
+        StateDigest::from_bytes([0; 32]),
+        non_zero(4),
+        None,
+        true,
+    ) {
+        Ok(value) => value,
+        Err(error) => panic!("{error:?}"),
+    };
+    let receipt = model
+        .recover_observed(&nonce, &evidence, None, Timestamp::new(399))
+        .unwrap_or_else(|error| panic!("{error:?}"))
+        .unwrap_or_else(|| panic!("exact absence proof should commit"));
+    assert_eq!(receipt.outcome(), ReceiptOutcome::Retired);
+    let journal = model
+        .slot_record(&fixture.slot(fixture.owner))
+        .and_then(|record| record.journal_record(&nonce))
+        .unwrap_or_else(|| panic!("terminal receipt should remain"));
+    assert!(journal.drain_lineage().is_none());
+    assert_eq!(journal.state_generation(), Some(non_zero(4)));
+    assert_eq!(journal.status(), JournalStatus::Committed);
 }
 
 #[test]

--- a/crates/astrid-package-service/src/lifecycle/tests/lineage_tests.rs
+++ b/crates/astrid-package-service/src/lifecycle/tests/lineage_tests.rs
@@ -1,0 +1,273 @@
+use super::cure_tests::begin_activation;
+use super::*;
+use crate::digest::ProvenanceDigest;
+use crate::journal::RecoveryEvidence;
+use crate::state::InstalledStateSpec;
+
+#[derive(Clone, Copy)]
+enum DrainResolution {
+    Cancel,
+    Expire,
+    Recover,
+}
+
+fn recovery_evidence_for(
+    token: RecoveryToken,
+    observed: StateDigest,
+    generation: NonZeroU64,
+) -> PackageServiceResult<RecoveryEvidence> {
+    RecoveryEvidence::new(token, observed, generation, None, true)
+}
+
+fn current_state(model: &PackageServiceModel, fixture: &Fixture) -> CanonicalInstalledState {
+    model
+        .slot_record(&fixture.slot(fixture.owner))
+        .and_then(PackageSlotRecord::state)
+        .cloned()
+        .unwrap_or_else(|| panic!("canonical state should exist"))
+}
+
+fn drain_to_boundary(
+    proof_count: usize,
+) -> (Fixture, PackageServiceModel, CanonicalInstalledState, Nonce) {
+    let fixture = Fixture::new();
+    let mut model = PackageServiceModel::new(policy(8));
+    install(&mut model, &fixture, 1);
+    let base = current_state(&model, &fixture);
+    let nonce = begin_update(&mut model, &fixture);
+    for proof in 0..proof_count {
+        model
+            .prove_drain_leases(
+                &nonce,
+                u32::try_from(proof + 10).unwrap_or(u32::MAX),
+                Timestamp::new(150),
+            )
+            .unwrap_or_else(|error| panic!("drain proof should advance: {error:?}"));
+    }
+    (fixture, model, base, nonce)
+}
+
+fn assert_base_content(
+    restored: &CanonicalInstalledState,
+    base: &CanonicalInstalledState,
+    nonce: &Nonce,
+    generation: u64,
+) {
+    assert_eq!(restored.artifact(), base.artifact());
+    assert_eq!(restored.content_root(), base.content_root());
+    assert_eq!(restored.manifest(), base.manifest());
+    assert_eq!(restored.authority_digest(), base.authority_digest());
+    assert_eq!(restored.provenance(), base.provenance());
+    assert_eq!(restored.lifecycle_plan(), base.lifecycle_plan());
+    assert_eq!(restored.lifecycle_state(), &LifecycleState::Inactive);
+    assert_eq!(restored.completing_nonce(), *nonce);
+    assert_eq!(restored.generation_value().get(), generation);
+}
+
+#[test]
+fn drain_resolution_restores_the_exact_successor_of_the_boundary() {
+    for proof_count in [0, 1, 3] {
+        for resolution in [
+            DrainResolution::Cancel,
+            DrainResolution::Expire,
+            DrainResolution::Recover,
+        ] {
+            let (fixture, mut model, base, nonce) = drain_to_boundary(proof_count);
+            let boundary = current_state(&model, &fixture).generation_value().get();
+            let expected_generation = boundary + 1;
+            let token = model
+                .slot_record(&fixture.slot(fixture.owner))
+                .and_then(|record| record.journal_record(&nonce))
+                .map(OperationJournalRecord::recovery_token)
+                .unwrap_or_else(|| panic!("drain record should remain"));
+
+            match resolution {
+                DrainResolution::Cancel => {
+                    model
+                        .cancel(&nonce, Timestamp::new(150))
+                        .unwrap_or_else(|error| panic!("drain cancel should resolve: {error:?}"));
+                },
+                DrainResolution::Expire => {
+                    let result = model
+                        .expire_drain(&nonce, Timestamp::new(250), true)
+                        .unwrap_or_else(|error| panic!("drain expiry should resolve: {error:?}"));
+                    assert_eq!(result, DrainResult::Completed);
+                },
+                DrainResolution::Recover => {
+                    model
+                        .mark_unknown(&nonce, Timestamp::new(160))
+                        .unwrap_or_else(|error| panic!("drain should become unknown: {error:?}"));
+                    let evidence =
+                        recovery_evidence_for(token, base.digest(), base.generation_value())
+                            .unwrap_or_else(|error| panic!("{error:?}"));
+                    model
+                        .recover(&nonce, &evidence, Timestamp::new(190))
+                        .unwrap_or_else(|error| {
+                            panic!("old-state recovery should resolve: {error:?}")
+                        });
+                },
+            }
+
+            let restored = current_state(&model, &fixture);
+            assert_base_content(&restored, &base, &nonce, expected_generation);
+            assert_eq!(
+                model
+                    .slot_record(&fixture.slot(fixture.owner))
+                    .and_then(|record| record.journal_record(&nonce))
+                    .map(OperationJournalRecord::state_generation),
+                Some(Some(non_zero(expected_generation)))
+            );
+        }
+    }
+}
+
+fn reject_old_evidence(
+    model: &mut PackageServiceModel,
+    fixture: &Fixture,
+    nonce: &Nonce,
+    observed: Option<&CanonicalInstalledState>,
+    generation: NonZeroU64,
+) {
+    let token = model
+        .slot_record(&fixture.slot(fixture.owner))
+        .and_then(|record| record.journal_record(nonce))
+        .map(OperationJournalRecord::recovery_token)
+        .unwrap_or_else(|| panic!("recovery token should remain"));
+    let base_digest = model
+        .slot_record(&fixture.slot(fixture.owner))
+        .and_then(|record| record.journal_record(nonce))
+        .map(OperationJournalRecord::before_state)
+        .unwrap_or_else(|| panic!("operation boundary should remain"));
+    let evidence = recovery_evidence_for(token, base_digest, generation)
+        .unwrap_or_else(|error| panic!("{error:?}"));
+    let before = current_state(model, fixture);
+    let error = match observed {
+        Some(observed) => model
+            .recover_observed(nonce, &evidence, Some(observed), Timestamp::new(190))
+            .err()
+            .unwrap_or_else(|| panic!("non-canonical generation must fail closed")),
+        None => model
+            .recover(nonce, &evidence, Timestamp::new(190))
+            .err()
+            .unwrap_or_else(|| panic!("non-canonical generation must fail closed")),
+    };
+    assert!(matches!(error, PackageServiceError::RecoveryUnresolved));
+    assert_eq!(current_state(model, fixture), before);
+    assert_eq!(
+        model
+            .slot_record(&fixture.slot(fixture.owner))
+            .and_then(|record| record.journal_record(nonce))
+            .map(OperationJournalRecord::status),
+        Some(JournalStatus::Unknown)
+    );
+}
+
+#[test]
+fn old_state_recovery_rejects_every_noncanonical_generation_claim() {
+    let fixture = Fixture::new();
+    let mut model = PackageServiceModel::new(policy(8));
+    install(&mut model, &fixture, 1);
+    begin_activation(&mut model, &fixture, 8);
+    let lifecycle_plan = ExpectedPackageState::Exact(current_state(&model, &fixture).digest())
+        .lifecycle_plan_digest(Operation::Deactivate)
+        .unwrap_or_else(|error| panic!("{error:?}"));
+    let state = current_state(&model, &fixture).digest();
+    let context = fixture.context(
+        Operation::Deactivate,
+        ExpectedPackageState::Exact(state),
+        lifecycle_plan,
+        (fixture.owner, fixture.caller),
+        1,
+        Nonce::from_bytes([9; 32]),
+    );
+    let lifecycle_nonce = fixture
+        .begin(&mut model, context, 125)
+        .unwrap_or_else(|error| panic!("{error:?}"));
+    model
+        .begin_work(&lifecycle_nonce, Timestamp::new(130))
+        .unwrap_or_else(|error| panic!("{error:?}"));
+    model
+        .complete(&lifecycle_nonce, None, None, true, Timestamp::new(135))
+        .unwrap_or_else(|error| panic!("{error:?}"));
+
+    let base = current_state(&model, &fixture);
+    assert_eq!(base.generation_value().get(), 3);
+    let nonce = begin_update(&mut model, &fixture);
+    model
+        .prove_drain_leases(&nonce, 17, Timestamp::new(145))
+        .unwrap_or_else(|error| panic!("{error:?}"));
+    model
+        .prove_drain_leases(&nonce, 0, Timestamp::new(150))
+        .unwrap_or_else(|error| panic!("{error:?}"));
+    model
+        .mark_unknown(&nonce, Timestamp::new(160))
+        .unwrap_or_else(|error| panic!("{error:?}"));
+    let boundary = current_state(&model, &fixture).generation_value().get();
+    assert_eq!(boundary, 6);
+    let service_generation = model
+        .slot_record(&fixture.slot(fixture.owner))
+        .and_then(|record| record.journal_record(&nonce))
+        .map(|record| non_zero(record.context().service_generation().get()))
+        .unwrap_or_else(|| panic!("service generation should remain"));
+
+    reject_old_evidence(
+        &mut model,
+        &fixture,
+        &nonce,
+        None,
+        non_zero(base.generation_value().get() - 1),
+    );
+    reject_old_evidence(
+        &mut model,
+        &fixture,
+        &nonce,
+        None,
+        non_zero(base.generation_value().get() + 1),
+    );
+    reject_old_evidence(&mut model, &fixture, &nonce, None, non_zero(boundary + 2));
+    reject_old_evidence(&mut model, &fixture, &nonce, None, service_generation);
+}
+
+#[test]
+fn old_state_recovery_rejects_a_mutated_spoof_of_the_base() {
+    let fixture = Fixture::new();
+    let mut model = PackageServiceModel::new(policy(8));
+    install(&mut model, &fixture, 1);
+    begin_activation(&mut model, &fixture, 8);
+    let base = current_state(&model, &fixture);
+    let nonce = begin_update(&mut model, &fixture);
+    model
+        .prove_drain_leases(&nonce, 0, Timestamp::new(150))
+        .unwrap_or_else(|error| panic!("{error:?}"));
+    model
+        .mark_unknown(&nonce, Timestamp::new(160))
+        .unwrap_or_else(|error| panic!("{error:?}"));
+
+    let authority = model
+        .slot_record(&fixture.slot(fixture.owner))
+        .and_then(|record| record.journal_record(&nonce))
+        .map(|record| *record.authority_digest())
+        .unwrap_or_else(|| panic!("drain authority should remain"));
+    let spoofed = CanonicalInstalledState::new(InstalledStateSpec {
+        owner: base.slot().owner(),
+        package_object: base.slot().package_object(),
+        artifact: *base.artifact(),
+        content_root: *base.content_root(),
+        manifest: base.manifest().clone(),
+        authority_digest: authority,
+        provenance: ProvenanceDigest::from_bytes([25; 32]),
+        lifecycle_state: *base.lifecycle_state(),
+        lifecycle_plan: *base.lifecycle_plan(),
+        generation: base.generation_value(),
+        completing_nonce: base.completing_nonce(),
+    })
+    .unwrap_or_else(|error| panic!("{error:?}"));
+    assert_ne!(spoofed.digest(), base.digest());
+    reject_old_evidence(
+        &mut model,
+        &fixture,
+        &nonce,
+        Some(&spoofed),
+        base.generation_value(),
+    );
+}

--- a/crates/astrid-package-service/src/lifecycle/tests/lineage_tests.rs
+++ b/crates/astrid-package-service/src/lifecycle/tests/lineage_tests.rs
@@ -40,11 +40,19 @@ fn drain_to_boundary(
         model
             .prove_drain_leases(
                 &nonce,
-                u32::try_from(proof + 10).unwrap_or(u32::MAX),
+                u32::try_from(proof)
+                    .ok()
+                    .and_then(|proof| proof.checked_add(10))
+                    .unwrap_or(u32::MAX),
                 Timestamp::new(150),
             )
             .unwrap_or_else(|error| panic!("drain proof should advance: {error:?}"));
-        let expected_boundary = 2 + proof as u64 + 1;
+        let proof_value = u64::try_from(proof)
+            .unwrap_or_else(|error| panic!("proof count is bounded: {error:?}"));
+        let expected_boundary = 2u64
+            .checked_add(proof_value)
+            .and_then(|sum| sum.checked_add(1))
+            .unwrap_or(u64::MAX);
         let proved = current_state(&model, &fixture);
         assert_eq!(proved.generation_value().get(), expected_boundary);
         let lineage = model
@@ -87,8 +95,10 @@ fn drain_resolution_restores_the_exact_successor_of_the_boundary() {
             let token = model
                 .slot_record(&fixture.slot(fixture.owner))
                 .and_then(|record| record.journal_record(&nonce))
-                .map(OperationJournalRecord::recovery_token)
-                .unwrap_or_else(|| panic!("drain record should remain"));
+                .map_or_else(
+                    || panic!("drain record should remain"),
+                    OperationJournalRecord::recovery_token,
+                );
 
             match resolution {
                 DrainResolution::Cancel => {
@@ -152,13 +162,17 @@ fn reject_old_evidence(
     let token = model
         .slot_record(&fixture.slot(fixture.owner))
         .and_then(|record| record.journal_record(nonce))
-        .map(OperationJournalRecord::recovery_token)
-        .unwrap_or_else(|| panic!("recovery token should remain"));
+        .map_or_else(
+            || panic!("recovery token should remain"),
+            OperationJournalRecord::recovery_token,
+        );
     let base_digest = model
         .slot_record(&fixture.slot(fixture.owner))
         .and_then(|record| record.journal_record(nonce))
-        .map(OperationJournalRecord::before_state)
-        .unwrap_or_else(|| panic!("operation boundary should remain"));
+        .map_or_else(
+            || panic!("operation boundary should remain"),
+            OperationJournalRecord::before_state,
+        );
     let evidence = recovery_evidence_for(token, base_digest, generation)
         .unwrap_or_else(|error| panic!("{error:?}"));
     let before = current_state(model, fixture);
@@ -232,8 +246,10 @@ fn old_state_recovery_rejects_every_noncanonical_generation_claim() {
     let service_generation = model
         .slot_record(&fixture.slot(fixture.owner))
         .and_then(|record| record.journal_record(&nonce))
-        .map(|record| non_zero(record.context().service_generation().get()))
-        .unwrap_or_else(|| panic!("service generation should remain"));
+        .map_or_else(
+            || panic!("service generation should remain"),
+            |record| non_zero(record.context().service_generation().get()),
+        );
 
     reject_old_evidence(&mut model, &fixture, &nonce, None, non_zero(2));
     reject_old_evidence(&mut model, &fixture, &nonce, None, non_zero(4));
@@ -276,8 +292,10 @@ fn absence_recovery_requires_the_recorded_removal_lineage() {
     let token = model
         .slot_record(&fixture.slot(fixture.owner))
         .and_then(|record| record.journal_record(&nonce))
-        .map(OperationJournalRecord::recovery_token)
-        .unwrap_or_else(|| panic!("no-drain token should remain"));
+        .map_or_else(
+            || panic!("no-drain token should remain"),
+            OperationJournalRecord::recovery_token,
+        );
     let evidence = match RecoveryEvidence::new(
         token,
         StateDigest::from_bytes([0; 32]),
@@ -311,8 +329,10 @@ fn exact_removal_recovery_clears_lineage_and_retains_terminal_receipt() {
     let token = model
         .slot_record(&fixture.slot(fixture.owner))
         .and_then(|record| record.journal_record(&nonce))
-        .map(OperationJournalRecord::recovery_token)
-        .unwrap_or_else(|| panic!("removal token should remain"));
+        .map_or_else(
+            || panic!("removal token should remain"),
+            OperationJournalRecord::recovery_token,
+        );
     let old_receipt = match RecoveryEvidence::new(
         token,
         base.digest(),
@@ -387,8 +407,10 @@ fn old_state_recovery_rejects_a_mutated_spoof_of_the_base() {
     let authority = model
         .slot_record(&fixture.slot(fixture.owner))
         .and_then(|record| record.journal_record(&nonce))
-        .map(|record| *record.authority_digest())
-        .unwrap_or_else(|| panic!("drain authority should remain"));
+        .map_or_else(
+            || panic!("drain authority should remain"),
+            |record| *record.authority_digest(),
+        );
     let spoofed = CanonicalInstalledState::new(InstalledStateSpec {
         owner: base.slot().owner(),
         package_object: base.slot().package_object(),

--- a/crates/astrid-package-service/src/lifecycle/tests/successor_tests.rs
+++ b/crates/astrid-package-service/src/lifecycle/tests/successor_tests.rs
@@ -41,6 +41,7 @@ enum ObservedMutation {
     Nonce(Nonce),
 }
 
+#[derive(Clone, Copy)]
 enum ExpectedRecoveryFailure {
     Unresolved,
     BindingMismatch,
@@ -374,13 +375,17 @@ fn observed_recovery_boundary_accepts_only_the_exact_successor() {
     let authority_digest = model
         .slot_record(&slot)
         .and_then(|record| record.journal_record(&nonce))
-        .map(|record| *record.authority_digest())
-        .unwrap_or_else(|| panic!("unknown authority should remain"));
+        .map_or_else(
+            || panic!("unknown authority should remain"),
+            |record| *record.authority_digest(),
+        );
     let token = model
         .slot_record(&slot)
         .and_then(|record| record.journal_record(&nonce))
-        .map(OperationJournalRecord::recovery_token)
-        .unwrap_or_else(|| panic!("unknown token should remain"));
+        .map_or_else(
+            || panic!("unknown token should remain"),
+            OperationJournalRecord::recovery_token,
+        );
     let valid_generation = non_zero(draining.generation_value().get() + 1);
     let valid = activation_state(&context, authority_digest, valid_generation)
         .unwrap_or_else(|_| panic!("valid activation state should construct"));
@@ -397,18 +402,30 @@ fn observed_recovery_boundary_accepts_only_the_exact_successor() {
         .unwrap_or_else(|| panic!("exact observed state should produce a receipt"));
     assert_eq!(receipt.outcome(), ReceiptOutcome::Activated);
     assert_eq!(current_state(&model, &fixture), valid);
+}
 
+#[test]
+fn deactivation_recovery_rejects_stale_and_skipped_states() {
+    let fixture = Fixture::new();
+    let mut model = PackageServiceModel::new(policy(8));
+    install(&mut model, &fixture, 1);
+    let slot = fixture.slot(fixture.owner);
+    begin_activation(&mut model, &fixture, 4);
     let activation = begin_lifecycle_without_commit(&mut model, &fixture, Operation::Deactivate, 6);
     let authority_digest = model
         .slot_record(&slot)
         .and_then(|record| record.journal_record(&activation))
-        .map(|record| *record.authority_digest())
-        .unwrap_or_else(|| panic!("second unknown authority should remain"));
+        .map_or_else(
+            || panic!("second unknown authority should remain"),
+            |record| *record.authority_digest(),
+        );
     let token = model
         .slot_record(&slot)
         .and_then(|record| record.journal_record(&activation))
-        .map(OperationJournalRecord::recovery_token)
-        .unwrap_or_else(|| panic!("second unknown token should remain"));
+        .map_or_else(
+            || panic!("second unknown token should remain"),
+            OperationJournalRecord::recovery_token,
+        );
     let deactivation_context = model
         .context_for(&activation)
         .unwrap_or_else(|_| panic!("second unknown context should remain"));
@@ -512,13 +529,17 @@ fn observed_boundary_rejects_each_mutated_recovery_binding() {
     let authority = model
         .slot_record(&slot)
         .and_then(|record| record.journal_record(&nonce))
-        .map(|record| *record.authority_digest())
-        .unwrap_or_else(|| panic!("unknown authority should remain"));
+        .map_or_else(
+            || panic!("unknown authority should remain"),
+            |record| *record.authority_digest(),
+        );
     let token = model
         .slot_record(&slot)
         .and_then(|record| record.journal_record(&nonce))
-        .map(OperationJournalRecord::recovery_token)
-        .unwrap_or_else(|| panic!("unknown token should remain"));
+        .map_or_else(
+            || panic!("unknown token should remain"),
+            OperationJournalRecord::recovery_token,
+        );
     let valid = new_installed_state(
         &context,
         authority,
@@ -528,48 +549,7 @@ fn observed_boundary_rejects_each_mutated_recovery_binding() {
     )
     .unwrap_or_else(|error| panic!("valid update state should construct: {error:?}"));
 
-    let alternate_artifact =
-        match ArtifactIdentity::new(format(1), non_zero(129), sha(21), digest(21)) {
-            Ok(value) => value,
-            Err(error) => panic!("alternate artifact should construct: {error:?}"),
-        };
-    let alternate_manifest = match ManifestIdentity::new(
-        manifest_format(1),
-        base_manifest_name(&valid),
-        base_manifest_version(&valid),
-        digest(22),
-    ) {
-        Ok(value) => value,
-        Err(error) => panic!("alternate manifest should construct: {error:?}"),
-    };
-    let mutations = [
-        ObservedMutation::Owner(fixture.other_owner),
-        ObservedMutation::PackageObject(PackageObject::from_bytes([45; 32])),
-        ObservedMutation::Artifact(alternate_artifact),
-        ObservedMutation::Content(digest(23)),
-        ObservedMutation::Manifest(alternate_manifest),
-        ObservedMutation::Authority(AuthorityDecisionDigest::from_bytes([24; 32])),
-        ObservedMutation::Provenance(ProvenanceDigest::from_bytes([25; 32])),
-        ObservedMutation::Lifecycle(LifecycleState::Active),
-        ObservedMutation::Plan(plan_digest(26)),
-        ObservedMutation::Generation(non_zero(2)),
-        ObservedMutation::Generation(non_zero(4)),
-        ObservedMutation::Nonce(Nonce::from_bytes([27; 32])),
-    ];
-    for mutation in mutations {
-        let mutated = mutated_state(&valid, mutation).unwrap_or_else(|error| panic!("{error:?}"));
-        let evidence =
-            recovery_evidence_for(token, mutated.digest(), mutated.generation_value(), None)
-                .unwrap_or_else(|error| panic!("{error:?}"));
-        reject_observed_recovery(
-            &mut model,
-            &fixture,
-            &nonce,
-            &mutated,
-            &evidence,
-            ExpectedRecoveryFailure::Unresolved,
-        );
-    }
+    reject_mutated_update_bindings(&mut model, &fixture, &nonce, token, &valid);
 
     let runtime_mismatch = recovery_evidence_for(token, valid.digest(), non_zero(2), None)
         .unwrap_or_else(|error| panic!("{error:?}"));
@@ -621,6 +601,52 @@ fn observed_boundary_rejects_each_mutated_recovery_binding() {
         &evidence_digest_mismatch,
         ExpectedRecoveryFailure::Unresolved,
     );
+}
+
+fn reject_mutated_update_bindings(
+    model: &mut PackageServiceModel,
+    fixture: &Fixture,
+    nonce: &Nonce,
+    token: RecoveryToken,
+    valid: &CanonicalInstalledState,
+) {
+    let alternate_artifact = ArtifactIdentity::new(format(1), non_zero(129), sha(21), digest(21))
+        .unwrap_or_else(|error| panic!("alternate artifact should construct: {error:?}"));
+    let alternate_manifest = ManifestIdentity::new(
+        manifest_format(1),
+        base_manifest_name(valid),
+        base_manifest_version(valid),
+        digest(22),
+    )
+    .unwrap_or_else(|error| panic!("alternate manifest should construct: {error:?}"));
+    let mutations = [
+        ObservedMutation::Owner(fixture.other_owner),
+        ObservedMutation::PackageObject(PackageObject::from_bytes([45; 32])),
+        ObservedMutation::Artifact(alternate_artifact),
+        ObservedMutation::Content(digest(23)),
+        ObservedMutation::Manifest(alternate_manifest),
+        ObservedMutation::Authority(AuthorityDecisionDigest::from_bytes([24; 32])),
+        ObservedMutation::Provenance(ProvenanceDigest::from_bytes([25; 32])),
+        ObservedMutation::Lifecycle(LifecycleState::Active),
+        ObservedMutation::Plan(plan_digest(26)),
+        ObservedMutation::Generation(non_zero(2)),
+        ObservedMutation::Generation(non_zero(4)),
+        ObservedMutation::Nonce(Nonce::from_bytes([27; 32])),
+    ];
+    for mutation in mutations {
+        let mutated = mutated_state(valid, mutation).unwrap_or_else(|error| panic!("{error:?}"));
+        let evidence =
+            recovery_evidence_for(token, mutated.digest(), mutated.generation_value(), None)
+                .unwrap_or_else(|error| panic!("{error:?}"));
+        reject_observed_recovery(
+            model,
+            fixture,
+            nonce,
+            &mutated,
+            &evidence,
+            ExpectedRecoveryFailure::Unresolved,
+        );
+    }
 }
 
 fn base_manifest_name(state: &CanonicalInstalledState) -> crate::identity::PackageName {

--- a/crates/astrid-package-service/src/lifecycle/tests/successor_tests.rs
+++ b/crates/astrid-package-service/src/lifecycle/tests/successor_tests.rs
@@ -41,6 +41,11 @@ enum ObservedMutation {
     Nonce(Nonce),
 }
 
+enum ExpectedRecoveryFailure {
+    Unresolved,
+    BindingMismatch,
+}
+
 fn mutated_state(
     base: &CanonicalInstalledState,
     mutation: ObservedMutation,
@@ -131,18 +136,22 @@ fn reject_observed_recovery(
     nonce: &Nonce,
     observed: &CanonicalInstalledState,
     evidence: &RecoveryEvidence,
+    expected: ExpectedRecoveryFailure,
 ) {
     let before = current_state(model, fixture);
     let error = model
         .recover_observed(nonce, evidence, Some(observed), Timestamp::new(220))
         .err()
         .unwrap_or_else(|| panic!("invalid observed state must fail closed"));
-    assert!(matches!(
-        error,
-        PackageServiceError::RecoveryUnresolved
-            | PackageServiceError::BindingMismatch
-            | PackageServiceError::AuthorityExpired
-    ));
+    let correct = match expected {
+        ExpectedRecoveryFailure::Unresolved => {
+            matches!(error, PackageServiceError::RecoveryUnresolved)
+        },
+        ExpectedRecoveryFailure::BindingMismatch => {
+            matches!(error, PackageServiceError::BindingMismatch)
+        },
+    };
+    assert!(correct, "unexpected recovery failure: {error:?}");
     assert_eq!(current_state(model, fixture), before);
 }
 
@@ -426,6 +435,7 @@ fn observed_recovery_boundary_accepts_only_the_exact_successor() {
         &activation,
         &skipped,
         &mismatched_evidence,
+        ExpectedRecoveryFailure::Unresolved,
     );
 
     let skipped_evidence =
@@ -437,6 +447,7 @@ fn observed_recovery_boundary_accepts_only_the_exact_successor() {
         &activation,
         &skipped,
         &skipped_evidence,
+        ExpectedRecoveryFailure::Unresolved,
     );
 
     let stale = new_installed_state(
@@ -450,7 +461,14 @@ fn observed_recovery_boundary_accepts_only_the_exact_successor() {
     let stale_evidence =
         recovery_evidence_for(token, stale.digest(), stale.generation_value(), None)
             .unwrap_or_else(|_| panic!("stale evidence should construct"));
-    reject_observed_recovery(&mut model, &fixture, &activation, &stale, &stale_evidence);
+    reject_observed_recovery(
+        &mut model,
+        &fixture,
+        &activation,
+        &stale,
+        &stale_evidence,
+        ExpectedRecoveryFailure::Unresolved,
+    );
 
     let wrong_token_evidence = recovery_evidence_for(
         RecoveryToken::from_bytes([9; 32]),
@@ -465,6 +483,7 @@ fn observed_recovery_boundary_accepts_only_the_exact_successor() {
         &activation,
         &stale,
         &wrong_token_evidence,
+        ExpectedRecoveryFailure::Unresolved,
     );
 
     let zero_receipt_evidence = RecoveryEvidence::new(
@@ -482,9 +501,9 @@ fn observed_boundary_rejects_each_mutated_recovery_binding() {
     let fixture = Fixture::new();
     let mut model = PackageServiceModel::new(policy(8));
     install(&mut model, &fixture, 1);
-    let nonce = begin_update(&mut model, &fixture);
+    let nonce = begin_update_with_deadline(&mut model, &fixture, Timestamp::new(400));
     model
-        .mark_unknown(&nonce, Timestamp::new(180))
+        .mark_unknown(&nonce, Timestamp::new(150))
         .unwrap_or_else(|_| panic!("unknown boundary should be recorded"));
     let slot = fixture.slot(fixture.owner);
     let context = model
@@ -500,8 +519,14 @@ fn observed_boundary_rejects_each_mutated_recovery_binding() {
         .and_then(|record| record.journal_record(&nonce))
         .map(OperationJournalRecord::recovery_token)
         .unwrap_or_else(|| panic!("unknown token should remain"));
-    let valid = activation_state(&context, authority, non_zero(2))
-        .unwrap_or_else(|error| panic!("valid update state should construct: {error:?}"));
+    let valid = new_installed_state(
+        &context,
+        authority,
+        &validated_artifact(13),
+        LifecycleState::Inactive,
+        non_zero(3),
+    )
+    .unwrap_or_else(|error| panic!("valid update state should construct: {error:?}"));
 
     let alternate_artifact =
         match ArtifactIdentity::new(format(1), non_zero(129), sha(21), digest(21)) {
@@ -533,38 +558,47 @@ fn observed_boundary_rejects_each_mutated_recovery_binding() {
     ];
     for mutation in mutations {
         let mutated = mutated_state(&valid, mutation).unwrap_or_else(|error| panic!("{error:?}"));
-        let evidence = recovery_evidence_for(
-            token,
-            mutated.digest(),
-            mutated.generation_value(),
-            Some(digest(31)),
-        )
-        .unwrap_or_else(|error| panic!("{error:?}"));
-        reject_observed_recovery(&mut model, &fixture, &nonce, &mutated, &evidence);
+        let evidence =
+            recovery_evidence_for(token, mutated.digest(), mutated.generation_value(), None)
+                .unwrap_or_else(|error| panic!("{error:?}"));
+        reject_observed_recovery(
+            &mut model,
+            &fixture,
+            &nonce,
+            &mutated,
+            &evidence,
+            ExpectedRecoveryFailure::Unresolved,
+        );
     }
 
     let runtime_mismatch = recovery_evidence_for(token, valid.digest(), non_zero(2), None)
         .unwrap_or_else(|error| panic!("{error:?}"));
-    reject_observed_recovery(&mut model, &fixture, &nonce, &valid, &runtime_mismatch);
+    reject_observed_recovery(
+        &mut model,
+        &fixture,
+        &nonce,
+        &valid,
+        &runtime_mismatch,
+        ExpectedRecoveryFailure::Unresolved,
+    );
 
-    let missing_receipt = recovery_evidence_for(token, valid.digest(), non_zero(2), None)
-        .unwrap_or_else(|error| panic!("{error:?}"));
-    reject_observed_recovery(&mut model, &fixture, &nonce, &valid, &missing_receipt);
+    let unexpected_receipt =
+        recovery_evidence_for(token, valid.digest(), non_zero(3), Some(digest(31)))
+            .unwrap_or_else(|error| panic!("{error:?}"));
+    reject_observed_recovery(
+        &mut model,
+        &fixture,
+        &nonce,
+        &valid,
+        &unexpected_receipt,
+        ExpectedRecoveryFailure::BindingMismatch,
+    );
 
     let wrong_token = recovery_evidence_for(
         RecoveryToken::from_bytes([28; 32]),
         valid.digest(),
-        non_zero(2),
-        Some(digest(31)),
-    )
-    .unwrap_or_else(|error| panic!("{error:?}"));
-    reject_observed_recovery(&mut model, &fixture, &nonce, &valid, &wrong_token);
-
-    let evidence_digest_mismatch = recovery_evidence_for(
-        token,
-        StateDigest::from_bytes([29; 32]),
-        non_zero(2),
-        Some(digest(31)),
+        non_zero(3),
+        None,
     )
     .unwrap_or_else(|error| panic!("{error:?}"));
     reject_observed_recovery(
@@ -572,7 +606,20 @@ fn observed_boundary_rejects_each_mutated_recovery_binding() {
         &fixture,
         &nonce,
         &valid,
+        &wrong_token,
+        ExpectedRecoveryFailure::Unresolved,
+    );
+
+    let evidence_digest_mismatch =
+        recovery_evidence_for(token, StateDigest::from_bytes([29; 32]), non_zero(3), None)
+            .unwrap_or_else(|error| panic!("{error:?}"));
+    reject_observed_recovery(
+        &mut model,
+        &fixture,
+        &nonce,
+        &valid,
         &evidence_digest_mismatch,
+        ExpectedRecoveryFailure::Unresolved,
     );
 }
 

--- a/crates/astrid-package-service/src/lifecycle/tests/successor_tests.rs
+++ b/crates/astrid-package-service/src/lifecycle/tests/successor_tests.rs
@@ -200,7 +200,7 @@ fn recorded_drain_deadline_blocks_success_at_and_after_boundary() {
     assert_eq!(restored.lifecycle_state(), &LifecycleState::Inactive);
     assert_eq!(
         restored.generation_value().get(),
-        draining.generation_value().get()
+        proved.generation_value().get() + 1
     );
 }
 

--- a/crates/astrid-package-service/src/lifecycle/tests/successor_tests.rs
+++ b/crates/astrid-package-service/src/lifecycle/tests/successor_tests.rs
@@ -1,0 +1,585 @@
+use super::cure_tests::begin_activation;
+use super::*;
+use crate::digest::{AuthorityDecisionDigest, ProvenanceDigest};
+use crate::journal::RecoveryEvidence;
+use crate::state::InstalledStateSpec;
+
+fn recovery_evidence_for(
+    token: RecoveryToken,
+    observed: StateDigest,
+    generation: NonZeroU64,
+    activation_receipt: Option<Blake3Digest>,
+) -> PackageServiceResult<RecoveryEvidence> {
+    RecoveryEvidence::new(token, observed, generation, activation_receipt, true)
+}
+
+fn activation_state(
+    context: &OperationContext,
+    authority_digest: AuthorityDecisionDigest,
+    generation: NonZeroU64,
+) -> PackageServiceResult<CanonicalInstalledState> {
+    new_installed_state(
+        context,
+        authority_digest,
+        &validated_artifact(12),
+        LifecycleState::Active,
+        generation,
+    )
+}
+
+enum ObservedMutation {
+    Owner(PrincipalUid),
+    PackageObject(PackageObject),
+    Artifact(ArtifactIdentity),
+    Content(Blake3Digest),
+    Manifest(ManifestIdentity),
+    Authority(AuthorityDecisionDigest),
+    Provenance(ProvenanceDigest),
+    Lifecycle(LifecycleState),
+    Plan(PlanDigest),
+    Generation(NonZeroU64),
+    Nonce(Nonce),
+}
+
+fn mutated_state(
+    base: &CanonicalInstalledState,
+    mutation: ObservedMutation,
+) -> PackageServiceResult<CanonicalInstalledState> {
+    let mut owner = base.slot().owner();
+    let mut package_object = base.slot().package_object();
+    let mut artifact = *base.artifact();
+    let mut content_root = *base.content_root();
+    let mut manifest = base.manifest().clone();
+    let mut authority = *base.authority_digest();
+    let mut provenance = *base.provenance();
+    let mut lifecycle = *base.lifecycle_state();
+    let mut plan = *base.lifecycle_plan();
+    let mut generation = base.generation_value();
+    let mut nonce = base.completing_nonce();
+    match mutation {
+        ObservedMutation::Owner(value) => owner = value,
+        ObservedMutation::PackageObject(value) => package_object = value,
+        ObservedMutation::Artifact(value) => artifact = value,
+        ObservedMutation::Content(value) => content_root = value,
+        ObservedMutation::Manifest(value) => manifest = value,
+        ObservedMutation::Authority(value) => authority = value,
+        ObservedMutation::Provenance(value) => provenance = value,
+        ObservedMutation::Lifecycle(value) => lifecycle = value,
+        ObservedMutation::Plan(value) => plan = value,
+        ObservedMutation::Generation(value) => generation = value,
+        ObservedMutation::Nonce(value) => nonce = value,
+    }
+    CanonicalInstalledState::new(InstalledStateSpec {
+        owner,
+        package_object,
+        artifact,
+        content_root,
+        manifest,
+        authority_digest: authority,
+        provenance,
+        lifecycle_state: lifecycle,
+        lifecycle_plan: plan,
+        generation,
+        completing_nonce: nonce,
+    })
+}
+
+fn begin_lifecycle_without_commit(
+    model: &mut PackageServiceModel,
+    fixture: &Fixture,
+    operation: Operation,
+    nonce_byte: u8,
+) -> Nonce {
+    let state = model
+        .slot_record(&fixture.slot(fixture.owner))
+        .and_then(|record| record.state().map(CanonicalInstalledState::digest))
+        .unwrap_or_else(|| panic!("installed state should exist"));
+    let plan = ExpectedPackageState::Exact(state)
+        .lifecycle_plan_digest(operation)
+        .unwrap_or_else(|_| panic!("activation plan is valid"));
+    let context = fixture.context(
+        operation,
+        ExpectedPackageState::Exact(state),
+        plan,
+        (fixture.owner, fixture.caller),
+        1,
+        Nonce::from_bytes([nonce_byte; 32]),
+    );
+    let nonce = fixture
+        .begin(model, context, 130)
+        .unwrap_or_else(|error| panic!("activation should be admitted: {error:?}"));
+    model
+        .begin_work(&nonce, Timestamp::new(140))
+        .unwrap_or_else(|_| panic!("activation work should start"));
+    model
+        .mark_unknown(&nonce, Timestamp::new(150))
+        .unwrap_or_else(|_| panic!("activation should become unknown"));
+    nonce
+}
+
+fn current_state(model: &PackageServiceModel, fixture: &Fixture) -> CanonicalInstalledState {
+    model
+        .slot_record(&fixture.slot(fixture.owner))
+        .and_then(PackageSlotRecord::state)
+        .cloned()
+        .unwrap_or_else(|| panic!("canonical state should exist"))
+}
+
+fn reject_observed_recovery(
+    model: &mut PackageServiceModel,
+    fixture: &Fixture,
+    nonce: &Nonce,
+    observed: &CanonicalInstalledState,
+    evidence: &RecoveryEvidence,
+) {
+    let before = current_state(model, fixture);
+    let error = model
+        .recover_observed(nonce, evidence, Some(observed), Timestamp::new(220))
+        .err()
+        .unwrap_or_else(|| panic!("invalid observed state must fail closed"));
+    assert!(matches!(
+        error,
+        PackageServiceError::RecoveryUnresolved
+            | PackageServiceError::BindingMismatch
+            | PackageServiceError::AuthorityExpired
+    ));
+    assert_eq!(current_state(model, fixture), before);
+}
+
+#[test]
+fn recorded_drain_deadline_blocks_success_at_and_after_boundary() {
+    let fixture = Fixture::new();
+    let mut model = PackageServiceModel::new(policy(8));
+    install(&mut model, &fixture, 1);
+    let nonce = begin_update(&mut model, &fixture);
+    let draining = current_state(&model, &fixture);
+
+    for now in [200, 201] {
+        let error = model
+            .prove_drain_leases(&nonce, 0, Timestamp::new(now))
+            .err()
+            .unwrap_or_else(|| panic!("late proof must fail"));
+        assert!(matches!(error, PackageServiceError::AuthorityExpired));
+    }
+
+    model
+        .prove_drain_leases(&nonce, 0, Timestamp::new(199))
+        .unwrap_or_else(|_| panic!("proof before the deadline should succeed"));
+    let proved = current_state(&model, &fixture);
+    assert_eq!(
+        proved.generation_value().get(),
+        draining.generation_value().get() + 1
+    );
+    for now in [200, 201] {
+        let error = model
+            .complete(
+                &nonce,
+                Some(&validated_artifact(13)),
+                None,
+                true,
+                Timestamp::new(now),
+            )
+            .err()
+            .unwrap_or_else(|| panic!("late replacement must fail"));
+        assert!(matches!(error, PackageServiceError::AuthorityExpired));
+    }
+    assert_eq!(current_state(&model, &fixture), proved);
+
+    let error = model
+        .cancel(&nonce, Timestamp::new(200))
+        .err()
+        .unwrap_or_else(|| panic!("late cancellation must not restore content"));
+    assert!(matches!(error, PackageServiceError::LifecycleTransition));
+    assert_eq!(current_state(&model, &fixture), proved);
+
+    let result = model
+        .expire_drain(&nonce, Timestamp::new(200), true)
+        .unwrap_or_else(|_| panic!("exact-boundary expiry should be explicit"));
+    assert_eq!(result, DrainResult::Completed);
+    let restored = current_state(&model, &fixture);
+    assert_eq!(restored.lifecycle_state(), &LifecycleState::Inactive);
+    assert_eq!(
+        restored.generation_value().get(),
+        draining.generation_value().get()
+    );
+}
+
+#[test]
+fn activation_cancellation_without_a_drain_preserves_content() {
+    let fixture = Fixture::new();
+    let mut model = PackageServiceModel::new(policy(8));
+    install(&mut model, &fixture, 1);
+    let before = current_state(&model, &fixture);
+    let state = before.digest();
+    let plan = ExpectedPackageState::Exact(state)
+        .lifecycle_plan_digest(Operation::Activate)
+        .unwrap_or_else(|_| panic!("activation plan is valid"));
+    let context = fixture.context(
+        Operation::Activate,
+        ExpectedPackageState::Exact(state),
+        plan,
+        (fixture.owner, fixture.caller),
+        1,
+        Nonce::from_bytes([7; 32]),
+    );
+    let nonce = fixture
+        .begin(&mut model, context, 130)
+        .unwrap_or_else(|error| panic!("activation should be admitted: {error:?}"));
+    model
+        .begin_work(&nonce, Timestamp::new(140))
+        .unwrap_or_else(|error| panic!("activation work should start: {error:?}"));
+
+    model
+        .cancel(&nonce, Timestamp::new(150))
+        .unwrap_or_else(|error| panic!("non-drain cancellation should abort: {error:?}"));
+
+    assert_eq!(current_state(&model, &fixture), before);
+    assert_eq!(
+        model
+            .slot_record(&fixture.slot(fixture.owner))
+            .and_then(|record| record.journal_record(&nonce))
+            .map(OperationJournalRecord::status),
+        Some(JournalStatus::Aborted)
+    );
+}
+
+#[test]
+fn exact_boundary_expiry_proves_absence_without_late_completion() {
+    let fixture = Fixture::new();
+    let mut model = PackageServiceModel::new(policy(8));
+    install(&mut model, &fixture, 1);
+    let nonce = begin_remove(&mut model, &fixture);
+    model
+        .prove_drain_leases(&nonce, 0, Timestamp::new(399))
+        .unwrap_or_else(|_| panic!("removal proof should succeed before deadline"));
+    let error = model
+        .complete(&nonce, None, None, true, Timestamp::new(400))
+        .err()
+        .unwrap_or_else(|| panic!("late removal completion must fail"));
+    assert!(matches!(error, PackageServiceError::AuthorityExpired));
+    let result = model
+        .expire_drain(&nonce, Timestamp::new(400), true)
+        .unwrap_or_else(|_| panic!("exact-boundary absence proof should be explicit"));
+    assert_eq!(result, DrainResult::Completed);
+    assert!(
+        model
+            .slot_record(&fixture.slot(fixture.owner))
+            .and_then(PackageSlotRecord::state)
+            .is_none()
+    );
+}
+
+#[test]
+fn zero_activation_evidence_is_refused_at_every_boundary() {
+    assert!(
+        RecoveryEvidence::new(
+            RecoveryToken::from_bytes([1; 32]),
+            StateDigest::from_bytes([2; 32]),
+            non_zero(1),
+            Some(digest(0)),
+            false,
+        )
+        .is_err(),
+        "zero activation receipt must be rejected at construction"
+    );
+
+    let fixture = Fixture::new();
+    let mut model = PackageServiceModel::new(policy(8));
+    install(&mut model, &fixture, 1);
+    let state = current_state(&model, &fixture).digest();
+    let plan = ExpectedPackageState::Exact(state)
+        .lifecycle_plan_digest(Operation::Activate)
+        .unwrap_or_else(|_| panic!("activation plan is valid"));
+    let context = fixture.context(
+        Operation::Activate,
+        ExpectedPackageState::Exact(state),
+        plan,
+        (fixture.owner, fixture.caller),
+        1,
+        Nonce::from_bytes([4; 32]),
+    );
+    let nonce = fixture
+        .begin(&mut model, context, 130)
+        .unwrap_or_else(|_| panic!("activation should be admitted"));
+    model
+        .begin_work(&nonce, Timestamp::new(140))
+        .unwrap_or_else(|_| panic!("activation work should start"));
+    let error = model
+        .complete(&nonce, None, Some(digest(0)), true, Timestamp::new(150))
+        .err()
+        .unwrap_or_else(|| panic!("zero runtime receipt must fail"));
+    assert!(matches!(error, PackageServiceError::BindingMismatch));
+}
+
+#[test]
+fn lifecycle_transitions_rebind_the_completing_nonce() {
+    let fixture = Fixture::new();
+    let mut model = PackageServiceModel::new(policy(8));
+    let install_nonce = Nonce::from_bytes([1; 32]);
+    install(&mut model, &fixture, 1);
+    let installed = current_state(&model, &fixture);
+    assert_eq!(installed.completing_nonce(), install_nonce);
+
+    let activation_nonce = begin_activation(&mut model, &fixture, 4);
+    let active = current_state(&model, &fixture);
+    assert_eq!(active.completing_nonce(), activation_nonce);
+    assert_eq!(active.generation_value().get(), 2);
+
+    let state = active.digest();
+    let plan = ExpectedPackageState::Exact(state)
+        .lifecycle_plan_digest(Operation::Deactivate)
+        .unwrap_or_else(|_| panic!("deactivation plan is valid"));
+    let context = fixture.context(
+        Operation::Deactivate,
+        ExpectedPackageState::Exact(state),
+        plan,
+        (fixture.owner, fixture.caller),
+        1,
+        Nonce::from_bytes([5; 32]),
+    );
+    let nonce = fixture
+        .begin(&mut model, context, 130)
+        .unwrap_or_else(|_| panic!("deactivation should be admitted"));
+    model
+        .begin_work(&nonce, Timestamp::new(140))
+        .unwrap_or_else(|_| panic!("deactivation work should start"));
+    model
+        .complete(&nonce, None, None, true, Timestamp::new(150))
+        .unwrap_or_else(|_| panic!("deactivation should commit"));
+    let inactive = current_state(&model, &fixture);
+    assert_eq!(inactive.completing_nonce(), nonce);
+    assert_eq!(inactive.generation_value().get(), 3);
+}
+
+#[test]
+fn observed_recovery_boundary_accepts_only_the_exact_successor() {
+    let fixture = Fixture::new();
+    let mut model = PackageServiceModel::new(policy(8));
+    install(&mut model, &fixture, 1);
+    let draining = current_state(&model, &fixture);
+    let nonce = begin_lifecycle_without_commit(&mut model, &fixture, Operation::Activate, 4);
+    let context = model
+        .context_for(&nonce)
+        .unwrap_or_else(|_| panic!("unknown context should remain"));
+    let slot = fixture.slot(fixture.owner);
+    let authority_digest = model
+        .slot_record(&slot)
+        .and_then(|record| record.journal_record(&nonce))
+        .map(|record| *record.authority_digest())
+        .unwrap_or_else(|| panic!("unknown authority should remain"));
+    let token = model
+        .slot_record(&slot)
+        .and_then(|record| record.journal_record(&nonce))
+        .map(OperationJournalRecord::recovery_token)
+        .unwrap_or_else(|| panic!("unknown token should remain"));
+    let valid_generation = non_zero(draining.generation_value().get() + 1);
+    let valid = activation_state(&context, authority_digest, valid_generation)
+        .unwrap_or_else(|_| panic!("valid activation state should construct"));
+    let valid_evidence = recovery_evidence_for(
+        token,
+        valid.digest(),
+        valid.generation_value(),
+        Some(digest(31)),
+    )
+    .unwrap_or_else(|_| panic!("valid evidence should construct"));
+    let receipt = model
+        .recover_observed(&nonce, &valid_evidence, Some(&valid), Timestamp::new(220))
+        .unwrap_or_else(|error| panic!("exact observed state should recover: {error:?}"))
+        .unwrap_or_else(|| panic!("exact observed state should produce a receipt"));
+    assert_eq!(receipt.outcome(), ReceiptOutcome::Activated);
+    assert_eq!(current_state(&model, &fixture), valid);
+
+    let activation = begin_lifecycle_without_commit(&mut model, &fixture, Operation::Deactivate, 6);
+    let authority_digest = model
+        .slot_record(&slot)
+        .and_then(|record| record.journal_record(&activation))
+        .map(|record| *record.authority_digest())
+        .unwrap_or_else(|| panic!("second unknown authority should remain"));
+    let token = model
+        .slot_record(&slot)
+        .and_then(|record| record.journal_record(&activation))
+        .map(OperationJournalRecord::recovery_token)
+        .unwrap_or_else(|| panic!("second unknown token should remain"));
+    let deactivation_context = model
+        .context_for(&activation)
+        .unwrap_or_else(|_| panic!("second unknown context should remain"));
+    let current = current_state(&model, &fixture);
+    let skipped = new_installed_state(
+        &deactivation_context,
+        authority_digest,
+        &validated_artifact(12),
+        LifecycleState::Inactive,
+        non_zero(current.generation_value().get() + 2),
+    )
+    .unwrap_or_else(|_| panic!("skipped activation state should construct"));
+
+    let mismatched_evidence = recovery_evidence_for(
+        token,
+        StateDigest::from_bytes([90; 32]),
+        skipped.generation_value(),
+        None,
+    )
+    .unwrap_or_else(|_| panic!("mismatched evidence should construct"));
+    reject_observed_recovery(
+        &mut model,
+        &fixture,
+        &activation,
+        &skipped,
+        &mismatched_evidence,
+    );
+
+    let skipped_evidence =
+        recovery_evidence_for(token, skipped.digest(), skipped.generation_value(), None)
+            .unwrap_or_else(|_| panic!("skipped evidence should construct"));
+    reject_observed_recovery(
+        &mut model,
+        &fixture,
+        &activation,
+        &skipped,
+        &skipped_evidence,
+    );
+
+    let stale = new_installed_state(
+        &deactivation_context,
+        authority_digest,
+        &validated_artifact(12),
+        LifecycleState::Inactive,
+        non_zero(current.generation_value().get()),
+    )
+    .unwrap_or_else(|_| panic!("stale activation state should construct"));
+    let stale_evidence =
+        recovery_evidence_for(token, stale.digest(), stale.generation_value(), None)
+            .unwrap_or_else(|_| panic!("stale evidence should construct"));
+    reject_observed_recovery(&mut model, &fixture, &activation, &stale, &stale_evidence);
+
+    let wrong_token_evidence = recovery_evidence_for(
+        RecoveryToken::from_bytes([9; 32]),
+        stale.digest(),
+        stale.generation_value(),
+        None,
+    )
+    .unwrap_or_else(|_| panic!("wrong-token evidence should construct"));
+    reject_observed_recovery(
+        &mut model,
+        &fixture,
+        &activation,
+        &stale,
+        &wrong_token_evidence,
+    );
+
+    let zero_receipt_evidence = RecoveryEvidence::new(
+        token,
+        stale.digest(),
+        stale.generation_value(),
+        Some(digest(0)),
+        true,
+    );
+    assert!(zero_receipt_evidence.is_err());
+}
+
+#[test]
+fn observed_boundary_rejects_each_mutated_recovery_binding() {
+    let fixture = Fixture::new();
+    let mut model = PackageServiceModel::new(policy(8));
+    install(&mut model, &fixture, 1);
+    let nonce = begin_update(&mut model, &fixture);
+    model
+        .mark_unknown(&nonce, Timestamp::new(180))
+        .unwrap_or_else(|_| panic!("unknown boundary should be recorded"));
+    let slot = fixture.slot(fixture.owner);
+    let context = model
+        .context_for(&nonce)
+        .unwrap_or_else(|_| panic!("unknown context should remain"));
+    let authority = model
+        .slot_record(&slot)
+        .and_then(|record| record.journal_record(&nonce))
+        .map(|record| *record.authority_digest())
+        .unwrap_or_else(|| panic!("unknown authority should remain"));
+    let token = model
+        .slot_record(&slot)
+        .and_then(|record| record.journal_record(&nonce))
+        .map(OperationJournalRecord::recovery_token)
+        .unwrap_or_else(|| panic!("unknown token should remain"));
+    let valid = activation_state(&context, authority, non_zero(2))
+        .unwrap_or_else(|error| panic!("valid update state should construct: {error:?}"));
+
+    let alternate_artifact =
+        match ArtifactIdentity::new(format(1), non_zero(129), sha(21), digest(21)) {
+            Ok(value) => value,
+            Err(error) => panic!("alternate artifact should construct: {error:?}"),
+        };
+    let alternate_manifest = match ManifestIdentity::new(
+        manifest_format(1),
+        base_manifest_name(&valid),
+        base_manifest_version(&valid),
+        digest(22),
+    ) {
+        Ok(value) => value,
+        Err(error) => panic!("alternate manifest should construct: {error:?}"),
+    };
+    let mutations = [
+        ObservedMutation::Owner(fixture.other_owner),
+        ObservedMutation::PackageObject(PackageObject::from_bytes([45; 32])),
+        ObservedMutation::Artifact(alternate_artifact),
+        ObservedMutation::Content(digest(23)),
+        ObservedMutation::Manifest(alternate_manifest),
+        ObservedMutation::Authority(AuthorityDecisionDigest::from_bytes([24; 32])),
+        ObservedMutation::Provenance(ProvenanceDigest::from_bytes([25; 32])),
+        ObservedMutation::Lifecycle(LifecycleState::Active),
+        ObservedMutation::Plan(plan_digest(26)),
+        ObservedMutation::Generation(non_zero(2)),
+        ObservedMutation::Generation(non_zero(4)),
+        ObservedMutation::Nonce(Nonce::from_bytes([27; 32])),
+    ];
+    for mutation in mutations {
+        let mutated = mutated_state(&valid, mutation).unwrap_or_else(|error| panic!("{error:?}"));
+        let evidence = recovery_evidence_for(
+            token,
+            mutated.digest(),
+            mutated.generation_value(),
+            Some(digest(31)),
+        )
+        .unwrap_or_else(|error| panic!("{error:?}"));
+        reject_observed_recovery(&mut model, &fixture, &nonce, &mutated, &evidence);
+    }
+
+    let runtime_mismatch = recovery_evidence_for(token, valid.digest(), non_zero(2), None)
+        .unwrap_or_else(|error| panic!("{error:?}"));
+    reject_observed_recovery(&mut model, &fixture, &nonce, &valid, &runtime_mismatch);
+
+    let missing_receipt = recovery_evidence_for(token, valid.digest(), non_zero(2), None)
+        .unwrap_or_else(|error| panic!("{error:?}"));
+    reject_observed_recovery(&mut model, &fixture, &nonce, &valid, &missing_receipt);
+
+    let wrong_token = recovery_evidence_for(
+        RecoveryToken::from_bytes([28; 32]),
+        valid.digest(),
+        non_zero(2),
+        Some(digest(31)),
+    )
+    .unwrap_or_else(|error| panic!("{error:?}"));
+    reject_observed_recovery(&mut model, &fixture, &nonce, &valid, &wrong_token);
+
+    let evidence_digest_mismatch = recovery_evidence_for(
+        token,
+        StateDigest::from_bytes([29; 32]),
+        non_zero(2),
+        Some(digest(31)),
+    )
+    .unwrap_or_else(|error| panic!("{error:?}"));
+    reject_observed_recovery(
+        &mut model,
+        &fixture,
+        &nonce,
+        &valid,
+        &evidence_digest_mismatch,
+    );
+}
+
+fn base_manifest_name(state: &CanonicalInstalledState) -> crate::identity::PackageName {
+    state.manifest().package_name().clone()
+}
+
+fn base_manifest_version(state: &CanonicalInstalledState) -> crate::identity::PackageVersion {
+    state.manifest().package_version().clone()
+}

--- a/crates/astrid-package-service/src/policy.rs
+++ b/crates/astrid-package-service/src/policy.rs
@@ -1,0 +1,189 @@
+use crate::context::{Duration, Timestamp};
+use crate::error::PackageServiceError;
+use crate::journal::{JournalStatus, OperationJournalRecord};
+use std::num::NonZeroU64;
+use std::time::Duration as StdDuration;
+
+const fn non_zero(value: u64) -> NonZeroU64 {
+    match NonZeroU64::new(value) {
+        Some(value) => value,
+        None => panic!("bounded policy capacity is non-zero"),
+    }
+}
+
+/// Retention bounds for a terminal record class.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RetentionWindow {
+    minimum: StdDuration,
+    maximum: StdDuration,
+}
+
+impl RetentionWindow {
+    /// Constructs finite retention bounds with `maximum >= minimum`.
+    pub fn new(minimum: StdDuration, maximum: StdDuration) -> Result<Self, PackageServiceError> {
+        if minimum.is_zero() || maximum < minimum {
+            return Err(PackageServiceError::InvalidValue("retention"));
+        }
+        Ok(Self { minimum, maximum })
+    }
+
+    /// Returns the guaranteed minimum retention.
+    #[must_use]
+    pub const fn minimum(&self) -> StdDuration {
+        self.minimum
+    }
+
+    /// Returns the finite hard retention maximum.
+    #[must_use]
+    pub const fn maximum(&self) -> StdDuration {
+        self.maximum
+    }
+}
+
+/// Retention policy by terminal outcome class.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct JournalRetention {
+    receipts: RetentionWindow,
+    terminal_failures: RetentionWindow,
+}
+
+impl JournalRetention {
+    /// Constructs finite retention classes.
+    pub fn new(receipts: RetentionWindow, terminal_failures: RetentionWindow) -> Self {
+        Self {
+            receipts,
+            terminal_failures,
+        }
+    }
+
+    fn window(&self, record: &OperationJournalRecord) -> Option<RetentionWindow> {
+        match record.status() {
+            JournalStatus::Committed => Some(self.receipts),
+            JournalStatus::Failed | JournalStatus::Expired | JournalStatus::Aborted => {
+                Some(self.terminal_failures)
+            },
+            JournalStatus::Intent | JournalStatus::Executing | JournalStatus::Unknown => None,
+        }
+    }
+}
+
+/// Bounded occupancy and collection policy.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct JournalPolicy {
+    record_capacity: NonZeroU64,
+    byte_capacity: NonZeroU64,
+    tombstone_capacity: NonZeroU64,
+    gc_batch_limit: NonZeroU64,
+    retention: JournalRetention,
+}
+
+impl JournalPolicy {
+    /// Constructs a finite, nonzero policy.
+    #[must_use]
+    pub const fn new(
+        record_capacity: NonZeroU64,
+        byte_capacity: NonZeroU64,
+        tombstone_capacity: NonZeroU64,
+        gc_batch_limit: NonZeroU64,
+        retention: JournalRetention,
+    ) -> Self {
+        Self {
+            record_capacity,
+            byte_capacity,
+            tombstone_capacity,
+            gc_batch_limit,
+            retention,
+        }
+    }
+
+    /// Named finite defaults for a private embedded model.
+    #[must_use]
+    pub fn default_policy() -> Self {
+        let receipts =
+            match RetentionWindow::new(Duration::from_hours(7 * 24), Duration::from_hours(90 * 24))
+            {
+                Ok(value) => value,
+                Err(_) => panic!("named receipt retention bounds are valid"),
+            };
+        let terminal_failures =
+            match RetentionWindow::new(Duration::from_hours(24), Duration::from_hours(30 * 24)) {
+                Ok(value) => value,
+                Err(_) => panic!("named failure retention bounds are valid"),
+            };
+        Self::new(
+            non_zero(1_024),
+            non_zero(4 * 1_024 * 1_024),
+            non_zero(4_096),
+            non_zero(64),
+            JournalRetention::new(receipts, terminal_failures),
+        )
+    }
+
+    /// Returns whether collection is allowed and how many records may go.
+    #[must_use]
+    pub const fn collection_batch_limit(&self) -> u64 {
+        self.gc_batch_limit.get()
+    }
+
+    /// Returns true only when a terminal record is eligible.
+    #[must_use]
+    pub fn retention_eligible(&self, record: &OperationJournalRecord, now: Timestamp) -> bool {
+        let Some(window) = self.retention.window(record) else {
+            return false;
+        };
+        let Some(age) = now.seconds_since(record.terminal_at()) else {
+            return false;
+        };
+        age >= window.maximum.as_secs()
+    }
+
+    pub(crate) fn has_admission_room(
+        &self,
+        occupancy: &crate::policy::Occupancy,
+        record_bytes: u64,
+    ) -> bool {
+        occupancy.records < self.record_capacity.get()
+            && occupancy
+                .bytes
+                .checked_add(record_bytes)
+                .is_some_and(|bytes| bytes <= self.byte_capacity.get())
+    }
+
+    pub(crate) const fn tombstone_capacity(&self) -> u64 {
+        self.tombstone_capacity.get()
+    }
+
+    pub(crate) fn admission_error(&self) -> PackageServiceError {
+        PackageServiceError::QuotaExhausted
+    }
+}
+
+/// Occupancy measured over authoritative journal records and tombstones.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct Occupancy {
+    records: u64,
+    bytes: u64,
+    tombstones: u64,
+}
+
+impl Occupancy {
+    pub(crate) const fn add_record(&mut self, bytes: u64) {
+        self.records += 1;
+        self.bytes += bytes;
+    }
+
+    pub(crate) const fn remove_record(&mut self, bytes: u64) {
+        self.records -= 1;
+        self.bytes -= bytes;
+    }
+
+    pub(crate) const fn add_tombstone(&mut self) {
+        self.tombstones += 1;
+    }
+
+    /// Returns current record, byte, and tombstone occupancy.
+    #[must_use]
+    pub const fn values(&self) -> (u64, u64, u64) {
+        (self.records, self.bytes, self.tombstones)
+    }
+}

--- a/crates/astrid-package-service/src/policy.rs
+++ b/crates/astrid-package-service/src/policy.rs
@@ -1,5 +1,5 @@
 use crate::context::{Duration, Timestamp};
-use crate::error::PackageServiceError;
+use crate::error::{PackageServiceError, PackageServiceResult};
 use crate::journal::{JournalStatus, OperationJournalRecord};
 use std::num::NonZeroU64;
 use std::time::Duration as StdDuration;
@@ -20,6 +20,9 @@ pub struct RetentionWindow {
 
 impl RetentionWindow {
     /// Constructs finite retention bounds with `maximum >= minimum`.
+    ///
+    /// # Errors
+    /// Returns [`PackageServiceError::InvalidValue`] for zero or inverted bounds.
     pub fn new(minimum: StdDuration, maximum: StdDuration) -> Result<Self, PackageServiceError> {
         if minimum.is_zero() || maximum < minimum {
             return Err(PackageServiceError::InvalidValue("retention"));
@@ -49,6 +52,7 @@ pub struct JournalRetention {
 
 impl JournalRetention {
     /// Constructs finite retention classes.
+    #[must_use]
     pub fn new(receipts: RetentionWindow, terminal_failures: RetentionWindow) -> Self {
         Self {
             receipts,
@@ -97,18 +101,21 @@ impl JournalPolicy {
     }
 
     /// Named finite defaults for a private embedded model.
+    ///
+    /// # Panics
+    /// Panics only if named constants violate their constructor invariants.
     #[must_use]
     pub fn default_policy() -> Self {
         let receipts =
             match RetentionWindow::new(Duration::from_hours(7 * 24), Duration::from_hours(90 * 24))
             {
                 Ok(value) => value,
-                Err(_) => panic!("named receipt retention bounds are valid"),
+                Err(error) => panic!("named receipt retention bounds are valid: {error:?}"),
             };
         let terminal_failures =
             match RetentionWindow::new(Duration::from_hours(24), Duration::from_hours(30 * 24)) {
                 Ok(value) => value,
-                Err(_) => panic!("named failure retention bounds are valid"),
+                Err(error) => panic!("named failure retention bounds are valid: {error:?}"),
             };
         Self::new(
             non_zero(1_024),
@@ -153,7 +160,7 @@ impl JournalPolicy {
         self.tombstone_capacity.get()
     }
 
-    pub(crate) fn admission_error(&self) -> PackageServiceError {
+    pub(crate) const fn admission_error() -> PackageServiceError {
         PackageServiceError::QuotaExhausted
     }
 }
@@ -167,18 +174,40 @@ pub struct Occupancy {
 }
 
 impl Occupancy {
-    pub(crate) const fn add_record(&mut self, bytes: u64) {
-        self.records += 1;
-        self.bytes += bytes;
+    pub(crate) fn add_record(&mut self, bytes: u64) -> PackageServiceResult<()> {
+        let records = self
+            .records
+            .checked_add(1)
+            .ok_or(PackageServiceError::OccupancyCorruption)?;
+        let bytes_total = self
+            .bytes
+            .checked_add(bytes)
+            .ok_or(PackageServiceError::OccupancyCorruption)?;
+        self.records = records;
+        self.bytes = bytes_total;
+        Ok(())
     }
 
-    pub(crate) const fn remove_record(&mut self, bytes: u64) {
-        self.records -= 1;
-        self.bytes -= bytes;
+    pub(crate) fn remove_record(&mut self, bytes: u64) -> PackageServiceResult<()> {
+        let records = self
+            .records
+            .checked_sub(1)
+            .ok_or(PackageServiceError::OccupancyCorruption)?;
+        let bytes_total = self
+            .bytes
+            .checked_sub(bytes)
+            .ok_or(PackageServiceError::OccupancyCorruption)?;
+        self.records = records;
+        self.bytes = bytes_total;
+        Ok(())
     }
 
-    pub(crate) const fn add_tombstone(&mut self) {
-        self.tombstones += 1;
+    pub(crate) fn add_tombstone(&mut self) -> PackageServiceResult<()> {
+        self.tombstones = self
+            .tombstones
+            .checked_add(1)
+            .ok_or(PackageServiceError::OccupancyCorruption)?;
+        Ok(())
     }
 
     /// Returns current record, byte, and tombstone occupancy.

--- a/crates/astrid-package-service/src/state.rs
+++ b/crates/astrid-package-service/src/state.rs
@@ -164,6 +164,55 @@ pub struct CanonicalInstalledState {
     digest: StateDigest,
 }
 
+/// The immutable prior content and authoritative boundary of an active drain.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct DrainLineage {
+    base_state: CanonicalInstalledState,
+    boundary_generation: NonZeroU64,
+}
+
+impl DrainLineage {
+    pub(crate) fn new(
+        base_state: CanonicalInstalledState,
+        boundary_generation: NonZeroU64,
+    ) -> PackageServiceResult<Self> {
+        if !base_state.has_valid_digest()
+            || matches!(
+                base_state.lifecycle_state(),
+                LifecycleState::Draining { .. }
+            )
+            || boundary_generation.get() <= base_state.generation_value().get()
+        {
+            return Err(PackageServiceError::InvalidValue("drain lineage"));
+        }
+        Ok(Self {
+            base_state,
+            boundary_generation,
+        })
+    }
+
+    pub(crate) fn advanced(&self) -> PackageServiceResult<Self> {
+        let generation = self
+            .boundary_generation
+            .get()
+            .checked_add(1)
+            .ok_or(PackageServiceError::GenerationOverflow)?;
+        let generation = NonZeroU64::try_from(generation).map_err(PackageServiceError::from)?;
+        Ok(Self {
+            base_state: self.base_state.clone(),
+            boundary_generation: generation,
+        })
+    }
+
+    pub(crate) const fn base_state(&self) -> &CanonicalInstalledState {
+        &self.base_state
+    }
+
+    pub(crate) const fn boundary_generation(&self) -> NonZeroU64 {
+        self.boundary_generation
+    }
+}
+
 impl CanonicalInstalledState {
     /// Constructs, validates, and digests a canonical installed state.
     pub fn new(spec: InstalledStateSpec) -> PackageServiceResult<Self> {

--- a/crates/astrid-package-service/src/state.rs
+++ b/crates/astrid-package-service/src/state.rs
@@ -36,6 +36,9 @@ impl ExpectedPackageState {
     }
 
     /// Derives the state-bound plan digest for a canonical lifecycle action.
+    ///
+    /// # Errors
+    /// Returns typed failures when absent state or the operation is not lifecycle-only.
     pub fn lifecycle_plan_digest(&self, operation: Operation) -> PackageServiceResult<PlanDigest> {
         let Self::Exact(state_digest) = self else {
             return Err(PackageServiceError::ExpectedStateMismatch);
@@ -215,6 +218,9 @@ impl DrainLineage {
 
 impl CanonicalInstalledState {
     /// Constructs, validates, and digests a canonical installed state.
+    ///
+    /// # Errors
+    /// Returns [`PackageServiceError::InvalidValue`] for zero authoritative bindings.
     pub fn new(spec: InstalledStateSpec) -> PackageServiceResult<Self> {
         let InstalledStateSpec {
             owner,

--- a/crates/astrid-package-service/src/state.rs
+++ b/crates/astrid-package-service/src/state.rs
@@ -1,8 +1,10 @@
 use crate::bytes::PrincipalUid;
+use crate::context::Operation;
 use crate::context::Timestamp;
 use crate::digest::{
     AuthorityDecisionDigest, Blake3Digest, DigestWriter, PlanDigest, ProvenanceDigest, StateDigest,
 };
+use crate::error::{PackageServiceError, PackageServiceResult};
 use crate::identity::{
     ArtifactIdentity, ManifestIdentity, Nonce, PackageObject, STATE_SCHEMA_VERSION,
     StateSchemaVersion,
@@ -31,6 +33,28 @@ impl ExpectedPackageState {
     pub(crate) fn matches_digest(&self, actual: StateDigest) -> bool {
         matches!(self, Self::Exact(expected) if expected.as_bytes() == actual.as_bytes())
             || matches!(self, Self::Absent if actual.as_bytes() == &[0; 32])
+    }
+
+    /// Derives the state-bound plan digest for a canonical lifecycle action.
+    pub fn lifecycle_plan_digest(&self, operation: Operation) -> PackageServiceResult<PlanDigest> {
+        let Self::Exact(state_digest) = self else {
+            return Err(PackageServiceError::ExpectedStateMismatch);
+        };
+        if !matches!(
+            operation,
+            Operation::Activate | Operation::Deactivate | Operation::Remove
+        ) {
+            return Err(PackageServiceError::LifecycleTransition);
+        }
+        let mut writer = DigestWriter::new();
+        writer.tag(match operation {
+            Operation::Activate => 1,
+            Operation::Deactivate => 2,
+            Operation::Remove => 3,
+            _ => 0,
+        });
+        writer.digest(state_digest);
+        Ok(writer.finish("astrid.package.lifecycle-plan.v1"))
     }
 }
 
@@ -141,9 +165,8 @@ pub struct CanonicalInstalledState {
 }
 
 impl CanonicalInstalledState {
-    /// Constructs and digests a canonical installed state.
-    #[must_use]
-    pub fn new(spec: InstalledStateSpec) -> Self {
+    /// Constructs, validates, and digests a canonical installed state.
+    pub fn new(spec: InstalledStateSpec) -> PackageServiceResult<Self> {
         let InstalledStateSpec {
             owner,
             package_object,
@@ -157,6 +180,12 @@ impl CanonicalInstalledState {
             generation,
             completing_nonce,
         } = spec;
+        if authority_digest.as_bytes() == &[0; 32]
+            || provenance.as_bytes() == &[0; 32]
+            || content_root.as_bytes() == &[0; 32]
+        {
+            return Err(PackageServiceError::InvalidValue("installed-state digest"));
+        }
         let mut value = Self {
             schema_version: STATE_SCHEMA_VERSION,
             owner,
@@ -175,7 +204,7 @@ impl CanonicalInstalledState {
         let mut writer = DigestWriter::new();
         value.write(&mut writer);
         value.digest = writer.finish("astrid.package.installed-state.v1");
-        value
+        Ok(value)
     }
 
     fn write(&self, writer: &mut DigestWriter) {
@@ -221,6 +250,30 @@ impl CanonicalInstalledState {
     #[must_use]
     pub const fn generation_value(&self) -> NonZeroU64 {
         self.generation
+    }
+
+    /// Returns the exact-byte artifact identity.
+    #[must_use]
+    pub const fn artifact(&self) -> &ArtifactIdentity {
+        &self.artifact
+    }
+
+    /// Returns the immutable content root.
+    #[must_use]
+    pub const fn content_root(&self) -> &Blake3Digest {
+        &self.content_root
+    }
+
+    /// Returns the exact manifest identity.
+    #[must_use]
+    pub const fn manifest(&self) -> &ManifestIdentity {
+        &self.manifest
+    }
+
+    /// Returns the lifecycle plan bound by the completing operation.
+    #[must_use]
+    pub const fn lifecycle_plan(&self) -> &PlanDigest {
+        &self.lifecycle_plan
     }
 
     /// Returns the nonce that completed this canonical state.

--- a/crates/astrid-package-service/src/state.rs
+++ b/crates/astrid-package-service/src/state.rs
@@ -1,0 +1,282 @@
+use crate::bytes::PrincipalUid;
+use crate::context::Timestamp;
+use crate::digest::{
+    AuthorityDecisionDigest, Blake3Digest, DigestWriter, PlanDigest, ProvenanceDigest, StateDigest,
+};
+use crate::identity::{
+    ArtifactIdentity, ManifestIdentity, Nonce, PackageObject, STATE_SCHEMA_VERSION,
+    StateSchemaVersion,
+};
+use std::num::NonZeroU64;
+
+/// Canonical absence or exact canonical installed-state digest.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ExpectedPackageState {
+    /// No authoritative installed state exists.
+    Absent,
+    /// The exact canonical digest must remain visible.
+    Exact(StateDigest),
+}
+
+impl ExpectedPackageState {
+    /// Returns the digest used for stale-state checks; absent is a fixed zero digest.
+    #[must_use]
+    pub const fn digest(&self) -> StateDigest {
+        match self {
+            Self::Absent => StateDigest::from_bytes([0; 32]),
+            Self::Exact(digest) => *digest,
+        }
+    }
+
+    pub(crate) fn matches_digest(&self, actual: StateDigest) -> bool {
+        matches!(self, Self::Exact(expected) if expected.as_bytes() == actual.as_bytes())
+            || matches!(self, Self::Absent if actual.as_bytes() == &[0; 32])
+    }
+}
+
+/// Immutable owner/package slot identity.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct PackageSlot {
+    owner: PrincipalUid,
+    package_object: PackageObject,
+}
+
+impl PackageSlot {
+    /// Creates an owner-scoped slot.
+    #[must_use]
+    pub const fn new(owner: PrincipalUid, package_object: PackageObject) -> Self {
+        Self {
+            owner,
+            package_object,
+        }
+    }
+
+    /// Returns the immutable owner.
+    #[must_use]
+    pub const fn owner(&self) -> PrincipalUid {
+        self.owner
+    }
+
+    /// Returns the immutable package object.
+    #[must_use]
+    pub const fn package_object(&self) -> PackageObject {
+        self.package_object
+    }
+}
+
+/// Drain destination recorded while old leases disappear.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DrainDestination {
+    /// Drain before a replacement commit.
+    Replacement,
+    /// Drain before final removal.
+    Removal,
+}
+
+/// Canonical lifecycle state, including bounded drain details.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum LifecycleState {
+    /// No active runtime generation.
+    Inactive,
+    /// Canonical state and runtime generation agree.
+    Active,
+    /// A bounded drain is durable and activation is refused.
+    Draining {
+        /// The recorded destination.
+        destination: DrainDestination,
+        /// The bounded drain deadline.
+        deadline: Timestamp,
+        /// The operation nonce that owns the drain.
+        nonce: Nonce,
+        /// The exact number of live leases still draining.
+        live_leases: u32,
+    },
+}
+
+impl LifecycleState {
+    const fn tag(&self) -> u8 {
+        match self {
+            Self::Inactive => 1,
+            Self::Active => 2,
+            Self::Draining { .. } => 3,
+        }
+    }
+
+    fn write(&self, writer: &mut DigestWriter) {
+        writer.tag(self.tag());
+        if let Self::Draining {
+            destination,
+            deadline,
+            nonce,
+            live_leases,
+        } = self
+        {
+            writer.tag(match destination {
+                DrainDestination::Replacement => 1,
+                DrainDestination::Removal => 2,
+            });
+            writer.u64(deadline.get());
+            writer.bytes(nonce.as_bytes());
+            writer.u64(u64::from(*live_leases));
+        }
+    }
+}
+
+/// The single authoritative installed-state object for one owner/package slot.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CanonicalInstalledState {
+    schema_version: StateSchemaVersion,
+    owner: PrincipalUid,
+    package_object: PackageObject,
+    artifact: ArtifactIdentity,
+    content_root: Blake3Digest,
+    manifest: ManifestIdentity,
+    authority_digest: AuthorityDecisionDigest,
+    provenance: ProvenanceDigest,
+    lifecycle_state: LifecycleState,
+    lifecycle_plan: PlanDigest,
+    generation: NonZeroU64,
+    completing_nonce: Nonce,
+    digest: StateDigest,
+}
+
+impl CanonicalInstalledState {
+    /// Constructs and digests a canonical installed state.
+    #[must_use]
+    pub fn new(spec: InstalledStateSpec) -> Self {
+        let InstalledStateSpec {
+            owner,
+            package_object,
+            artifact,
+            content_root,
+            manifest,
+            authority_digest,
+            provenance,
+            lifecycle_state,
+            lifecycle_plan,
+            generation,
+            completing_nonce,
+        } = spec;
+        let mut value = Self {
+            schema_version: STATE_SCHEMA_VERSION,
+            owner,
+            package_object,
+            artifact,
+            content_root,
+            manifest,
+            authority_digest,
+            provenance,
+            lifecycle_state,
+            lifecycle_plan,
+            generation,
+            completing_nonce,
+            digest: StateDigest::from_bytes([0; 32]),
+        };
+        let mut writer = DigestWriter::new();
+        value.write(&mut writer);
+        value.digest = writer.finish("astrid.package.installed-state.v1");
+        value
+    }
+
+    fn write(&self, writer: &mut DigestWriter) {
+        writer.u64(u64::from(self.schema_version.get()));
+        writer.bytes(self.owner.as_bytes());
+        writer.bytes(self.package_object.as_bytes());
+        writer.u64(u64::from(self.artifact.format_version()));
+        writer.u64(self.artifact.size_bytes());
+        writer.digest(self.artifact.sha256());
+        writer.digest(self.artifact.blake3());
+        writer.digest(&self.content_root);
+        writer.u64(u64::from(self.manifest.format_version()));
+        writer.bytes(self.manifest.package_name().as_str().as_bytes());
+        writer.bytes(self.manifest.package_version().as_str().as_bytes());
+        writer.digest(self.manifest.manifest_digest());
+        writer.digest(&self.authority_digest);
+        writer.digest(&self.provenance);
+        self.lifecycle_state.write(writer);
+        writer.digest(&self.lifecycle_plan);
+        writer.u64(self.generation.get());
+        writer.bytes(self.completing_nonce.as_bytes());
+    }
+
+    /// Returns the canonical state digest.
+    #[must_use]
+    pub const fn digest(&self) -> StateDigest {
+        self.digest
+    }
+
+    /// Returns the owner/package identity.
+    #[must_use]
+    pub const fn slot(&self) -> PackageSlot {
+        PackageSlot::new(self.owner, self.package_object)
+    }
+
+    /// Returns the lifecycle state.
+    #[must_use]
+    pub const fn lifecycle_state(&self) -> &LifecycleState {
+        &self.lifecycle_state
+    }
+
+    /// Returns the canonical state generation.
+    #[must_use]
+    pub const fn generation_value(&self) -> NonZeroU64 {
+        self.generation
+    }
+
+    /// Returns the nonce that completed this canonical state.
+    #[must_use]
+    pub const fn completing_nonce(&self) -> Nonce {
+        self.completing_nonce
+    }
+
+    /// Returns the canonical authenticated-authority decision digest.
+    #[must_use]
+    pub const fn authority_digest(&self) -> &AuthorityDecisionDigest {
+        &self.authority_digest
+    }
+
+    pub(crate) fn set_lifecycle_state(
+        &mut self,
+        lifecycle_state: LifecycleState,
+        plan: PlanDigest,
+        generation: NonZeroU64,
+    ) {
+        self.lifecycle_state = lifecycle_state;
+        self.lifecycle_plan = plan;
+        self.generation = generation;
+        self.redigest();
+    }
+
+    pub(crate) fn redigest(&mut self) {
+        let mut writer = DigestWriter::new();
+        self.write(&mut writer);
+        self.digest = writer.finish("astrid.package.installed-state.v1");
+    }
+}
+
+/// Input for one canonical installed-state value before digesting.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct InstalledStateSpec {
+    /// Immutable owner UID.
+    pub owner: PrincipalUid,
+    /// Immutable package object identity.
+    pub package_object: PackageObject,
+    /// Exact-byte artifact identity.
+    pub artifact: ArtifactIdentity,
+    /// Immutable content root.
+    pub content_root: Blake3Digest,
+    /// Exact manifest identity.
+    pub manifest: ManifestIdentity,
+    /// Canonical authenticated-authority decision digest.
+    pub authority_digest: AuthorityDecisionDigest,
+    /// Attribution evidence digest.
+    pub provenance: ProvenanceDigest,
+    /// Canonical lifecycle state.
+    pub lifecycle_state: LifecycleState,
+    /// Lifecycle plan digest.
+    pub lifecycle_plan: PlanDigest,
+    /// Canonical generation.
+    pub generation: NonZeroU64,
+    /// Completing operation nonce.
+    pub completing_nonce: Nonce,
+}

--- a/crates/astrid-package-service/src/state.rs
+++ b/crates/astrid-package-service/src/state.rs
@@ -282,21 +282,43 @@ impl CanonicalInstalledState {
         self.completing_nonce
     }
 
+    /// Returns the canonical state schema version.
+    #[must_use]
+    pub(crate) const fn schema_version(&self) -> StateSchemaVersion {
+        self.schema_version
+    }
+
     /// Returns the canonical authenticated-authority decision digest.
     #[must_use]
     pub const fn authority_digest(&self) -> &AuthorityDecisionDigest {
         &self.authority_digest
     }
 
-    pub(crate) fn set_lifecycle_state(
+    /// Returns the attribution evidence digest retained with canonical state.
+    #[must_use]
+    pub const fn provenance(&self) -> &ProvenanceDigest {
+        &self.provenance
+    }
+
+    /// Returns whether the retained digest covers the retained canonical fields.
+    pub(crate) fn has_valid_digest(&self) -> bool {
+        let mut writer = DigestWriter::new();
+        self.write(&mut writer);
+        let candidate: StateDigest = writer.finish("astrid.package.installed-state.v1");
+        candidate == self.digest
+    }
+
+    pub(crate) fn set_lifecycle_result(
         &mut self,
         lifecycle_state: LifecycleState,
         plan: PlanDigest,
         generation: NonZeroU64,
+        completing_nonce: Nonce,
     ) {
         self.lifecycle_state = lifecycle_state;
         self.lifecycle_plan = plan;
         self.generation = generation;
+        self.completing_nonce = completing_nonce;
         self.redigest();
     }
 

--- a/crates/astrid-package-service/tests/public_contract.rs
+++ b/crates/astrid-package-service/tests/public_contract.rs
@@ -4,7 +4,7 @@ use astrid_package_service::{
     ComponentIdentity, DrainDestination, DrainPlan, ExpectedPackageState, InstalledStateSpec,
     LifecycleState, ManifestFormatVersion, ManifestIdentity, Nonce, OperationReceipt, PackageName,
     PackageObject, PackageServiceError, PackageVersion, PrincipalUid, ProvenanceDigest,
-    ServiceGeneration, StateDigest, Timestamp,
+    ServiceGeneration, StateDigest, Timestamp, operation_commit_plan_digest,
 };
 use std::any::TypeId;
 use std::num::{NonZeroU32, NonZeroU64};
@@ -30,14 +30,14 @@ fn digest(byte: u8) -> Blake3Digest {
 fn package_name() -> PackageName {
     match PackageName::new("example-package") {
         Ok(value) => value,
-        Err(_) => panic!("fixed package name is valid"),
+        Err(error) => panic!("fixed package name is valid: {error:?}"),
     }
 }
 
 fn package_version() -> PackageVersion {
     match PackageVersion::new("1.2.3") {
         Ok(value) => value,
-        Err(_) => panic!("fixed package version is valid"),
+        Err(error) => panic!("fixed package version is valid: {error:?}"),
     }
 }
 
@@ -49,7 +49,7 @@ fn artifact_identity() -> ArtifactIdentity {
         digest(3),
     ) {
         Ok(value) => value,
-        Err(_) => panic!("fixed artifact identity is valid"),
+        Err(error) => panic!("fixed artifact identity is valid: {error:?}"),
     }
 }
 
@@ -61,7 +61,7 @@ fn manifest_identity() -> ManifestIdentity {
         digest(4),
     ) {
         Ok(value) => value,
-        Err(_) => panic!("fixed manifest identity is valid"),
+        Err(error) => panic!("fixed manifest identity is valid: {error:?}"),
     }
 }
 
@@ -95,7 +95,7 @@ fn public_drain_plan_constructor_preserves_state_binding() {
         Nonce::from_bytes([2; 32]),
     ) {
         Ok(value) => value,
-        Err(_) => panic!("valid drain plan should construct"),
+        Err(error) => panic!("valid drain plan should construct: {error:?}"),
     };
     assert_eq!(plan.destination(), DrainDestination::Replacement);
     assert_eq!(plan.deadline(), Timestamp::new(20));
@@ -179,7 +179,7 @@ fn public_authority_constructors_reject_zero_evidence() {
         digest(3),
     ) {
         Ok(value) => value,
-        Err(_) => panic!("fixed issuer is valid"),
+        Err(error) => panic!("fixed issuer is valid: {error:?}"),
     };
     let context = astrid_package_service::OperationContextSpec {
         nonce: Nonce::from_bytes([4; 32]),
@@ -193,10 +193,20 @@ fn public_authority_constructors_reject_zero_evidence() {
         package_object: PackageObject::from_bytes([7; 32]),
         artifact: artifact_identity(),
         manifest: manifest_identity(),
+        content_root: digest(8),
+        provenance: astrid_package_service::ProvenanceDigest::from_bytes([8; 32]),
         plan_digest: astrid_package_service::PlanDigest::from_bytes([8; 32]),
+        commit_plan_digest: operation_commit_plan_digest(
+            astrid_package_service::Operation::Install,
+            &artifact_identity(),
+            &manifest_identity(),
+            &digest(8),
+            &astrid_package_service::ProvenanceDigest::from_bytes([8; 32]),
+            None,
+        ),
         budget: astrid_package_service::ResourceBudget::new(
             non_zero_u64(4_096),
-            astrid_package_service::ResourceClasses::new(true, true, true, true),
+            astrid_package_service::ResourceClasses::new([true, true, true, true]),
         ),
         expiry: Timestamp::new(1_000),
     };
@@ -208,7 +218,7 @@ fn public_authority_constructors_reject_zero_evidence() {
     let context =
         match astrid_package_service::OperationContext::new(context, &service, Timestamp::ZERO) {
             Ok(value) => value,
-            Err(_) => panic!("fixed context is valid"),
+            Err(error) => panic!("fixed context is valid: {error:?}"),
         };
     assert!(matches!(
         AuthenticatedAuthority::bind(&context, issuer, Blake3Digest::from_bytes([0; 32])),

--- a/crates/astrid-package-service/tests/public_contract.rs
+++ b/crates/astrid-package-service/tests/public_contract.rs
@@ -1,0 +1,230 @@
+use astrid_package_service::{
+    ArtifactFormatVersion, ArtifactIdentity, AuthenticatedAuthority, AuthorityIssuer,
+    AuthorityIssuerClass, AuthorityIssuerIdentity, Blake3Digest, CanonicalInstalledState,
+    ComponentIdentity, DrainDestination, DrainPlan, ExpectedPackageState, InstalledStateSpec,
+    LifecycleState, ManifestFormatVersion, ManifestIdentity, Nonce, OperationReceipt, PackageName,
+    PackageObject, PackageServiceError, PackageVersion, PrincipalUid, ProvenanceDigest,
+    ServiceGeneration, StateDigest, Timestamp,
+};
+use std::any::TypeId;
+use std::num::{NonZeroU32, NonZeroU64};
+
+fn non_zero_u32(value: u32) -> NonZeroU32 {
+    match NonZeroU32::new(value) {
+        Some(value) => value,
+        None => panic!("test format is non-zero"),
+    }
+}
+
+fn non_zero_u64(value: u64) -> NonZeroU64 {
+    match NonZeroU64::new(value) {
+        Some(value) => value,
+        None => panic!("test generation is non-zero"),
+    }
+}
+
+fn digest(byte: u8) -> Blake3Digest {
+    Blake3Digest::from_bytes([byte; 32])
+}
+
+fn package_name() -> PackageName {
+    match PackageName::new("example-package") {
+        Ok(value) => value,
+        Err(_) => panic!("fixed package name is valid"),
+    }
+}
+
+fn package_version() -> PackageVersion {
+    match PackageVersion::new("1.2.3") {
+        Ok(value) => value,
+        Err(_) => panic!("fixed package version is valid"),
+    }
+}
+
+fn artifact_identity() -> ArtifactIdentity {
+    match ArtifactIdentity::new(
+        ArtifactFormatVersion::new(non_zero_u32(1)),
+        non_zero_u64(128),
+        astrid_package_service::Sha256Digest::from_bytes([2; 32]),
+        digest(3),
+    ) {
+        Ok(value) => value,
+        Err(_) => panic!("fixed artifact identity is valid"),
+    }
+}
+
+fn manifest_identity() -> ManifestIdentity {
+    match ManifestIdentity::new(
+        ManifestFormatVersion::new(non_zero_u32(1)),
+        package_name(),
+        package_version(),
+        digest(4),
+    ) {
+        Ok(value) => value,
+        Err(_) => panic!("fixed manifest identity is valid"),
+    }
+}
+
+fn installed_state_spec(
+    authority: astrid_package_service::AuthorityDecisionDigest,
+    provenance: ProvenanceDigest,
+    content_root: Blake3Digest,
+) -> InstalledStateSpec {
+    InstalledStateSpec {
+        owner: PrincipalUid::from_bytes([1; 32]),
+        package_object: PackageObject::from_bytes([2; 32]),
+        artifact: artifact_identity(),
+        content_root,
+        manifest: manifest_identity(),
+        authority_digest: authority,
+        provenance,
+        lifecycle_state: LifecycleState::Inactive,
+        lifecycle_plan: astrid_package_service::PlanDigest::from_bytes([7; 32]),
+        generation: non_zero_u64(1),
+        completing_nonce: Nonce::from_bytes([3; 32]),
+    }
+}
+
+#[test]
+fn public_drain_plan_constructor_preserves_state_binding() {
+    let state = ExpectedPackageState::Exact(StateDigest::from_bytes([1; 32]));
+    let plan = match DrainPlan::new(
+        DrainDestination::Replacement,
+        state,
+        Timestamp::new(20),
+        Nonce::from_bytes([2; 32]),
+    ) {
+        Ok(value) => value,
+        Err(_) => panic!("valid drain plan should construct"),
+    };
+    assert_eq!(plan.destination(), DrainDestination::Replacement);
+    assert_eq!(plan.deadline(), Timestamp::new(20));
+    assert!(matches!(
+        DrainPlan::new(
+            DrainDestination::Removal,
+            ExpectedPackageState::Absent,
+            Timestamp::new(20),
+            Nonce::from_bytes([2; 32]),
+        ),
+        Err(PackageServiceError::InvalidValue(_))
+    ));
+    assert!(matches!(
+        DrainPlan::new(
+            DrainDestination::Removal,
+            ExpectedPackageState::Exact(StateDigest::from_bytes([1; 32])),
+            Timestamp::new(20),
+            Nonce::from_bytes([0; 32]),
+        ),
+        Err(PackageServiceError::InvalidValue(_))
+    ));
+    assert!(matches!(
+        DrainPlan::new(
+            DrainDestination::Removal,
+            ExpectedPackageState::Exact(StateDigest::from_bytes([1; 32])),
+            Timestamp::ZERO,
+            Nonce::from_bytes([2; 32]),
+        ),
+        Err(PackageServiceError::InvalidValue(_))
+    ));
+}
+
+#[test]
+fn public_state_constructor_rejects_zero_binding_digests() {
+    let authority = astrid_package_service::AuthorityDecisionDigest::from_bytes([4; 32]);
+    let provenance = ProvenanceDigest::from_bytes([5; 32]);
+    let content_root = digest(6);
+    let valid = installed_state_spec(authority, provenance, content_root);
+    assert!(
+        CanonicalInstalledState::new(valid).is_ok(),
+        "valid installed state should construct"
+    );
+    for spec in [
+        installed_state_spec(
+            astrid_package_service::AuthorityDecisionDigest::from_bytes([0; 32]),
+            provenance,
+            content_root,
+        ),
+        installed_state_spec(
+            authority,
+            ProvenanceDigest::from_bytes([0; 32]),
+            content_root,
+        ),
+        installed_state_spec(authority, provenance, Blake3Digest::from_bytes([0; 32])),
+    ] {
+        assert!(
+            matches!(
+                CanonicalInstalledState::new(spec),
+                Err(PackageServiceError::InvalidValue(_))
+            ),
+            "zero binding digest must be rejected"
+        );
+    }
+}
+
+#[test]
+fn public_authority_constructors_reject_zero_evidence() {
+    assert!(matches!(
+        AuthorityIssuer::new(
+            AuthorityIssuerClass::ExplicitApproval,
+            AuthorityIssuerIdentity::from_bytes([1; 32]),
+            AuthorityIssuerIdentity::from_bytes([2; 32]),
+            Blake3Digest::from_bytes([0; 32]),
+        ),
+        Err(PackageServiceError::AuthorityIssuerRejected)
+    ));
+    let issuer = match AuthorityIssuer::new(
+        AuthorityIssuerClass::ExplicitApproval,
+        AuthorityIssuerIdentity::from_bytes([1; 32]),
+        AuthorityIssuerIdentity::from_bytes([2; 32]),
+        digest(3),
+    ) {
+        Ok(value) => value,
+        Err(_) => panic!("fixed issuer is valid"),
+    };
+    let context = astrid_package_service::OperationContextSpec {
+        nonce: Nonce::from_bytes([4; 32]),
+        operation: astrid_package_service::Operation::Install,
+        expected_state: ExpectedPackageState::Absent,
+        effective_caller: PrincipalUid::from_bytes([5; 32]),
+        approver: astrid_package_service::ApproverIdentity::Principal(PrincipalUid::from_bytes(
+            [5; 32],
+        )),
+        target_owner: PrincipalUid::from_bytes([6; 32]),
+        package_object: PackageObject::from_bytes([7; 32]),
+        artifact: artifact_identity(),
+        manifest: manifest_identity(),
+        plan_digest: astrid_package_service::PlanDigest::from_bytes([8; 32]),
+        budget: astrid_package_service::ResourceBudget::new(
+            non_zero_u64(4_096),
+            astrid_package_service::ResourceClasses::new(true, true, true, true),
+        ),
+        expiry: Timestamp::new(1_000),
+    };
+    let service = astrid_package_service::AdmittedService::new(
+        ComponentIdentity::from_bytes([9; 32]),
+        ServiceGeneration::new(non_zero_u64(1)),
+        digest(10),
+    );
+    let context =
+        match astrid_package_service::OperationContext::new(context, &service, Timestamp::ZERO) {
+            Ok(value) => value,
+            Err(_) => panic!("fixed context is valid"),
+        };
+    assert!(matches!(
+        AuthenticatedAuthority::bind(&context, issuer, Blake3Digest::from_bytes([0; 32])),
+        Err(PackageServiceError::AuthorityIssuerRejected)
+    ));
+}
+
+#[test]
+fn next_tranche_types_are_publicly_addressable() {
+    assert_eq!(
+        TypeId::of::<OperationReceipt>(),
+        TypeId::of::<OperationReceipt>()
+    );
+    assert_ne!(LifecycleState::Active, LifecycleState::Inactive);
+    assert_ne!(DrainDestination::Replacement, DrainDestination::Removal);
+    assert_eq!(Timestamp::ZERO.get(), 0);
+    assert_eq!(package_name().as_str(), "example-package");
+    assert_eq!(package_version().as_str(), "1.2.3");
+}


### PR DESCRIPTION
## Linked Issue

Tracking #1750. Superseded by #1800.

## Summary

Preserved non-landing evidence for the first registry-neutral package-service lifecycle design.

Independent review rejected this implementation. The replacement was rewritten, reviewed, and landed through #1800; #1750 is closed. This PR must not be merged or retargeted.

## Changes

- Introduced the original private package-service contract and state model.
- Supplied adversarial tests that informed the accepted replacement.
- Does not represent the implementation now present on `os/universal`.

## Verification

- Accepted replacement: #1800.
- Current disposition: superseded evidence, not a merge candidate.

## AI / Tool Assistance

Assisted-by: Codex:GLM-5.3 Flash

AI assistance was used for the original implementation. The maintainer owns the rejection and supersession decision.

## Checklist

- [x] Superseding landed PR identified
- [x] Historical evidence preserved
- [ ] Ready to merge

