### PR TITLE
feat(kernel): add private audit chain with rolling root and bounded verifier handoff

### DIFF
--- a/changes/1759.added.md
+++ b/changes/1759.added.md
@@ -1,0 +1,27 @@
+Added kernel-private audit-chain mechanics for native security events:
+a versioned, injective, bounded, length-delimited canonical codec; a rolling
+BLAKE3 root whose tag binds algorithm id, codec version, boot/session identity,
+and sequence; one atomic mutation-side transition that commits frame, checked
+non-wrapping `audit_seq`, and root advance together or fails before commit; and
+a kernel-owned fixed-capacity relay with checked cursors, credits/acks,
+bounded redelivery, and generation-bumped resync.
+
+Typed attribution restates the landed #1705/#1758 identity fields through
+ceiling-enforced constructors, and bounded denials never disclose foreign
+object identity. Relay capacity is statically derived from the maximum
+mandatory terminal/invalidation records one admitted atomic batch can produce
+at the frozen ceilings, never a single global death slot. Checkpoints are
+kernel-authenticated and bound to boot/session, exact seq, root, codec
+version, and relay generation.
+
+A separate private host verifier (`kernel/tools/native-audit-verifier`)
+independently decodes the canonical frames, folds the same root algorithm,
+verifies checkpoints, and reports Invalid versus Incomplete without skipping,
+extrapolating, or rewriting already-rooted events. Kernel tests cross-check
+frames, roots, and checkpoints against that verifier.
+
+No observer or serial hooks, public WIT, hosted audit, IPC transport, relation
+delta reuse, cross-boot durability, or runtime (q35) claims are included in
+this slice.
+
+Tracking #1759

--- a/changes/1759.added.md
+++ b/changes/1759.added.md
@@ -8,7 +8,14 @@ bounded redelivery, and generation-bumped resync.
 
 Typed attribution restates the landed #1705/#1758 identity fields through
 ceiling-enforced constructors, and bounded denials never disclose foreign
-object identity. Relay capacity is statically derived from the maximum
+object identity. Authority ids and checkpoint verification keys now require
+opaque kernel-held entropy in addition to the live boot/session identity. The
+entropy input is a crate-private newtype with a zero-rejecting constructor and
+erasure on drop; it is absent from canonical frames, checkpoint wire, and the
+untrusted handoff. Kernel tests reconstruct the superseded public-only key
+derivation from observed handoff fields and prove that forged handoff,
+checkpoint, and acknowledgement material fail under the genuine trusted
+anchor. Relay capacity is statically derived from the maximum
 mandatory terminal/invalidation records one admitted atomic batch can produce
 at the frozen ceilings: all 16 capability instances, 4 endpoints, 8 endpoint
 queues, and the dying domain identity, for a reserve of 29. Ordinary records
@@ -27,8 +34,8 @@ trusted kernel-origin anchor (a modeled trusted channel in this unwired slice)
 and must bind the handoff against that anchor before any verification session
 starts; structurally valid self-authenticated handoffs, checkpoints sealed
 under forged contexts, and forged retirement receipts fail closed. This first
-slice does not wire production anchor delivery, checkpoint-key minting,
-provisioning, or rotation.
+slice does not wire production secret provisioning, delivery, custody, or
+rotation.
 
 A separate private host verifier (`kernel/tools/native-audit-verifier`)
 independently decodes the canonical frames, folds the same root algorithm,

--- a/changes/1759.added.md
+++ b/changes/1759.added.md
@@ -10,17 +10,23 @@ Typed attribution restates the landed #1705/#1758 identity fields through
 ceiling-enforced constructors, and bounded denials never disclose foreign
 object identity. Relay capacity is statically derived from the maximum
 mandatory terminal/invalidation records one admitted atomic batch can produce
-at the frozen ceilings, never a single global death slot. Checkpoints are
-kernel-authenticated and bound to boot/session, exact seq, root, codec
-version, and relay generation with a keyed kernel tag instead of a public
-verifier-recomputable digest. This first slice does not wire production
-checkpoint-key minting, provisioning, or rotation.
+at the frozen ceilings: all 16 capability instances, 4 endpoints, 8 endpoint
+queues, and the dying domain identity, for a reserve of 29. Ordinary records
+cannot consume that headroom. Checkpoints are kernel-authenticated and bound
+to boot/session, exact seq, root, codec version, and relay generation with a
+keyed kernel tag instead of a public verifier-recomputable digest; trusted
+restore preserves the checkpoint's relay generation rather than resetting it.
+Verifier acknowledgements additionally require a keyed successful-fold receipt
+bound to the exact canonical frame and source root. This first slice does not
+wire production checkpoint-key minting, provisioning, or rotation.
 
 A separate private host verifier (`kernel/tools/native-audit-verifier`)
 independently decodes the canonical frames, folds the same root algorithm,
 verifies checkpoints, and reports Invalid versus Incomplete without skipping,
 extrapolating, or rewriting already-rooted events. Kernel tests cross-check
-frames, roots, and checkpoints against that verifier.
+frames, roots, and checkpoints against that verifier. Sequence overflow and
+relay-generation mismatch fail closed without partial commit; generation zero
+is invalid on both sides.
 
 No observer or serial hooks, public WIT, hosted audit, IPC transport, relation
 delta reuse, cross-boot durability, or runtime (q35) claims are included in

--- a/changes/1759.added.md
+++ b/changes/1759.added.md
@@ -14,11 +14,13 @@ at the frozen ceilings: all 16 capability instances, 4 endpoints, 8 endpoint
 queues, and the dying domain identity, for a reserve of 29. Ordinary records
 cannot consume that headroom. Checkpoints are kernel-authenticated and bound
 to boot/session, exact seq, root, codec version, and relay generation with a
-keyed kernel tag instead of a public verifier-recomputable digest; trusted
-restore preserves the checkpoint's relay generation rather than resetting it.
-Verifier acknowledgements additionally require a keyed successful-fold receipt
-bound to the exact canonical frame and source root. This first slice does not
-wire production checkpoint-key minting, provisioning, or rotation.
+keyed kernel tag and kernel-minted authority context instead of a public
+verifier-recomputable digest or caller-selectable key; trusted restore
+preserves the checkpoint's relay generation rather than resetting it. Verifier
+acknowledgements additionally require a successful-fold receipt bound to the
+live boot/session, relay generation, exact canonical frame, and source root.
+This first slice does not wire production checkpoint-key minting, provisioning,
+or rotation.
 
 A separate private host verifier (`kernel/tools/native-audit-verifier`)
 independently decodes the canonical frames, folds the same root algorithm,

--- a/changes/1759.added.md
+++ b/changes/1759.added.md
@@ -19,8 +19,16 @@ verifier-recomputable digest or caller-selectable key; trusted restore
 preserves the checkpoint's relay generation rather than resetting it. Verifier
 acknowledgements additionally require a successful-fold receipt bound to the
 live boot/session, relay generation, exact canonical frame, and source root.
-This first slice does not wire production checkpoint-key minting, provisioning,
-or rotation.
+The verifier handoff is untrusted binding evidence: it names the authority id
+and boot/session identity and carries only a kernel-keyed minting tag, never
+verification material, so no handoff authenticates itself. The host verifier
+accepts its authority only through an explicitly injected, independently
+trusted kernel-origin anchor (a modeled trusted channel in this unwired slice)
+and must bind the handoff against that anchor before any verification session
+starts; structurally valid self-authenticated handoffs, checkpoints sealed
+under forged contexts, and forged retirement receipts fail closed. This first
+slice does not wire production anchor delivery, checkpoint-key minting,
+provisioning, or rotation.
 
 A separate private host verifier (`kernel/tools/native-audit-verifier`)
 independently decodes the canonical frames, folds the same root algorithm,
@@ -34,7 +42,7 @@ No observer or serial hooks, public WIT, hosted audit, IPC transport, relation
 delta reuse, cross-boot durability, or runtime (q35) claims are included in
 this slice.
 
-First-slice residuals include observer/serial hooks and production checkpoint
-key lifecycle for a later sequenced change.
+First-slice residuals include observer/serial hooks, production anchor
+delivery, and production checkpoint key lifecycle for a later sequenced change.
 
 Tracking #1759

--- a/changes/1759.added.md
+++ b/changes/1759.added.md
@@ -12,7 +12,9 @@ object identity. Relay capacity is statically derived from the maximum
 mandatory terminal/invalidation records one admitted atomic batch can produce
 at the frozen ceilings, never a single global death slot. Checkpoints are
 kernel-authenticated and bound to boot/session, exact seq, root, codec
-version, and relay generation.
+version, and relay generation with a keyed kernel tag instead of a public
+verifier-recomputable digest. This first slice does not wire production
+checkpoint-key minting, provisioning, or rotation.
 
 A separate private host verifier (`kernel/tools/native-audit-verifier`)
 independently decodes the canonical frames, folds the same root algorithm,
@@ -23,5 +25,8 @@ frames, roots, and checkpoints against that verifier.
 No observer or serial hooks, public WIT, hosted audit, IPC transport, relation
 delta reuse, cross-boot durability, or runtime (q35) claims are included in
 this slice.
+
+First-slice residuals include observer/serial hooks and production checkpoint
+key lifecycle for a later sequenced change.
 
 Tracking #1759

--- a/kernel/Cargo.lock
+++ b/kernel/Cargo.lock
@@ -52,8 +52,10 @@ version = "0.0.0"
 dependencies = [
  "astrid-native-closure",
  "astrid-system-generation",
+ "blake3",
  "bootloader_api",
  "linked_list_allocator",
+ "native-audit-verifier",
  "raw-cpuid",
  "spin",
  "x86_64",
@@ -405,11 +407,11 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "astrid-native-closure",
-    "astrid-system-generation",
-    "blake3",
-    "bootloader_api",
-    "serde_json",
-    "wait-timeout",
+ "astrid-system-generation",
+ "blake3",
+ "bootloader_api",
+ "serde_json",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -456,6 +458,13 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "native-audit-verifier"
+version = "0.0.0"
+dependencies = [
+ "blake3",
+]
 
 [[package]]
 name = "once_cell"

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/astrid-system-generation",
     "tools/kimage",
     "tools/ktest",
+    "tools/native-audit-verifier",
 ]
 exclude = ["tools/bootloader"]
 

--- a/kernel/crates/astrid-native-kernel/Cargo.toml
+++ b/kernel/crates/astrid-native-kernel/Cargo.toml
@@ -30,3 +30,10 @@ raw-cpuid = "=11.6.0"
 
 astrid-native-closure = { path = "../astrid-native-closure" }
 astrid-system-generation = { path = "../astrid-system-generation", default-features = false, features = ["emulator-fixture"] }
+# Rolling audit root. Same frozen pure backend as the sibling kernel crates.
+blake3 = { version = "=1.8.5", default-features = false, features = ["pure"] }
+
+[dev-dependencies]
+# Private host verifier: kernel audit tests cross-check the canonical frames,
+# rolling root, and checkpoint tags against the independent decoder.
+native-audit-verifier = { path = "../../tools/native-audit-verifier" }

--- a/kernel/crates/astrid-native-kernel/src/audit/chain.rs
+++ b/kernel/crates/astrid-native-kernel/src/audit/chain.rs
@@ -5,10 +5,11 @@
 use super::codec::{Frame, MAX_FRAME_BYTES};
 use super::relay::AuditRelay;
 use super::root;
-use super::types::{AuditCheckpoint, AuditError, AuditEvent, BootSessionId};
+use super::types::{AuditCheckpoint, AuditError, AuditEvent, BootSessionId, CheckpointAuthKey};
 
 pub(crate) struct AuditChain {
     boot: BootSessionId,
+    auth_key: CheckpointAuthKey,
     seq: u64,
     root: [u8; root::ROOT_LEN],
     relay: AuditRelay,
@@ -16,9 +17,10 @@ pub(crate) struct AuditChain {
 
 impl AuditChain {
     /// Starts a new boot/session chain at the domain-separated genesis root.
-    pub fn genesis(boot: BootSessionId) -> Self {
+    pub fn genesis(boot: BootSessionId, auth_key: CheckpointAuthKey) -> Self {
         Self {
             boot,
+            auth_key,
             seq: 0,
             root: root::genesis(boot),
             relay: AuditRelay::new(boot),
@@ -27,9 +29,15 @@ impl AuditChain {
 
     /// Restores a chain from previously sealed trusted state. Crate-private
     /// until a later slice wires checkpoint restore into a consumer.
-    pub(crate) fn restore(boot: BootSessionId, seq: u64, root: [u8; root::ROOT_LEN]) -> Self {
+    pub(crate) fn restore(
+        boot: BootSessionId,
+        auth_key: CheckpointAuthKey,
+        seq: u64,
+        root: [u8; root::ROOT_LEN],
+    ) -> Self {
         Self {
             boot,
+            auth_key,
             seq,
             root,
             relay: AuditRelay::new(boot),
@@ -66,25 +74,33 @@ impl AuditChain {
             .seq
             .checked_add(1)
             .ok_or(AuditError::SequenceOverflow)?;
-        let prev_root = if self.seq == 0 { None } else { Some(self.root) };
-        let frame = Frame::new(self.boot, next, &event, prev_root);
+        let prev_root = Some(self.root);
+        let frame = Frame::new(self.boot, next, &event, prev_root)?;
         let mut buf = [0; MAX_FRAME_BYTES];
         let encoded = frame.encode(&mut buf)?;
         let next_root = root::advance(self.root, self.boot, next, encoded);
 
-        // Commit: frame, checked seq, and rolling root advance together.
+        // The relay is mandatory for this first-slice mutation transition.
+        // A reserve or window failure returns before either authoritative
+        // cursor advances, so no rooted record is stranded outside the
+        // bounded handoff proof. The fallible relay publish performs every
+        // check before mutating a slot or cursor.
+        self.relay.publish(
+            next,
+            encoded,
+            next_root,
+            event.class().is_terminal_or_invalidation(),
+        )?;
+
+        // Commit: frame, checked seq, rolling root, and relay handoff all
+        // advance together after every fallible step has succeeded.
         self.seq = next;
         self.root = next_root;
-
-        // Downstream only. A window overflow latches the relay; later
-        // publishes fail until an explicit resync rebinds it. The committed
-        // record above is authoritative regardless.
-        let _ = self.relay.publish(next, encoded, next_root);
         Ok(next)
     }
 
     /// Kernel-authenticated checkpoint bound to the exact current state.
     pub fn checkpoint(&self) -> AuditCheckpoint {
-        self.relay.checkpoint(self.root, self.seq)
+        self.relay.checkpoint(self.root, self.seq, self.auth_key)
     }
 }

--- a/kernel/crates/astrid-native-kernel/src/audit/chain.rs
+++ b/kernel/crates/astrid-native-kernel/src/audit/chain.rs
@@ -1,0 +1,90 @@
+//! The atomic mutation-side transition: one call commits the canonical
+//! frame, the checked `audit_seq` advance, and the rolling-root advance
+//! together, or fails before any state changes.
+
+use super::codec::{Frame, MAX_FRAME_BYTES};
+use super::relay::AuditRelay;
+use super::root;
+use super::types::{AuditCheckpoint, AuditError, AuditEvent, BootSessionId};
+
+pub(crate) struct AuditChain {
+    boot: BootSessionId,
+    seq: u64,
+    root: [u8; root::ROOT_LEN],
+    relay: AuditRelay,
+}
+
+impl AuditChain {
+    /// Starts a new boot/session chain at the domain-separated genesis root.
+    pub fn genesis(boot: BootSessionId) -> Self {
+        Self {
+            boot,
+            seq: 0,
+            root: root::genesis(boot),
+            relay: AuditRelay::new(boot),
+        }
+    }
+
+    /// Restores a chain from previously sealed trusted state. Crate-private
+    /// until a later slice wires checkpoint restore into a consumer.
+    pub(crate) fn restore(boot: BootSessionId, seq: u64, root: [u8; root::ROOT_LEN]) -> Self {
+        Self {
+            boot,
+            seq,
+            root,
+            relay: AuditRelay::new(boot),
+        }
+    }
+
+    pub const fn boot(&self) -> BootSessionId {
+        self.boot
+    }
+
+    pub const fn seq(&self) -> u64 {
+        self.seq
+    }
+
+    pub const fn root(&self) -> &[u8; root::ROOT_LEN] {
+        &self.root
+    }
+
+    pub const fn relay(&self) -> &AuditRelay {
+        &self.relay
+    }
+
+    pub fn relay_mut(&mut self) -> &mut AuditRelay {
+        &mut self.relay
+    }
+
+    /// Appends one mandatory event as one atomic transition. All fallible
+    /// steps complete on temporaries before the single commit; a failure
+    /// leaves sequence, root, and relay untouched. Relay publication is
+    /// downstream evidence only: its overflow is an explicit handoff state
+    /// and can never omit or rewrite the already-rooted event.
+    pub fn append(&mut self, event: AuditEvent) -> Result<u64, AuditError> {
+        let next = self
+            .seq
+            .checked_add(1)
+            .ok_or(AuditError::SequenceOverflow)?;
+        let prev_root = if self.seq == 0 { None } else { Some(self.root) };
+        let frame = Frame::new(self.boot, next, &event, prev_root);
+        let mut buf = [0; MAX_FRAME_BYTES];
+        let encoded = frame.encode(&mut buf)?;
+        let next_root = root::advance(self.root, self.boot, next, encoded);
+
+        // Commit: frame, checked seq, and rolling root advance together.
+        self.seq = next;
+        self.root = next_root;
+
+        // Downstream only. A window overflow latches the relay; later
+        // publishes fail until an explicit resync rebinds it. The committed
+        // record above is authoritative regardless.
+        let _ = self.relay.publish(next, encoded, next_root);
+        Ok(next)
+    }
+
+    /// Kernel-authenticated checkpoint bound to the exact current state.
+    pub fn checkpoint(&self) -> AuditCheckpoint {
+        self.relay.checkpoint(self.root, self.seq)
+    }
+}

--- a/kernel/crates/astrid-native-kernel/src/audit/chain.rs
+++ b/kernel/crates/astrid-native-kernel/src/audit/chain.rs
@@ -5,11 +5,11 @@
 use super::codec::{Frame, MAX_FRAME_BYTES};
 use super::relay::AuditRelay;
 use super::root;
-use super::types::{AuditCheckpoint, AuditError, AuditEvent, BootSessionId, CheckpointAuthKey};
+use super::types::{AuditAuthority, AuditCheckpoint, AuditError, AuditEvent, BootSessionId};
 
 pub(crate) struct AuditChain {
     boot: BootSessionId,
-    auth_key: CheckpointAuthKey,
+    authority: AuditAuthority,
     seq: u64,
     root: [u8; root::ROOT_LEN],
     relay: AuditRelay,
@@ -17,10 +17,11 @@ pub(crate) struct AuditChain {
 
 impl AuditChain {
     /// Starts a new boot/session chain at the domain-separated genesis root.
-    pub fn genesis(boot: BootSessionId, auth_key: CheckpointAuthKey) -> Self {
+    pub fn genesis(boot: BootSessionId) -> Self {
+        let authority = AuditAuthority::mint(boot);
         Self {
             boot,
-            auth_key,
+            authority,
             seq: 0,
             root: root::genesis(boot),
             relay: AuditRelay::new(boot),
@@ -32,10 +33,13 @@ impl AuditChain {
     /// relay generation; the relay generation is preserved rather than reset.
     pub(crate) fn restore(
         checkpoint: AuditCheckpoint,
-        auth_key: CheckpointAuthKey,
+        authority: AuditAuthority,
     ) -> Result<Self, AuditError> {
+        if checkpoint.boot() != authority.boot() {
+            return Err(AuditError::CheckpointMismatch);
+        }
         if checkpoint.codec_version() != super::CODEC_VERSION
-            || !checkpoint.verify_tag(auth_key)
+            || !checkpoint.verify_tag(authority.context())
             || checkpoint.relay_generation() == 0
         {
             return Err(AuditError::CheckpointMismatch);
@@ -48,7 +52,7 @@ impl AuditChain {
             AuditRelay::restore(checkpoint.boot(), checkpoint.relay_generation(), next_seq)?;
         Ok(Self {
             boot: checkpoint.boot(),
-            auth_key,
+            authority,
             seq: checkpoint.seq(),
             root: checkpoint.root(),
             relay,
@@ -57,6 +61,10 @@ impl AuditChain {
 
     pub const fn boot(&self) -> BootSessionId {
         self.boot
+    }
+
+    pub(crate) const fn authority(&self) -> AuditAuthority {
+        self.authority
     }
 
     pub const fn seq(&self) -> u64 {
@@ -73,6 +81,27 @@ impl AuditChain {
 
     pub fn relay_mut(&mut self) -> &mut AuditRelay {
         &mut self.relay
+    }
+
+    /// Acknowledges through the chain's kernel-owned authentication context;
+    /// callers can present only the verifier's successful-fold receipt.
+    pub fn ack(
+        &mut self,
+        seq: u64,
+        folded_root: [u8; root::ROOT_LEN],
+        receipt_tag: [u8; root::ROOT_LEN],
+    ) -> Result<(), AuditError> {
+        self.relay
+            .ack(seq, folded_root, receipt_tag, self.authority.context())
+    }
+
+    /// Generation-bumps the relay and seals recovery with the same
+    /// kernel-owned authority.
+    pub fn resync(&mut self) -> Result<AuditCheckpoint, AuditError> {
+        let current_root = self.root;
+        let current_seq = self.seq;
+        self.relay
+            .resync(current_root, current_seq, self.authority.context())
     }
 
     /// Appends one mandatory event as one atomic transition. All fallible
@@ -112,6 +141,7 @@ impl AuditChain {
 
     /// Kernel-authenticated checkpoint bound to the exact current state.
     pub fn checkpoint(&self) -> AuditCheckpoint {
-        self.relay.checkpoint(self.root, self.seq, self.auth_key)
+        self.relay
+            .checkpoint(self.root, self.seq, self.authority.context())
     }
 }

--- a/kernel/crates/astrid-native-kernel/src/audit/chain.rs
+++ b/kernel/crates/astrid-native-kernel/src/audit/chain.rs
@@ -5,7 +5,9 @@
 use super::codec::{Frame, MAX_FRAME_BYTES};
 use super::relay::AuditRelay;
 use super::root;
-use super::types::{AuditAuthority, AuditCheckpoint, AuditError, AuditEvent, BootSessionId};
+use super::types::{
+    AuditAuthority, AuditCheckpoint, AuditError, AuditEvent, BootSessionId, KernelSecretEntropy,
+};
 
 pub(crate) struct AuditChain {
     boot: BootSessionId,
@@ -17,15 +19,15 @@ pub(crate) struct AuditChain {
 
 impl AuditChain {
     /// Starts a new boot/session chain at the domain-separated genesis root.
-    pub fn genesis(boot: BootSessionId) -> Self {
-        let authority = AuditAuthority::mint(boot);
-        Self {
+    pub fn genesis(boot: BootSessionId, secret: KernelSecretEntropy) -> Result<Self, AuditError> {
+        let authority = AuditAuthority::mint(boot, secret).ok_or(AuditError::MalformedFrame)?;
+        Ok(Self {
             boot,
             authority,
             seq: 0,
             root: root::genesis(boot),
             relay: AuditRelay::new(boot),
-        }
+        })
     }
 
     /// Restores from a previously sealed trusted checkpoint. The checkpoint

--- a/kernel/crates/astrid-native-kernel/src/audit/chain.rs
+++ b/kernel/crates/astrid-native-kernel/src/audit/chain.rs
@@ -27,21 +27,32 @@ impl AuditChain {
         }
     }
 
-    /// Restores a chain from previously sealed trusted state. Crate-private
-    /// until a later slice wires checkpoint restore into a consumer.
+    /// Restores from a previously sealed trusted checkpoint. The checkpoint
+    /// itself binds boot/session, exact sequence, root, codec/version, and
+    /// relay generation; the relay generation is preserved rather than reset.
     pub(crate) fn restore(
-        boot: BootSessionId,
+        checkpoint: AuditCheckpoint,
         auth_key: CheckpointAuthKey,
-        seq: u64,
-        root: [u8; root::ROOT_LEN],
-    ) -> Self {
-        Self {
-            boot,
-            auth_key,
-            seq,
-            root,
-            relay: AuditRelay::new(boot),
+    ) -> Result<Self, AuditError> {
+        if checkpoint.codec_version() != super::CODEC_VERSION
+            || !checkpoint.verify_tag(auth_key)
+            || checkpoint.relay_generation() == 0
+        {
+            return Err(AuditError::CheckpointMismatch);
         }
+        let next_seq = checkpoint
+            .seq()
+            .checked_add(1)
+            .ok_or(AuditError::SequenceOverflow)?;
+        let relay =
+            AuditRelay::restore(checkpoint.boot(), checkpoint.relay_generation(), next_seq)?;
+        Ok(Self {
+            boot: checkpoint.boot(),
+            auth_key,
+            seq: checkpoint.seq(),
+            root: checkpoint.root(),
+            relay,
+        })
     }
 
     pub const fn boot(&self) -> BootSessionId {

--- a/kernel/crates/astrid-native-kernel/src/audit/codec.rs
+++ b/kernel/crates/astrid-native-kernel/src/audit/codec.rs
@@ -10,7 +10,7 @@ use core::num::NonZeroU64;
 use super::types::{
     AUDIT_MAX_PAYLOAD, AuditCapabilityInstance, AuditCheckpoint, AuditClass, AuditError,
     AuditEvent, AuditObject, AuditObjectKind, AuditRights, AuditSubject, BootSessionId,
-    CheckpointAuthKey, DenialContext,
+    CheckpointAuthContext, DenialContext,
 };
 use super::{CODEC_VERSION, root};
 
@@ -33,9 +33,9 @@ const FRAME_OVERHEAD_BYTES: usize = 4   // total length
 pub(crate) const MAX_FRAME_BYTES: usize = FRAME_OVERHEAD_BYTES + AUDIT_MAX_PAYLOAD + root::ROOT_LEN;
 
 /// Fixed checkpoint wire size: envelope, codec version, boot, seq, root,
-/// relay generation, kernel tag.
+/// relay generation, authority id, kernel tag.
 pub(crate) const CHECKPOINT_WIRE_BYTES: usize =
-    4 + 2 + 16 + 8 + root::ROOT_LEN + 8 + root::ROOT_LEN;
+    4 + 2 + 16 + 8 + root::ROOT_LEN + 8 + 8 + root::ROOT_LEN;
 
 /// One canonical frame: the decoded form of the frozen wire representation.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -277,10 +277,10 @@ fn decode_capability_instance(
 /// kernel tag is the authentication; decoding always re-verifies it.
 pub(crate) fn encode_checkpoint<'out>(
     checkpoint: &AuditCheckpoint,
-    auth_key: CheckpointAuthKey,
+    context: CheckpointAuthContext,
     out: &'out mut [u8; CHECKPOINT_WIRE_BYTES],
 ) -> Result<&'out [u8], AuditError> {
-    if !checkpoint.verify_tag(auth_key) {
+    if checkpoint.authority_id() != context.authority_id() || !checkpoint.verify_tag(context) {
         return Err(AuditError::CheckpointMismatch);
     }
     let mut writer = Writer::new(out);
@@ -290,6 +290,7 @@ pub(crate) fn encode_checkpoint<'out>(
     writer.u64(checkpoint.seq())?;
     writer.raw(&checkpoint.root())?;
     writer.u64(checkpoint.relay_generation())?;
+    writer.u64(checkpoint.authority_id())?;
     writer.raw(&checkpoint.tag())?;
     let end = writer.finish()?;
     Ok(&out[..end])
@@ -297,7 +298,7 @@ pub(crate) fn encode_checkpoint<'out>(
 
 pub(crate) fn decode_checkpoint(
     bytes: &[u8],
-    auth_key: CheckpointAuthKey,
+    context: CheckpointAuthContext,
 ) -> Result<AuditCheckpoint, AuditError> {
     let mut reader = Reader::new(bytes)?;
     let total = reader.u32()? as usize;
@@ -315,6 +316,10 @@ pub(crate) fn decode_checkpoint(
     let mut root_bytes = [0; root::ROOT_LEN];
     reader.fill(&mut root_bytes)?;
     let relay_generation = reader.u64()?;
+    let authority_id = reader.u64()?;
+    if authority_id != context.authority_id() {
+        return Err(AuditError::CheckpointMismatch);
+    }
     let mut tag = [0; root::ROOT_LEN];
     reader.fill(&mut tag)?;
     if reader.remaining() != 0 {
@@ -323,7 +328,7 @@ pub(crate) fn decode_checkpoint(
     if relay_generation == 0 {
         return Err(AuditError::MalformedFrame);
     }
-    let expected = AuditCheckpoint::seal(boot, seq, root_bytes, relay_generation, auth_key)?;
+    let expected = AuditCheckpoint::seal(boot, seq, root_bytes, relay_generation, context)?;
     if expected.codec_version() != codec_version || expected.tag() != tag {
         return Err(AuditError::CheckpointMismatch);
     }

--- a/kernel/crates/astrid-native-kernel/src/audit/codec.rs
+++ b/kernel/crates/astrid-native-kernel/src/audit/codec.rs
@@ -10,7 +10,7 @@ use core::num::NonZeroU64;
 use super::types::{
     AUDIT_MAX_PAYLOAD, AuditCapabilityInstance, AuditCheckpoint, AuditClass, AuditError,
     AuditEvent, AuditObject, AuditObjectKind, AuditRights, AuditSubject, BootSessionId,
-    DenialContext,
+    CheckpointAuthKey, DenialContext,
 };
 use super::{CODEC_VERSION, root};
 
@@ -57,10 +57,18 @@ impl Frame {
         seq: u64,
         event: &AuditEvent,
         prev_root: Option<[u8; root::ROOT_LEN]>,
-    ) -> Self {
+    ) -> Result<Self, AuditError> {
+        if event.class() == AuditClass::BoundedDenial {
+            if event.object().is_some() {
+                return Err(AuditError::UnauthorizedDisclosure);
+            }
+            if DenialContext::from_payload(event.payload()).is_none() {
+                return Err(AuditError::MalformedFrame);
+            }
+        }
         let mut payload = [0; AUDIT_MAX_PAYLOAD];
         payload[..event.payload().len()].copy_from_slice(event.payload());
-        Self {
+        Ok(Self {
             boot,
             seq,
             class: event.class(),
@@ -70,7 +78,7 @@ impl Frame {
             payload,
             payload_len: event.payload().len(),
             prev_root,
-        }
+        })
     }
 
     pub(crate) fn encode<'out>(
@@ -82,6 +90,9 @@ impl Frame {
         writer.u16(CODEC_VERSION)?;
         writer.raw(&self.boot.bytes())?;
         writer.u64(self.seq)?;
+        if self.class == AuditClass::BoundedDenial && self.object.is_some() {
+            return Err(AuditError::UnauthorizedDisclosure);
+        }
         writer.u16(self.class.discriminant())?;
         writer.u8(self.subject.slot())?;
         writer.u64(self.subject.generation().get())?;
@@ -266,8 +277,12 @@ fn decode_capability_instance(
 /// kernel tag is the authentication; decoding always re-verifies it.
 pub(crate) fn encode_checkpoint<'out>(
     checkpoint: &AuditCheckpoint,
+    auth_key: CheckpointAuthKey,
     out: &'out mut [u8; CHECKPOINT_WIRE_BYTES],
 ) -> Result<&'out [u8], AuditError> {
+    if !checkpoint.verify_tag(auth_key) {
+        return Err(AuditError::CheckpointMismatch);
+    }
     let mut writer = Writer::new(out);
     writer.skip_total_length()?;
     writer.u16(checkpoint.codec_version())?;
@@ -280,7 +295,10 @@ pub(crate) fn encode_checkpoint<'out>(
     Ok(&out[..end])
 }
 
-pub(crate) fn decode_checkpoint(bytes: &[u8]) -> Result<AuditCheckpoint, AuditError> {
+pub(crate) fn decode_checkpoint(
+    bytes: &[u8],
+    auth_key: CheckpointAuthKey,
+) -> Result<AuditCheckpoint, AuditError> {
     let mut reader = Reader::new(bytes)?;
     let total = reader.u32()? as usize;
     if bytes.len() - 4 != total || bytes.len() != CHECKPOINT_WIRE_BYTES {
@@ -302,7 +320,7 @@ pub(crate) fn decode_checkpoint(bytes: &[u8]) -> Result<AuditCheckpoint, AuditEr
     if reader.remaining() != 0 {
         return Err(AuditError::MalformedFrame);
     }
-    let expected = AuditCheckpoint::seal(boot, seq, root_bytes, relay_generation);
+    let expected = AuditCheckpoint::seal(boot, seq, root_bytes, relay_generation, auth_key);
     if expected.codec_version() != codec_version || expected.tag() != tag {
         return Err(AuditError::CheckpointMismatch);
     }

--- a/kernel/crates/astrid-native-kernel/src/audit/codec.rs
+++ b/kernel/crates/astrid-native-kernel/src/audit/codec.rs
@@ -1,0 +1,407 @@
+//! Versioned, injective, bounded, length-delimited canonical codec.
+//!
+//! Every field has a frozen width or an explicit discriminant; every
+//! variable region is length-bounded and strictly checked, so each frame has
+//! exactly one canonical byte representation and decoding rejects any
+//! non-canonical slack.
+
+use core::num::NonZeroU64;
+
+use super::types::{
+    AUDIT_MAX_PAYLOAD, AuditCapabilityInstance, AuditCheckpoint, AuditClass, AuditError,
+    AuditEvent, AuditObject, AuditObjectKind, AuditRights, AuditSubject, BootSessionId,
+    DenialContext,
+};
+use super::{CODEC_VERSION, root};
+
+/// Envelope plus every fixed-width field except payload and the
+/// previous-root choice. The widest object variant is a capability instance:
+/// projection token, capability slot, capability generation, object kind,
+/// object token.
+const FRAME_OVERHEAD_BYTES: usize = 4   // total length
+    + 2 // codec version
+    + 16 // boot/session identity
+    + 8 // audit_seq
+    + 2 // class
+    + 1 + 8 // subject slot + generation
+    + 1 // object tag
+    + (8 + 1 + 8 + 1 + 8) // widest typed object
+    + 2 // rights
+    + 2 // payload length
+    + 1; // previous-root flag
+
+pub(crate) const MAX_FRAME_BYTES: usize = FRAME_OVERHEAD_BYTES + AUDIT_MAX_PAYLOAD + root::ROOT_LEN;
+
+/// Fixed checkpoint wire size: envelope, codec version, boot, seq, root,
+/// relay generation, kernel tag.
+pub(crate) const CHECKPOINT_WIRE_BYTES: usize =
+    4 + 2 + 16 + 8 + root::ROOT_LEN + 8 + root::ROOT_LEN;
+
+/// One canonical frame: the decoded form of the frozen wire representation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Frame {
+    boot: BootSessionId,
+    seq: u64,
+    class: AuditClass,
+    subject: AuditSubject,
+    object: Option<AuditObject>,
+    rights: AuditRights,
+    payload: [u8; AUDIT_MAX_PAYLOAD],
+    payload_len: usize,
+    prev_root: Option<[u8; root::ROOT_LEN]>,
+}
+
+impl Frame {
+    pub(crate) fn new(
+        boot: BootSessionId,
+        seq: u64,
+        event: &AuditEvent,
+        prev_root: Option<[u8; root::ROOT_LEN]>,
+    ) -> Self {
+        let mut payload = [0; AUDIT_MAX_PAYLOAD];
+        payload[..event.payload().len()].copy_from_slice(event.payload());
+        Self {
+            boot,
+            seq,
+            class: event.class(),
+            subject: event.subject(),
+            object: event.object(),
+            rights: event.rights(),
+            payload,
+            payload_len: event.payload().len(),
+            prev_root,
+        }
+    }
+
+    pub(crate) fn encode<'out>(
+        &self,
+        out: &'out mut [u8; MAX_FRAME_BYTES],
+    ) -> Result<&'out [u8], AuditError> {
+        let mut writer = Writer::new(out);
+        writer.skip_total_length()?;
+        writer.u16(CODEC_VERSION)?;
+        writer.raw(&self.boot.bytes())?;
+        writer.u64(self.seq)?;
+        writer.u16(self.class.discriminant())?;
+        writer.u8(self.subject.slot())?;
+        writer.u64(self.subject.generation().get())?;
+        match self.object {
+            None => writer.u8(0)?,
+            Some(AuditObject::Domain { slot, generation }) => {
+                writer.u8(1)?;
+                writer.u8(slot)?;
+                writer.u64(generation.get())?;
+            },
+            Some(AuditObject::Endpoint {
+                pool_index,
+                generation,
+            }) => {
+                writer.u8(2)?;
+                writer.u8(pool_index)?;
+                writer.u64(generation.get())?;
+            },
+            Some(AuditObject::CapabilityInstance(instance)) => {
+                writer.u8(3)?;
+                writer.u64(instance.projection_token().get())?;
+                writer.u8(instance.capability_slot())?;
+                writer.u64(instance.capability_generation().get())?;
+                writer.u8(instance.object_kind().discriminant())?;
+                writer.u64(instance.object_token().get())?;
+            },
+        }
+        writer.u16(self.rights.bits())?;
+        writer.u16(self.payload_len as u16)?;
+        writer.raw(&self.payload[..self.payload_len])?;
+        match self.prev_root {
+            None => writer.u8(0)?,
+            Some(prev_root) => {
+                writer.u8(1)?;
+                writer.raw(&prev_root)?;
+            },
+        }
+        let end = writer.finish()?;
+        Ok(&out[..end])
+    }
+
+    pub(crate) fn boot(self) -> BootSessionId {
+        self.boot
+    }
+
+    pub(crate) fn seq(self) -> u64 {
+        self.seq
+    }
+
+    pub(crate) fn class(self) -> AuditClass {
+        self.class
+    }
+
+    pub(crate) fn subject(self) -> AuditSubject {
+        self.subject
+    }
+
+    pub(crate) fn object(self) -> Option<AuditObject> {
+        self.object
+    }
+
+    pub(crate) fn rights(self) -> AuditRights {
+        self.rights
+    }
+
+    pub(crate) fn payload(self) -> [u8; AUDIT_MAX_PAYLOAD] {
+        self.payload
+    }
+
+    pub(crate) fn payload_len(self) -> usize {
+        self.payload_len
+    }
+
+    pub(crate) fn prev_root(self) -> Option<[u8; root::ROOT_LEN]> {
+        self.prev_root
+    }
+}
+
+/// Strict canonical decode: unknown codec versions, unknown discriminants,
+/// out-of-ceiling values, zero generations, a zero sequence, or any trailing
+/// slack fail closed.
+pub(crate) fn decode(bytes: &[u8]) -> Result<Frame, AuditError> {
+    let mut reader = Reader::new(bytes)?;
+    let total = reader.u32()? as usize;
+    if bytes.len() - 4 != total {
+        return Err(AuditError::MalformedFrame);
+    }
+    let codec_version = reader.u16()?;
+    if codec_version != CODEC_VERSION {
+        return Err(AuditError::MalformedFrame);
+    }
+    let mut boot = [0; 16];
+    reader.fill(&mut boot)?;
+    let boot = BootSessionId::new(boot).ok_or(AuditError::MalformedFrame)?;
+    let seq = reader.u64()?;
+    if seq == 0 {
+        return Err(AuditError::MalformedFrame);
+    }
+    let class = AuditClass::from_discriminant(reader.u16()?).ok_or(AuditError::MalformedFrame)?;
+    let slot = reader.u8()?;
+    let generation = NonZeroU64::new(reader.u64()?).ok_or(AuditError::MalformedFrame)?;
+    let subject = AuditSubject::from_parts(slot, generation).ok_or(AuditError::MalformedFrame)?;
+    let object = match reader.u8()? {
+        0 => None,
+        1 => {
+            let slot = reader.u8()? as usize;
+            let generation = reader.u64()?;
+            Some(AuditObject::domain(slot, generation).ok_or(AuditError::MalformedFrame)?)
+        },
+        2 => {
+            let pool_index = reader.u8()? as usize;
+            let generation = reader.u64()?;
+            Some(AuditObject::endpoint(pool_index, generation).ok_or(AuditError::MalformedFrame)?)
+        },
+        3 => Some(AuditObject::CapabilityInstance(decode_capability_instance(
+            &mut reader,
+        )?)),
+        _ => return Err(AuditError::MalformedFrame),
+    };
+    let rights = AuditRights::from_bits(reader.u16()?).ok_or(AuditError::MalformedFrame)?;
+    let payload_len = reader.u16()? as usize;
+    if payload_len > AUDIT_MAX_PAYLOAD {
+        return Err(AuditError::MalformedFrame);
+    }
+    let mut payload = [0; AUDIT_MAX_PAYLOAD];
+    reader.fill(&mut payload[..payload_len])?;
+    let prev_root = match reader.u8()? {
+        0 => None,
+        1 => {
+            let mut prev_root = [0; root::ROOT_LEN];
+            reader.fill(&mut prev_root)?;
+            Some(prev_root)
+        },
+        _ => return Err(AuditError::MalformedFrame),
+    };
+    if reader.remaining() != 0 {
+        return Err(AuditError::MalformedFrame);
+    }
+    if class == AuditClass::BoundedDenial {
+        // A denial must never carry a foreign object identity, and its
+        // payload is exactly the bounded typed context.
+        if object.is_some() {
+            return Err(AuditError::UnauthorizedDisclosure);
+        }
+        if DenialContext::from_payload(&payload[..payload_len]).is_none() {
+            return Err(AuditError::MalformedFrame);
+        }
+    }
+    Ok(Frame {
+        boot,
+        seq,
+        class,
+        subject,
+        object,
+        rights,
+        payload,
+        payload_len,
+        prev_root,
+    })
+}
+
+fn decode_capability_instance(
+    reader: &mut Reader<'_>,
+) -> Result<AuditCapabilityInstance, AuditError> {
+    let projection_token = reader.u64()?;
+    let capability_slot = reader.u8()? as usize;
+    let capability_generation = reader.u64()?;
+    let object_kind =
+        AuditObjectKind::from_discriminant(reader.u8()?).ok_or(AuditError::MalformedFrame)?;
+    let object_token = reader.u64()?;
+    AuditCapabilityInstance::try_new(
+        projection_token,
+        capability_slot,
+        capability_generation,
+        object_kind,
+        object_token,
+    )
+    .ok_or(AuditError::MalformedFrame)
+}
+
+/// Canonical checkpoint wire form: bounded, versioned, and tag-bound. The
+/// kernel tag is the authentication; decoding always re-verifies it.
+pub(crate) fn encode_checkpoint<'out>(
+    checkpoint: &AuditCheckpoint,
+    out: &'out mut [u8; CHECKPOINT_WIRE_BYTES],
+) -> Result<&'out [u8], AuditError> {
+    let mut writer = Writer::new(out);
+    writer.skip_total_length()?;
+    writer.u16(checkpoint.codec_version())?;
+    writer.raw(&checkpoint.boot().bytes())?;
+    writer.u64(checkpoint.seq())?;
+    writer.raw(&checkpoint.root())?;
+    writer.u64(checkpoint.relay_generation())?;
+    writer.raw(&checkpoint.tag())?;
+    let end = writer.finish()?;
+    Ok(&out[..end])
+}
+
+pub(crate) fn decode_checkpoint(bytes: &[u8]) -> Result<AuditCheckpoint, AuditError> {
+    let mut reader = Reader::new(bytes)?;
+    let total = reader.u32()? as usize;
+    if bytes.len() - 4 != total || bytes.len() != CHECKPOINT_WIRE_BYTES {
+        return Err(AuditError::MalformedFrame);
+    }
+    let codec_version = reader.u16()?;
+    if codec_version != CODEC_VERSION {
+        return Err(AuditError::MalformedFrame);
+    }
+    let mut boot = [0; 16];
+    reader.fill(&mut boot)?;
+    let boot = BootSessionId::new(boot).ok_or(AuditError::MalformedFrame)?;
+    let seq = reader.u64()?;
+    let mut root_bytes = [0; root::ROOT_LEN];
+    reader.fill(&mut root_bytes)?;
+    let relay_generation = reader.u64()?;
+    let mut tag = [0; root::ROOT_LEN];
+    reader.fill(&mut tag)?;
+    if reader.remaining() != 0 {
+        return Err(AuditError::MalformedFrame);
+    }
+    let expected = AuditCheckpoint::seal(boot, seq, root_bytes, relay_generation);
+    if expected.codec_version() != codec_version || expected.tag() != tag {
+        return Err(AuditError::CheckpointMismatch);
+    }
+    Ok(expected)
+}
+
+struct Writer<'a> {
+    buf: &'a mut [u8],
+    pos: usize,
+}
+
+impl<'a> Writer<'a> {
+    fn new(buf: &'a mut [u8]) -> Self {
+        Self { buf, pos: 0 }
+    }
+
+    fn skip_total_length(&mut self) -> Result<(), AuditError> {
+        self.raw(&[0; 4])
+    }
+
+    fn finish(&mut self) -> Result<usize, AuditError> {
+        let total = self.pos - 4;
+        let total = u32::try_from(total).map_err(|_| AuditError::EncodeOverflow)?;
+        self.buf[0..4].copy_from_slice(&total.to_le_bytes());
+        Ok(self.pos)
+    }
+
+    fn raw(&mut self, bytes: &[u8]) -> Result<(), AuditError> {
+        if self.buf.len() - self.pos < bytes.len() {
+            return Err(AuditError::EncodeOverflow);
+        }
+        self.buf[self.pos..self.pos + bytes.len()].copy_from_slice(bytes);
+        self.pos += bytes.len();
+        Ok(())
+    }
+
+    fn u8(&mut self, value: u8) -> Result<(), AuditError> {
+        self.raw(&[value])
+    }
+
+    fn u16(&mut self, value: u16) -> Result<(), AuditError> {
+        self.raw(&value.to_le_bytes())
+    }
+
+    fn u64(&mut self, value: u64) -> Result<(), AuditError> {
+        self.raw(&value.to_le_bytes())
+    }
+}
+
+struct Reader<'a> {
+    bytes: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Reader<'a> {
+    fn new(bytes: &'a [u8]) -> Result<Self, AuditError> {
+        if bytes.len() < 4 {
+            return Err(AuditError::MalformedFrame);
+        }
+        Ok(Self { bytes, pos: 0 })
+    }
+
+    fn remaining(&self) -> usize {
+        self.bytes.len() - self.pos
+    }
+
+    fn take(&mut self, len: usize) -> Result<&'a [u8], AuditError> {
+        if self.remaining() < len {
+            return Err(AuditError::MalformedFrame);
+        }
+        let start = self.pos;
+        self.pos += len;
+        Ok(&self.bytes[start..self.pos])
+    }
+
+    fn fill(&mut self, out: &mut [u8]) -> Result<(), AuditError> {
+        out.copy_from_slice(self.take(out.len())?);
+        Ok(())
+    }
+
+    fn u8(&mut self) -> Result<u8, AuditError> {
+        Ok(self.take(1)?[0])
+    }
+
+    fn u16(&mut self) -> Result<u16, AuditError> {
+        Ok(u16::from_le_bytes(
+            self.take(2)?.try_into().expect("two bytes"),
+        ))
+    }
+
+    fn u32(&mut self) -> Result<u32, AuditError> {
+        Ok(u32::from_le_bytes(
+            self.take(4)?.try_into().expect("four bytes"),
+        ))
+    }
+
+    fn u64(&mut self) -> Result<u64, AuditError> {
+        Ok(u64::from_le_bytes(
+            self.take(8)?.try_into().expect("eight bytes"),
+        ))
+    }
+}

--- a/kernel/crates/astrid-native-kernel/src/audit/codec.rs
+++ b/kernel/crates/astrid-native-kernel/src/audit/codec.rs
@@ -320,7 +320,10 @@ pub(crate) fn decode_checkpoint(
     if reader.remaining() != 0 {
         return Err(AuditError::MalformedFrame);
     }
-    let expected = AuditCheckpoint::seal(boot, seq, root_bytes, relay_generation, auth_key);
+    if relay_generation == 0 {
+        return Err(AuditError::MalformedFrame);
+    }
+    let expected = AuditCheckpoint::seal(boot, seq, root_bytes, relay_generation, auth_key)?;
     if expected.codec_version() != codec_version || expected.tag() != tag {
         return Err(AuditError::CheckpointMismatch);
     }

--- a/kernel/crates/astrid-native-kernel/src/audit/mod.rs
+++ b/kernel/crates/astrid-native-kernel/src/audit/mod.rs
@@ -32,5 +32,5 @@ pub(crate) use types::{
     AUDIT_CAP_OBJECT_POOL, AUDIT_CAP_SLOTS_PER_DOMAIN, AUDIT_DOMAIN_SLOTS, AUDIT_ENDPOINT_POOL,
     AUDIT_MAX_PAYLOAD, AuditCapabilityInstance, AuditCheckpoint, AuditClass, AuditError,
     AuditEvent, AuditObject, AuditObjectKind, AuditRights, AuditSubject, BootSessionId,
-    DenialContext, DenialReason, MAX_TERMINAL_RECORDS_PER_BATCH,
+    CheckpointAuthKey, DenialContext, DenialReason, MAX_TERMINAL_RECORDS_PER_BATCH,
 };

--- a/kernel/crates/astrid-native-kernel/src/audit/mod.rs
+++ b/kernel/crates/astrid-native-kernel/src/audit/mod.rs
@@ -30,7 +30,7 @@ pub(crate) use relay::{AUDIT_RELAY_SLOTS, AuditRelay, RelayRecord};
 #[allow(unused_imports)]
 pub(crate) use types::{
     AUDIT_CAP_OBJECT_POOL, AUDIT_CAP_SLOTS_PER_DOMAIN, AUDIT_DOMAIN_SLOTS, AUDIT_ENDPOINT_POOL,
-    AUDIT_MAX_PAYLOAD, AuditCapabilityInstance, AuditCheckpoint, AuditClass, AuditError,
-    AuditEvent, AuditObject, AuditObjectKind, AuditRights, AuditSubject, BootSessionId,
-    CheckpointAuthKey, DenialContext, DenialReason, MAX_TERMINAL_RECORDS_PER_BATCH,
+    AUDIT_MAX_PAYLOAD, AuditAuthority, AuditCapabilityInstance, AuditCheckpoint, AuditClass,
+    AuditError, AuditEvent, AuditObject, AuditObjectKind, AuditRights, AuditSubject, BootSessionId,
+    DenialContext, DenialReason, MAX_TERMINAL_RECORDS_PER_BATCH,
 };

--- a/kernel/crates/astrid-native-kernel/src/audit/mod.rs
+++ b/kernel/crates/astrid-native-kernel/src/audit/mod.rs
@@ -32,5 +32,5 @@ pub(crate) use types::{
     AUDIT_CAP_OBJECT_POOL, AUDIT_CAP_SLOTS_PER_DOMAIN, AUDIT_DOMAIN_SLOTS, AUDIT_ENDPOINT_POOL,
     AUDIT_MAX_PAYLOAD, AuditAuthority, AuditCapabilityInstance, AuditCheckpoint, AuditClass,
     AuditError, AuditEvent, AuditObject, AuditObjectKind, AuditRights, AuditSubject, BootSessionId,
-    DenialContext, DenialReason, MAX_TERMINAL_RECORDS_PER_BATCH,
+    DenialContext, DenialReason, KernelSecretEntropy, MAX_TERMINAL_RECORDS_PER_BATCH,
 };

--- a/kernel/crates/astrid-native-kernel/src/audit/mod.rs
+++ b/kernel/crates/astrid-native-kernel/src/audit/mod.rs
@@ -1,0 +1,36 @@
+//! Kernel-private security-event audit chain.
+//!
+//! Private canonical frames, checked sequence order, a rolling BLAKE3 root,
+//! one atomic mutation-side append transition, and a bounded verifier handoff
+//! relay. The kernel is the only authority; the separate
+//! `native-audit-verifier` host tool reconstructs and compares. Relay and
+//! verifier delivery are downstream evidence only and never feed the root.
+
+mod chain;
+mod codec;
+mod relay;
+mod root;
+mod types;
+
+#[cfg(test)]
+mod tests;
+
+/// Frozen canonical frame-codec version. The rolling-root tag and the
+/// checkpoint wire form bind it.
+pub(crate) const CODEC_VERSION: u16 = 1;
+
+// Crate-visible re-exports stay ahead of the first production consumer, the
+// same dead-code-preserving posture as the landed relation projection.
+#[allow(unused_imports)]
+pub(crate) use chain::AuditChain;
+#[allow(unused_imports)]
+pub(crate) use codec::{Frame, MAX_FRAME_BYTES, decode, decode_checkpoint, encode_checkpoint};
+#[allow(unused_imports)]
+pub(crate) use relay::{AUDIT_RELAY_SLOTS, AuditRelay, RelayRecord};
+#[allow(unused_imports)]
+pub(crate) use types::{
+    AUDIT_CAP_OBJECT_POOL, AUDIT_CAP_SLOTS_PER_DOMAIN, AUDIT_DOMAIN_SLOTS, AUDIT_ENDPOINT_POOL,
+    AUDIT_MAX_PAYLOAD, AuditCapabilityInstance, AuditCheckpoint, AuditClass, AuditError,
+    AuditEvent, AuditObject, AuditObjectKind, AuditRights, AuditSubject, BootSessionId,
+    DenialContext, DenialReason, MAX_TERMINAL_RECORDS_PER_BATCH,
+};

--- a/kernel/crates/astrid-native-kernel/src/audit/relay.rs
+++ b/kernel/crates/astrid-native-kernel/src/audit/relay.rs
@@ -5,7 +5,8 @@
 use super::codec::MAX_FRAME_BYTES;
 use super::root;
 use super::types::{
-    AuditCheckpoint, AuditError, BootSessionId, CheckpointAuthKey, MAX_TERMINAL_RECORDS_PER_BATCH,
+    AuditCheckpoint, AuditError, BootSessionId, CheckpointAuthContext,
+    MAX_TERMINAL_RECORDS_PER_BATCH,
 };
 
 /// Distinct from the #1758 32-entry relation delta rings and their two
@@ -181,7 +182,7 @@ impl AuditRelay {
         seq: u64,
         folded_root: [u8; root::ROOT_LEN],
         receipt_tag: [u8; root::ROOT_LEN],
-        auth_key: CheckpointAuthKey,
+        context: CheckpointAuthContext,
     ) -> Result<(), AuditError> {
         if self.outstanding == 0 || seq != self.oldest_seq {
             return Err(AuditError::RelayStaleCursor);
@@ -198,10 +199,12 @@ impl AuditRelay {
             return Err(AuditError::RootMismatch);
         }
         if root::ack_tag(
+            self.boot,
+            self.generation,
             slot.record.seq(),
             slot.record.root(),
             slot.record.frame(),
-            &auth_key,
+            &context,
         ) != receipt_tag
         {
             return Err(AuditError::RootMismatch);
@@ -219,7 +222,7 @@ impl AuditRelay {
         &mut self,
         current_root: [u8; root::ROOT_LEN],
         current_seq: u64,
-        auth_key: CheckpointAuthKey,
+        context: CheckpointAuthContext,
     ) -> Result<AuditCheckpoint, AuditError> {
         let next_seq = current_seq
             .checked_add(1)
@@ -233,7 +236,7 @@ impl AuditRelay {
         self.next_seq = next_seq;
         self.oldest_seq = self.next_seq;
         self.credits = 0;
-        Ok(self.checkpoint(current_root, current_seq, auth_key))
+        Ok(self.checkpoint(current_root, current_seq, context))
     }
 
     /// Trusted checkpoint bound to boot/session, exact seq, root, codec
@@ -242,14 +245,14 @@ impl AuditRelay {
         &self,
         current_root: [u8; root::ROOT_LEN],
         current_seq: u64,
-        auth_key: CheckpointAuthKey,
+        context: CheckpointAuthContext,
     ) -> AuditCheckpoint {
         AuditCheckpoint::seal(
             self.boot,
             current_seq,
             current_root,
             self.generation,
-            auth_key,
+            context,
         )
         .expect("current relay generation is nonzero")
     }

--- a/kernel/crates/astrid-native-kernel/src/audit/relay.rs
+++ b/kernel/crates/astrid-native-kernel/src/audit/relay.rs
@@ -1,0 +1,212 @@
+//! Kernel-owned bounded audit relay: preallocated slots, checked cursors,
+//! credits/acks, bounded redelivery, and no dynamic allocation. Relay state
+//! is flow control only; it is never authority and never a root input.
+
+use super::codec::MAX_FRAME_BYTES;
+use super::root;
+use super::types::{AuditCheckpoint, AuditError, BootSessionId, MAX_TERMINAL_RECORDS_PER_BATCH};
+
+/// Distinct from the #1758 32-entry relation delta rings and their two
+/// reader slots. The window statically reserves capacity for at least one
+/// full admitted atomic batch of mandatory terminal/invalidation records.
+pub(crate) const AUDIT_RELAY_SLOTS: usize = 64;
+
+const _: () = assert!(
+    AUDIT_RELAY_SLOTS >= MAX_TERMINAL_RECORDS_PER_BATCH,
+    "audit relay must reserve a full admitted batch of terminal records",
+);
+
+/// One retained, already-rooted record handed downstream.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RelayRecord {
+    seq: u64,
+    root: [u8; root::ROOT_LEN],
+    frame_len: usize,
+    frame: [u8; MAX_FRAME_BYTES],
+}
+
+impl RelayRecord {
+    pub(crate) fn new(seq: u64, root: [u8; root::ROOT_LEN], frame: &[u8]) -> Self {
+        let mut stored = [0; MAX_FRAME_BYTES];
+        stored[..frame.len()].copy_from_slice(frame);
+        Self {
+            seq,
+            root,
+            frame_len: frame.len(),
+            frame: stored,
+        }
+    }
+
+    pub const fn seq(self) -> u64 {
+        self.seq
+    }
+
+    pub const fn root(self) -> [u8; root::ROOT_LEN] {
+        self.root
+    }
+
+    pub fn frame(&self) -> &[u8] {
+        &self.frame[..self.frame_len]
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SlotState {
+    Buffered,
+    InFlight,
+}
+
+#[derive(Clone, Copy)]
+struct Slot {
+    record: RelayRecord,
+    state: SlotState,
+}
+
+/// Fixed-capacity handoff window for already-rooted records. Overflow is an
+/// explicit `HandoffIncomplete`/`ResyncRequired` state: the authoritative
+/// chain is untouched, nothing is silently omitted, and recovery is a
+/// generation-bumped resync from a trusted checkpoint.
+pub struct AuditRelay {
+    boot: BootSessionId,
+    generation: u64,
+    next_seq: u64,
+    oldest_seq: u64,
+    outstanding: usize,
+    credits: u64,
+    slots: [Option<Slot>; AUDIT_RELAY_SLOTS],
+}
+
+impl AuditRelay {
+    pub(super) fn new(boot: BootSessionId) -> Self {
+        Self {
+            boot,
+            generation: 1,
+            next_seq: 1,
+            oldest_seq: 1,
+            outstanding: 0,
+            credits: 0,
+            slots: [None; AUDIT_RELAY_SLOTS],
+        }
+    }
+
+    /// Publishes one already-rooted record. Window overflow keeps the
+    /// authoritative event rooted but downstream-invisible until a resync.
+    pub(super) fn publish(
+        &mut self,
+        seq: u64,
+        frame: &[u8],
+        root: [u8; root::ROOT_LEN],
+    ) -> Result<(), AuditError> {
+        if seq != self.next_seq {
+            return Err(AuditError::RelayInvalidCursor);
+        }
+        if self.outstanding == AUDIT_RELAY_SLOTS {
+            return Err(AuditError::RelayWindowOverflow);
+        }
+        let index = Self::slot_index(seq);
+        self.slots[index] = Some(Slot {
+            record: RelayRecord::new(seq, root, frame),
+            state: SlotState::Buffered,
+        });
+        self.next_seq = seq.checked_add(1).ok_or(AuditError::SequenceOverflow)?;
+        self.outstanding += 1;
+        Ok(())
+    }
+
+    pub fn grant_credits(&mut self, credits: u64) -> Result<(), AuditError> {
+        self.credits = self
+            .credits
+            .checked_add(credits)
+            .ok_or(AuditError::RelayInvalidCursor)?;
+        Ok(())
+    }
+
+    /// Non-blocking take of the oldest buffered record, consuming one credit.
+    pub fn take(&mut self) -> Option<RelayRecord> {
+        if self.credits == 0 {
+            return None;
+        }
+        let index = self.oldest_buffered_index()?;
+        if let Some(slot) = self.slots[index].as_mut() {
+            slot.state = SlotState::InFlight;
+        }
+        self.credits -= 1;
+        self.slots[index].map(|slot| slot.record)
+    }
+
+    /// Bounded redelivery of every outstanding record in sequence order
+    /// (lost ack). Never rewrites or omits an already-rooted event.
+    pub fn redeliver(&self) -> impl Iterator<Item = RelayRecord> + '_ {
+        (0..self.outstanding).filter_map(move |offset| {
+            let seq = self.oldest_seq + offset as u64;
+            let index = Self::slot_index(seq);
+            self.slots[index].map(|slot| slot.record)
+        })
+    }
+
+    /// Retires exactly the oldest outstanding record. Contiguity enforced.
+    pub fn ack(&mut self, seq: u64) -> Result<(), AuditError> {
+        if self.outstanding == 0 || seq != self.oldest_seq {
+            return Err(AuditError::RelayStaleCursor);
+        }
+        let index = Self::slot_index(seq);
+        self.slots[index] = None;
+        self.oldest_seq = seq.checked_add(1).ok_or(AuditError::SequenceOverflow)?;
+        self.outstanding -= 1;
+        Ok(())
+    }
+
+    /// Window-overflow recovery: bump the relay generation, drop buffered
+    /// evidence, and return a trusted checkpoint for verifier restart. The
+    /// kernel root is untouched.
+    pub fn resync(
+        &mut self,
+        current_root: [u8; root::ROOT_LEN],
+        current_seq: u64,
+    ) -> Result<AuditCheckpoint, AuditError> {
+        self.generation = self
+            .generation
+            .checked_add(1)
+            .ok_or(AuditError::RelayGenerationOverflow)?;
+        self.slots = [None; AUDIT_RELAY_SLOTS];
+        self.outstanding = 0;
+        self.next_seq = current_seq
+            .checked_add(1)
+            .ok_or(AuditError::SequenceOverflow)?;
+        self.oldest_seq = self.next_seq;
+        self.credits = 0;
+        Ok(self.checkpoint(current_root, current_seq))
+    }
+
+    /// Trusted checkpoint bound to boot/session, exact seq, root, codec
+    /// version, and relay generation.
+    pub fn checkpoint(
+        &self,
+        current_root: [u8; root::ROOT_LEN],
+        current_seq: u64,
+    ) -> AuditCheckpoint {
+        AuditCheckpoint::seal(self.boot, current_seq, current_root, self.generation)
+    }
+
+    pub(super) const fn generation(self) -> u64 {
+        self.generation
+    }
+
+    fn slot_index(seq: u64) -> usize {
+        ((seq - 1) % AUDIT_RELAY_SLOTS as u64) as usize
+    }
+
+    fn oldest_buffered_index(&self) -> Option<usize> {
+        (0..self.outstanding)
+            .map(|offset| Self::slot_index(self.oldest_seq + offset as u64))
+            .find(|index| {
+                matches!(
+                    self.slots[*index],
+                    Some(Slot {
+                        state: SlotState::Buffered,
+                        ..
+                    })
+                )
+            })
+    }
+}

--- a/kernel/crates/astrid-native-kernel/src/audit/relay.rs
+++ b/kernel/crates/astrid-native-kernel/src/audit/relay.rs
@@ -91,6 +91,28 @@ impl AuditRelay {
         }
     }
 
+    /// Restores flow-control state from a trusted checkpoint without losing
+    /// its relay generation. Outstanding evidence is explicitly not carried
+    /// across the restart; a verifier restarts from this checkpoint.
+    pub(super) fn restore(
+        boot: BootSessionId,
+        generation: u64,
+        next_seq: u64,
+    ) -> Result<Self, AuditError> {
+        if generation == 0 {
+            return Err(AuditError::MalformedFrame);
+        }
+        Ok(Self {
+            boot,
+            generation,
+            next_seq,
+            oldest_seq: next_seq,
+            outstanding: 0,
+            credits: 0,
+            slots: [None; AUDIT_RELAY_SLOTS],
+        })
+    }
+
     /// Publishes one already-rooted record. Window overflow keeps the
     /// authoritative event rooted but downstream-invisible until a resync.
     pub(super) fn publish(
@@ -151,10 +173,16 @@ impl AuditRelay {
         })
     }
 
-    /// Retires exactly the oldest outstanding record. Contiguity enforced.
-    /// Retires exactly the oldest in-flight record after the caller proves
-    /// that folding its canonical frame produced this record's source root.
-    pub fn ack(&mut self, seq: u64, folded_root: [u8; root::ROOT_LEN]) -> Result<(), AuditError> {
+    /// Retires exactly the oldest in-flight record. Besides contiguity and
+    /// source-root equality, the caller must present the keyed receipt emitted
+    /// only by a successful independent fold of this exact canonical frame.
+    pub fn ack(
+        &mut self,
+        seq: u64,
+        folded_root: [u8; root::ROOT_LEN],
+        receipt_tag: [u8; root::ROOT_LEN],
+        auth_key: CheckpointAuthKey,
+    ) -> Result<(), AuditError> {
         if self.outstanding == 0 || seq != self.oldest_seq {
             return Err(AuditError::RelayStaleCursor);
         }
@@ -167,6 +195,15 @@ impl AuditRelay {
             return Err(AuditError::RelayNotInFlight);
         }
         if slot.record.root() != folded_root {
+            return Err(AuditError::RootMismatch);
+        }
+        if root::ack_tag(
+            slot.record.seq(),
+            slot.record.root(),
+            slot.record.frame(),
+            &auth_key,
+        ) != receipt_tag
+        {
             return Err(AuditError::RootMismatch);
         }
         self.slots[index] = None;
@@ -214,9 +251,10 @@ impl AuditRelay {
             self.generation,
             auth_key,
         )
+        .expect("current relay generation is nonzero")
     }
 
-    pub(super) const fn generation(self) -> u64 {
+    pub(super) const fn generation(&self) -> u64 {
         self.generation
     }
 

--- a/kernel/crates/astrid-native-kernel/src/audit/relay.rs
+++ b/kernel/crates/astrid-native-kernel/src/audit/relay.rs
@@ -4,7 +4,9 @@
 
 use super::codec::MAX_FRAME_BYTES;
 use super::root;
-use super::types::{AuditCheckpoint, AuditError, BootSessionId, MAX_TERMINAL_RECORDS_PER_BATCH};
+use super::types::{
+    AuditCheckpoint, AuditError, BootSessionId, CheckpointAuthKey, MAX_TERMINAL_RECORDS_PER_BATCH,
+};
 
 /// Distinct from the #1758 32-entry relation delta rings and their two
 /// reader slots. The window statically reserves capacity for at least one
@@ -96,19 +98,24 @@ impl AuditRelay {
         seq: u64,
         frame: &[u8],
         root: [u8; root::ROOT_LEN],
+        mandatory: bool,
     ) -> Result<(), AuditError> {
         if seq != self.next_seq {
             return Err(AuditError::RelayInvalidCursor);
         }
+        let next_seq = seq.checked_add(1).ok_or(AuditError::SequenceOverflow)?;
         if self.outstanding == AUDIT_RELAY_SLOTS {
-            return Err(AuditError::RelayWindowOverflow);
+            return Err(AuditError::HandoffIncomplete);
+        }
+        if !mandatory && self.outstanding >= AUDIT_RELAY_SLOTS - MAX_TERMINAL_RECORDS_PER_BATCH {
+            return Err(AuditError::HandoffIncomplete);
         }
         let index = Self::slot_index(seq);
         self.slots[index] = Some(Slot {
             record: RelayRecord::new(seq, root, frame),
             state: SlotState::Buffered,
         });
-        self.next_seq = seq.checked_add(1).ok_or(AuditError::SequenceOverflow)?;
+        self.next_seq = next_seq;
         self.outstanding += 1;
         Ok(())
     }
@@ -145,13 +152,25 @@ impl AuditRelay {
     }
 
     /// Retires exactly the oldest outstanding record. Contiguity enforced.
-    pub fn ack(&mut self, seq: u64) -> Result<(), AuditError> {
+    /// Retires exactly the oldest in-flight record after the caller proves
+    /// that folding its canonical frame produced this record's source root.
+    pub fn ack(&mut self, seq: u64, folded_root: [u8; root::ROOT_LEN]) -> Result<(), AuditError> {
         if self.outstanding == 0 || seq != self.oldest_seq {
             return Err(AuditError::RelayStaleCursor);
         }
         let index = Self::slot_index(seq);
+        let next_oldest = seq.checked_add(1).ok_or(AuditError::SequenceOverflow)?;
+        let Some(slot) = self.slots[index] else {
+            return Err(AuditError::RelayInvalidCursor);
+        };
+        if slot.state != SlotState::InFlight {
+            return Err(AuditError::RelayNotInFlight);
+        }
+        if slot.record.root() != folded_root {
+            return Err(AuditError::RootMismatch);
+        }
         self.slots[index] = None;
-        self.oldest_seq = seq.checked_add(1).ok_or(AuditError::SequenceOverflow)?;
+        self.oldest_seq = next_oldest;
         self.outstanding -= 1;
         Ok(())
     }
@@ -163,19 +182,21 @@ impl AuditRelay {
         &mut self,
         current_root: [u8; root::ROOT_LEN],
         current_seq: u64,
+        auth_key: CheckpointAuthKey,
     ) -> Result<AuditCheckpoint, AuditError> {
+        let next_seq = current_seq
+            .checked_add(1)
+            .ok_or(AuditError::SequenceOverflow)?;
         self.generation = self
             .generation
             .checked_add(1)
             .ok_or(AuditError::RelayGenerationOverflow)?;
         self.slots = [None; AUDIT_RELAY_SLOTS];
         self.outstanding = 0;
-        self.next_seq = current_seq
-            .checked_add(1)
-            .ok_or(AuditError::SequenceOverflow)?;
+        self.next_seq = next_seq;
         self.oldest_seq = self.next_seq;
         self.credits = 0;
-        Ok(self.checkpoint(current_root, current_seq))
+        Ok(self.checkpoint(current_root, current_seq, auth_key))
     }
 
     /// Trusted checkpoint bound to boot/session, exact seq, root, codec
@@ -184,8 +205,15 @@ impl AuditRelay {
         &self,
         current_root: [u8; root::ROOT_LEN],
         current_seq: u64,
+        auth_key: CheckpointAuthKey,
     ) -> AuditCheckpoint {
-        AuditCheckpoint::seal(self.boot, current_seq, current_root, self.generation)
+        AuditCheckpoint::seal(
+            self.boot,
+            current_seq,
+            current_root,
+            self.generation,
+            auth_key,
+        )
     }
 
     pub(super) const fn generation(self) -> u64 {

--- a/kernel/crates/astrid-native-kernel/src/audit/root.rs
+++ b/kernel/crates/astrid-native-kernel/src/audit/root.rs
@@ -9,7 +9,7 @@
 
 use blake3::Hasher;
 
-use super::types::{BootSessionId, CheckpointAuthKey};
+use super::types::{BootSessionId, CheckpointAuthContext};
 
 pub(crate) const ROOT_LEN: usize = 32;
 
@@ -18,6 +18,8 @@ pub(crate) const ROOT_DOMAIN_TAG: &[u8] = b"astrid.native-kernel.audit-root.v1";
 pub(crate) const GENESIS_DOMAIN_TAG: &[u8] = b"astrid.native-kernel.audit-genesis.v1";
 pub(crate) const CHECKPOINT_DOMAIN_TAG: &[u8] = b"astrid.native-kernel.audit-checkpoint.v1";
 pub(crate) const ACK_DOMAIN_TAG: &[u8] = b"astrid.native-kernel.audit-ack.v1";
+pub(crate) const VERIFIER_HANDOFF_DOMAIN_TAG: &[u8] =
+    b"astrid.native-kernel.audit-verifier-handoff.v1";
 
 pub(crate) fn genesis(boot: BootSessionId) -> [u8; ROOT_LEN] {
     let mut hasher = Hasher::new();
@@ -49,15 +51,16 @@ pub(crate) fn checkpoint_tag(
     seq: u64,
     root: [u8; ROOT_LEN],
     relay_generation: u64,
-    auth_key: CheckpointAuthKey,
+    context: &CheckpointAuthContext,
 ) -> [u8; ROOT_LEN] {
-    let mut hasher = Hasher::new_keyed(&auth_key.bytes());
+    let mut hasher = Hasher::new_keyed(&context.verification_key());
     hasher.update(CHECKPOINT_DOMAIN_TAG);
     hasher.update(&super::CODEC_VERSION.to_le_bytes());
     hasher.update(&boot.bytes());
     hasher.update(&seq.to_le_bytes());
     hasher.update(&root);
     hasher.update(&relay_generation.to_le_bytes());
+    hasher.update(&context.authority_id().to_le_bytes());
     hasher.finalize().into()
 }
 
@@ -65,16 +68,37 @@ pub(crate) fn checkpoint_tag(
 /// successfully folded. Relay acknowledgements consume this evidence; relay
 /// flow control still never becomes root authority.
 pub(crate) fn ack_tag(
+    boot: BootSessionId,
+    relay_generation: u64,
     seq: u64,
     source_root: [u8; ROOT_LEN],
     frame: &[u8],
-    auth_key: &CheckpointAuthKey,
+    context: &CheckpointAuthContext,
 ) -> [u8; ROOT_LEN] {
-    let mut hasher = Hasher::new_keyed(&auth_key.bytes());
+    let mut hasher = Hasher::new_keyed(&context.verification_key());
     hasher.update(ACK_DOMAIN_TAG);
     hasher.update(&super::CODEC_VERSION.to_le_bytes());
+    hasher.update(&context.authority_id().to_le_bytes());
+    hasher.update(&boot.bytes());
+    hasher.update(&relay_generation.to_le_bytes());
     hasher.update(&seq.to_le_bytes());
     hasher.update(&source_root);
     hasher.update(frame);
+    hasher.finalize().into()
+}
+
+/// Authenticates the opaque capability handed to the independent verifier.
+/// Possession of this sealed context is the verifier authority for exactly
+/// one boot/session; no caller-selectable raw key constructor exists.
+pub(crate) fn verifier_handoff_tag(
+    boot: BootSessionId,
+    authority_id: u64,
+    verification_key: &[u8; ROOT_LEN],
+) -> [u8; ROOT_LEN] {
+    let mut hasher = Hasher::new_keyed(verification_key);
+    hasher.update(VERIFIER_HANDOFF_DOMAIN_TAG);
+    hasher.update(&super::CODEC_VERSION.to_le_bytes());
+    hasher.update(&boot.bytes());
+    hasher.update(&authority_id.to_le_bytes());
     hasher.finalize().into()
 }

--- a/kernel/crates/astrid-native-kernel/src/audit/root.rs
+++ b/kernel/crates/astrid-native-kernel/src/audit/root.rs
@@ -1,0 +1,60 @@
+//! Rolling BLAKE3 root: the only root algorithm in this slice.
+//!
+//! `R_0 = BLAKE3(domain-separated genesis)` and
+//! `R_n = BLAKE3(tag || R_{n-1} || canonical_frame_n)` where the tag binds
+//! the algorithm id, frame-codec version, boot/session identity, and
+//! sequence. The previous root also rides inside the canonical frame for
+//! authenticity, but the fold consumes `R_{n-1}` directly, so there is no
+//! second encoding of the root.
+
+use blake3::Hasher;
+
+use super::types::BootSessionId;
+
+pub(crate) const ROOT_LEN: usize = 32;
+
+pub(crate) const ROOT_ALGORITHM_ID: &[u8] = b"BLAKE3-256";
+pub(crate) const ROOT_DOMAIN_TAG: &[u8] = b"astrid.native-kernel.audit-root.v1";
+pub(crate) const GENESIS_DOMAIN_TAG: &[u8] = b"astrid.native-kernel.audit-genesis.v1";
+pub(crate) const CHECKPOINT_DOMAIN_TAG: &[u8] = b"astrid.native-kernel.audit-checkpoint.v1";
+
+pub(crate) fn genesis(boot: BootSessionId) -> [u8; ROOT_LEN] {
+    let mut hasher = Hasher::new();
+    hasher.update(GENESIS_DOMAIN_TAG);
+    hasher.update(&boot.bytes());
+    hasher.update(&super::CODEC_VERSION.to_le_bytes());
+    hasher.finalize().into()
+}
+
+pub(crate) fn advance(
+    previous_root: [u8; ROOT_LEN],
+    boot: BootSessionId,
+    seq: u64,
+    frame: &[u8],
+) -> [u8; ROOT_LEN] {
+    let mut hasher = Hasher::new();
+    hasher.update(ROOT_DOMAIN_TAG);
+    hasher.update(ROOT_ALGORITHM_ID);
+    hasher.update(&super::CODEC_VERSION.to_le_bytes());
+    hasher.update(&boot.bytes());
+    hasher.update(&seq.to_le_bytes());
+    hasher.update(&previous_root);
+    hasher.update(frame);
+    hasher.finalize().into()
+}
+
+pub(crate) fn checkpoint_tag(
+    boot: BootSessionId,
+    seq: u64,
+    root: [u8; ROOT_LEN],
+    relay_generation: u64,
+) -> [u8; ROOT_LEN] {
+    let mut hasher = Hasher::new();
+    hasher.update(CHECKPOINT_DOMAIN_TAG);
+    hasher.update(&super::CODEC_VERSION.to_le_bytes());
+    hasher.update(&boot.bytes());
+    hasher.update(&seq.to_le_bytes());
+    hasher.update(&root);
+    hasher.update(&relay_generation.to_le_bytes());
+    hasher.finalize().into()
+}

--- a/kernel/crates/astrid-native-kernel/src/audit/root.rs
+++ b/kernel/crates/astrid-native-kernel/src/audit/root.rs
@@ -9,7 +9,7 @@
 
 use blake3::Hasher;
 
-use super::types::BootSessionId;
+use super::types::{BootSessionId, CheckpointAuthKey};
 
 pub(crate) const ROOT_LEN: usize = 32;
 
@@ -48,8 +48,9 @@ pub(crate) fn checkpoint_tag(
     seq: u64,
     root: [u8; ROOT_LEN],
     relay_generation: u64,
+    auth_key: CheckpointAuthKey,
 ) -> [u8; ROOT_LEN] {
-    let mut hasher = Hasher::new();
+    let mut hasher = Hasher::new_keyed(&auth_key.bytes());
     hasher.update(CHECKPOINT_DOMAIN_TAG);
     hasher.update(&super::CODEC_VERSION.to_le_bytes());
     hasher.update(&boot.bytes());

--- a/kernel/crates/astrid-native-kernel/src/audit/root.rs
+++ b/kernel/crates/astrid-native-kernel/src/audit/root.rs
@@ -87,9 +87,10 @@ pub(crate) fn ack_tag(
     hasher.finalize().into()
 }
 
-/// Authenticates the opaque capability handed to the independent verifier.
-/// Possession of this sealed context is the verifier authority for exactly
-/// one boot/session; no caller-selectable raw key constructor exists.
+/// Keys the kernel minting tag bound into the untrusted verifier handoff.
+/// The verification key never travels inside the handoff; the tag is
+/// checkable only by a holder of the independently trusted kernel-origin
+/// anchor, so a caller-minted handoff cannot authenticate itself.
 pub(crate) fn verifier_handoff_tag(
     boot: BootSessionId,
     authority_id: u64,

--- a/kernel/crates/astrid-native-kernel/src/audit/root.rs
+++ b/kernel/crates/astrid-native-kernel/src/audit/root.rs
@@ -17,6 +17,7 @@ pub(crate) const ROOT_ALGORITHM_ID: &[u8] = b"BLAKE3-256";
 pub(crate) const ROOT_DOMAIN_TAG: &[u8] = b"astrid.native-kernel.audit-root.v1";
 pub(crate) const GENESIS_DOMAIN_TAG: &[u8] = b"astrid.native-kernel.audit-genesis.v1";
 pub(crate) const CHECKPOINT_DOMAIN_TAG: &[u8] = b"astrid.native-kernel.audit-checkpoint.v1";
+pub(crate) const ACK_DOMAIN_TAG: &[u8] = b"astrid.native-kernel.audit-ack.v1";
 
 pub(crate) fn genesis(boot: BootSessionId) -> [u8; ROOT_LEN] {
     let mut hasher = Hasher::new();
@@ -57,5 +58,23 @@ pub(crate) fn checkpoint_tag(
     hasher.update(&seq.to_le_bytes());
     hasher.update(&root);
     hasher.update(&relay_generation.to_le_bytes());
+    hasher.finalize().into()
+}
+
+/// Binds a verifier receipt to the exact canonical frame and source root it
+/// successfully folded. Relay acknowledgements consume this evidence; relay
+/// flow control still never becomes root authority.
+pub(crate) fn ack_tag(
+    seq: u64,
+    source_root: [u8; ROOT_LEN],
+    frame: &[u8],
+    auth_key: &CheckpointAuthKey,
+) -> [u8; ROOT_LEN] {
+    let mut hasher = Hasher::new_keyed(&auth_key.bytes());
+    hasher.update(ACK_DOMAIN_TAG);
+    hasher.update(&super::CODEC_VERSION.to_le_bytes());
+    hasher.update(&seq.to_le_bytes());
+    hasher.update(&source_root);
+    hasher.update(frame);
     hasher.finalize().into()
 }

--- a/kernel/crates/astrid-native-kernel/src/audit/root.rs
+++ b/kernel/crates/astrid-native-kernel/src/audit/root.rs
@@ -53,7 +53,7 @@ pub(crate) fn checkpoint_tag(
     relay_generation: u64,
     context: &CheckpointAuthContext,
 ) -> [u8; ROOT_LEN] {
-    let mut hasher = Hasher::new_keyed(&context.verification_key());
+    let mut hasher = Hasher::new_keyed(&context.verification_key().bytes());
     hasher.update(CHECKPOINT_DOMAIN_TAG);
     hasher.update(&super::CODEC_VERSION.to_le_bytes());
     hasher.update(&boot.bytes());
@@ -75,7 +75,7 @@ pub(crate) fn ack_tag(
     frame: &[u8],
     context: &CheckpointAuthContext,
 ) -> [u8; ROOT_LEN] {
-    let mut hasher = Hasher::new_keyed(&context.verification_key());
+    let mut hasher = Hasher::new_keyed(&context.verification_key().bytes());
     hasher.update(ACK_DOMAIN_TAG);
     hasher.update(&super::CODEC_VERSION.to_le_bytes());
     hasher.update(&context.authority_id().to_le_bytes());

--- a/kernel/crates/astrid-native-kernel/src/audit/tests.rs
+++ b/kernel/crates/astrid-native-kernel/src/audit/tests.rs
@@ -188,10 +188,8 @@ fn append_folds_with_mandatory_source_root() {
 
         chain.relay_mut().grant_credits(1).unwrap();
         let record = chain.relay_mut().take().unwrap();
-        assert_eq!(
-            host_verifier.fold(record.frame(), record.root()).unwrap(),
-            seq
-        );
+        let receipt = host_verifier.fold(record.frame(), record.root()).unwrap();
+        assert_eq!(receipt.seq(), seq);
         assert_eq!(host_verifier.root(), *chain.root());
     }
 }
@@ -282,7 +280,9 @@ fn foreign_boot_and_missing_previous_root_are_invalid() {
 #[test]
 fn sequence_overflow_fails_closed_without_commit() {
     let chain_boot = boot();
-    let mut chain = AuditChain::restore(chain_boot, auth_key(), u64::MAX, [9; 32]);
+    let checkpoint =
+        AuditCheckpoint::seal(chain_boot, u64::MAX - 1, [9; 32], 1, auth_key()).unwrap();
+    let mut chain = AuditChain::restore(checkpoint, auth_key()).unwrap();
     let before = (chain.seq(), *chain.root());
     assert_eq!(
         chain.append(domain_event(AuditClass::DomainCreate)),
@@ -295,6 +295,7 @@ fn sequence_overflow_fails_closed_without_commit() {
 fn ack_requires_take_in_flight_and_matching_folded_root() {
     let chain_boot = boot();
     let mut chain = AuditChain::genesis(chain_boot, auth_key());
+    let mut host_verifier = verifier();
     chain
         .append(domain_event(AuditClass::DomainCreate))
         .unwrap();
@@ -303,19 +304,87 @@ fn ack_requires_take_in_flight_and_matching_folded_root() {
     chain.relay_mut().grant_credits(1).unwrap();
     let first = chain.relay_mut().take().unwrap();
     assert_eq!(chain.relay().redeliver().count(), 2);
+    let first_receipt = host_verifier.fold(first.frame(), first.root()).unwrap();
     assert_eq!(
-        chain.relay_mut().ack(first.seq(), [0; 32]),
+        chain
+            .relay_mut()
+            .ack(first.seq(), first.root(), [0; 32], auth_key()),
         Err(AuditError::RootMismatch)
     );
-    chain.relay_mut().ack(first.seq(), first.root()).unwrap();
+    chain
+        .relay_mut()
+        .ack(
+            first.seq(),
+            first_receipt.folded_root(),
+            first_receipt.ack_tag(),
+            auth_key(),
+        )
+        .unwrap();
 
     assert_eq!(
-        chain.relay_mut().ack(first.seq(), first.root()),
+        chain.relay_mut().ack(
+            first.seq(),
+            first_receipt.folded_root(),
+            first_receipt.ack_tag(),
+            auth_key()
+        ),
         Err(AuditError::RelayStaleCursor)
     );
     chain.relay_mut().grant_credits(1).unwrap();
     let second = chain.relay_mut().take().unwrap();
-    chain.relay_mut().ack(second.seq(), second.root()).unwrap();
+    let second_receipt = host_verifier.fold(second.frame(), second.root()).unwrap();
+    chain
+        .relay_mut()
+        .ack(
+            second.seq(),
+            second_receipt.folded_root(),
+            second_receipt.ack_tag(),
+            auth_key(),
+        )
+        .unwrap();
+}
+
+#[test]
+fn ack_before_take_does_not_retire_a_buffered_slot() {
+    let chain_boot = boot();
+    let mut chain = AuditChain::genesis(chain_boot, auth_key());
+    chain
+        .append(domain_event(AuditClass::DomainCreate))
+        .unwrap();
+    let before = chain.relay().redeliver().count();
+    assert_eq!(before, 1);
+    assert_eq!(
+        chain.relay_mut().ack(1, [0; 32], [0; 32], auth_key()),
+        Err(AuditError::RelayNotInFlight)
+    );
+    assert_eq!(chain.relay().redeliver().count(), before);
+    chain.relay_mut().grant_credits(1).unwrap();
+    assert!(chain.relay_mut().take().is_some());
+}
+
+#[test]
+fn restored_checkpoint_preserves_trusted_relay_generation() {
+    let chain_boot = boot();
+    let mut chain = AuditChain::genesis(chain_boot, auth_key());
+    for _ in 0..AUDIT_RELAY_SLOTS {
+        chain
+            .append(domain_event(AuditClass::DomainReclaim))
+            .unwrap();
+    }
+    let current_root = *chain.root();
+    let current_seq = chain.seq();
+    let checkpoint = chain
+        .relay_mut()
+        .resync(current_root, current_seq, auth_key())
+        .unwrap();
+    assert_eq!(checkpoint.relay_generation(), 2);
+
+    let restored = AuditChain::restore(checkpoint, auth_key()).unwrap();
+    assert_eq!(restored.boot(), checkpoint.boot());
+    assert_eq!(restored.seq(), checkpoint.seq());
+    assert_eq!(*restored.root(), checkpoint.root());
+    assert_eq!(restored.relay().generation(), 2);
+    assert!(restored.relay().redeliver().next().is_none());
 }
 
 #[test]
@@ -325,7 +394,7 @@ fn reserved_headroom_and_overflow_fail_before_atomic_commit() {
     for _ in 0..(AUDIT_RELAY_SLOTS - MAX_TERMINAL_RECORDS_PER_BATCH) {
         chain.append(domain_event(AuditClass::DomainEnter)).unwrap();
     }
-    assert_eq!(chain.seq(), 43);
+    assert_eq!(chain.seq(), 35);
 
     let before = (
         chain.seq(),
@@ -345,7 +414,7 @@ fn reserved_headroom_and_overflow_fail_before_atomic_commit() {
         before
     );
 
-    for expected_seq in 44u64..=(AUDIT_RELAY_SLOTS as u64) {
+    for expected_seq in 36u64..=(AUDIT_RELAY_SLOTS as u64) {
         let seq = chain
             .append(domain_event(AuditClass::DomainReclaim))
             .unwrap();
@@ -369,6 +438,76 @@ fn reserved_headroom_and_overflow_fail_before_atomic_commit() {
         full
     );
     assert_eq!(chain.relay().redeliver().count(), AUDIT_RELAY_SLOTS);
+}
+
+#[test]
+fn verifier_sequence_overflow_is_atomic_and_repeatable() {
+    let checkpoint = AuditCheckpoint::seal(boot(), u64::MAX - 1, [9; 32], 1, auth_key()).unwrap();
+    let mut wire = [0; native_audit_verifier::CHECKPOINT_WIRE_BYTES];
+    let bytes = encode_checkpoint(&checkpoint, auth_key(), &mut wire).unwrap();
+    let mut verifier =
+        native_audit_verifier::AuditVerifier::from_checkpoint(bytes, host_key()).unwrap();
+    let before = (verifier.next_seq(), verifier.root());
+    let event = domain_event(AuditClass::DomainCreate);
+    let frame = Frame::new(boot(), u64::MAX, &event, Some([9; 32])).unwrap();
+    let mut buf = [0; MAX_FRAME_BYTES];
+    let encoded = frame.encode(&mut buf).unwrap();
+    let claimed = root::advance([9; 32], boot(), u64::MAX, encoded);
+    assert_eq!(
+        verifier.fold(encoded, claimed),
+        Err(native_audit_verifier::FoldFailure::SequenceOverflow)
+    );
+    assert_eq!(
+        verifier.fold(encoded, claimed),
+        Err(native_audit_verifier::FoldFailure::SequenceOverflow)
+    );
+    assert_eq!((verifier.next_seq(), verifier.root()), before);
+}
+
+#[test]
+fn explicitly_mismatched_previous_root_is_invalid() {
+    let chain_boot = boot();
+    let wrong_previous = [0xAA; 32];
+    let event = domain_event(AuditClass::DomainCreate);
+    let frame = Frame::new(chain_boot, 1, &event, Some(wrong_previous)).unwrap();
+    let mut buf = [0; MAX_FRAME_BYTES];
+    let encoded = frame.encode(&mut buf).unwrap();
+    let claimed = root::advance(wrong_previous, chain_boot, 1, encoded);
+    let mut host_verifier = verifier();
+    assert!(matches!(
+        host_verifier.fold(encoded, claimed),
+        Err(native_audit_verifier::FoldFailure::Invalid(
+            native_audit_verifier::InvalidReason::PreviousRootMismatch
+        ))
+    ));
+}
+
+#[test]
+fn kernel_and_verifier_reject_zero_relay_generation() {
+    let chain_boot = boot();
+    let chain = AuditChain::genesis(chain_boot, auth_key());
+    let seq = chain.seq();
+    let root = *chain.root();
+    let mut wire = [0; native_audit_verifier::CHECKPOINT_WIRE_BYTES];
+    encode_checkpoint(&chain.checkpoint(), auth_key(), &mut wire).unwrap();
+    let generation_offset = 4 + 2 + 16 + 8 + 32;
+    wire[generation_offset..generation_offset + 8].copy_from_slice(&0u64.to_le_bytes());
+    let zero_tag = root::checkpoint_tag(chain_boot, seq, root, 0, auth_key());
+    let tag_offset = native_audit_verifier::CHECKPOINT_WIRE_BYTES - 32;
+    wire[tag_offset..].copy_from_slice(&zero_tag);
+
+    assert_eq!(
+        decode_checkpoint(&wire, auth_key()),
+        Err(AuditError::MalformedFrame)
+    );
+    assert_eq!(
+        native_audit_verifier::verify_checkpoint(&wire, host_key()),
+        Err(native_audit_verifier::VerifyFailure::Malformed)
+    );
+    assert_eq!(
+        AuditCheckpoint::seal(chain_boot, seq, root, 0, auth_key()),
+        Err(AuditError::MalformedFrame)
+    );
 }
 
 #[test]
@@ -398,10 +537,8 @@ fn resync_is_generation_bound_and_restores_flow() {
     chain.relay_mut().grant_credits(1).unwrap();
     let record = chain.relay_mut().take().unwrap();
     assert_eq!(record.seq(), seq);
-    assert_eq!(
-        host_verifier.fold(record.frame(), record.root()).unwrap(),
-        seq
-    );
+    let receipt = host_verifier.fold(record.frame(), record.root()).unwrap();
+    assert_eq!(receipt.seq(), seq);
 }
 
 #[test]
@@ -444,6 +581,6 @@ fn checkpoint_is_kernel_authenticated_and_state_bound() {
 
 #[test]
 fn batch_reserve_is_static_and_inside_the_window() {
-    assert_eq!(MAX_TERMINAL_RECORDS_PER_BATCH, 21);
+    assert_eq!(MAX_TERMINAL_RECORDS_PER_BATCH, 29);
     assert!(AUDIT_RELAY_SLOTS >= MAX_TERMINAL_RECORDS_PER_BATCH);
 }

--- a/kernel/crates/astrid-native-kernel/src/audit/tests.rs
+++ b/kernel/crates/astrid-native-kernel/src/audit/tests.rs
@@ -67,12 +67,33 @@ fn encode_frame(
     FrameBuf::new(frame.encode(&mut buf).unwrap())
 }
 
+/// Models the independently trusted kernel-origin anchor channel: the
+/// kernel's live context is injected into the verifier directly, never
+/// through the untrusted handoff.
+fn anchor_of(live: AuditAuthority) -> native_audit_verifier::AuthContext {
+    native_audit_verifier::AuthContext::from_trusted_anchor(
+        live.context().authority_id(),
+        live.boot().bytes(),
+        live.context().verification_key(),
+    )
+    .unwrap()
+}
+
+fn foreign(boot_byte: u8) -> AuditAuthority {
+    AuditAuthority::mint(BootSessionId::new([boot_byte; 16]).unwrap())
+}
+
 fn host_context() -> native_audit_verifier::AuthContext {
-    native_audit_verifier::AuthContext::from_handoff(&authority().verifier_handoff()).unwrap()
+    anchor_of(authority())
+}
+
+fn host_handoff() -> [u8; native_audit_verifier::AUTHORITY_HANDOFF_BYTES] {
+    authority().verifier_handoff()
 }
 
 fn verifier() -> native_audit_verifier::AuditVerifier {
-    native_audit_verifier::AuditVerifier::genesis(boot().bytes(), host_context()).unwrap()
+    native_audit_verifier::AuditVerifier::genesis(boot().bytes(), host_context(), &host_handoff())
+        .unwrap()
 }
 
 #[test]
@@ -253,12 +274,13 @@ fn foreign_boot_and_missing_previous_root_are_invalid() {
     chain
         .append(domain_event(AuditClass::DomainCreate))
         .unwrap();
-    let foreign_authority = AuditAuthority::mint(BootSessionId::new([8; 16]).unwrap());
-    let foreign_context =
-        native_audit_verifier::AuthContext::from_handoff(&foreign_authority.verifier_handoff())
-            .unwrap();
-    let mut foreign =
-        native_audit_verifier::AuditVerifier::genesis([8; 16], foreign_context).unwrap();
+    let foreign_authority = foreign(8);
+    let mut foreign = native_audit_verifier::AuditVerifier::genesis(
+        [8; 16],
+        anchor_of(foreign_authority),
+        &foreign_authority.verifier_handoff(),
+    )
+    .unwrap();
     chain.relay_mut().grant_credits(1).unwrap();
     let record = chain.relay_mut().take().unwrap();
     assert!(matches!(
@@ -439,8 +461,12 @@ fn verifier_sequence_overflow_is_atomic_and_repeatable() {
         AuditCheckpoint::seal(boot(), u64::MAX - 1, [9; 32], 1, authority().context()).unwrap();
     let mut wire = [0; native_audit_verifier::CHECKPOINT_WIRE_BYTES];
     let bytes = encode_checkpoint(&checkpoint, authority().context(), &mut wire).unwrap();
-    let mut verifier =
-        native_audit_verifier::AuditVerifier::from_checkpoint(bytes, host_context()).unwrap();
+    let mut verifier = native_audit_verifier::AuditVerifier::from_checkpoint(
+        bytes,
+        host_context(),
+        &host_handoff(),
+    )
+    .unwrap();
     let before = (verifier.next_seq(), verifier.root());
     let event = domain_event(AuditClass::DomainCreate);
     let frame = Frame::new(boot(), u64::MAX, &event, Some([9; 32])).unwrap();
@@ -518,8 +544,12 @@ fn resync_is_generation_bound_and_restores_flow() {
 
     let mut wire = [0; native_audit_verifier::CHECKPOINT_WIRE_BYTES];
     let bytes = encode_checkpoint(&checkpoint, authority().context(), &mut wire).unwrap();
-    let mut host_verifier =
-        native_audit_verifier::AuditVerifier::from_checkpoint(bytes, host_context()).unwrap();
+    let mut host_verifier = native_audit_verifier::AuditVerifier::from_checkpoint(
+        bytes,
+        host_context(),
+        &host_handoff(),
+    )
+    .unwrap();
     assert_eq!(host_verifier.root(), *chain.root());
 
     let seq = chain.append(domain_event(AuditClass::DomainEnter)).unwrap();
@@ -542,7 +572,14 @@ fn checkpoint_is_kernel_authenticated_and_state_bound() {
 
     let mut wire = [0; native_audit_verifier::CHECKPOINT_WIRE_BYTES];
     let bytes = encode_checkpoint(&checkpoint, authority().context(), &mut wire).unwrap();
-    assert!(native_audit_verifier::AuditVerifier::from_checkpoint(bytes, host_context()).is_ok());
+    assert!(
+        native_audit_verifier::AuditVerifier::from_checkpoint(
+            bytes,
+            host_context(),
+            &host_handoff()
+        )
+        .is_ok()
+    );
 
     // Replace the sealed tag with the rejected verifier-local unkeyed tag.
     let mut unkeyed = [0; native_audit_verifier::CHECKPOINT_WIRE_BYTES];
@@ -585,16 +622,18 @@ fn foreign_or_arbitrary_context_cannot_authenticate_or_retire() {
         encode_checkpoint(&chain.checkpoint(), authority().context(), &mut wire).unwrap();
     let arbitrary_handoff = [7; native_audit_verifier::AUTHORITY_HANDOFF_BYTES];
     assert_eq!(
-        native_audit_verifier::AuthContext::from_handoff(&arbitrary_handoff),
+        host_context().bind_handoff(&arbitrary_handoff),
         Err(native_audit_verifier::VerifyFailure::Malformed)
     );
 
-    let foreign_authority = AuditAuthority::mint(BootSessionId::new([8; 16]).unwrap());
-    let foreign_context =
-        native_audit_verifier::AuthContext::from_handoff(&foreign_authority.verifier_handoff())
-            .unwrap();
+    let foreign_authority = foreign(8);
+    let foreign_context = anchor_of(foreign_authority);
     assert!(matches!(
-        native_audit_verifier::AuditVerifier::genesis(chain_boot.bytes(), foreign_context),
+        native_audit_verifier::AuditVerifier::genesis(
+            chain_boot.bytes(),
+            foreign_context,
+            &foreign_authority.verifier_handoff()
+        ),
         Err(native_audit_verifier::VerifyFailure::Malformed)
     ));
     assert_eq!(
@@ -616,7 +655,170 @@ fn foreign_or_arbitrary_context_cannot_authenticate_or_retire() {
 }
 
 #[test]
+fn handoff_is_untrusted_binding_without_verification_material() {
+    let live = authority();
+    let key = live.context().verification_key();
+    let handoff = live.verifier_handoff();
+
+    assert_eq!(
+        handoff.len(),
+        native_audit_verifier::AUTHORITY_HANDOFF_BYTES
+    );
+    assert_eq!(&handoff[..8], b"ASAUDCTX");
+    assert_eq!(
+        u64::from_le_bytes(handoff[8..16].try_into().unwrap()),
+        live.context().authority_id()
+    );
+    assert_eq!(&handoff[16..32], &boot().bytes());
+    // The kernel verification key must not ride in any window of the
+    // untrusted handoff.
+    assert!(handoff.windows(32).all(|window| window != key));
+
+    assert_eq!(host_context().bind_handoff(&handoff), Ok(()));
+    assert!(
+        native_audit_verifier::AuditVerifier::genesis(boot().bytes(), host_context(), &handoff)
+            .is_ok()
+    );
+}
+
+#[test]
+fn structurally_valid_self_authenticated_handoff_is_rejected() {
+    let chain_boot = boot();
+    let live = authority();
+    let attacker_key = [0xB0; 32];
+
+    // Structurally valid: correct magic, the live authority id and boot,
+    // and a tag the attacker computed under a self-chosen key.
+    let mut forged = [0; native_audit_verifier::AUTHORITY_HANDOFF_BYTES];
+    forged[..8].copy_from_slice(b"ASAUDCTX");
+    forged[8..16].copy_from_slice(&live.context().authority_id().to_le_bytes());
+    forged[16..32].copy_from_slice(&chain_boot.bytes());
+    let attacker_tag =
+        root::verifier_handoff_tag(chain_boot, live.context().authority_id(), &attacker_key);
+    forged[32..].copy_from_slice(&attacker_tag);
+
+    assert_eq!(
+        host_context().bind_handoff(&forged),
+        Err(native_audit_verifier::VerifyFailure::HandoffUnbound)
+    );
+    assert!(matches!(
+        native_audit_verifier::AuditVerifier::genesis(chain_boot.bytes(), host_context(), &forged),
+        Err(native_audit_verifier::VerifyFailure::HandoffUnbound)
+    ));
+
+    // A self-consistent tag under a foreign boot fails the identity binding.
+    let foreign_boot = foreign(9);
+    let mut foreign = forged;
+    foreign[16..32].copy_from_slice(&foreign_boot.boot().bytes());
+    let foreign_tag = root::verifier_handoff_tag(
+        foreign_boot.boot(),
+        live.context().authority_id(),
+        &attacker_key,
+    );
+    foreign[32..].copy_from_slice(&foreign_tag);
+    assert_eq!(
+        host_context().bind_handoff(&foreign),
+        Err(native_audit_verifier::VerifyFailure::HandoffUnbound)
+    );
+}
+
+#[test]
+fn checkpoint_under_forged_context_is_rejected() {
+    let chain_boot = boot();
+    // Arbitrary attacker-chosen root and sequence sealed under an
+    // attacker-chosen key reusing only the public identity fields.
+    let forged_key = [0xB0; 32];
+    let mut hasher = Hasher::new_keyed(&forged_key);
+    hasher.update(root::CHECKPOINT_DOMAIN_TAG);
+    hasher.update(&super::CODEC_VERSION.to_le_bytes());
+    hasher.update(&chain_boot.bytes());
+    hasher.update(&999u64.to_le_bytes());
+    hasher.update(&[0xAA; root::ROOT_LEN]);
+    hasher.update(&1u64.to_le_bytes());
+    hasher.update(&authority().context().authority_id().to_le_bytes());
+    let forged_tag: [u8; 32] = hasher.finalize().into();
+
+    let mut wire = [0; native_audit_verifier::CHECKPOINT_WIRE_BYTES];
+    let body_len = (native_audit_verifier::CHECKPOINT_WIRE_BYTES - 4) as u32;
+    wire[0..4].copy_from_slice(&body_len.to_le_bytes());
+    let mut pos = 4;
+    wire[pos..pos + 2].copy_from_slice(&super::CODEC_VERSION.to_le_bytes());
+    pos += 2;
+    wire[pos..pos + 16].copy_from_slice(&chain_boot.bytes());
+    pos += 16;
+    wire[pos..pos + 8].copy_from_slice(&999u64.to_le_bytes());
+    pos += 8;
+    wire[pos..pos + root::ROOT_LEN].copy_from_slice(&[0xAA; root::ROOT_LEN]);
+    pos += root::ROOT_LEN;
+    wire[pos..pos + 8].copy_from_slice(&1u64.to_le_bytes());
+    pos += 8;
+    wire[pos..pos + 8].copy_from_slice(&authority().context().authority_id().to_le_bytes());
+    pos += 8;
+    wire[pos..].copy_from_slice(&forged_tag);
+
+    assert_eq!(
+        native_audit_verifier::verify_checkpoint(&wire, &host_context()),
+        Err(native_audit_verifier::VerifyFailure::CheckpointMismatch)
+    );
+    assert!(matches!(
+        native_audit_verifier::AuditVerifier::from_checkpoint(
+            &wire,
+            host_context(),
+            &host_handoff()
+        ),
+        Err(native_audit_verifier::VerifyFailure::CheckpointMismatch)
+    ));
+    assert_eq!(
+        decode_checkpoint(&wire, authority().context()),
+        Err(AuditError::CheckpointMismatch)
+    );
+}
+
+#[test]
+fn forged_retirement_receipt_is_rejected() {
+    let chain_boot = boot();
+    let mut chain = AuditChain::genesis(chain_boot);
+    chain
+        .append(domain_event(AuditClass::DomainCreate))
+        .unwrap();
+    let mut host_verifier = verifier();
+
+    chain.relay_mut().grant_credits(1).unwrap();
+    let record = chain.relay_mut().take().unwrap();
+    let genuine = host_verifier.fold(record.frame(), record.root()).unwrap();
+
+    // A receipt minted under an attacker-chosen key fails even with the
+    // correct folded root, sequence, frame, and source root.
+    let forged_key = [0xB0; 32];
+    let mut hasher = Hasher::new_keyed(&forged_key);
+    hasher.update(root::ACK_DOMAIN_TAG);
+    hasher.update(&super::CODEC_VERSION.to_le_bytes());
+    hasher.update(&authority().context().authority_id().to_le_bytes());
+    hasher.update(&chain_boot.bytes());
+    hasher.update(&chain.relay().generation().to_le_bytes());
+    hasher.update(&record.seq().to_le_bytes());
+    hasher.update(&record.root());
+    hasher.update(record.frame());
+    let forged_tag: [u8; 32] = hasher.finalize().into();
+
+    assert_eq!(
+        chain.ack(record.seq(), record.root(), forged_tag),
+        Err(AuditError::RootMismatch)
+    );
+    assert_eq!(chain.relay().redeliver().count(), 1);
+
+    // The genuine verifier receipt still retires exactly the in-flight
+    // record.
+    chain
+        .ack(record.seq(), genuine.folded_root(), genuine.ack_tag())
+        .unwrap();
+    assert_eq!(chain.relay().redeliver().count(), 0);
+}
+
+#[test]
 fn batch_reserve_is_static_and_inside_the_window() {
     assert_eq!(MAX_TERMINAL_RECORDS_PER_BATCH, 29);
-    assert!(AUDIT_RELAY_SLOTS >= MAX_TERMINAL_RECORDS_PER_BATCH);
+    // Statically re-proves the relay's own compile-time headroom invariant
+    // from the test side, keeping the reserve story falsifiable here too.
+    const { assert!(AUDIT_RELAY_SLOTS >= MAX_TERMINAL_RECORDS_PER_BATCH) }
 }

--- a/kernel/crates/astrid-native-kernel/src/audit/tests.rs
+++ b/kernel/crates/astrid-native-kernel/src/audit/tests.rs
@@ -2,9 +2,14 @@
 
 use super::*;
 use crate::ipc::DomainToken;
+use blake3::Hasher;
 
 fn boot() -> BootSessionId {
     BootSessionId::new([7; 16]).unwrap()
+}
+
+fn auth_key() -> CheckpointAuthKey {
+    CheckpointAuthKey::new([0x5a; 32]).unwrap()
 }
 
 fn subject(slot: u64, generation: u64) -> AuditSubject {
@@ -31,8 +36,6 @@ fn capability_object(
     .unwrap()
 }
 
-/// Fixed-buffer frame storage: the kernel is `no_std`, so tests hold encoded
-/// bytes in arrays instead of heap vectors.
 struct FrameBuf {
     bytes: [u8; MAX_FRAME_BYTES],
     len: usize,
@@ -59,19 +62,31 @@ fn encode_frame(
     event: &AuditEvent,
     prev: Option<[u8; 32]>,
 ) -> FrameBuf {
-    let frame = Frame::new(chain_boot, seq, event, prev);
+    let frame = Frame::new(chain_boot, seq, event, prev).unwrap();
     let mut buf = [0; MAX_FRAME_BYTES];
     FrameBuf::new(frame.encode(&mut buf).unwrap())
+}
+
+fn host_key() -> native_audit_verifier::CheckpointKey {
+    native_audit_verifier::CheckpointKey::new(auth_key().bytes()).unwrap()
+}
+
+fn verifier() -> native_audit_verifier::AuditVerifier {
+    native_audit_verifier::AuditVerifier::genesis(boot().bytes(), host_key()).unwrap()
 }
 
 #[test]
 fn roundtrip_and_injectivity() {
     let chain_boot = boot();
+    let genesis = root::genesis(chain_boot);
     let cases = [
         domain_event(AuditClass::DomainCreate),
-        domain_event(AuditClass::IpcSend).with_object(AuditObject::endpoint(2, 5).unwrap()),
+        domain_event(AuditClass::IpcSend)
+            .with_object(AuditObject::endpoint(2, 5).unwrap())
+            .unwrap(),
         domain_event(AuditClass::CapabilityDerive)
             .with_object(capability_object(9, 3, 4, 11))
+            .unwrap()
             .with_rights(AuditRights::from_bits(0b0101).unwrap()),
         AuditEvent::denial(
             subject(1, 2),
@@ -81,12 +96,12 @@ fn roundtrip_and_injectivity() {
             .with_payload(&[0xAA; 64])
             .unwrap(),
     ];
-    let encoded: [FrameBuf; 5] = [
-        encode_frame(chain_boot, 1, &cases[0], None),
-        encode_frame(chain_boot, 1, &cases[1], None),
-        encode_frame(chain_boot, 1, &cases[2], None),
-        encode_frame(chain_boot, 1, &cases[3], None),
-        encode_frame(chain_boot, 1, &cases[4], None),
+    let encoded = [
+        encode_frame(chain_boot, 1, &cases[0], Some(genesis)),
+        encode_frame(chain_boot, 1, &cases[1], Some(genesis)),
+        encode_frame(chain_boot, 1, &cases[2], Some(genesis)),
+        encode_frame(chain_boot, 1, &cases[3], Some(genesis)),
+        encode_frame(chain_boot, 1, &cases[4], Some(genesis)),
     ];
     for bytes in &encoded {
         let decoded = decode(bytes.as_slice()).unwrap();
@@ -102,10 +117,12 @@ fn roundtrip_and_injectivity() {
 }
 
 #[test]
-fn rejects_malformed_and_non_canonical() {
+fn rejects_malformed_non_canonical_and_disclosing_inputs() {
     let chain_boot = boot();
-    let event = domain_event(AuditClass::DomainAdmit).with_object(capability_object(1, 0, 1, 1));
-    let valid = encode_frame(chain_boot, 1, &event, None);
+    let event = domain_event(AuditClass::DomainAdmit)
+        .with_object(capability_object(1, 0, 1, 1))
+        .unwrap();
+    let valid = encode_frame(chain_boot, 1, &event, Some(root::genesis(chain_boot)));
 
     let truncated = &valid.as_slice()[..valid.len - 1];
     assert!(matches!(decode(truncated), Err(AuditError::MalformedFrame)));
@@ -126,20 +143,6 @@ fn rejects_malformed_and_non_canonical() {
         Err(AuditError::MalformedFrame)
     ));
 
-    let mut bad_seq = FrameBuf::new(valid.as_slice());
-    bad_seq.bytes[22..30].copy_from_slice(&0u64.to_le_bytes());
-    assert!(matches!(
-        decode(bad_seq.as_slice()),
-        Err(AuditError::MalformedFrame)
-    ));
-
-    let mut zero_boot = FrameBuf::new(valid.as_slice());
-    zero_boot.bytes[6..22].fill(0);
-    assert!(matches!(
-        decode(zero_boot.as_slice()),
-        Err(AuditError::MalformedFrame)
-    ));
-
     let denial = encode_frame(
         chain_boot,
         1,
@@ -147,19 +150,27 @@ fn rejects_malformed_and_non_canonical() {
             subject(0, 1),
             DenialContext::new(DenialReason::StaleIdentity, [0; 8]),
         ),
-        None,
+        Some(root::genesis(chain_boot)),
     );
     assert!(matches!(
         decode(denial.as_slice()),
         Ok(frame) if frame.class() == AuditClass::BoundedDenial && frame.object().is_none()
     ));
+
+    let denial_event = AuditEvent::new(AuditClass::BoundedDenial, subject(0, 1));
+    assert!(
+        denial_event
+            .with_object(capability_object(1, 0, 1, 1))
+            .is_none()
+    );
+    assert!(AuditObject::capability_instance(1, 0, 1, AuditObjectKind::Domain, 1).is_none());
 }
 
 #[test]
-fn chain_append_is_atomic_and_verifier_fold_matches_root() {
+fn append_folds_with_mandatory_source_root() {
     let chain_boot = boot();
-    let mut chain = AuditChain::genesis(chain_boot);
-    let mut verifier = native_audit_verifier::AuditVerifier::genesis(chain_boot.bytes()).unwrap();
+    let mut chain = AuditChain::genesis(chain_boot, auth_key());
+    let mut host_verifier = verifier();
 
     for expected_seq in 1u64..=5 {
         let class = match expected_seq {
@@ -169,26 +180,26 @@ fn chain_append_is_atomic_and_verifier_fold_matches_root() {
             4 => AuditClass::GenerationAdvance,
             _ => AuditClass::DomainReclaim,
         };
-        let event = domain_event(class).with_object(capability_object(expected_seq, 1, 2, 3));
+        let event = domain_event(class)
+            .with_object(capability_object(expected_seq, 1, 2, 3))
+            .unwrap();
         let seq = chain.append(event).unwrap();
         assert_eq!(seq, expected_seq);
 
         chain.relay_mut().grant_credits(1).unwrap();
         let record = chain.relay_mut().take().unwrap();
         assert_eq!(
-            verifier
-                .fold_with_root(record.frame(), Some(record.root()))
-                .unwrap(),
-            expected_seq
+            host_verifier.fold(record.frame(), record.root()).unwrap(),
+            seq
         );
-        assert_eq!(verifier.root(), *chain.root());
+        assert_eq!(host_verifier.root(), *chain.root());
     }
 }
 
 #[test]
 fn tamper_is_invalid_gap_is_incomplete_duplicate_is_invalid() {
     let chain_boot = boot();
-    let mut chain = AuditChain::genesis(chain_boot);
+    let mut chain = AuditChain::genesis(chain_boot, auth_key());
     for class in [
         AuditClass::DomainCreate,
         AuditClass::DomainAdmit,
@@ -197,39 +208,40 @@ fn tamper_is_invalid_gap_is_incomplete_duplicate_is_invalid() {
         chain.append(domain_event(class)).unwrap();
     }
     let mut records = [FrameBuf::new(&[]), FrameBuf::new(&[]), FrameBuf::new(&[])];
+    let mut roots = [[0; 32]; 3];
     {
         chain.relay_mut().grant_credits(3).unwrap();
         let mut count = 0;
         while let Some(record) = chain.relay_mut().take() {
             records[count] = FrameBuf::new(record.frame());
+            roots[count] = record.root();
             count += 1;
         }
         assert_eq!(count, 3);
     }
 
-    let mut verifier = native_audit_verifier::AuditVerifier::genesis(chain_boot.bytes()).unwrap();
+    let mut host_verifier = verifier();
     let mut tampered = FrameBuf::new(records[0].as_slice());
     let last = tampered.len - 1;
     tampered.bytes[last] ^= 0xFF;
     assert!(matches!(
-        verifier.fold(tampered.as_slice()),
+        host_verifier.fold(tampered.as_slice(), roots[0]),
         Err(native_audit_verifier::FoldFailure::Invalid(_))
     ));
 
-    let mut verifier = native_audit_verifier::AuditVerifier::genesis(chain_boot.bytes()).unwrap();
-    verifier.fold(records[0].as_slice()).unwrap();
-    // records[2] without records[1] is a gap: Incomplete, never a skip.
+    let mut host_verifier = verifier();
+    host_verifier.fold(records[0].as_slice(), roots[0]).unwrap();
     assert!(matches!(
-        verifier.fold(records[2].as_slice()),
+        host_verifier.fold(records[2].as_slice(), roots[2]),
         Err(native_audit_verifier::FoldFailure::Incomplete(
             native_audit_verifier::IncompleteReason::SequenceGap
         ))
     ));
 
-    let mut verifier = native_audit_verifier::AuditVerifier::genesis(chain_boot.bytes()).unwrap();
-    verifier.fold(records[0].as_slice()).unwrap();
+    let mut host_verifier = verifier();
+    host_verifier.fold(records[0].as_slice(), roots[0]).unwrap();
     assert!(matches!(
-        verifier.fold(records[0].as_slice()),
+        host_verifier.fold(records[0].as_slice(), roots[0]),
         Err(native_audit_verifier::FoldFailure::Invalid(
             native_audit_verifier::InvalidReason::DuplicateOrReorder
         ))
@@ -237,9 +249,40 @@ fn tamper_is_invalid_gap_is_incomplete_duplicate_is_invalid() {
 }
 
 #[test]
+fn foreign_boot_and_missing_previous_root_are_invalid() {
+    let chain_boot = boot();
+    let mut chain = AuditChain::genesis(chain_boot, auth_key());
+    chain
+        .append(domain_event(AuditClass::DomainCreate))
+        .unwrap();
+    let mut foreign = native_audit_verifier::AuditVerifier::genesis([8; 16], host_key()).unwrap();
+    chain.relay_mut().grant_credits(1).unwrap();
+    let record = chain.relay_mut().take().unwrap();
+    assert!(matches!(
+        foreign.fold(record.frame(), record.root()),
+        Err(native_audit_verifier::FoldFailure::Invalid(
+            native_audit_verifier::InvalidReason::ForeignBoot
+        ))
+    ));
+
+    let mut host_verifier = verifier();
+    let event = domain_event(AuditClass::DomainCreate);
+    let frame = Frame::new(chain_boot, 1, &event, None).unwrap();
+    let mut buf = [0; MAX_FRAME_BYTES];
+    let encoded = frame.encode(&mut buf).unwrap();
+    let expected = root::advance(root::genesis(chain_boot), chain_boot, 1, encoded);
+    assert!(matches!(
+        host_verifier.fold(encoded, expected),
+        Err(native_audit_verifier::FoldFailure::Invalid(
+            native_audit_verifier::InvalidReason::PreviousRootMismatch
+        ))
+    ));
+}
+
+#[test]
 fn sequence_overflow_fails_closed_without_commit() {
     let chain_boot = boot();
-    let mut chain = AuditChain::restore(chain_boot, u64::MAX, [9; 32]);
+    let mut chain = AuditChain::restore(chain_boot, auth_key(), u64::MAX, [9; 32]);
     let before = (chain.seq(), *chain.root());
     assert_eq!(
         chain.append(domain_event(AuditClass::DomainCreate)),
@@ -249,9 +292,9 @@ fn sequence_overflow_fails_closed_without_commit() {
 }
 
 #[test]
-fn relay_flow_credits_acks_and_redelivery() {
+fn ack_requires_take_in_flight_and_matching_folded_root() {
     let chain_boot = boot();
-    let mut chain = AuditChain::genesis(chain_boot);
+    let mut chain = AuditChain::genesis(chain_boot, auth_key());
     chain
         .append(domain_event(AuditClass::DomainCreate))
         .unwrap();
@@ -259,96 +302,144 @@ fn relay_flow_credits_acks_and_redelivery() {
 
     chain.relay_mut().grant_credits(1).unwrap();
     let first = chain.relay_mut().take().unwrap();
-    // Lost ack: both records stay outstanding and can be redelivered.
-    let mut redelivered = chain.relay().redeliver();
-    assert_eq!(redelivered.next().unwrap().frame(), first.frame());
-    assert_eq!(redelivered.count(), 1);
+    assert_eq!(chain.relay().redeliver().count(), 2);
+    assert_eq!(
+        chain.relay_mut().ack(first.seq(), [0; 32]),
+        Err(AuditError::RootMismatch)
+    );
+    chain.relay_mut().ack(first.seq(), first.root()).unwrap();
 
-    chain.relay_mut().ack(first.seq()).unwrap();
+    assert_eq!(
+        chain.relay_mut().ack(first.seq(), first.root()),
+        Err(AuditError::RelayStaleCursor)
+    );
     chain.relay_mut().grant_credits(1).unwrap();
     let second = chain.relay_mut().take().unwrap();
-    assert_eq!(second.seq(), 2);
-    chain.relay_mut().ack(second.seq()).unwrap();
-
-    assert!(chain.relay_mut().ack(first.seq()).is_err());
+    chain.relay_mut().ack(second.seq(), second.root()).unwrap();
 }
 
 #[test]
-fn window_overflow_keeps_authority_and_resync_rebinds() {
+fn reserved_headroom_and_overflow_fail_before_atomic_commit() {
     let chain_boot = boot();
-    let mut chain = AuditChain::genesis(chain_boot);
-    let total = AUDIT_RELAY_SLOTS as u64 + 2;
-    for index in 0..total {
-        let class = if index % 2 == 0 {
-            AuditClass::DomainEnter
-        } else {
-            AuditClass::DomainExit
-        };
-        let seq = chain.append(domain_event(class)).unwrap();
-        assert_eq!(seq, index + 1);
+    let mut chain = AuditChain::genesis(chain_boot, auth_key());
+    for _ in 0..(AUDIT_RELAY_SLOTS - MAX_TERMINAL_RECORDS_PER_BATCH) {
+        chain.append(domain_event(AuditClass::DomainEnter)).unwrap();
     }
-    // The window latched at capacity; the two newest rooted events wait for a
-    // resync while every retained record stays intact and in order.
-    assert_eq!(chain.seq(), total);
-    assert_eq!(chain.relay().redeliver().count(), AUDIT_RELAY_SLOTS);
+    assert_eq!(chain.seq(), 43);
 
+    let before = (
+        chain.seq(),
+        *chain.root(),
+        chain.relay().redeliver().count(),
+    );
+    assert_eq!(
+        chain.append(domain_event(AuditClass::DomainEnter)),
+        Err(AuditError::HandoffIncomplete)
+    );
+    assert_eq!(
+        (
+            chain.seq(),
+            *chain.root(),
+            chain.relay().redeliver().count()
+        ),
+        before
+    );
+
+    for expected_seq in 44u64..=(AUDIT_RELAY_SLOTS as u64) {
+        let seq = chain
+            .append(domain_event(AuditClass::DomainReclaim))
+            .unwrap();
+        assert_eq!(seq, expected_seq);
+    }
+    let full = (
+        chain.seq(),
+        *chain.root(),
+        chain.relay().redeliver().count(),
+    );
+    assert_eq!(
+        chain.append(domain_event(AuditClass::DomainReclaim)),
+        Err(AuditError::HandoffIncomplete)
+    );
+    assert_eq!(
+        (
+            chain.seq(),
+            *chain.root(),
+            chain.relay().redeliver().count()
+        ),
+        full
+    );
+    assert_eq!(chain.relay().redeliver().count(), AUDIT_RELAY_SLOTS);
+}
+
+#[test]
+fn resync_is_generation_bound_and_restores_flow() {
+    let chain_boot = boot();
+    let mut chain = AuditChain::genesis(chain_boot, auth_key());
+    for _ in 0..AUDIT_RELAY_SLOTS {
+        chain
+            .append(domain_event(AuditClass::DomainReclaim))
+            .unwrap();
+    }
     let current_root = *chain.root();
     let current_seq = chain.seq();
-    let checkpoint = chain.relay_mut().resync(current_root, current_seq).unwrap();
-    assert_eq!(checkpoint.seq(), chain.seq());
-    assert_eq!(checkpoint.relay_generation(), 2);
-    let mut wire = [0; native_audit_verifier::CHECKPOINT_WIRE_BYTES];
-    let bytes = encode_checkpoint(&checkpoint, &mut wire).unwrap();
-    let mut verifier = native_audit_verifier::AuditVerifier::from_checkpoint(bytes).unwrap();
-    assert_eq!(verifier.root(), *chain.root());
-
-    // After resync the relay accepts further publishes and the verifier
-    // continues from the trusted checkpoint.
-    let seq = chain
-        .append(domain_event(AuditClass::DomainCancel))
+    let checkpoint = chain
+        .relay_mut()
+        .resync(current_root, current_seq, auth_key())
         .unwrap();
+    assert_eq!(checkpoint.relay_generation(), 2);
+
+    let mut wire = [0; native_audit_verifier::CHECKPOINT_WIRE_BYTES];
+    let bytes = encode_checkpoint(&checkpoint, auth_key(), &mut wire).unwrap();
+    let mut host_verifier =
+        native_audit_verifier::AuditVerifier::from_checkpoint(bytes, host_key()).unwrap();
+    assert_eq!(host_verifier.root(), *chain.root());
+
+    let seq = chain.append(domain_event(AuditClass::DomainEnter)).unwrap();
     chain.relay_mut().grant_credits(1).unwrap();
     let record = chain.relay_mut().take().unwrap();
     assert_eq!(record.seq(), seq);
     assert_eq!(
-        verifier
-            .fold_with_root(record.frame(), Some(record.root()))
-            .unwrap(),
+        host_verifier.fold(record.frame(), record.root()).unwrap(),
         seq
     );
-    assert_eq!(verifier.root(), *chain.root());
 }
 
 #[test]
-fn checkpoint_is_kernel_authenticated_and_binds_state() {
+fn checkpoint_is_kernel_authenticated_and_state_bound() {
     let chain_boot = boot();
-    let mut chain = AuditChain::genesis(chain_boot);
+    let mut chain = AuditChain::genesis(chain_boot, auth_key());
     chain
         .append(domain_event(AuditClass::DomainCreate))
         .unwrap();
     let checkpoint = chain.checkpoint();
-    assert!(checkpoint.verify_tag());
+    assert!(checkpoint.verify_tag(auth_key()));
 
     let mut wire = [0; native_audit_verifier::CHECKPOINT_WIRE_BYTES];
-    let bytes = encode_checkpoint(&checkpoint, &mut wire).unwrap();
-    assert!(
-        native_audit_verifier::AuditVerifier::from_checkpoint(bytes).is_ok(),
-        "verifier accepts a kernel-sealed checkpoint"
-    );
+    let bytes = encode_checkpoint(&checkpoint, auth_key(), &mut wire).unwrap();
+    assert!(native_audit_verifier::AuditVerifier::from_checkpoint(bytes, host_key()).is_ok());
 
-    let mut tampered = [0; native_audit_verifier::CHECKPOINT_WIRE_BYTES];
-    tampered.copy_from_slice(bytes);
-    let last = tampered.len() - 1;
-    tampered[last] ^= 1;
+    // Replace the sealed tag with the rejected verifier-local unkeyed tag.
+    let mut unkeyed = [0; native_audit_verifier::CHECKPOINT_WIRE_BYTES];
+    unkeyed.copy_from_slice(bytes);
+    let mut hasher = Hasher::new();
+    hasher.update(root::CHECKPOINT_DOMAIN_TAG);
+    hasher.update(&super::CODEC_VERSION.to_le_bytes());
+    hasher.update(&checkpoint.boot().bytes());
+    hasher.update(&checkpoint.seq().to_le_bytes());
+    hasher.update(&checkpoint.root());
+    hasher.update(&checkpoint.relay_generation().to_le_bytes());
+    let unkeyed_tag: [u8; 32] = hasher.finalize().into();
+    let tag_start = native_audit_verifier::CHECKPOINT_WIRE_BYTES - root::ROOT_LEN;
+    unkeyed[tag_start..].copy_from_slice(&unkeyed_tag);
     assert_eq!(
-        native_audit_verifier::verify_checkpoint(&tampered),
+        native_audit_verifier::verify_checkpoint(&unkeyed, host_key()),
         Err(native_audit_verifier::VerifyFailure::CheckpointMismatch)
     );
     assert_eq!(
-        decode_checkpoint(&tampered),
+        decode_checkpoint(&unkeyed, auth_key()),
         Err(AuditError::CheckpointMismatch)
     );
-    assert_eq!(decode_checkpoint(bytes).unwrap(), checkpoint);
+    assert_eq!(decode_checkpoint(bytes, auth_key()).unwrap(), checkpoint);
 }
 
 #[test]

--- a/kernel/crates/astrid-native-kernel/src/audit/tests.rs
+++ b/kernel/crates/astrid-native-kernel/src/audit/tests.rs
@@ -8,8 +8,12 @@ fn boot() -> BootSessionId {
     BootSessionId::new([7; 16]).unwrap()
 }
 
+fn secret() -> KernelSecretEntropy {
+    KernelSecretEntropy::new([0x5A; 32]).unwrap()
+}
+
 fn authority() -> AuditAuthority {
-    AuditAuthority::mint(boot())
+    AuditAuthority::mint(boot(), secret()).unwrap()
 }
 
 fn subject(slot: u64, generation: u64) -> AuditSubject {
@@ -74,13 +78,13 @@ fn anchor_of(live: AuditAuthority) -> native_audit_verifier::AuthContext {
     native_audit_verifier::AuthContext::from_trusted_anchor(
         live.context().authority_id(),
         live.boot().bytes(),
-        live.context().verification_key(),
+        live.context().verification_key().bytes(),
     )
     .unwrap()
 }
 
 fn foreign(boot_byte: u8) -> AuditAuthority {
-    AuditAuthority::mint(BootSessionId::new([boot_byte; 16]).unwrap())
+    AuditAuthority::mint(BootSessionId::new([boot_byte; 16]).unwrap(), secret()).unwrap()
 }
 
 fn host_context() -> native_audit_verifier::AuthContext {
@@ -94,6 +98,10 @@ fn host_handoff() -> [u8; native_audit_verifier::AUTHORITY_HANDOFF_BYTES] {
 fn verifier() -> native_audit_verifier::AuditVerifier {
     native_audit_verifier::AuditVerifier::genesis(boot().bytes(), host_context(), &host_handoff())
         .unwrap()
+}
+
+fn genesis_chain(chain_boot: BootSessionId) -> AuditChain {
+    AuditChain::genesis(chain_boot, secret()).unwrap()
 }
 
 #[test]
@@ -190,7 +198,7 @@ fn rejects_malformed_non_canonical_and_disclosing_inputs() {
 #[test]
 fn append_folds_with_mandatory_source_root() {
     let chain_boot = boot();
-    let mut chain = AuditChain::genesis(chain_boot);
+    let mut chain = genesis_chain(chain_boot);
     let mut host_verifier = verifier();
 
     for expected_seq in 1u64..=5 {
@@ -218,7 +226,7 @@ fn append_folds_with_mandatory_source_root() {
 #[test]
 fn tamper_is_invalid_gap_is_incomplete_duplicate_is_invalid() {
     let chain_boot = boot();
-    let mut chain = AuditChain::genesis(chain_boot);
+    let mut chain = genesis_chain(chain_boot);
     for class in [
         AuditClass::DomainCreate,
         AuditClass::DomainAdmit,
@@ -270,7 +278,7 @@ fn tamper_is_invalid_gap_is_incomplete_duplicate_is_invalid() {
 #[test]
 fn foreign_boot_and_missing_previous_root_are_invalid() {
     let chain_boot = boot();
-    let mut chain = AuditChain::genesis(chain_boot);
+    let mut chain = genesis_chain(chain_boot);
     chain
         .append(domain_event(AuditClass::DomainCreate))
         .unwrap();
@@ -321,7 +329,7 @@ fn sequence_overflow_fails_closed_without_commit() {
 #[test]
 fn ack_requires_take_in_flight_and_matching_folded_root() {
     let chain_boot = boot();
-    let mut chain = AuditChain::genesis(chain_boot);
+    let mut chain = genesis_chain(chain_boot);
     let mut host_verifier = verifier();
     chain
         .append(domain_event(AuditClass::DomainCreate))
@@ -367,7 +375,7 @@ fn ack_requires_take_in_flight_and_matching_folded_root() {
 #[test]
 fn ack_before_take_does_not_retire_a_buffered_slot() {
     let chain_boot = boot();
-    let mut chain = AuditChain::genesis(chain_boot);
+    let mut chain = genesis_chain(chain_boot);
     chain
         .append(domain_event(AuditClass::DomainCreate))
         .unwrap();
@@ -385,7 +393,7 @@ fn ack_before_take_does_not_retire_a_buffered_slot() {
 #[test]
 fn restored_checkpoint_preserves_trusted_relay_generation() {
     let chain_boot = boot();
-    let mut chain = AuditChain::genesis(chain_boot);
+    let mut chain = genesis_chain(chain_boot);
     for _ in 0..AUDIT_RELAY_SLOTS {
         chain
             .append(domain_event(AuditClass::DomainReclaim))
@@ -405,7 +413,7 @@ fn restored_checkpoint_preserves_trusted_relay_generation() {
 #[test]
 fn reserved_headroom_and_overflow_fail_before_atomic_commit() {
     let chain_boot = boot();
-    let mut chain = AuditChain::genesis(chain_boot);
+    let mut chain = genesis_chain(chain_boot);
     for _ in 0..(AUDIT_RELAY_SLOTS - MAX_TERMINAL_RECORDS_PER_BATCH) {
         chain.append(domain_event(AuditClass::DomainEnter)).unwrap();
     }
@@ -505,7 +513,7 @@ fn explicitly_mismatched_previous_root_is_invalid() {
 #[test]
 fn kernel_and_verifier_reject_zero_relay_generation() {
     let chain_boot = boot();
-    let chain = AuditChain::genesis(chain_boot);
+    let chain = genesis_chain(chain_boot);
     let seq = chain.seq();
     let root = *chain.root();
     let mut wire = [0; native_audit_verifier::CHECKPOINT_WIRE_BYTES];
@@ -533,7 +541,7 @@ fn kernel_and_verifier_reject_zero_relay_generation() {
 #[test]
 fn resync_is_generation_bound_and_restores_flow() {
     let chain_boot = boot();
-    let mut chain = AuditChain::genesis(chain_boot);
+    let mut chain = genesis_chain(chain_boot);
     for _ in 0..AUDIT_RELAY_SLOTS {
         chain
             .append(domain_event(AuditClass::DomainReclaim))
@@ -563,7 +571,7 @@ fn resync_is_generation_bound_and_restores_flow() {
 #[test]
 fn checkpoint_is_kernel_authenticated_and_state_bound() {
     let chain_boot = boot();
-    let mut chain = AuditChain::genesis(chain_boot);
+    let mut chain = genesis_chain(chain_boot);
     chain
         .append(domain_event(AuditClass::DomainCreate))
         .unwrap();
@@ -612,7 +620,7 @@ fn checkpoint_is_kernel_authenticated_and_state_bound() {
 #[test]
 fn foreign_or_arbitrary_context_cannot_authenticate_or_retire() {
     let chain_boot = boot();
-    let mut chain = AuditChain::genesis(chain_boot);
+    let mut chain = genesis_chain(chain_boot);
     chain
         .append(domain_event(AuditClass::DomainCreate))
         .unwrap();
@@ -657,7 +665,7 @@ fn foreign_or_arbitrary_context_cannot_authenticate_or_retire() {
 #[test]
 fn handoff_is_untrusted_binding_without_verification_material() {
     let live = authority();
-    let key = live.context().verification_key();
+    let key = live.context().verification_key().bytes();
     let handoff = live.verifier_handoff();
 
     assert_eq!(
@@ -723,6 +731,97 @@ fn structurally_valid_self_authenticated_handoff_is_rejected() {
 }
 
 #[test]
+fn observed_public_derivation_cannot_forge_binding_or_material() {
+    let chain_boot = boot();
+    let live = authority();
+    let handoff = live.verifier_handoff();
+    let genuine_anchor = host_context();
+
+    // Reconstruct the rejected public-only derivation from exactly the
+    // fields an observer can read out of the untrusted handoff.
+    let observed_id = u64::from_le_bytes(handoff[8..16].try_into().expect("fixed handoff layout"));
+    let mut old_key_hasher = Hasher::new();
+    old_key_hasher.update(b"astrid.native-kernel.audit-authority-root.v1");
+    old_key_hasher.update(&handoff[16..32]);
+    old_key_hasher.update(b"astrid.native-kernel.audit-authority-key.v1");
+    old_key_hasher.update(&observed_id.to_le_bytes());
+    let old_key: [u8; 32] = old_key_hasher.finalize().into();
+
+    let mut forged_handoff = handoff;
+    forged_handoff[32..].copy_from_slice(&root::verifier_handoff_tag(
+        chain_boot,
+        observed_id,
+        &old_key,
+    ));
+    assert_eq!(
+        genuine_anchor.bind_handoff(&forged_handoff),
+        Err(native_audit_verifier::VerifyFailure::HandoffUnbound)
+    );
+    assert!(matches!(
+        native_audit_verifier::AuditVerifier::genesis(
+            chain_boot.bytes(),
+            genuine_anchor,
+            &forged_handoff
+        ),
+        Err(native_audit_verifier::VerifyFailure::HandoffUnbound)
+    ));
+
+    let mut chain = genesis_chain(chain_boot);
+    chain
+        .append(domain_event(AuditClass::DomainCreate))
+        .unwrap();
+    let checkpoint = chain.checkpoint();
+    let mut genuine_wire = [0; native_audit_verifier::CHECKPOINT_WIRE_BYTES];
+    let genuine_wire = encode_checkpoint(&checkpoint, live.context(), &mut genuine_wire).unwrap();
+    let mut forged_checkpoint = [0; native_audit_verifier::CHECKPOINT_WIRE_BYTES];
+    forged_checkpoint.copy_from_slice(genuine_wire);
+
+    let mut forged_tag_hasher = Hasher::new_keyed(&old_key);
+    forged_tag_hasher.update(root::CHECKPOINT_DOMAIN_TAG);
+    forged_tag_hasher.update(&super::CODEC_VERSION.to_le_bytes());
+    forged_tag_hasher.update(&checkpoint.boot().bytes());
+    forged_tag_hasher.update(&checkpoint.seq().to_le_bytes());
+    forged_tag_hasher.update(&checkpoint.root());
+    forged_tag_hasher.update(&checkpoint.relay_generation().to_le_bytes());
+    forged_tag_hasher.update(&checkpoint.authority_id().to_le_bytes());
+    let forged_tag: [u8; 32] = forged_tag_hasher.finalize().into();
+    let tag_offset = native_audit_verifier::CHECKPOINT_WIRE_BYTES - root::ROOT_LEN;
+    forged_checkpoint[tag_offset..].copy_from_slice(&forged_tag);
+
+    assert_eq!(
+        native_audit_verifier::verify_checkpoint(&forged_checkpoint, &genuine_anchor),
+        Err(native_audit_verifier::VerifyFailure::CheckpointMismatch)
+    );
+    assert!(matches!(
+        native_audit_verifier::AuditVerifier::from_checkpoint(
+            &forged_checkpoint,
+            genuine_anchor,
+            &handoff
+        ),
+        Err(native_audit_verifier::VerifyFailure::CheckpointMismatch)
+    ));
+
+    chain.relay_mut().grant_credits(1).unwrap();
+    let record = chain.relay_mut().take().unwrap();
+    let mut forged_ack_hasher = Hasher::new_keyed(&old_key);
+    forged_ack_hasher.update(root::ACK_DOMAIN_TAG);
+    forged_ack_hasher.update(&super::CODEC_VERSION.to_le_bytes());
+    forged_ack_hasher.update(&observed_id.to_le_bytes());
+    forged_ack_hasher.update(&chain_boot.bytes());
+    forged_ack_hasher.update(&chain.relay().generation().to_le_bytes());
+    forged_ack_hasher.update(&record.seq().to_le_bytes());
+    forged_ack_hasher.update(&record.root());
+    forged_ack_hasher.update(record.frame());
+    let forged_ack: [u8; 32] = forged_ack_hasher.finalize().into();
+
+    assert_eq!(
+        chain.ack(record.seq(), record.root(), forged_ack),
+        Err(AuditError::RootMismatch)
+    );
+    assert_eq!(chain.relay().redeliver().count(), 1);
+}
+
+#[test]
 fn checkpoint_under_forged_context_is_rejected() {
     let chain_boot = boot();
     // Arbitrary attacker-chosen root and sequence sealed under an
@@ -777,7 +876,7 @@ fn checkpoint_under_forged_context_is_rejected() {
 #[test]
 fn forged_retirement_receipt_is_rejected() {
     let chain_boot = boot();
-    let mut chain = AuditChain::genesis(chain_boot);
+    let mut chain = genesis_chain(chain_boot);
     chain
         .append(domain_event(AuditClass::DomainCreate))
         .unwrap();

--- a/kernel/crates/astrid-native-kernel/src/audit/tests.rs
+++ b/kernel/crates/astrid-native-kernel/src/audit/tests.rs
@@ -1,0 +1,358 @@
+//! Kernel/harness-private regressions for the #1759 audit freeze.
+
+use super::*;
+use crate::ipc::DomainToken;
+
+fn boot() -> BootSessionId {
+    BootSessionId::new([7; 16]).unwrap()
+}
+
+fn subject(slot: u64, generation: u64) -> AuditSubject {
+    AuditSubject::from_domain(DomainToken::new(slot, generation).unwrap())
+}
+
+fn domain_event(class: AuditClass) -> AuditEvent {
+    AuditEvent::new(class, subject(0, 1))
+}
+
+fn capability_object(
+    projection_token: u64,
+    slot: usize,
+    generation: u64,
+    object_token: u64,
+) -> AuditObject {
+    AuditObject::capability_instance(
+        projection_token,
+        slot,
+        generation,
+        AuditObjectKind::Endpoint,
+        object_token,
+    )
+    .unwrap()
+}
+
+/// Fixed-buffer frame storage: the kernel is `no_std`, so tests hold encoded
+/// bytes in arrays instead of heap vectors.
+struct FrameBuf {
+    bytes: [u8; MAX_FRAME_BYTES],
+    len: usize,
+}
+
+impl FrameBuf {
+    fn new(encoded: &[u8]) -> Self {
+        let mut bytes = [0; MAX_FRAME_BYTES];
+        bytes[..encoded.len()].copy_from_slice(encoded);
+        Self {
+            bytes,
+            len: encoded.len(),
+        }
+    }
+
+    fn as_slice(&self) -> &[u8] {
+        &self.bytes[..self.len]
+    }
+}
+
+fn encode_frame(
+    chain_boot: BootSessionId,
+    seq: u64,
+    event: &AuditEvent,
+    prev: Option<[u8; 32]>,
+) -> FrameBuf {
+    let frame = Frame::new(chain_boot, seq, event, prev);
+    let mut buf = [0; MAX_FRAME_BYTES];
+    FrameBuf::new(frame.encode(&mut buf).unwrap())
+}
+
+#[test]
+fn roundtrip_and_injectivity() {
+    let chain_boot = boot();
+    let cases = [
+        domain_event(AuditClass::DomainCreate),
+        domain_event(AuditClass::IpcSend).with_object(AuditObject::endpoint(2, 5).unwrap()),
+        domain_event(AuditClass::CapabilityDerive)
+            .with_object(capability_object(9, 3, 4, 11))
+            .with_rights(AuditRights::from_bits(0b0101).unwrap()),
+        AuditEvent::denial(
+            subject(1, 2),
+            DenialContext::new(DenialReason::ForeignObject, [1; 8]),
+        ),
+        domain_event(AuditClass::RootCheckpoint)
+            .with_payload(&[0xAA; 64])
+            .unwrap(),
+    ];
+    let encoded: [FrameBuf; 5] = [
+        encode_frame(chain_boot, 1, &cases[0], None),
+        encode_frame(chain_boot, 1, &cases[1], None),
+        encode_frame(chain_boot, 1, &cases[2], None),
+        encode_frame(chain_boot, 1, &cases[3], None),
+        encode_frame(chain_boot, 1, &cases[4], None),
+    ];
+    for bytes in &encoded {
+        let decoded = decode(bytes.as_slice()).unwrap();
+        let mut reencoded_buf = [0; MAX_FRAME_BYTES];
+        let reencoded = decoded.encode(&mut reencoded_buf).unwrap();
+        assert_eq!(reencoded, bytes.as_slice());
+    }
+    for left in 0..encoded.len() {
+        for right in (left + 1)..encoded.len() {
+            assert_ne!(encoded[left].as_slice(), encoded[right].as_slice());
+        }
+    }
+}
+
+#[test]
+fn rejects_malformed_and_non_canonical() {
+    let chain_boot = boot();
+    let event = domain_event(AuditClass::DomainAdmit).with_object(capability_object(1, 0, 1, 1));
+    let valid = encode_frame(chain_boot, 1, &event, None);
+
+    let truncated = &valid.as_slice()[..valid.len - 1];
+    assert!(matches!(decode(truncated), Err(AuditError::MalformedFrame)));
+
+    let mut slack = [0u8; MAX_FRAME_BYTES + 1];
+    slack[..valid.len].copy_from_slice(valid.as_slice());
+    assert!(matches!(
+        decode(&slack[..=valid.len]),
+        Err(AuditError::MalformedFrame)
+    ));
+
+    let mut bad_class = FrameBuf::new(valid.as_slice());
+    let class_index = 4 + 2 + 16 + 8;
+    bad_class.bytes[class_index] = 0;
+    bad_class.bytes[class_index + 1] = 99;
+    assert!(matches!(
+        decode(bad_class.as_slice()),
+        Err(AuditError::MalformedFrame)
+    ));
+
+    let mut bad_seq = FrameBuf::new(valid.as_slice());
+    bad_seq.bytes[22..30].copy_from_slice(&0u64.to_le_bytes());
+    assert!(matches!(
+        decode(bad_seq.as_slice()),
+        Err(AuditError::MalformedFrame)
+    ));
+
+    let mut zero_boot = FrameBuf::new(valid.as_slice());
+    zero_boot.bytes[6..22].fill(0);
+    assert!(matches!(
+        decode(zero_boot.as_slice()),
+        Err(AuditError::MalformedFrame)
+    ));
+
+    let denial = encode_frame(
+        chain_boot,
+        1,
+        &AuditEvent::denial(
+            subject(0, 1),
+            DenialContext::new(DenialReason::StaleIdentity, [0; 8]),
+        ),
+        None,
+    );
+    assert!(matches!(
+        decode(denial.as_slice()),
+        Ok(frame) if frame.class() == AuditClass::BoundedDenial && frame.object().is_none()
+    ));
+}
+
+#[test]
+fn chain_append_is_atomic_and_verifier_fold_matches_root() {
+    let chain_boot = boot();
+    let mut chain = AuditChain::genesis(chain_boot);
+    let mut verifier = native_audit_verifier::AuditVerifier::genesis(chain_boot.bytes()).unwrap();
+
+    for expected_seq in 1u64..=5 {
+        let class = match expected_seq {
+            1 => AuditClass::DomainCreate,
+            2 => AuditClass::CapabilityDerive,
+            3 => AuditClass::IpcSend,
+            4 => AuditClass::GenerationAdvance,
+            _ => AuditClass::DomainReclaim,
+        };
+        let event = domain_event(class).with_object(capability_object(expected_seq, 1, 2, 3));
+        let seq = chain.append(event).unwrap();
+        assert_eq!(seq, expected_seq);
+
+        chain.relay_mut().grant_credits(1).unwrap();
+        let record = chain.relay_mut().take().unwrap();
+        assert_eq!(
+            verifier
+                .fold_with_root(record.frame(), Some(record.root()))
+                .unwrap(),
+            expected_seq
+        );
+        assert_eq!(verifier.root(), *chain.root());
+    }
+}
+
+#[test]
+fn tamper_is_invalid_gap_is_incomplete_duplicate_is_invalid() {
+    let chain_boot = boot();
+    let mut chain = AuditChain::genesis(chain_boot);
+    for class in [
+        AuditClass::DomainCreate,
+        AuditClass::DomainAdmit,
+        AuditClass::DomainStart,
+    ] {
+        chain.append(domain_event(class)).unwrap();
+    }
+    let mut records = [FrameBuf::new(&[]), FrameBuf::new(&[]), FrameBuf::new(&[])];
+    {
+        chain.relay_mut().grant_credits(3).unwrap();
+        let mut count = 0;
+        while let Some(record) = chain.relay_mut().take() {
+            records[count] = FrameBuf::new(record.frame());
+            count += 1;
+        }
+        assert_eq!(count, 3);
+    }
+
+    let mut verifier = native_audit_verifier::AuditVerifier::genesis(chain_boot.bytes()).unwrap();
+    let mut tampered = FrameBuf::new(records[0].as_slice());
+    let last = tampered.len - 1;
+    tampered.bytes[last] ^= 0xFF;
+    assert!(matches!(
+        verifier.fold(tampered.as_slice()),
+        Err(native_audit_verifier::FoldFailure::Invalid(_))
+    ));
+
+    let mut verifier = native_audit_verifier::AuditVerifier::genesis(chain_boot.bytes()).unwrap();
+    verifier.fold(records[0].as_slice()).unwrap();
+    // records[2] without records[1] is a gap: Incomplete, never a skip.
+    assert!(matches!(
+        verifier.fold(records[2].as_slice()),
+        Err(native_audit_verifier::FoldFailure::Incomplete(
+            native_audit_verifier::IncompleteReason::SequenceGap
+        ))
+    ));
+
+    let mut verifier = native_audit_verifier::AuditVerifier::genesis(chain_boot.bytes()).unwrap();
+    verifier.fold(records[0].as_slice()).unwrap();
+    assert!(matches!(
+        verifier.fold(records[0].as_slice()),
+        Err(native_audit_verifier::FoldFailure::Invalid(
+            native_audit_verifier::InvalidReason::DuplicateOrReorder
+        ))
+    ));
+}
+
+#[test]
+fn sequence_overflow_fails_closed_without_commit() {
+    let chain_boot = boot();
+    let mut chain = AuditChain::restore(chain_boot, u64::MAX, [9; 32]);
+    let before = (chain.seq(), *chain.root());
+    assert_eq!(
+        chain.append(domain_event(AuditClass::DomainCreate)),
+        Err(AuditError::SequenceOverflow)
+    );
+    assert_eq!((chain.seq(), *chain.root()), before);
+}
+
+#[test]
+fn relay_flow_credits_acks_and_redelivery() {
+    let chain_boot = boot();
+    let mut chain = AuditChain::genesis(chain_boot);
+    chain
+        .append(domain_event(AuditClass::DomainCreate))
+        .unwrap();
+    chain.append(domain_event(AuditClass::DomainAdmit)).unwrap();
+
+    chain.relay_mut().grant_credits(1).unwrap();
+    let first = chain.relay_mut().take().unwrap();
+    // Lost ack: both records stay outstanding and can be redelivered.
+    let mut redelivered = chain.relay().redeliver();
+    assert_eq!(redelivered.next().unwrap().frame(), first.frame());
+    assert_eq!(redelivered.count(), 1);
+
+    chain.relay_mut().ack(first.seq()).unwrap();
+    chain.relay_mut().grant_credits(1).unwrap();
+    let second = chain.relay_mut().take().unwrap();
+    assert_eq!(second.seq(), 2);
+    chain.relay_mut().ack(second.seq()).unwrap();
+
+    assert!(chain.relay_mut().ack(first.seq()).is_err());
+}
+
+#[test]
+fn window_overflow_keeps_authority_and_resync_rebinds() {
+    let chain_boot = boot();
+    let mut chain = AuditChain::genesis(chain_boot);
+    let total = AUDIT_RELAY_SLOTS as u64 + 2;
+    for index in 0..total {
+        let class = if index % 2 == 0 {
+            AuditClass::DomainEnter
+        } else {
+            AuditClass::DomainExit
+        };
+        let seq = chain.append(domain_event(class)).unwrap();
+        assert_eq!(seq, index + 1);
+    }
+    // The window latched at capacity; the two newest rooted events wait for a
+    // resync while every retained record stays intact and in order.
+    assert_eq!(chain.seq(), total);
+    assert_eq!(chain.relay().redeliver().count(), AUDIT_RELAY_SLOTS);
+
+    let current_root = *chain.root();
+    let current_seq = chain.seq();
+    let checkpoint = chain.relay_mut().resync(current_root, current_seq).unwrap();
+    assert_eq!(checkpoint.seq(), chain.seq());
+    assert_eq!(checkpoint.relay_generation(), 2);
+    let mut wire = [0; native_audit_verifier::CHECKPOINT_WIRE_BYTES];
+    let bytes = encode_checkpoint(&checkpoint, &mut wire).unwrap();
+    let mut verifier = native_audit_verifier::AuditVerifier::from_checkpoint(bytes).unwrap();
+    assert_eq!(verifier.root(), *chain.root());
+
+    // After resync the relay accepts further publishes and the verifier
+    // continues from the trusted checkpoint.
+    let seq = chain
+        .append(domain_event(AuditClass::DomainCancel))
+        .unwrap();
+    chain.relay_mut().grant_credits(1).unwrap();
+    let record = chain.relay_mut().take().unwrap();
+    assert_eq!(record.seq(), seq);
+    assert_eq!(
+        verifier
+            .fold_with_root(record.frame(), Some(record.root()))
+            .unwrap(),
+        seq
+    );
+    assert_eq!(verifier.root(), *chain.root());
+}
+
+#[test]
+fn checkpoint_is_kernel_authenticated_and_binds_state() {
+    let chain_boot = boot();
+    let mut chain = AuditChain::genesis(chain_boot);
+    chain
+        .append(domain_event(AuditClass::DomainCreate))
+        .unwrap();
+    let checkpoint = chain.checkpoint();
+    assert!(checkpoint.verify_tag());
+
+    let mut wire = [0; native_audit_verifier::CHECKPOINT_WIRE_BYTES];
+    let bytes = encode_checkpoint(&checkpoint, &mut wire).unwrap();
+    assert!(
+        native_audit_verifier::AuditVerifier::from_checkpoint(bytes).is_ok(),
+        "verifier accepts a kernel-sealed checkpoint"
+    );
+
+    let mut tampered = [0; native_audit_verifier::CHECKPOINT_WIRE_BYTES];
+    tampered.copy_from_slice(bytes);
+    let last = tampered.len() - 1;
+    tampered[last] ^= 1;
+    assert_eq!(
+        native_audit_verifier::verify_checkpoint(&tampered),
+        Err(native_audit_verifier::VerifyFailure::CheckpointMismatch)
+    );
+    assert_eq!(
+        decode_checkpoint(&tampered),
+        Err(AuditError::CheckpointMismatch)
+    );
+    assert_eq!(decode_checkpoint(bytes).unwrap(), checkpoint);
+}
+
+#[test]
+fn batch_reserve_is_static_and_inside_the_window() {
+    assert_eq!(MAX_TERMINAL_RECORDS_PER_BATCH, 21);
+    assert!(AUDIT_RELAY_SLOTS >= MAX_TERMINAL_RECORDS_PER_BATCH);
+}

--- a/kernel/crates/astrid-native-kernel/src/audit/tests.rs
+++ b/kernel/crates/astrid-native-kernel/src/audit/tests.rs
@@ -8,8 +8,8 @@ fn boot() -> BootSessionId {
     BootSessionId::new([7; 16]).unwrap()
 }
 
-fn auth_key() -> CheckpointAuthKey {
-    CheckpointAuthKey::new([0x5a; 32]).unwrap()
+fn authority() -> AuditAuthority {
+    AuditAuthority::mint(boot())
 }
 
 fn subject(slot: u64, generation: u64) -> AuditSubject {
@@ -67,12 +67,12 @@ fn encode_frame(
     FrameBuf::new(frame.encode(&mut buf).unwrap())
 }
 
-fn host_key() -> native_audit_verifier::CheckpointKey {
-    native_audit_verifier::CheckpointKey::new(auth_key().bytes()).unwrap()
+fn host_context() -> native_audit_verifier::AuthContext {
+    native_audit_verifier::AuthContext::from_handoff(&authority().verifier_handoff()).unwrap()
 }
 
 fn verifier() -> native_audit_verifier::AuditVerifier {
-    native_audit_verifier::AuditVerifier::genesis(boot().bytes(), host_key()).unwrap()
+    native_audit_verifier::AuditVerifier::genesis(boot().bytes(), host_context()).unwrap()
 }
 
 #[test]
@@ -169,7 +169,7 @@ fn rejects_malformed_non_canonical_and_disclosing_inputs() {
 #[test]
 fn append_folds_with_mandatory_source_root() {
     let chain_boot = boot();
-    let mut chain = AuditChain::genesis(chain_boot, auth_key());
+    let mut chain = AuditChain::genesis(chain_boot);
     let mut host_verifier = verifier();
 
     for expected_seq in 1u64..=5 {
@@ -197,7 +197,7 @@ fn append_folds_with_mandatory_source_root() {
 #[test]
 fn tamper_is_invalid_gap_is_incomplete_duplicate_is_invalid() {
     let chain_boot = boot();
-    let mut chain = AuditChain::genesis(chain_boot, auth_key());
+    let mut chain = AuditChain::genesis(chain_boot);
     for class in [
         AuditClass::DomainCreate,
         AuditClass::DomainAdmit,
@@ -249,11 +249,16 @@ fn tamper_is_invalid_gap_is_incomplete_duplicate_is_invalid() {
 #[test]
 fn foreign_boot_and_missing_previous_root_are_invalid() {
     let chain_boot = boot();
-    let mut chain = AuditChain::genesis(chain_boot, auth_key());
+    let mut chain = AuditChain::genesis(chain_boot);
     chain
         .append(domain_event(AuditClass::DomainCreate))
         .unwrap();
-    let mut foreign = native_audit_verifier::AuditVerifier::genesis([8; 16], host_key()).unwrap();
+    let foreign_authority = AuditAuthority::mint(BootSessionId::new([8; 16]).unwrap());
+    let foreign_context =
+        native_audit_verifier::AuthContext::from_handoff(&foreign_authority.verifier_handoff())
+            .unwrap();
+    let mut foreign =
+        native_audit_verifier::AuditVerifier::genesis([8; 16], foreign_context).unwrap();
     chain.relay_mut().grant_credits(1).unwrap();
     let record = chain.relay_mut().take().unwrap();
     assert!(matches!(
@@ -281,8 +286,8 @@ fn foreign_boot_and_missing_previous_root_are_invalid() {
 fn sequence_overflow_fails_closed_without_commit() {
     let chain_boot = boot();
     let checkpoint =
-        AuditCheckpoint::seal(chain_boot, u64::MAX - 1, [9; 32], 1, auth_key()).unwrap();
-    let mut chain = AuditChain::restore(checkpoint, auth_key()).unwrap();
+        AuditCheckpoint::seal(chain_boot, u64::MAX - 1, [9; 32], 1, authority().context()).unwrap();
+    let mut chain = AuditChain::restore(checkpoint, authority()).unwrap();
     let before = (chain.seq(), *chain.root());
     assert_eq!(
         chain.append(domain_event(AuditClass::DomainCreate)),
@@ -294,7 +299,7 @@ fn sequence_overflow_fails_closed_without_commit() {
 #[test]
 fn ack_requires_take_in_flight_and_matching_folded_root() {
     let chain_boot = boot();
-    let mut chain = AuditChain::genesis(chain_boot, auth_key());
+    let mut chain = AuditChain::genesis(chain_boot);
     let mut host_verifier = verifier();
     chain
         .append(domain_event(AuditClass::DomainCreate))
@@ -306,27 +311,22 @@ fn ack_requires_take_in_flight_and_matching_folded_root() {
     assert_eq!(chain.relay().redeliver().count(), 2);
     let first_receipt = host_verifier.fold(first.frame(), first.root()).unwrap();
     assert_eq!(
-        chain
-            .relay_mut()
-            .ack(first.seq(), first.root(), [0; 32], auth_key()),
+        chain.ack(first.seq(), first.root(), [0; 32]),
         Err(AuditError::RootMismatch)
     );
     chain
-        .relay_mut()
         .ack(
             first.seq(),
             first_receipt.folded_root(),
             first_receipt.ack_tag(),
-            auth_key(),
         )
         .unwrap();
 
     assert_eq!(
-        chain.relay_mut().ack(
+        chain.ack(
             first.seq(),
             first_receipt.folded_root(),
-            first_receipt.ack_tag(),
-            auth_key()
+            first_receipt.ack_tag()
         ),
         Err(AuditError::RelayStaleCursor)
     );
@@ -334,12 +334,10 @@ fn ack_requires_take_in_flight_and_matching_folded_root() {
     let second = chain.relay_mut().take().unwrap();
     let second_receipt = host_verifier.fold(second.frame(), second.root()).unwrap();
     chain
-        .relay_mut()
         .ack(
             second.seq(),
             second_receipt.folded_root(),
             second_receipt.ack_tag(),
-            auth_key(),
         )
         .unwrap();
 }
@@ -347,14 +345,14 @@ fn ack_requires_take_in_flight_and_matching_folded_root() {
 #[test]
 fn ack_before_take_does_not_retire_a_buffered_slot() {
     let chain_boot = boot();
-    let mut chain = AuditChain::genesis(chain_boot, auth_key());
+    let mut chain = AuditChain::genesis(chain_boot);
     chain
         .append(domain_event(AuditClass::DomainCreate))
         .unwrap();
     let before = chain.relay().redeliver().count();
     assert_eq!(before, 1);
     assert_eq!(
-        chain.relay_mut().ack(1, [0; 32], [0; 32], auth_key()),
+        chain.ack(1, [0; 32], [0; 32]),
         Err(AuditError::RelayNotInFlight)
     );
     assert_eq!(chain.relay().redeliver().count(), before);
@@ -365,21 +363,16 @@ fn ack_before_take_does_not_retire_a_buffered_slot() {
 #[test]
 fn restored_checkpoint_preserves_trusted_relay_generation() {
     let chain_boot = boot();
-    let mut chain = AuditChain::genesis(chain_boot, auth_key());
+    let mut chain = AuditChain::genesis(chain_boot);
     for _ in 0..AUDIT_RELAY_SLOTS {
         chain
             .append(domain_event(AuditClass::DomainReclaim))
             .unwrap();
     }
-    let current_root = *chain.root();
-    let current_seq = chain.seq();
-    let checkpoint = chain
-        .relay_mut()
-        .resync(current_root, current_seq, auth_key())
-        .unwrap();
+    let checkpoint = chain.resync().unwrap();
     assert_eq!(checkpoint.relay_generation(), 2);
 
-    let restored = AuditChain::restore(checkpoint, auth_key()).unwrap();
+    let restored = AuditChain::restore(checkpoint, authority()).unwrap();
     assert_eq!(restored.boot(), checkpoint.boot());
     assert_eq!(restored.seq(), checkpoint.seq());
     assert_eq!(*restored.root(), checkpoint.root());
@@ -390,7 +383,7 @@ fn restored_checkpoint_preserves_trusted_relay_generation() {
 #[test]
 fn reserved_headroom_and_overflow_fail_before_atomic_commit() {
     let chain_boot = boot();
-    let mut chain = AuditChain::genesis(chain_boot, auth_key());
+    let mut chain = AuditChain::genesis(chain_boot);
     for _ in 0..(AUDIT_RELAY_SLOTS - MAX_TERMINAL_RECORDS_PER_BATCH) {
         chain.append(domain_event(AuditClass::DomainEnter)).unwrap();
     }
@@ -442,11 +435,12 @@ fn reserved_headroom_and_overflow_fail_before_atomic_commit() {
 
 #[test]
 fn verifier_sequence_overflow_is_atomic_and_repeatable() {
-    let checkpoint = AuditCheckpoint::seal(boot(), u64::MAX - 1, [9; 32], 1, auth_key()).unwrap();
+    let checkpoint =
+        AuditCheckpoint::seal(boot(), u64::MAX - 1, [9; 32], 1, authority().context()).unwrap();
     let mut wire = [0; native_audit_verifier::CHECKPOINT_WIRE_BYTES];
-    let bytes = encode_checkpoint(&checkpoint, auth_key(), &mut wire).unwrap();
+    let bytes = encode_checkpoint(&checkpoint, authority().context(), &mut wire).unwrap();
     let mut verifier =
-        native_audit_verifier::AuditVerifier::from_checkpoint(bytes, host_key()).unwrap();
+        native_audit_verifier::AuditVerifier::from_checkpoint(bytes, host_context()).unwrap();
     let before = (verifier.next_seq(), verifier.root());
     let event = domain_event(AuditClass::DomainCreate);
     let frame = Frame::new(boot(), u64::MAX, &event, Some([9; 32])).unwrap();
@@ -485,27 +479,27 @@ fn explicitly_mismatched_previous_root_is_invalid() {
 #[test]
 fn kernel_and_verifier_reject_zero_relay_generation() {
     let chain_boot = boot();
-    let chain = AuditChain::genesis(chain_boot, auth_key());
+    let chain = AuditChain::genesis(chain_boot);
     let seq = chain.seq();
     let root = *chain.root();
     let mut wire = [0; native_audit_verifier::CHECKPOINT_WIRE_BYTES];
-    encode_checkpoint(&chain.checkpoint(), auth_key(), &mut wire).unwrap();
+    encode_checkpoint(&chain.checkpoint(), authority().context(), &mut wire).unwrap();
     let generation_offset = 4 + 2 + 16 + 8 + 32;
     wire[generation_offset..generation_offset + 8].copy_from_slice(&0u64.to_le_bytes());
-    let zero_tag = root::checkpoint_tag(chain_boot, seq, root, 0, auth_key());
+    let zero_tag = root::checkpoint_tag(chain_boot, seq, root, 0, &authority().context());
     let tag_offset = native_audit_verifier::CHECKPOINT_WIRE_BYTES - 32;
     wire[tag_offset..].copy_from_slice(&zero_tag);
 
     assert_eq!(
-        decode_checkpoint(&wire, auth_key()),
+        decode_checkpoint(&wire, authority().context()),
         Err(AuditError::MalformedFrame)
     );
     assert_eq!(
-        native_audit_verifier::verify_checkpoint(&wire, host_key()),
+        native_audit_verifier::verify_checkpoint(&wire, &host_context()),
         Err(native_audit_verifier::VerifyFailure::Malformed)
     );
     assert_eq!(
-        AuditCheckpoint::seal(chain_boot, seq, root, 0, auth_key()),
+        AuditCheckpoint::seal(chain_boot, seq, root, 0, authority().context()),
         Err(AuditError::MalformedFrame)
     );
 }
@@ -513,24 +507,19 @@ fn kernel_and_verifier_reject_zero_relay_generation() {
 #[test]
 fn resync_is_generation_bound_and_restores_flow() {
     let chain_boot = boot();
-    let mut chain = AuditChain::genesis(chain_boot, auth_key());
+    let mut chain = AuditChain::genesis(chain_boot);
     for _ in 0..AUDIT_RELAY_SLOTS {
         chain
             .append(domain_event(AuditClass::DomainReclaim))
             .unwrap();
     }
-    let current_root = *chain.root();
-    let current_seq = chain.seq();
-    let checkpoint = chain
-        .relay_mut()
-        .resync(current_root, current_seq, auth_key())
-        .unwrap();
+    let checkpoint = chain.resync().unwrap();
     assert_eq!(checkpoint.relay_generation(), 2);
 
     let mut wire = [0; native_audit_verifier::CHECKPOINT_WIRE_BYTES];
-    let bytes = encode_checkpoint(&checkpoint, auth_key(), &mut wire).unwrap();
+    let bytes = encode_checkpoint(&checkpoint, authority().context(), &mut wire).unwrap();
     let mut host_verifier =
-        native_audit_verifier::AuditVerifier::from_checkpoint(bytes, host_key()).unwrap();
+        native_audit_verifier::AuditVerifier::from_checkpoint(bytes, host_context()).unwrap();
     assert_eq!(host_verifier.root(), *chain.root());
 
     let seq = chain.append(domain_event(AuditClass::DomainEnter)).unwrap();
@@ -544,16 +533,16 @@ fn resync_is_generation_bound_and_restores_flow() {
 #[test]
 fn checkpoint_is_kernel_authenticated_and_state_bound() {
     let chain_boot = boot();
-    let mut chain = AuditChain::genesis(chain_boot, auth_key());
+    let mut chain = AuditChain::genesis(chain_boot);
     chain
         .append(domain_event(AuditClass::DomainCreate))
         .unwrap();
     let checkpoint = chain.checkpoint();
-    assert!(checkpoint.verify_tag(auth_key()));
+    assert!(checkpoint.verify_tag(authority().context()));
 
     let mut wire = [0; native_audit_verifier::CHECKPOINT_WIRE_BYTES];
-    let bytes = encode_checkpoint(&checkpoint, auth_key(), &mut wire).unwrap();
-    assert!(native_audit_verifier::AuditVerifier::from_checkpoint(bytes, host_key()).is_ok());
+    let bytes = encode_checkpoint(&checkpoint, authority().context(), &mut wire).unwrap();
+    assert!(native_audit_verifier::AuditVerifier::from_checkpoint(bytes, host_context()).is_ok());
 
     // Replace the sealed tag with the rejected verifier-local unkeyed tag.
     let mut unkeyed = [0; native_audit_verifier::CHECKPOINT_WIRE_BYTES];
@@ -565,18 +554,65 @@ fn checkpoint_is_kernel_authenticated_and_state_bound() {
     hasher.update(&checkpoint.seq().to_le_bytes());
     hasher.update(&checkpoint.root());
     hasher.update(&checkpoint.relay_generation().to_le_bytes());
+    hasher.update(&checkpoint.authority_id().to_le_bytes());
     let unkeyed_tag: [u8; 32] = hasher.finalize().into();
     let tag_start = native_audit_verifier::CHECKPOINT_WIRE_BYTES - root::ROOT_LEN;
     unkeyed[tag_start..].copy_from_slice(&unkeyed_tag);
     assert_eq!(
-        native_audit_verifier::verify_checkpoint(&unkeyed, host_key()),
+        native_audit_verifier::verify_checkpoint(&unkeyed, &host_context()),
         Err(native_audit_verifier::VerifyFailure::CheckpointMismatch)
     );
     assert_eq!(
-        decode_checkpoint(&unkeyed, auth_key()),
+        decode_checkpoint(&unkeyed, authority().context()),
         Err(AuditError::CheckpointMismatch)
     );
-    assert_eq!(decode_checkpoint(bytes, auth_key()).unwrap(), checkpoint);
+    assert_eq!(
+        decode_checkpoint(bytes, authority().context()).unwrap(),
+        checkpoint
+    );
+}
+
+#[test]
+fn foreign_or_arbitrary_context_cannot_authenticate_or_retire() {
+    let chain_boot = boot();
+    let mut chain = AuditChain::genesis(chain_boot);
+    chain
+        .append(domain_event(AuditClass::DomainCreate))
+        .unwrap();
+
+    let mut wire = [0; native_audit_verifier::CHECKPOINT_WIRE_BYTES];
+    let checkpoint_wire =
+        encode_checkpoint(&chain.checkpoint(), authority().context(), &mut wire).unwrap();
+    let arbitrary_handoff = [7; native_audit_verifier::AUTHORITY_HANDOFF_BYTES];
+    assert_eq!(
+        native_audit_verifier::AuthContext::from_handoff(&arbitrary_handoff),
+        Err(native_audit_verifier::VerifyFailure::Malformed)
+    );
+
+    let foreign_authority = AuditAuthority::mint(BootSessionId::new([8; 16]).unwrap());
+    let foreign_context =
+        native_audit_verifier::AuthContext::from_handoff(&foreign_authority.verifier_handoff())
+            .unwrap();
+    assert!(matches!(
+        native_audit_verifier::AuditVerifier::genesis(chain_boot.bytes(), foreign_context),
+        Err(native_audit_verifier::VerifyFailure::Malformed)
+    ));
+    assert_eq!(
+        native_audit_verifier::verify_checkpoint(checkpoint_wire, &foreign_context),
+        Err(native_audit_verifier::VerifyFailure::Malformed)
+    );
+    assert_eq!(
+        decode_checkpoint(checkpoint_wire, foreign_authority.context()),
+        Err(AuditError::CheckpointMismatch)
+    );
+
+    chain.relay_mut().grant_credits(1).unwrap();
+    let record = chain.relay_mut().take().unwrap();
+    assert_eq!(
+        chain.ack(record.seq(), record.root(), [0; 32]),
+        Err(AuditError::RootMismatch)
+    );
+    assert_eq!(chain.relay().redeliver().count(), 1);
 }
 
 #[test]

--- a/kernel/crates/astrid-native-kernel/src/audit/types.rs
+++ b/kernel/crates/astrid-native-kernel/src/audit/types.rs
@@ -63,9 +63,65 @@ const AUTHORITY_ROOT_DOMAIN: &[u8] = b"astrid.native-kernel.audit-authority-root
 const AUTHORITY_ID_DOMAIN: &[u8] = b"astrid.native-kernel.audit-authority-id.v1";
 const AUTHORITY_KEY_DOMAIN: &[u8] = b"astrid.native-kernel.audit-authority-key.v1";
 
+/// Kernel-held entropy supplied to one audit authority. It is never part of
+/// the canonical frames, checkpoint wire, or untrusted handoff. A dropped
+/// value erases its bytes; no constructor exports or copies the input.
+pub(crate) struct KernelSecretEntropy([u8; 32]);
+
+impl KernelSecretEntropy {
+    pub(crate) fn new(bytes: [u8; 32]) -> Option<Self> {
+        if bytes.iter().all(|byte| *byte == 0) {
+            return None;
+        }
+        Some(Self(bytes))
+    }
+
+    const fn bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+impl Drop for KernelSecretEntropy {
+    fn drop(&mut self) {
+        self.0.fill(0);
+    }
+}
+
+impl core::fmt::Debug for KernelSecretEntropy {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("KernelSecretEntropy(REDACTED)")
+    }
+}
+
+/// Typed authentication key derived from kernel-held entropy. Its bytes are
+/// exposed only to the modeled independently trusted anchor; they never
+/// enter a frame, checkpoint wire, or untrusted handoff.
+#[derive(Clone, Copy)]
+pub(crate) struct VerificationKey([u8; 32]);
+
+impl VerificationKey {
+    pub(crate) fn new(bytes: [u8; 32]) -> Option<Self> {
+        if bytes.iter().all(|byte| *byte == 0) {
+            return None;
+        }
+        Some(Self(bytes))
+    }
+
+    pub(crate) const fn bytes(self) -> [u8; 32] {
+        self.0
+    }
+}
+
+impl core::fmt::Debug for VerificationKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("VerificationKey(REDACTED)")
+    }
+}
+
 /// Opaque kernel-owned authentication context. It is derived inside the
-/// kernel from the live boot identity and cannot be constructed from
-/// caller-selected bytes. Its authority id is part of every checkpoint tag.
+/// kernel from live boot identity and kernel-held entropy; the public boot
+/// identity alone is insufficient to reconstruct either its id or key. Its
+/// authority id is part of every checkpoint tag.
 ///
 /// The verification key stays kernel-side for the whole boot/session. It
 /// reaches the verifier only through an independently trusted kernel-origin
@@ -73,16 +129,17 @@ const AUTHORITY_KEY_DOMAIN: &[u8] = b"astrid.native-kernel.audit-authority-key.v
 /// handoff carries none of it. Production anchor delivery and key
 /// lifecycle remain named #1759 residuals, and no fixed production secret
 /// is introduced.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy)]
 pub(crate) struct CheckpointAuthContext {
     authority_id: u64,
-    verification_key: [u8; 32],
+    verification_key: VerificationKey,
 }
 
 impl CheckpointAuthContext {
-    fn mint(boot: BootSessionId) -> Self {
+    fn mint(boot: BootSessionId, secret: KernelSecretEntropy) -> Option<Self> {
         let mut id_hasher = Hasher::new();
         id_hasher.update(AUTHORITY_ROOT_DOMAIN);
+        id_hasher.update(secret.bytes());
         id_hasher.update(&boot.bytes());
         id_hasher.update(AUTHORITY_ID_DOMAIN);
         let id_digest: [u8; 32] = id_hasher.finalize().into();
@@ -93,22 +150,22 @@ impl CheckpointAuthContext {
 
         let mut key_hasher = Hasher::new();
         key_hasher.update(AUTHORITY_ROOT_DOMAIN);
+        key_hasher.update(secret.bytes());
         key_hasher.update(&boot.bytes());
         key_hasher.update(AUTHORITY_KEY_DOMAIN);
         key_hasher.update(&authority_id.to_le_bytes());
-        let verification_key: [u8; 32] = key_hasher.finalize().into();
-        debug_assert!(verification_key != [0; 32]);
-        Self {
+        let verification_key = VerificationKey::new(key_hasher.finalize().into())?;
+        Some(Self {
             authority_id,
             verification_key,
-        }
+        })
     }
 
     pub(crate) const fn authority_id(self) -> u64 {
         self.authority_id
     }
 
-    pub(crate) const fn verification_key(self) -> [u8; 32] {
+    pub(crate) const fn verification_key(self) -> VerificationKey {
         self.verification_key
     }
 }
@@ -123,7 +180,7 @@ impl core::fmt::Debug for CheckpointAuthContext {
 /// is untrusted binding evidence: it names the authority and carries a
 /// keyed minting tag, never verification material, so it cannot
 /// authenticate itself.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug)]
 pub(crate) struct AuditAuthority {
     boot: BootSessionId,
     context: CheckpointAuthContext,
@@ -134,11 +191,11 @@ pub(crate) struct AuditAuthority {
 const VERIFIER_HANDOFF_BYTES: usize = 8 + 8 + 16 + root::ROOT_LEN;
 
 impl AuditAuthority {
-    pub fn mint(boot: BootSessionId) -> Self {
-        Self {
+    pub fn mint(boot: BootSessionId, secret: KernelSecretEntropy) -> Option<Self> {
+        Some(Self {
             boot,
-            context: CheckpointAuthContext::mint(boot),
-        }
+            context: CheckpointAuthContext::mint(boot, secret)?,
+        })
     }
 
     pub const fn boot(self) -> BootSessionId {
@@ -162,7 +219,7 @@ impl AuditAuthority {
         let tag = root::verifier_handoff_tag(
             self.boot,
             self.context.authority_id(),
-            &self.context.verification_key(),
+            &self.context.verification_key().bytes(),
         );
         handoff[32..].copy_from_slice(&tag);
         handoff

--- a/kernel/crates/astrid-native-kernel/src/audit/types.rs
+++ b/kernel/crates/astrid-native-kernel/src/audit/types.rs
@@ -1,0 +1,566 @@
+//! Typed identities, event classes, and capacity derivation for the private
+//! audit chain.
+
+use core::num::NonZeroU64;
+
+use super::root;
+use crate::ipc::DomainToken;
+
+/// Restated landed #1705 protocol ceilings used for static capacity
+/// derivation only. If the landed pools change, this derivation must be
+/// recalculated before the audit relay remains sound (#1759 freeze).
+pub(crate) const AUDIT_DOMAIN_SLOTS: usize = 2;
+pub(crate) const AUDIT_CAP_SLOTS_PER_DOMAIN: usize = 8;
+pub(crate) const AUDIT_ENDPOINT_POOL: usize = 4;
+pub(crate) const AUDIT_CAP_OBJECT_POOL: usize = 16;
+/// Landed message payload ceiling. Audit payloads never exceed it.
+pub(crate) const AUDIT_MAX_PAYLOAD: usize = 64;
+
+const _: () = assert!(
+    AUDIT_DOMAIN_SLOTS * AUDIT_CAP_SLOTS_PER_DOMAIN == AUDIT_CAP_OBJECT_POOL,
+    "landed domain and capability pools disagree with the audit capacity derivation",
+);
+
+/// Maximum mandatory terminal/invalidation records one admitted atomic
+/// mutation batch can produce at the frozen ceilings: mass invalidation of
+/// every capability-instance slot of both domain slots, every endpoint, and
+/// the dying domain identity itself. This is the statically derived relay
+/// reserve, never a single global death slot.
+pub(crate) const MAX_TERMINAL_RECORDS_PER_BATCH: usize =
+    AUDIT_DOMAIN_SLOTS * AUDIT_CAP_SLOTS_PER_DOMAIN + AUDIT_ENDPOINT_POOL + 1;
+
+/// Boot-scoped audit session identity. A kernel restart mints a new identity;
+/// this slice claims no cross-boot durable continuity.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct BootSessionId([u8; 16]);
+
+impl BootSessionId {
+    /// Rejects the all-zero identity so two boots can never share one chain.
+    pub const fn new(bytes: [u8; 16]) -> Option<Self> {
+        let mut index = 0;
+        let mut any_nonzero = false;
+        while index < bytes.len() {
+            if bytes[index] != 0 {
+                any_nonzero = true;
+            }
+            index += 1;
+        }
+        if any_nonzero { Some(Self(bytes)) } else { None }
+    }
+
+    pub const fn bytes(self) -> [u8; 16] {
+        self.0
+    }
+}
+
+/// Landed caller identity (#1705 `DomainToken`): domain slot plus generation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct AuditSubject {
+    slot: u8,
+    generation: NonZeroU64,
+}
+
+impl AuditSubject {
+    pub fn from_domain(token: DomainToken) -> Self {
+        Self {
+            slot: token.slot().index() as u8,
+            generation: token.generation(),
+        }
+    }
+
+    pub(crate) fn from_parts(slot: u8, generation: NonZeroU64) -> Option<Self> {
+        if slot as usize >= AUDIT_DOMAIN_SLOTS {
+            return None;
+        }
+        Some(Self { slot, generation })
+    }
+
+    pub const fn slot(self) -> u8 {
+        self.slot
+    }
+
+    pub const fn generation(self) -> NonZeroU64 {
+        self.generation
+    }
+}
+
+/// Landed object kind (#1705 domain or endpoint object).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum AuditObjectKind {
+    Domain,
+    Endpoint,
+}
+
+impl AuditObjectKind {
+    pub(crate) const fn from_discriminant(value: u8) -> Option<Self> {
+        match value {
+            1 => Some(Self::Domain),
+            2 => Some(Self::Endpoint),
+            _ => None,
+        }
+    }
+
+    pub(crate) const fn discriminant(self) -> u8 {
+        match self {
+            Self::Domain => 1,
+            Self::Endpoint => 2,
+        }
+    }
+}
+
+/// Typed object identity for one frame. Values restate the landed #1705 and
+/// #1758 identity fields through ceiling-enforced constructors; this is
+/// attribution encoding, not a parallel identity authority.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum AuditObject {
+    Domain {
+        slot: u8,
+        generation: NonZeroU64,
+    },
+    Endpoint {
+        pool_index: u8,
+        generation: NonZeroU64,
+    },
+    CapabilityInstance(AuditCapabilityInstance),
+}
+
+impl AuditObject {
+    pub fn domain(slot: usize, generation: u64) -> Option<Self> {
+        if slot >= AUDIT_DOMAIN_SLOTS {
+            return None;
+        }
+        Some(Self::Domain {
+            slot: slot as u8,
+            generation: NonZeroU64::new(generation)?,
+        })
+    }
+
+    pub fn endpoint(pool_index: usize, generation: u64) -> Option<Self> {
+        if pool_index >= AUDIT_ENDPOINT_POOL {
+            return None;
+        }
+        Some(Self::Endpoint {
+            pool_index: pool_index as u8,
+            generation: NonZeroU64::new(generation)?,
+        })
+    }
+
+    pub fn capability_instance(
+        projection_token: u64,
+        capability_slot: usize,
+        capability_generation: u64,
+        object_kind: AuditObjectKind,
+        object_token: u64,
+    ) -> Option<Self> {
+        Some(Self::CapabilityInstance(AuditCapabilityInstance::try_new(
+            projection_token,
+            capability_slot,
+            capability_generation,
+            object_kind,
+            object_token,
+        )?))
+    }
+}
+
+/// Full landed #1758 capability-instance identity restated for attribution:
+/// kernel-issued projection token, capability-table slot, capability/object
+/// generations, and the held object identity.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct AuditCapabilityInstance {
+    projection_token: NonZeroU64,
+    capability_slot: u8,
+    capability_generation: NonZeroU64,
+    object_kind: AuditObjectKind,
+    object_token: NonZeroU64,
+}
+
+impl AuditCapabilityInstance {
+    pub fn try_new(
+        projection_token: u64,
+        capability_slot: usize,
+        capability_generation: u64,
+        object_kind: AuditObjectKind,
+        object_token: u64,
+    ) -> Option<Self> {
+        if capability_slot >= AUDIT_CAP_SLOTS_PER_DOMAIN {
+            return None;
+        }
+        Some(Self {
+            projection_token: NonZeroU64::new(projection_token)?,
+            capability_slot: capability_slot as u8,
+            capability_generation: NonZeroU64::new(capability_generation)?,
+            object_kind,
+            object_token: NonZeroU64::new(object_token)?,
+        })
+    }
+
+    pub const fn projection_token(self) -> NonZeroU64 {
+        self.projection_token
+    }
+
+    pub const fn capability_slot(self) -> u8 {
+        self.capability_slot
+    }
+
+    pub const fn capability_generation(self) -> NonZeroU64 {
+        self.capability_generation
+    }
+
+    pub const fn object_kind(self) -> AuditObjectKind {
+        self.object_kind
+    }
+
+    pub const fn object_token(self) -> NonZeroU64 {
+        self.object_token
+    }
+}
+
+/// Landed #1705 rights bits (`SEND=1 RECV=2 GRANT=4 IDENTIFY=8`). Unknown
+/// bits fail closed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct AuditRights(u16);
+
+impl AuditRights {
+    const LANDED_RIGHTS_MASK: u16 = 0b1111;
+
+    pub const fn from_bits(bits: u16) -> Option<Self> {
+        if bits & !Self::LANDED_RIGHTS_MASK == 0 {
+            Some(Self(bits))
+        } else {
+            None
+        }
+    }
+
+    pub const fn bits(self) -> u16 {
+        self.0
+    }
+}
+
+/// Typed denial reason. Denials never disclose a foreign object identity.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum DenialReason {
+    StaleIdentity = 1,
+    MissingCapability = 2,
+    RightsInsufficient = 3,
+    ForeignObject = 4,
+    CapacityExhausted = 5,
+    MalformedRequest = 6,
+}
+
+impl DenialReason {
+    pub(crate) const fn from_discriminant(value: u16) -> Option<Self> {
+        match value {
+            1 => Some(Self::StaleIdentity),
+            2 => Some(Self::MissingCapability),
+            3 => Some(Self::RightsInsufficient),
+            4 => Some(Self::ForeignObject),
+            5 => Some(Self::CapacityExhausted),
+            6 => Some(Self::MalformedRequest),
+            _ => None,
+        }
+    }
+
+    pub(crate) const fn discriminant(self) -> u16 {
+        match self {
+            Self::StaleIdentity => 1,
+            Self::MissingCapability => 2,
+            Self::RightsInsufficient => 3,
+            Self::ForeignObject => 4,
+            Self::CapacityExhausted => 5,
+            Self::MalformedRequest => 6,
+        }
+    }
+}
+
+/// Caller-visible denial context: one typed reason plus a bounded caller
+/// stamp. The canonical payload is `reason: u16` little-endian, then 8 stamp
+/// bytes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DenialContext {
+    reason: DenialReason,
+    stamp: [u8; 8],
+}
+
+impl DenialContext {
+    pub(crate) const PAYLOAD_LEN: usize = 10;
+
+    pub const fn new(reason: DenialReason, stamp: [u8; 8]) -> Self {
+        Self { reason, stamp }
+    }
+
+    pub(crate) fn payload_bytes(self) -> [u8; Self::PAYLOAD_LEN] {
+        let reason = self.reason.discriminant().to_le_bytes();
+        let mut out = [0u8; Self::PAYLOAD_LEN];
+        out[0] = reason[0];
+        out[1] = reason[1];
+        out[2..].copy_from_slice(&self.stamp);
+        out
+    }
+
+    pub(crate) fn from_payload(payload: &[u8]) -> Option<Self> {
+        if payload.len() != Self::PAYLOAD_LEN {
+            return None;
+        }
+        let reason = u16::from_le_bytes([payload[0], payload[1]]);
+        let mut stamp = [0u8; 8];
+        stamp.copy_from_slice(&payload[2..]);
+        Some(Self {
+            reason: DenialReason::from_discriminant(reason)?,
+            stamp,
+        })
+    }
+
+    pub const fn reason(self) -> DenialReason {
+        self.reason
+    }
+
+    pub const fn stamp(self) -> [u8; 8] {
+        self.stamp
+    }
+}
+
+/// Security-event class. Discriminant groups follow the #1759 freeze: domain
+/// lifecycle, capability, IPC, generation, root, and bounded denial.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum AuditClass {
+    DomainCreate = 1,
+    DomainAdmit = 2,
+    DomainStart = 3,
+    DomainEnter = 4,
+    DomainExit = 5,
+    DomainFault = 6,
+    DomainKill = 7,
+    DomainReclaim = 8,
+    DomainCancel = 9,
+    CapabilityDerive = 16,
+    CapabilityGrant = 17,
+    CapabilityRevoke = 18,
+    IpcSend = 32,
+    IpcRecv = 33,
+    IpcQueueDrop = 34,
+    IpcEndpointTeardown = 35,
+    GenerationAdvance = 48,
+    GenerationReject = 49,
+    GenerationOverflow = 50,
+    RootCheckpoint = 64,
+    RootOverflow = 65,
+    RootIncomplete = 66,
+    BoundedDenial = 80,
+}
+
+impl AuditClass {
+    pub(crate) const fn from_discriminant(value: u16) -> Option<Self> {
+        match value {
+            1 => Some(Self::DomainCreate),
+            2 => Some(Self::DomainAdmit),
+            3 => Some(Self::DomainStart),
+            4 => Some(Self::DomainEnter),
+            5 => Some(Self::DomainExit),
+            6 => Some(Self::DomainFault),
+            7 => Some(Self::DomainKill),
+            8 => Some(Self::DomainReclaim),
+            9 => Some(Self::DomainCancel),
+            16 => Some(Self::CapabilityDerive),
+            17 => Some(Self::CapabilityGrant),
+            18 => Some(Self::CapabilityRevoke),
+            32 => Some(Self::IpcSend),
+            33 => Some(Self::IpcRecv),
+            34 => Some(Self::IpcQueueDrop),
+            35 => Some(Self::IpcEndpointTeardown),
+            48 => Some(Self::GenerationAdvance),
+            49 => Some(Self::GenerationReject),
+            50 => Some(Self::GenerationOverflow),
+            64 => Some(Self::RootCheckpoint),
+            65 => Some(Self::RootOverflow),
+            66 => Some(Self::RootIncomplete),
+            80 => Some(Self::BoundedDenial),
+            _ => None,
+        }
+    }
+
+    pub(crate) const fn discriminant(self) -> u16 {
+        self as u16
+    }
+}
+
+/// One typed audit event before canonical encoding. Construction is
+/// fallible where a ceiling applies, so a frame can never encode a value the
+/// landed pools cannot produce.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct AuditEvent {
+    class: AuditClass,
+    subject: AuditSubject,
+    object: Option<AuditObject>,
+    rights: AuditRights,
+    payload: [u8; AUDIT_MAX_PAYLOAD],
+    payload_len: usize,
+}
+
+impl AuditEvent {
+    pub fn new(class: AuditClass, subject: AuditSubject) -> Self {
+        Self {
+            class,
+            subject,
+            object: None,
+            rights: AuditRights::from_bits(0).expect("zero is a valid rights mask"),
+            payload: [0; AUDIT_MAX_PAYLOAD],
+            payload_len: 0,
+        }
+    }
+
+    pub fn with_object(mut self, object: AuditObject) -> Self {
+        self.object = Some(object);
+        self
+    }
+
+    pub fn with_rights(mut self, rights: AuditRights) -> Self {
+        self.rights = rights;
+        self
+    }
+
+    pub fn with_payload(mut self, payload: &[u8]) -> Option<Self> {
+        if payload.len() > AUDIT_MAX_PAYLOAD {
+            return None;
+        }
+        self.payload = [0; AUDIT_MAX_PAYLOAD];
+        self.payload[..payload.len()].copy_from_slice(payload);
+        self.payload_len = payload.len();
+        Some(self)
+    }
+
+    /// A bounded denial under caller-visible/stamped context. The object
+    /// stays absent: an unauthorized attempt must not disclose foreign
+    /// object identity through the verifier projection.
+    pub fn denial(subject: AuditSubject, context: DenialContext) -> Self {
+        let payload = context.payload_bytes();
+        Self {
+            class: AuditClass::BoundedDenial,
+            subject,
+            object: None,
+            rights: AuditRights::from_bits(0).expect("zero is a valid rights mask"),
+            payload: [0; AUDIT_MAX_PAYLOAD],
+            payload_len: 0,
+        }
+        .with_payload(&payload)
+        .expect("denial payload fits the landed ceiling")
+    }
+
+    pub const fn class(self) -> AuditClass {
+        self.class
+    }
+
+    pub const fn subject(self) -> AuditSubject {
+        self.subject
+    }
+
+    pub const fn object(self) -> Option<AuditObject> {
+        self.object
+    }
+
+    pub const fn rights(self) -> AuditRights {
+        self.rights
+    }
+
+    pub fn payload(&self) -> &[u8] {
+        &self.payload[..self.payload_len]
+    }
+}
+
+/// Kernel-authenticated restart checkpoint bound to boot/session identity,
+/// exact `audit_seq`, root, codec version, and relay generation. A
+/// verifier-local cache alone is never a trusted checkpoint.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct AuditCheckpoint {
+    boot: BootSessionId,
+    seq: u64,
+    root: [u8; root::ROOT_LEN],
+    codec_version: u16,
+    relay_generation: u64,
+    tag: [u8; root::ROOT_LEN],
+}
+
+impl AuditCheckpoint {
+    pub(crate) fn seal(
+        boot: BootSessionId,
+        seq: u64,
+        root: [u8; root::ROOT_LEN],
+        relay_generation: u64,
+    ) -> Self {
+        let codec_version = super::CODEC_VERSION;
+        let tag = root::checkpoint_tag(boot, seq, root, relay_generation);
+        Self {
+            boot,
+            seq,
+            root,
+            codec_version,
+            relay_generation,
+            tag,
+        }
+    }
+
+    pub(crate) fn verify_tag(&self) -> bool {
+        root::checkpoint_tag(self.boot, self.seq, self.root, self.relay_generation) == self.tag
+    }
+
+    pub const fn boot(self) -> BootSessionId {
+        self.boot
+    }
+
+    pub const fn seq(self) -> u64 {
+        self.seq
+    }
+
+    pub const fn root(self) -> [u8; root::ROOT_LEN] {
+        self.root
+    }
+
+    pub const fn codec_version(self) -> u16 {
+        self.codec_version
+    }
+
+    pub const fn relay_generation(self) -> u64 {
+        self.relay_generation
+    }
+
+    pub const fn tag(self) -> [u8; root::ROOT_LEN] {
+        self.tag
+    }
+}
+
+/// Fail-closed audit errors. None of these are recoverable by wraparound or
+/// silent omission.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AuditError {
+    SequenceOverflow,
+    RelayGenerationOverflow,
+    PayloadTooLarge,
+    EncodeOverflow,
+    MalformedFrame,
+    UnauthorizedDisclosure,
+    RootMismatch,
+    CheckpointMismatch,
+    RelayWindowOverflow,
+    RelayInvalidCursor,
+    RelayStaleCursor,
+    BatchCapacityExhausted,
+}
+
+impl core::fmt::Display for AuditError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let text = match self {
+            Self::SequenceOverflow => "audit sequence overflow",
+            Self::RelayGenerationOverflow => "relay generation overflow",
+            Self::PayloadTooLarge => "payload exceeds the landed ceiling",
+            Self::EncodeOverflow => "canonical frame exceeds the fixed bound",
+            Self::MalformedFrame => "malformed canonical frame",
+            Self::UnauthorizedDisclosure => "denial frame discloses a foreign identity",
+            Self::RootMismatch => "rolling root mismatch",
+            Self::CheckpointMismatch => "checkpoint authentication mismatch",
+            Self::RelayWindowOverflow => "relay window overflow",
+            Self::RelayInvalidCursor => "relay cursor invalid",
+            Self::RelayStaleCursor => "relay cursor stale",
+            Self::BatchCapacityExhausted => "batch exceeds the static terminal reserve",
+        };
+        f.write_str(text)
+    }
+}

--- a/kernel/crates/astrid-native-kernel/src/audit/types.rs
+++ b/kernel/crates/astrid-native-kernel/src/audit/types.rs
@@ -13,6 +13,7 @@ pub(crate) const AUDIT_DOMAIN_SLOTS: usize = 2;
 pub(crate) const AUDIT_CAP_SLOTS_PER_DOMAIN: usize = 8;
 pub(crate) const AUDIT_ENDPOINT_POOL: usize = 4;
 pub(crate) const AUDIT_CAP_OBJECT_POOL: usize = 16;
+pub(crate) const AUDIT_QUEUES_PER_ENDPOINT: usize = 2;
 /// Landed message payload ceiling. Audit payloads never exceed it.
 pub(crate) const AUDIT_MAX_PAYLOAD: usize = 64;
 
@@ -23,11 +24,14 @@ const _: () = assert!(
 
 /// Maximum mandatory terminal/invalidation records one admitted atomic
 /// mutation batch can produce at the frozen ceilings: mass invalidation of
-/// every capability-instance slot of both domain slots, every endpoint, and
-/// the dying domain identity itself. This is the statically derived relay
-/// reserve, never a single global death slot.
-pub(crate) const MAX_TERMINAL_RECORDS_PER_BATCH: usize =
-    AUDIT_DOMAIN_SLOTS * AUDIT_CAP_SLOTS_PER_DOMAIN + AUDIT_ENDPOINT_POOL + 1;
+/// every capability-instance slot of both domain slots, every endpoint, both
+/// queues on every endpoint, and the dying domain identity itself. This is
+/// the statically derived relay reserve, never a single global death slot.
+pub(crate) const MAX_TERMINAL_RECORDS_PER_BATCH: usize = AUDIT_DOMAIN_SLOTS
+    * AUDIT_CAP_SLOTS_PER_DOMAIN
+    + AUDIT_ENDPOINT_POOL
+    + AUDIT_ENDPOINT_POOL * AUDIT_QUEUES_PER_ENDPOINT
+    + 1;
 
 /// Boot-scoped audit session identity. A kernel restart mints a new identity;
 /// this slice claims no cross-boot durable continuity.
@@ -540,17 +544,20 @@ impl AuditCheckpoint {
         root: [u8; root::ROOT_LEN],
         relay_generation: u64,
         auth_key: CheckpointAuthKey,
-    ) -> Self {
+    ) -> Result<Self, AuditError> {
+        if relay_generation == 0 {
+            return Err(AuditError::MalformedFrame);
+        }
         let codec_version = super::CODEC_VERSION;
         let tag = root::checkpoint_tag(boot, seq, root, relay_generation, auth_key);
-        Self {
+        Ok(Self {
             boot,
             seq,
             root,
             codec_version,
             relay_generation,
             tag,
-        }
+        })
     }
 
     pub(crate) fn verify_tag(&self, auth_key: CheckpointAuthKey) -> bool {

--- a/kernel/crates/astrid-native-kernel/src/audit/types.rs
+++ b/kernel/crates/astrid-native-kernel/src/audit/types.rs
@@ -3,6 +3,8 @@
 
 use core::num::NonZeroU64;
 
+use blake3::Hasher;
+
 use super::root;
 use crate::ipc::DomainToken;
 
@@ -57,33 +59,98 @@ impl BootSessionId {
     }
 }
 
-/// Kernel-only checkpoint authentication key. This slice intentionally does
-/// not authenticate checkpoints with a public, verifier-recomputable hash:
-/// without this key, a host cannot mint a different verifier-local cache.
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub struct CheckpointAuthKey([u8; 32]);
+const AUTHORITY_ROOT_DOMAIN: &[u8] = b"astrid.native-kernel.audit-authority-root.v1";
+const AUTHORITY_ID_DOMAIN: &[u8] = b"astrid.native-kernel.audit-authority-id.v1";
+const AUTHORITY_KEY_DOMAIN: &[u8] = b"astrid.native-kernel.audit-authority-key.v1";
 
-impl CheckpointAuthKey {
-    pub const fn new(bytes: [u8; 32]) -> Option<Self> {
-        let mut index = 0;
-        let mut any_nonzero = false;
-        while index < bytes.len() {
-            if bytes[index] != 0 {
-                any_nonzero = true;
-            }
-            index += 1;
+/// Opaque kernel-owned authentication context. It is derived inside the
+/// kernel from the live boot identity and cannot be constructed from
+/// caller-selected bytes. Its authority id is part of every checkpoint tag.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) struct CheckpointAuthContext {
+    authority_id: u64,
+    verification_key: [u8; 32],
+}
+
+impl CheckpointAuthContext {
+    fn mint(boot: BootSessionId) -> Self {
+        let mut id_hasher = Hasher::new();
+        id_hasher.update(AUTHORITY_ROOT_DOMAIN);
+        id_hasher.update(&boot.bytes());
+        id_hasher.update(AUTHORITY_ID_DOMAIN);
+        let id_digest: [u8; 32] = id_hasher.finalize().into();
+        let mut authority_id = u64::from_le_bytes(id_digest[..8].try_into().unwrap());
+        if authority_id == 0 {
+            authority_id = 1;
         }
-        if any_nonzero { Some(Self(bytes)) } else { None }
+
+        let mut key_hasher = Hasher::new();
+        key_hasher.update(AUTHORITY_ROOT_DOMAIN);
+        key_hasher.update(&boot.bytes());
+        key_hasher.update(AUTHORITY_KEY_DOMAIN);
+        key_hasher.update(&authority_id.to_le_bytes());
+        let verification_key: [u8; 32] = key_hasher.finalize().into();
+        debug_assert!(verification_key != [0; 32]);
+        Self {
+            authority_id,
+            verification_key,
+        }
     }
 
-    pub const fn bytes(self) -> [u8; 32] {
-        self.0
+    pub(crate) const fn authority_id(self) -> u64 {
+        self.authority_id
+    }
+
+    pub(crate) const fn verification_key(self) -> [u8; 32] {
+        self.verification_key
     }
 }
 
-impl core::fmt::Debug for CheckpointAuthKey {
+impl core::fmt::Debug for CheckpointAuthContext {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.write_str("CheckpointAuthKey(REDACTED)")
+        f.write_str("CheckpointAuthContext(REDACTED)")
+    }
+}
+
+/// Kernel-minted authority for one live boot/session. Its verifier handoff is
+/// an opaque sealed capability, not a caller-selectable raw key.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct AuditAuthority {
+    boot: BootSessionId,
+    context: CheckpointAuthContext,
+}
+
+impl AuditAuthority {
+    pub fn mint(boot: BootSessionId) -> Self {
+        Self {
+            boot,
+            context: CheckpointAuthContext::mint(boot),
+        }
+    }
+
+    pub const fn boot(self) -> BootSessionId {
+        self.boot
+    }
+
+    pub(crate) const fn context(self) -> CheckpointAuthContext {
+        self.context
+    }
+
+    /// Sealed opaque handoff accepted by `native-audit-verifier`. The private
+    /// first-slice layout carries no production lifecycle provisioning claim.
+    pub fn verifier_handoff(self) -> [u8; 96] {
+        let mut handoff = [0; 96];
+        handoff[..8].copy_from_slice(b"ASAUDCTX");
+        handoff[8..16].copy_from_slice(&self.context.authority_id().to_le_bytes());
+        handoff[16..32].copy_from_slice(&self.boot.bytes());
+        handoff[32..64].copy_from_slice(&self.context.verification_key());
+        let tag = root::verifier_handoff_tag(
+            self.boot,
+            self.context.authority_id(),
+            &self.context.verification_key(),
+        );
+        handoff[64..].copy_from_slice(&tag);
+        handoff
     }
 }
 
@@ -534,6 +601,7 @@ pub struct AuditCheckpoint {
     root: [u8; root::ROOT_LEN],
     codec_version: u16,
     relay_generation: u64,
+    authority_id: u64,
     tag: [u8; root::ROOT_LEN],
 }
 
@@ -543,30 +611,34 @@ impl AuditCheckpoint {
         seq: u64,
         root: [u8; root::ROOT_LEN],
         relay_generation: u64,
-        auth_key: CheckpointAuthKey,
+        context: CheckpointAuthContext,
     ) -> Result<Self, AuditError> {
-        if relay_generation == 0 {
+        if relay_generation == 0 || context.authority_id() == 0 {
             return Err(AuditError::MalformedFrame);
         }
         let codec_version = super::CODEC_VERSION;
-        let tag = root::checkpoint_tag(boot, seq, root, relay_generation, auth_key);
+        let tag = root::checkpoint_tag(boot, seq, root, relay_generation, &context);
         Ok(Self {
             boot,
             seq,
             root,
             codec_version,
             relay_generation,
+            authority_id: context.authority_id(),
             tag,
         })
     }
 
-    pub(crate) fn verify_tag(&self, auth_key: CheckpointAuthKey) -> bool {
+    pub(crate) fn verify_tag(&self, context: CheckpointAuthContext) -> bool {
+        if self.authority_id != context.authority_id() {
+            return false;
+        }
         root::checkpoint_tag(
             self.boot,
             self.seq,
             self.root,
             self.relay_generation,
-            auth_key,
+            &context,
         ) == self.tag
     }
 
@@ -588,6 +660,10 @@ impl AuditCheckpoint {
 
     pub const fn relay_generation(self) -> u64 {
         self.relay_generation
+    }
+
+    pub const fn authority_id(self) -> u64 {
+        self.authority_id
     }
 
     pub const fn tag(self) -> [u8; root::ROOT_LEN] {

--- a/kernel/crates/astrid-native-kernel/src/audit/types.rs
+++ b/kernel/crates/astrid-native-kernel/src/audit/types.rs
@@ -66,6 +66,13 @@ const AUTHORITY_KEY_DOMAIN: &[u8] = b"astrid.native-kernel.audit-authority-key.v
 /// Opaque kernel-owned authentication context. It is derived inside the
 /// kernel from the live boot identity and cannot be constructed from
 /// caller-selected bytes. Its authority id is part of every checkpoint tag.
+///
+/// The verification key stays kernel-side for the whole boot/session. It
+/// reaches the verifier only through an independently trusted kernel-origin
+/// channel that this unwired slice models by injection; the untrusted
+/// handoff carries none of it. Production anchor delivery and key
+/// lifecycle remain named #1759 residuals, and no fixed production secret
+/// is introduced.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub(crate) struct CheckpointAuthContext {
     authority_id: u64,
@@ -112,13 +119,19 @@ impl core::fmt::Debug for CheckpointAuthContext {
     }
 }
 
-/// Kernel-minted authority for one live boot/session. Its verifier handoff is
-/// an opaque sealed capability, not a caller-selectable raw key.
+/// Kernel-minted authority for one live boot/session. Its verifier handoff
+/// is untrusted binding evidence: it names the authority and carries a
+/// keyed minting tag, never verification material, so it cannot
+/// authenticate itself.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct AuditAuthority {
     boot: BootSessionId,
     context: CheckpointAuthContext,
 }
+
+/// Fixed wire size of the untrusted verifier handoff binding: magic,
+/// authority id, boot/session identity, and the keyed tag. No key material.
+const VERIFIER_HANDOFF_BYTES: usize = 8 + 8 + 16 + root::ROOT_LEN;
 
 impl AuditAuthority {
     pub fn mint(boot: BootSessionId) -> Self {
@@ -136,20 +149,22 @@ impl AuditAuthority {
         self.context
     }
 
-    /// Sealed opaque handoff accepted by `native-audit-verifier`. The private
-    /// first-slice layout carries no production lifecycle provisioning claim.
-    pub fn verifier_handoff(self) -> [u8; 96] {
-        let mut handoff = [0; 96];
+    /// Untrusted binding evidence accepted by `native-audit-verifier`. It
+    /// carries no verification material: the tag is checkable only against
+    /// the independently trusted kernel-origin anchor, so a caller-minted
+    /// handoff cannot authenticate itself. The private first-slice layout
+    /// carries no production lifecycle provisioning claim.
+    pub fn verifier_handoff(self) -> [u8; VERIFIER_HANDOFF_BYTES] {
+        let mut handoff = [0; VERIFIER_HANDOFF_BYTES];
         handoff[..8].copy_from_slice(b"ASAUDCTX");
         handoff[8..16].copy_from_slice(&self.context.authority_id().to_le_bytes());
         handoff[16..32].copy_from_slice(&self.boot.bytes());
-        handoff[32..64].copy_from_slice(&self.context.verification_key());
         let tag = root::verifier_handoff_tag(
             self.boot,
             self.context.authority_id(),
             &self.context.verification_key(),
         );
-        handoff[64..].copy_from_slice(&tag);
+        handoff[32..].copy_from_slice(&tag);
         handoff
     }
 }

--- a/kernel/crates/astrid-native-kernel/src/audit/types.rs
+++ b/kernel/crates/astrid-native-kernel/src/audit/types.rs
@@ -53,6 +53,36 @@ impl BootSessionId {
     }
 }
 
+/// Kernel-only checkpoint authentication key. This slice intentionally does
+/// not authenticate checkpoints with a public, verifier-recomputable hash:
+/// without this key, a host cannot mint a different verifier-local cache.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct CheckpointAuthKey([u8; 32]);
+
+impl CheckpointAuthKey {
+    pub const fn new(bytes: [u8; 32]) -> Option<Self> {
+        let mut index = 0;
+        let mut any_nonzero = false;
+        while index < bytes.len() {
+            if bytes[index] != 0 {
+                any_nonzero = true;
+            }
+            index += 1;
+        }
+        if any_nonzero { Some(Self(bytes)) } else { None }
+    }
+
+    pub const fn bytes(self) -> [u8; 32] {
+        self.0
+    }
+}
+
+impl core::fmt::Debug for CheckpointAuthKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("CheckpointAuthKey(REDACTED)")
+    }
+}
+
 /// Landed caller identity (#1705 `DomainToken`): domain slot plus generation.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct AuditSubject {
@@ -182,7 +212,10 @@ impl AuditCapabilityInstance {
         object_kind: AuditObjectKind,
         object_token: u64,
     ) -> Option<Self> {
-        if capability_slot >= AUDIT_CAP_SLOTS_PER_DOMAIN {
+        // Landed #1758 capability-instance projections name Endpoint objects
+        // only; a Domain identity is attribution, not the held object.
+        if capability_slot >= AUDIT_CAP_SLOTS_PER_DOMAIN || object_kind != AuditObjectKind::Endpoint
+        {
             return None;
         }
         Some(Self {
@@ -381,6 +414,24 @@ impl AuditClass {
     pub(crate) const fn discriminant(self) -> u16 {
         self as u16
     }
+
+    /// Classes whose relay records participate in the statically reserved
+    /// terminal/invalidation headroom. Ordinary records cannot consume the
+    /// headroom needed by one admitted atomic teardown batch.
+    pub(crate) const fn is_terminal_or_invalidation(self) -> bool {
+        matches!(
+            self,
+            Self::DomainKill
+                | Self::DomainReclaim
+                | Self::DomainCancel
+                | Self::CapabilityRevoke
+                | Self::IpcQueueDrop
+                | Self::IpcEndpointTeardown
+                | Self::GenerationOverflow
+                | Self::RootOverflow
+                | Self::RootIncomplete
+        )
+    }
 }
 
 /// One typed audit event before canonical encoding. Construction is
@@ -408,9 +459,12 @@ impl AuditEvent {
         }
     }
 
-    pub fn with_object(mut self, object: AuditObject) -> Self {
+    pub fn with_object(mut self, object: AuditObject) -> Option<Self> {
+        if self.class == AuditClass::BoundedDenial {
+            return None;
+        }
         self.object = Some(object);
-        self
+        Some(self)
     }
 
     pub fn with_rights(mut self, rights: AuditRights) -> Self {
@@ -485,9 +539,10 @@ impl AuditCheckpoint {
         seq: u64,
         root: [u8; root::ROOT_LEN],
         relay_generation: u64,
+        auth_key: CheckpointAuthKey,
     ) -> Self {
         let codec_version = super::CODEC_VERSION;
-        let tag = root::checkpoint_tag(boot, seq, root, relay_generation);
+        let tag = root::checkpoint_tag(boot, seq, root, relay_generation, auth_key);
         Self {
             boot,
             seq,
@@ -498,8 +553,14 @@ impl AuditCheckpoint {
         }
     }
 
-    pub(crate) fn verify_tag(&self) -> bool {
-        root::checkpoint_tag(self.boot, self.seq, self.root, self.relay_generation) == self.tag
+    pub(crate) fn verify_tag(&self, auth_key: CheckpointAuthKey) -> bool {
+        root::checkpoint_tag(
+            self.boot,
+            self.seq,
+            self.root,
+            self.relay_generation,
+            auth_key,
+        ) == self.tag
     }
 
     pub const fn boot(self) -> BootSessionId {
@@ -542,6 +603,8 @@ pub enum AuditError {
     RelayWindowOverflow,
     RelayInvalidCursor,
     RelayStaleCursor,
+    RelayNotInFlight,
+    HandoffIncomplete,
     BatchCapacityExhausted,
 }
 
@@ -559,6 +622,8 @@ impl core::fmt::Display for AuditError {
             Self::RelayWindowOverflow => "relay window overflow",
             Self::RelayInvalidCursor => "relay cursor invalid",
             Self::RelayStaleCursor => "relay cursor stale",
+            Self::RelayNotInFlight => "relay record is not in flight",
+            Self::HandoffIncomplete => "audit handoff is incomplete and requires resync",
             Self::BatchCapacityExhausted => "batch exceeds the static terminal reserve",
         };
         f.write_str(text)

--- a/kernel/crates/astrid-native-kernel/src/lib.rs
+++ b/kernel/crates/astrid-native-kernel/src/lib.rs
@@ -25,6 +25,10 @@ pub mod platform;
 // typechecking the frozen relation semantics.
 #[allow(dead_code)]
 mod relations;
+// Production-compiled ahead of its first consumer so the native target keeps
+// typechecking the frozen audit-chain semantics.
+#[allow(dead_code)]
+mod audit;
 #[cfg(not(test))]
 pub mod serial;
 #[cfg(not(test))]

--- a/kernel/tools/native-audit-verifier/Cargo.toml
+++ b/kernel/tools/native-audit-verifier/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "native-audit-verifier"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[lib]
+name = "native_audit_verifier"
+test = true
+bench = false
+
+[dependencies]
+# Same frozen pure backend as the kernel crates so digests cannot differ by
+# feature selection.
+blake3 = { version = "=1.8.5", default-features = false, features = ["pure"] }

--- a/kernel/tools/native-audit-verifier/src/lib.rs
+++ b/kernel/tools/native-audit-verifier/src/lib.rs
@@ -27,6 +27,8 @@ const CHECKPOINT_DOMAIN_TAG: &[u8] = b"astrid.native-kernel.audit-checkpoint.v1"
 pub enum VerifyFailure {
     Malformed,
     CheckpointMismatch,
+    SequenceOverflow,
+    StaleRelayGeneration,
 }
 
 /// One fold step failure. Invalid means the input contradicts the chain;
@@ -35,12 +37,15 @@ pub enum VerifyFailure {
 pub enum FoldFailure {
     Invalid(InvalidReason),
     Incomplete(IncompleteReason),
+    SequenceOverflow,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum InvalidReason {
     Malformed,
     DuplicateOrReorder,
+    ForeignBoot,
+    PreviousRootMismatch,
     RootMismatch,
     DenialDisclosure,
 }
@@ -59,6 +64,35 @@ pub struct CheckpointView {
     pub codec_version: u16,
     pub relay_generation: u64,
     pub tag: [u8; 32],
+}
+
+/// Kernel-only checkpoint authentication key. A checkpoint is trusted only
+/// when this key authenticates its complete state binding.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct CheckpointKey([u8; 32]);
+
+impl CheckpointKey {
+    pub const fn new(bytes: [u8; 32]) -> Option<Self> {
+        let mut index = 0;
+        let mut any_nonzero = false;
+        while index < bytes.len() {
+            if bytes[index] != 0 {
+                any_nonzero = true;
+            }
+            index += 1;
+        }
+        if any_nonzero { Some(Self(bytes)) } else { None }
+    }
+
+    pub const fn bytes(self) -> [u8; 32] {
+        self.0
+    }
+}
+
+impl core::fmt::Debug for CheckpointKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("CheckpointKey(REDACTED)")
+    }
 }
 
 fn genesis_root(boot: [u8; 16]) -> [u8; 32] {
@@ -81,8 +115,14 @@ fn advance(previous_root: [u8; 32], boot: [u8; 16], seq: u64, frame: &[u8]) -> [
     hasher.finalize().into()
 }
 
-fn checkpoint_tag(boot: [u8; 16], seq: u64, root: [u8; 32], relay_generation: u64) -> [u8; 32] {
-    let mut hasher = Hasher::new();
+fn checkpoint_tag(
+    boot: [u8; 16],
+    seq: u64,
+    root: [u8; 32],
+    relay_generation: u64,
+    auth_key: CheckpointKey,
+) -> [u8; 32] {
+    let mut hasher = Hasher::new_keyed(&auth_key.bytes());
     hasher.update(CHECKPOINT_DOMAIN_TAG);
     hasher.update(&CODEC_VERSION.to_le_bytes());
     hasher.update(&boot);
@@ -94,7 +134,10 @@ fn checkpoint_tag(boot: [u8; 16], seq: u64, root: [u8; 32], relay_generation: u6
 
 /// Tag-verifies a canonical checkpoint wire form. A verifier-local cache
 /// alone is never trusted; only this kernel-sealed binding is.
-pub fn verify_checkpoint(wire: &[u8]) -> Result<CheckpointView, VerifyFailure> {
+pub fn verify_checkpoint(
+    wire: &[u8],
+    auth_key: CheckpointKey,
+) -> Result<CheckpointView, VerifyFailure> {
     if wire.len() != CHECKPOINT_WIRE_BYTES {
         return Err(VerifyFailure::Malformed);
     }
@@ -139,7 +182,10 @@ pub fn verify_checkpoint(wire: &[u8]) -> Result<CheckpointView, VerifyFailure> {
         relay_generation,
         tag,
     };
-    if checkpoint_tag(boot, seq, root, relay_generation) != tag {
+    if relay_generation == 0 {
+        return Err(VerifyFailure::Malformed);
+    }
+    if checkpoint_tag(boot, seq, root, relay_generation, auth_key) != tag {
         return Err(VerifyFailure::CheckpointMismatch);
     }
     Ok(view)
@@ -151,10 +197,12 @@ pub struct AuditVerifier {
     boot: [u8; 16],
     next_seq: u64,
     root: [u8; 32],
+    auth_key: CheckpointKey,
+    relay_generation: u64,
 }
 
 impl AuditVerifier {
-    pub fn genesis(boot: [u8; 16]) -> Result<Self, VerifyFailure> {
+    pub fn genesis(boot: [u8; 16], auth_key: CheckpointKey) -> Result<Self, VerifyFailure> {
         if boot.iter().all(|byte| *byte == 0) {
             return Err(VerifyFailure::Malformed);
         }
@@ -162,33 +210,30 @@ impl AuditVerifier {
             boot,
             next_seq: 1,
             root: genesis_root(boot),
+            auth_key,
+            relay_generation: 1,
         })
     }
 
-    pub fn from_checkpoint(wire: &[u8]) -> Result<Self, VerifyFailure> {
-        let checkpoint = verify_checkpoint(wire)?;
+    pub fn from_checkpoint(wire: &[u8], auth_key: CheckpointKey) -> Result<Self, VerifyFailure> {
+        let checkpoint = verify_checkpoint(wire, auth_key)?;
+        let next_seq = checkpoint
+            .seq
+            .checked_add(1)
+            .ok_or(VerifyFailure::SequenceOverflow)?;
         Ok(Self {
             boot: checkpoint.boot,
-            next_seq: checkpoint.seq + 1,
             root: checkpoint.root,
+            next_seq,
+            auth_key,
+            relay_generation: checkpoint.relay_generation,
         })
     }
 
     /// Folds one canonical frame whose source root claim has already been
     /// checked by the caller's handoff record. Contiguity is enforced; a gap
     /// is Incomplete and a duplicate or reorder is Invalid. Never skips.
-    pub fn fold(&mut self, frame: &[u8]) -> Result<u64, FoldFailure> {
-        self.fold_with_root(frame, None)
-    }
-
-    /// Same as [`AuditVerifier::fold`] while also matching the per-record
-    /// root carried by the handoff (ack `N` only when the source root
-    /// matches).
-    pub fn fold_with_root(
-        &mut self,
-        frame: &[u8],
-        claimed_root: Option<[u8; 32]>,
-    ) -> Result<u64, FoldFailure> {
+    pub fn fold(&mut self, frame: &[u8], claimed_root: [u8; 32]) -> Result<u64, FoldFailure> {
         let view = wire::decode_frame(frame).map_err(|error| match error {
             wire::WireError::Malformed => FoldFailure::Invalid(InvalidReason::Malformed),
             wire::WireError::DenialDisclosure => {
@@ -201,14 +246,21 @@ impl AuditVerifier {
         if view.seq > self.next_seq {
             return Err(FoldFailure::Incomplete(IncompleteReason::SequenceGap));
         }
+        if view.boot != self.boot {
+            return Err(FoldFailure::Invalid(InvalidReason::ForeignBoot));
+        }
+        if view.prev_root != Some(self.root) {
+            return Err(FoldFailure::Invalid(InvalidReason::PreviousRootMismatch));
+        }
         let next_root = advance(self.root, self.boot, view.seq, frame);
-        if let Some(claimed) = claimed_root
-            && claimed != next_root
-        {
+        if claimed_root != next_root {
             return Err(FoldFailure::Invalid(InvalidReason::RootMismatch));
         }
         self.root = next_root;
-        self.next_seq += 1;
+        self.next_seq = self
+            .next_seq
+            .checked_add(1)
+            .ok_or(FoldFailure::SequenceOverflow)?;
         Ok(view.seq)
     }
 
@@ -216,13 +268,41 @@ impl AuditVerifier {
     /// source root must match exactly before any acknowledgement range is
     /// trusted across a restart.
     pub fn accept_checkpoint(&self, wire: &[u8]) -> Result<(), VerifyFailure> {
-        let checkpoint = verify_checkpoint(wire)?;
-        if checkpoint.boot != self.boot
-            || checkpoint.seq + 1 != self.next_seq
-            || checkpoint.root != self.root
+        let checkpoint = verify_checkpoint(wire, self.auth_key)?;
+        let next_seq = checkpoint
+            .seq
+            .checked_add(1)
+            .ok_or(VerifyFailure::SequenceOverflow)?;
+        if checkpoint.boot != self.boot || next_seq != self.next_seq || checkpoint.root != self.root
         {
             return Err(VerifyFailure::CheckpointMismatch);
         }
+        if checkpoint.relay_generation != self.relay_generation {
+            return Err(VerifyFailure::StaleRelayGeneration);
+        }
+        Ok(())
+    }
+
+    /// Accepts exactly one generation-bumped checkpoint after the same state
+    /// has been folded. This is the verifier side of explicit resync.
+    pub fn accept_resync_checkpoint(&mut self, wire: &[u8]) -> Result<(), VerifyFailure> {
+        let checkpoint = verify_checkpoint(wire, self.auth_key)?;
+        let next_seq = checkpoint
+            .seq
+            .checked_add(1)
+            .ok_or(VerifyFailure::SequenceOverflow)?;
+        let next_generation = self
+            .relay_generation
+            .checked_add(1)
+            .ok_or(VerifyFailure::Malformed)?;
+        if checkpoint.boot != self.boot
+            || next_seq != self.next_seq
+            || checkpoint.root != self.root
+            || checkpoint.relay_generation != next_generation
+        {
+            return Err(VerifyFailure::CheckpointMismatch);
+        }
+        self.relay_generation = next_generation;
         Ok(())
     }
 

--- a/kernel/tools/native-audit-verifier/src/lib.rs
+++ b/kernel/tools/native-audit-verifier/src/lib.rs
@@ -15,13 +15,16 @@ use blake3::Hasher;
 /// Frozen canonical frame-codec version this verifier understands.
 pub const CODEC_VERSION: u16 = 1;
 /// Fixed wire size of the canonical checkpoint form.
-pub const CHECKPOINT_WIRE_BYTES: usize = 4 + 2 + 16 + 8 + 32 + 8 + 32;
+pub const CHECKPOINT_WIRE_BYTES: usize = 4 + 2 + 16 + 8 + 32 + 8 + 8 + 32;
+/// Fixed size of a kernel-minted opaque verifier handoff.
+pub const AUTHORITY_HANDOFF_BYTES: usize = 96;
 
 const ROOT_ALGORITHM_ID: &[u8] = b"BLAKE3-256";
 const ROOT_DOMAIN_TAG: &[u8] = b"astrid.native-kernel.audit-root.v1";
 const GENESIS_DOMAIN_TAG: &[u8] = b"astrid.native-kernel.audit-genesis.v1";
 const CHECKPOINT_DOMAIN_TAG: &[u8] = b"astrid.native-kernel.audit-checkpoint.v1";
 const ACK_DOMAIN_TAG: &[u8] = b"astrid.native-kernel.audit-ack.v1";
+const VERIFIER_HANDOFF_DOMAIN_TAG: &[u8] = b"astrid.native-kernel.audit-verifier-handoff.v1";
 
 /// Hard decode failure of one input.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -88,35 +91,72 @@ pub struct CheckpointView {
     pub root: [u8; 32],
     pub codec_version: u16,
     pub relay_generation: u64,
+    pub authority_id: u64,
     pub tag: [u8; 32],
 }
 
-/// Kernel-only checkpoint authentication key. A checkpoint is trusted only
-/// when this key authenticates its complete state binding.
+/// Opaque kernel-minted verifier context. It can enter this crate only
+/// through a sealed handoff; a caller cannot construct a raw authority key.
 #[derive(Clone, Copy, PartialEq, Eq)]
-pub struct CheckpointKey([u8; 32]);
+pub struct AuthContext {
+    authority_id: u64,
+    boot: [u8; 16],
+    verification_key: [u8; 32],
+}
 
-impl CheckpointKey {
-    pub const fn new(bytes: [u8; 32]) -> Option<Self> {
-        let mut index = 0;
-        let mut any_nonzero = false;
-        while index < bytes.len() {
-            if bytes[index] != 0 {
-                any_nonzero = true;
-            }
-            index += 1;
+impl AuthContext {
+    /// Accepts only the sealed 96-byte capability minted by the kernel.
+    pub fn from_handoff(bytes: &[u8; AUTHORITY_HANDOFF_BYTES]) -> Result<Self, VerifyFailure> {
+        if bytes[..8] != *b"ASAUDCTX" {
+            return Err(VerifyFailure::Malformed);
         }
-        if any_nonzero { Some(Self(bytes)) } else { None }
+        let authority_id = u64::from_le_bytes(
+            bytes[8..16]
+                .try_into()
+                .ok()
+                .ok_or(VerifyFailure::Malformed)?,
+        );
+        let boot = bytes[16..32]
+            .try_into()
+            .ok()
+            .filter(|boot: &[u8; 16]| boot.iter().any(|byte| *byte != 0))
+            .ok_or(VerifyFailure::Malformed)?;
+        let verification_key = bytes[32..64]
+            .try_into()
+            .ok()
+            .filter(|key: &[u8; 32]| key.iter().any(|byte| *byte != 0))
+            .ok_or(VerifyFailure::Malformed)?;
+        let tag: [u8; 32] = bytes[64..]
+            .try_into()
+            .map_err(|_| VerifyFailure::Malformed)?;
+        if verifier_handoff_tag(boot, authority_id, &verification_key) != tag {
+            return Err(VerifyFailure::Malformed);
+        }
+        Ok(Self {
+            authority_id,
+            boot,
+            verification_key,
+        })
     }
 
-    pub const fn bytes(self) -> [u8; 32] {
-        self.0
+    #[cfg(test)]
+    fn mint(boot: [u8; 16], seed: u64) -> Self {
+        let mut hasher = Hasher::new();
+        hasher.update(b"native-audit-verifier-test-authority");
+        hasher.update(&boot);
+        hasher.update(&seed.to_le_bytes());
+        let digest: [u8; 32] = hasher.finalize().into();
+        Self {
+            authority_id: seed | 1,
+            boot,
+            verification_key: digest,
+        }
     }
 }
 
-impl core::fmt::Debug for CheckpointKey {
+impl core::fmt::Debug for AuthContext {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.write_str("CheckpointKey(REDACTED)")
+        f.write_str("AuthContext(REDACTED)")
     }
 }
 
@@ -145,25 +185,49 @@ fn checkpoint_tag(
     seq: u64,
     root: [u8; 32],
     relay_generation: u64,
-    auth_key: CheckpointKey,
+    context: &AuthContext,
 ) -> [u8; 32] {
-    let mut hasher = Hasher::new_keyed(&auth_key.bytes());
+    let mut hasher = Hasher::new_keyed(&context.verification_key);
     hasher.update(CHECKPOINT_DOMAIN_TAG);
     hasher.update(&CODEC_VERSION.to_le_bytes());
     hasher.update(&boot);
     hasher.update(&seq.to_le_bytes());
     hasher.update(&root);
     hasher.update(&relay_generation.to_le_bytes());
+    hasher.update(&context.authority_id.to_le_bytes());
     hasher.finalize().into()
 }
 
-fn ack_tag(seq: u64, source_root: [u8; 32], frame: &[u8], auth_key: CheckpointKey) -> [u8; 32] {
-    let mut hasher = Hasher::new_keyed(&auth_key.bytes());
+fn ack_tag(
+    boot: [u8; 16],
+    relay_generation: u64,
+    seq: u64,
+    source_root: [u8; 32],
+    frame: &[u8],
+    context: &AuthContext,
+) -> [u8; 32] {
+    let mut hasher = Hasher::new_keyed(&context.verification_key);
     hasher.update(ACK_DOMAIN_TAG);
     hasher.update(&CODEC_VERSION.to_le_bytes());
+    hasher.update(&context.authority_id.to_le_bytes());
+    hasher.update(&boot);
+    hasher.update(&relay_generation.to_le_bytes());
     hasher.update(&seq.to_le_bytes());
     hasher.update(&source_root);
     hasher.update(frame);
+    hasher.finalize().into()
+}
+
+fn verifier_handoff_tag(
+    boot: [u8; 16],
+    authority_id: u64,
+    verification_key: &[u8; 32],
+) -> [u8; 32] {
+    let mut hasher = Hasher::new_keyed(verification_key);
+    hasher.update(VERIFIER_HANDOFF_DOMAIN_TAG);
+    hasher.update(&CODEC_VERSION.to_le_bytes());
+    hasher.update(&boot);
+    hasher.update(&authority_id.to_le_bytes());
     hasher.finalize().into()
 }
 
@@ -171,7 +235,7 @@ fn ack_tag(seq: u64, source_root: [u8; 32], frame: &[u8], auth_key: CheckpointKe
 /// alone is never trusted; only this kernel-sealed binding is.
 pub fn verify_checkpoint(
     wire: &[u8],
-    auth_key: CheckpointKey,
+    context: &AuthContext,
 ) -> Result<CheckpointView, VerifyFailure> {
     if wire.len() != CHECKPOINT_WIRE_BYTES {
         return Err(VerifyFailure::Malformed);
@@ -200,6 +264,7 @@ pub fn verify_checkpoint(
         .ok()
         .ok_or(VerifyFailure::Malformed)?;
     let relay_generation = reader.u64().ok_or(VerifyFailure::Malformed)?;
+    let authority_id = reader.u64().ok_or(VerifyFailure::Malformed)?;
     let tag = reader
         .bytes(32)
         .ok_or(VerifyFailure::Malformed)?
@@ -215,12 +280,13 @@ pub fn verify_checkpoint(
         root,
         codec_version,
         relay_generation,
+        authority_id,
         tag,
     };
-    if relay_generation == 0 {
+    if relay_generation == 0 || authority_id != context.authority_id || boot != context.boot {
         return Err(VerifyFailure::Malformed);
     }
-    if checkpoint_tag(boot, seq, root, relay_generation, auth_key) != tag {
+    if checkpoint_tag(boot, seq, root, relay_generation, context) != tag {
         return Err(VerifyFailure::CheckpointMismatch);
     }
     Ok(view)
@@ -232,26 +298,29 @@ pub struct AuditVerifier {
     boot: [u8; 16],
     next_seq: u64,
     root: [u8; 32],
-    auth_key: CheckpointKey,
+    context: AuthContext,
     relay_generation: u64,
 }
 
 impl AuditVerifier {
-    pub fn genesis(boot: [u8; 16], auth_key: CheckpointKey) -> Result<Self, VerifyFailure> {
+    pub fn genesis(boot: [u8; 16], context: AuthContext) -> Result<Self, VerifyFailure> {
         if boot.iter().all(|byte| *byte == 0) {
+            return Err(VerifyFailure::Malformed);
+        }
+        if boot != context.boot {
             return Err(VerifyFailure::Malformed);
         }
         Ok(Self {
             boot,
             next_seq: 1,
             root: genesis_root(boot),
-            auth_key,
+            context,
             relay_generation: 1,
         })
     }
 
-    pub fn from_checkpoint(wire: &[u8], auth_key: CheckpointKey) -> Result<Self, VerifyFailure> {
-        let checkpoint = verify_checkpoint(wire, auth_key)?;
+    pub fn from_checkpoint(wire: &[u8], context: AuthContext) -> Result<Self, VerifyFailure> {
+        let checkpoint = verify_checkpoint(wire, &context)?;
         let next_seq = checkpoint
             .seq
             .checked_add(1)
@@ -260,7 +329,7 @@ impl AuditVerifier {
             boot: checkpoint.boot,
             root: checkpoint.root,
             next_seq,
-            auth_key,
+            context,
             relay_generation: checkpoint.relay_generation,
         })
     }
@@ -302,7 +371,14 @@ impl AuditVerifier {
         let receipt = FoldReceipt {
             seq: view.seq,
             folded_root: claimed_root,
-            ack_tag: ack_tag(view.seq, claimed_root, frame, self.auth_key),
+            ack_tag: ack_tag(
+                self.boot,
+                self.relay_generation,
+                view.seq,
+                claimed_root,
+                frame,
+                &self.context,
+            ),
         };
         self.root = next_root;
         self.next_seq = next_seq;
@@ -313,7 +389,7 @@ impl AuditVerifier {
     /// source root must match exactly before any acknowledgement range is
     /// trusted across a restart.
     pub fn accept_checkpoint(&self, wire: &[u8]) -> Result<(), VerifyFailure> {
-        let checkpoint = verify_checkpoint(wire, self.auth_key)?;
+        let checkpoint = verify_checkpoint(wire, &self.context)?;
         let next_seq = checkpoint
             .seq
             .checked_add(1)
@@ -331,7 +407,7 @@ impl AuditVerifier {
     /// Accepts exactly one generation-bumped checkpoint after the same state
     /// has been folded. This is the verifier side of explicit resync.
     pub fn accept_resync_checkpoint(&mut self, wire: &[u8]) -> Result<(), VerifyFailure> {
-        let checkpoint = verify_checkpoint(wire, self.auth_key)?;
+        let checkpoint = verify_checkpoint(wire, &self.context)?;
         let next_seq = checkpoint
             .seq
             .checked_add(1)

--- a/kernel/tools/native-audit-verifier/src/lib.rs
+++ b/kernel/tools/native-audit-verifier/src/lib.rs
@@ -21,6 +21,7 @@ const ROOT_ALGORITHM_ID: &[u8] = b"BLAKE3-256";
 const ROOT_DOMAIN_TAG: &[u8] = b"astrid.native-kernel.audit-root.v1";
 const GENESIS_DOMAIN_TAG: &[u8] = b"astrid.native-kernel.audit-genesis.v1";
 const CHECKPOINT_DOMAIN_TAG: &[u8] = b"astrid.native-kernel.audit-checkpoint.v1";
+const ACK_DOMAIN_TAG: &[u8] = b"astrid.native-kernel.audit-ack.v1";
 
 /// Hard decode failure of one input.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -53,6 +54,30 @@ pub enum InvalidReason {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum IncompleteReason {
     SequenceGap,
+}
+
+/// Opaque evidence that this verifier completed one fold. Relay code may
+/// acknowledge only with this receipt plus the same source root; it can never
+/// synthesize a retirement from an unfolded frame.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FoldReceipt {
+    seq: u64,
+    folded_root: [u8; 32],
+    ack_tag: [u8; 32],
+}
+
+impl FoldReceipt {
+    pub const fn seq(self) -> u64 {
+        self.seq
+    }
+
+    pub const fn folded_root(self) -> [u8; 32] {
+        self.folded_root
+    }
+
+    pub const fn ack_tag(self) -> [u8; 32] {
+        self.ack_tag
+    }
 }
 
 /// A kernel-authenticated checkpoint view, already tag-verified.
@@ -129,6 +154,16 @@ fn checkpoint_tag(
     hasher.update(&seq.to_le_bytes());
     hasher.update(&root);
     hasher.update(&relay_generation.to_le_bytes());
+    hasher.finalize().into()
+}
+
+fn ack_tag(seq: u64, source_root: [u8; 32], frame: &[u8], auth_key: CheckpointKey) -> [u8; 32] {
+    let mut hasher = Hasher::new_keyed(&auth_key.bytes());
+    hasher.update(ACK_DOMAIN_TAG);
+    hasher.update(&CODEC_VERSION.to_le_bytes());
+    hasher.update(&seq.to_le_bytes());
+    hasher.update(&source_root);
+    hasher.update(frame);
     hasher.finalize().into()
 }
 
@@ -233,7 +268,11 @@ impl AuditVerifier {
     /// Folds one canonical frame whose source root claim has already been
     /// checked by the caller's handoff record. Contiguity is enforced; a gap
     /// is Incomplete and a duplicate or reorder is Invalid. Never skips.
-    pub fn fold(&mut self, frame: &[u8], claimed_root: [u8; 32]) -> Result<u64, FoldFailure> {
+    pub fn fold(
+        &mut self,
+        frame: &[u8],
+        claimed_root: [u8; 32],
+    ) -> Result<FoldReceipt, FoldFailure> {
         let view = wire::decode_frame(frame).map_err(|error| match error {
             wire::WireError::Malformed => FoldFailure::Invalid(InvalidReason::Malformed),
             wire::WireError::DenialDisclosure => {
@@ -252,16 +291,22 @@ impl AuditVerifier {
         if view.prev_root != Some(self.root) {
             return Err(FoldFailure::Invalid(InvalidReason::PreviousRootMismatch));
         }
+        let next_seq = self
+            .next_seq
+            .checked_add(1)
+            .ok_or(FoldFailure::SequenceOverflow)?;
         let next_root = advance(self.root, self.boot, view.seq, frame);
         if claimed_root != next_root {
             return Err(FoldFailure::Invalid(InvalidReason::RootMismatch));
         }
+        let receipt = FoldReceipt {
+            seq: view.seq,
+            folded_root: claimed_root,
+            ack_tag: ack_tag(view.seq, claimed_root, frame, self.auth_key),
+        };
         self.root = next_root;
-        self.next_seq = self
-            .next_seq
-            .checked_add(1)
-            .ok_or(FoldFailure::SequenceOverflow)?;
-        Ok(view.seq)
+        self.next_seq = next_seq;
+        Ok(receipt)
     }
 
     /// Confirms a later kernel checkpoint against the folded state: the

--- a/kernel/tools/native-audit-verifier/src/lib.rs
+++ b/kernel/tools/native-audit-verifier/src/lib.rs
@@ -4,6 +4,12 @@
 //! frozen canonical frames, folds the rolling BLAKE3 root, checks
 //! kernel-authenticated checkpoints, and reports Invalid versus Incomplete.
 //! It never writes kernel state and is not a second fact base.
+//!
+//! Verification material enters only through an explicitly injected,
+//! independently trusted kernel-origin anchor. The untrusted verifier
+//! handoff carries no key material; it merely binds one boot/session
+//! authority instance to that anchor, and no envelope may authenticate
+//! itself with material carried inside the same untrusted input.
 
 pub mod wire;
 
@@ -16,8 +22,9 @@ use blake3::Hasher;
 pub const CODEC_VERSION: u16 = 1;
 /// Fixed wire size of the canonical checkpoint form.
 pub const CHECKPOINT_WIRE_BYTES: usize = 4 + 2 + 16 + 8 + 32 + 8 + 8 + 32;
-/// Fixed size of a kernel-minted opaque verifier handoff.
-pub const AUTHORITY_HANDOFF_BYTES: usize = 96;
+/// Fixed size of the kernel-minted untrusted handoff binding: magic,
+/// authority id, boot/session identity, keyed tag. No verification material.
+pub const AUTHORITY_HANDOFF_BYTES: usize = 64;
 
 const ROOT_ALGORITHM_ID: &[u8] = b"BLAKE3-256";
 const ROOT_DOMAIN_TAG: &[u8] = b"astrid.native-kernel.audit-root.v1";
@@ -30,6 +37,7 @@ const VERIFIER_HANDOFF_DOMAIN_TAG: &[u8] = b"astrid.native-kernel.audit-verifier
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum VerifyFailure {
     Malformed,
+    HandoffUnbound,
     CheckpointMismatch,
     SequenceOverflow,
     StaleRelayGeneration,
@@ -95,8 +103,14 @@ pub struct CheckpointView {
     pub tag: [u8; 32],
 }
 
-/// Opaque kernel-minted verifier context. It can enter this crate only
-/// through a sealed handoff; a caller cannot construct a raw authority key.
+/// Verifier authority bound to one independently trusted kernel-origin
+/// anchor. This is the modeled trusted channel of the unwired first slice:
+/// the anchor is injected from outside the untrusted handoff path, and
+/// production anchor delivery, provisioning, and key lifecycle are named
+/// #1759 residuals. It is the only way verification material enters this
+/// crate; there is deliberately no constructor from untrusted handoff
+/// bytes, because an envelope cannot authenticate itself with material
+/// carried inside it.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct AuthContext {
     authority_id: u64,
@@ -105,8 +119,32 @@ pub struct AuthContext {
 }
 
 impl AuthContext {
-    /// Accepts only the sealed 96-byte capability minted by the kernel.
-    pub fn from_handoff(bytes: &[u8; AUTHORITY_HANDOFF_BYTES]) -> Result<Self, VerifyFailure> {
+    /// The only trusted-entry constructor. Rejects degenerate anchors so a
+    /// zero authority id, zero boot, or zero key can never anchor a session.
+    pub fn from_trusted_anchor(
+        authority_id: u64,
+        boot: [u8; 16],
+        verification_key: [u8; 32],
+    ) -> Result<Self, VerifyFailure> {
+        if authority_id == 0
+            || boot.iter().all(|byte| *byte == 0)
+            || verification_key.iter().all(|byte| *byte == 0)
+        {
+            return Err(VerifyFailure::Malformed);
+        }
+        Ok(Self {
+            authority_id,
+            boot,
+            verification_key,
+        })
+    }
+
+    /// Binds untrusted handoff bytes against this trusted anchor. The
+    /// handoff must name the anchored authority id and boot, and its
+    /// minting tag must verify under the anchor key it does not carry.
+    /// A structurally valid but caller-minted handoff therefore stays
+    /// unbound: only the kernel-side key can produce the tag.
+    pub fn bind_handoff(&self, bytes: &[u8; AUTHORITY_HANDOFF_BYTES]) -> Result<(), VerifyFailure> {
         if bytes[..8] != *b"ASAUDCTX" {
             return Err(VerifyFailure::Malformed);
         }
@@ -121,36 +159,16 @@ impl AuthContext {
             .ok()
             .filter(|boot: &[u8; 16]| boot.iter().any(|byte| *byte != 0))
             .ok_or(VerifyFailure::Malformed)?;
-        let verification_key = bytes[32..64]
-            .try_into()
-            .ok()
-            .filter(|key: &[u8; 32]| key.iter().any(|byte| *byte != 0))
-            .ok_or(VerifyFailure::Malformed)?;
-        let tag: [u8; 32] = bytes[64..]
+        if authority_id != self.authority_id || boot != self.boot {
+            return Err(VerifyFailure::HandoffUnbound);
+        }
+        let tag: [u8; 32] = bytes[32..]
             .try_into()
             .map_err(|_| VerifyFailure::Malformed)?;
-        if verifier_handoff_tag(boot, authority_id, &verification_key) != tag {
-            return Err(VerifyFailure::Malformed);
+        if verifier_handoff_tag(boot, authority_id, &self.verification_key) != tag {
+            return Err(VerifyFailure::HandoffUnbound);
         }
-        Ok(Self {
-            authority_id,
-            boot,
-            verification_key,
-        })
-    }
-
-    #[cfg(test)]
-    fn mint(boot: [u8; 16], seed: u64) -> Self {
-        let mut hasher = Hasher::new();
-        hasher.update(b"native-audit-verifier-test-authority");
-        hasher.update(&boot);
-        hasher.update(&seed.to_le_bytes());
-        let digest: [u8; 32] = hasher.finalize().into();
-        Self {
-            authority_id: seed | 1,
-            boot,
-            verification_key: digest,
-        }
+        Ok(())
     }
 }
 
@@ -218,6 +236,10 @@ fn ack_tag(
     hasher.finalize().into()
 }
 
+/// Keys the kernel minting tag bound into the untrusted verifier handoff.
+/// The verification key never travels inside the handoff; the tag is
+/// checkable only by a holder of the independently trusted kernel-origin
+/// anchor, so a caller-minted handoff cannot authenticate itself.
 fn verifier_handoff_tag(
     boot: [u8; 16],
     authority_id: u64,
@@ -303,13 +325,20 @@ pub struct AuditVerifier {
 }
 
 impl AuditVerifier {
-    pub fn genesis(boot: [u8; 16], context: AuthContext) -> Result<Self, VerifyFailure> {
+    /// Starts from genesis only after binding the untrusted handoff against
+    /// the trusted anchor for the same boot.
+    pub fn genesis(
+        boot: [u8; 16],
+        context: AuthContext,
+        handoff: &[u8; AUTHORITY_HANDOFF_BYTES],
+    ) -> Result<Self, VerifyFailure> {
         if boot.iter().all(|byte| *byte == 0) {
             return Err(VerifyFailure::Malformed);
         }
         if boot != context.boot {
             return Err(VerifyFailure::Malformed);
         }
+        context.bind_handoff(handoff)?;
         Ok(Self {
             boot,
             next_seq: 1,
@@ -319,7 +348,14 @@ impl AuditVerifier {
         })
     }
 
-    pub fn from_checkpoint(wire: &[u8], context: AuthContext) -> Result<Self, VerifyFailure> {
+    /// Restarts from a kernel-sealed checkpoint only after binding the
+    /// untrusted handoff against the trusted anchor.
+    pub fn from_checkpoint(
+        wire: &[u8],
+        context: AuthContext,
+        handoff: &[u8; AUTHORITY_HANDOFF_BYTES],
+    ) -> Result<Self, VerifyFailure> {
+        context.bind_handoff(handoff)?;
         let checkpoint = verify_checkpoint(wire, &context)?;
         let next_seq = checkpoint
             .seq

--- a/kernel/tools/native-audit-verifier/src/lib.rs
+++ b/kernel/tools/native-audit-verifier/src/lib.rs
@@ -1,0 +1,236 @@
+//! Private host-side verifier for the native-kernel audit chain (#1759).
+//!
+//! The kernel is the only authority. This tool independently decodes the
+//! frozen canonical frames, folds the rolling BLAKE3 root, checks
+//! kernel-authenticated checkpoints, and reports Invalid versus Incomplete.
+//! It never writes kernel state and is not a second fact base.
+
+pub mod wire;
+
+#[cfg(test)]
+mod tests;
+
+use blake3::Hasher;
+
+/// Frozen canonical frame-codec version this verifier understands.
+pub const CODEC_VERSION: u16 = 1;
+/// Fixed wire size of the canonical checkpoint form.
+pub const CHECKPOINT_WIRE_BYTES: usize = 4 + 2 + 16 + 8 + 32 + 8 + 32;
+
+const ROOT_ALGORITHM_ID: &[u8] = b"BLAKE3-256";
+const ROOT_DOMAIN_TAG: &[u8] = b"astrid.native-kernel.audit-root.v1";
+const GENESIS_DOMAIN_TAG: &[u8] = b"astrid.native-kernel.audit-genesis.v1";
+const CHECKPOINT_DOMAIN_TAG: &[u8] = b"astrid.native-kernel.audit-checkpoint.v1";
+
+/// Hard decode failure of one input.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VerifyFailure {
+    Malformed,
+    CheckpointMismatch,
+}
+
+/// One fold step failure. Invalid means the input contradicts the chain;
+/// Incomplete means the truth cannot be established without more evidence.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FoldFailure {
+    Invalid(InvalidReason),
+    Incomplete(IncompleteReason),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum InvalidReason {
+    Malformed,
+    DuplicateOrReorder,
+    RootMismatch,
+    DenialDisclosure,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum IncompleteReason {
+    SequenceGap,
+}
+
+/// A kernel-authenticated checkpoint view, already tag-verified.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CheckpointView {
+    pub boot: [u8; 16],
+    pub seq: u64,
+    pub root: [u8; 32],
+    pub codec_version: u16,
+    pub relay_generation: u64,
+    pub tag: [u8; 32],
+}
+
+fn genesis_root(boot: [u8; 16]) -> [u8; 32] {
+    let mut hasher = Hasher::new();
+    hasher.update(GENESIS_DOMAIN_TAG);
+    hasher.update(&boot);
+    hasher.update(&CODEC_VERSION.to_le_bytes());
+    hasher.finalize().into()
+}
+
+fn advance(previous_root: [u8; 32], boot: [u8; 16], seq: u64, frame: &[u8]) -> [u8; 32] {
+    let mut hasher = Hasher::new();
+    hasher.update(ROOT_DOMAIN_TAG);
+    hasher.update(ROOT_ALGORITHM_ID);
+    hasher.update(&CODEC_VERSION.to_le_bytes());
+    hasher.update(&boot);
+    hasher.update(&seq.to_le_bytes());
+    hasher.update(&previous_root);
+    hasher.update(frame);
+    hasher.finalize().into()
+}
+
+fn checkpoint_tag(boot: [u8; 16], seq: u64, root: [u8; 32], relay_generation: u64) -> [u8; 32] {
+    let mut hasher = Hasher::new();
+    hasher.update(CHECKPOINT_DOMAIN_TAG);
+    hasher.update(&CODEC_VERSION.to_le_bytes());
+    hasher.update(&boot);
+    hasher.update(&seq.to_le_bytes());
+    hasher.update(&root);
+    hasher.update(&relay_generation.to_le_bytes());
+    hasher.finalize().into()
+}
+
+/// Tag-verifies a canonical checkpoint wire form. A verifier-local cache
+/// alone is never trusted; only this kernel-sealed binding is.
+pub fn verify_checkpoint(wire: &[u8]) -> Result<CheckpointView, VerifyFailure> {
+    if wire.len() != CHECKPOINT_WIRE_BYTES {
+        return Err(VerifyFailure::Malformed);
+    }
+    let mut reader = wire::Reader::new(wire).ok_or(VerifyFailure::Malformed)?;
+    let total = reader.u32().ok_or(VerifyFailure::Malformed)? as usize;
+    if wire.len() - 4 != total {
+        return Err(VerifyFailure::Malformed);
+    }
+    let codec_version = reader.u16().ok_or(VerifyFailure::Malformed)?;
+    if codec_version != CODEC_VERSION {
+        return Err(VerifyFailure::Malformed);
+    }
+    let boot = reader
+        .bytes(16)
+        .ok_or(VerifyFailure::Malformed)?
+        .try_into()
+        .ok()
+        .filter(|boot: &[u8; 16]| boot.iter().any(|byte| *byte != 0))
+        .ok_or(VerifyFailure::Malformed)?;
+    let seq = reader.u64().ok_or(VerifyFailure::Malformed)?;
+    let root = reader
+        .bytes(32)
+        .ok_or(VerifyFailure::Malformed)?
+        .try_into()
+        .ok()
+        .ok_or(VerifyFailure::Malformed)?;
+    let relay_generation = reader.u64().ok_or(VerifyFailure::Malformed)?;
+    let tag = reader
+        .bytes(32)
+        .ok_or(VerifyFailure::Malformed)?
+        .try_into()
+        .ok()
+        .ok_or(VerifyFailure::Malformed)?;
+    if reader.remaining() != 0 {
+        return Err(VerifyFailure::Malformed);
+    }
+    let view = CheckpointView {
+        boot,
+        seq,
+        root,
+        codec_version,
+        relay_generation,
+        tag,
+    };
+    if checkpoint_tag(boot, seq, root, relay_generation) != tag {
+        return Err(VerifyFailure::CheckpointMismatch);
+    }
+    Ok(view)
+}
+
+/// Independent fold state. Start from genesis or a verified checkpoint,
+/// then fold contiguous frames in order.
+pub struct AuditVerifier {
+    boot: [u8; 16],
+    next_seq: u64,
+    root: [u8; 32],
+}
+
+impl AuditVerifier {
+    pub fn genesis(boot: [u8; 16]) -> Result<Self, VerifyFailure> {
+        if boot.iter().all(|byte| *byte == 0) {
+            return Err(VerifyFailure::Malformed);
+        }
+        Ok(Self {
+            boot,
+            next_seq: 1,
+            root: genesis_root(boot),
+        })
+    }
+
+    pub fn from_checkpoint(wire: &[u8]) -> Result<Self, VerifyFailure> {
+        let checkpoint = verify_checkpoint(wire)?;
+        Ok(Self {
+            boot: checkpoint.boot,
+            next_seq: checkpoint.seq + 1,
+            root: checkpoint.root,
+        })
+    }
+
+    /// Folds one canonical frame whose source root claim has already been
+    /// checked by the caller's handoff record. Contiguity is enforced; a gap
+    /// is Incomplete and a duplicate or reorder is Invalid. Never skips.
+    pub fn fold(&mut self, frame: &[u8]) -> Result<u64, FoldFailure> {
+        self.fold_with_root(frame, None)
+    }
+
+    /// Same as [`AuditVerifier::fold`] while also matching the per-record
+    /// root carried by the handoff (ack `N` only when the source root
+    /// matches).
+    pub fn fold_with_root(
+        &mut self,
+        frame: &[u8],
+        claimed_root: Option<[u8; 32]>,
+    ) -> Result<u64, FoldFailure> {
+        let view = wire::decode_frame(frame).map_err(|error| match error {
+            wire::WireError::Malformed => FoldFailure::Invalid(InvalidReason::Malformed),
+            wire::WireError::DenialDisclosure => {
+                FoldFailure::Invalid(InvalidReason::DenialDisclosure)
+            },
+        })?;
+        if view.seq < self.next_seq {
+            return Err(FoldFailure::Invalid(InvalidReason::DuplicateOrReorder));
+        }
+        if view.seq > self.next_seq {
+            return Err(FoldFailure::Incomplete(IncompleteReason::SequenceGap));
+        }
+        let next_root = advance(self.root, self.boot, view.seq, frame);
+        if let Some(claimed) = claimed_root
+            && claimed != next_root
+        {
+            return Err(FoldFailure::Invalid(InvalidReason::RootMismatch));
+        }
+        self.root = next_root;
+        self.next_seq += 1;
+        Ok(view.seq)
+    }
+
+    /// Confirms a later kernel checkpoint against the folded state: the
+    /// source root must match exactly before any acknowledgement range is
+    /// trusted across a restart.
+    pub fn accept_checkpoint(&self, wire: &[u8]) -> Result<(), VerifyFailure> {
+        let checkpoint = verify_checkpoint(wire)?;
+        if checkpoint.boot != self.boot
+            || checkpoint.seq + 1 != self.next_seq
+            || checkpoint.root != self.root
+        {
+            return Err(VerifyFailure::CheckpointMismatch);
+        }
+        Ok(())
+    }
+
+    pub fn root(&self) -> [u8; 32] {
+        self.root
+    }
+
+    pub fn next_seq(&self) -> u64 {
+        self.next_seq
+    }
+}

--- a/kernel/tools/native-audit-verifier/src/tests.rs
+++ b/kernel/tools/native-audit-verifier/src/tests.rs
@@ -1,0 +1,271 @@
+//! Independent regressions for the frozen wire format and fold engine.
+
+use super::*;
+use blake3::Hasher;
+
+const BOOT: [u8; 16] = [7; 16];
+
+#[derive(Clone, Copy)]
+enum Object {
+    None,
+    Domain(u8, u64),
+    Endpoint(u8, u64),
+    Capability(u64, u8, u64, u8, u64),
+}
+
+fn body(
+    boot: [u8; 16],
+    seq: u64,
+    class: u16,
+    object: Object,
+    rights: u16,
+    payload: &[u8],
+    prev: Option<[u8; 32]>,
+) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(&CODEC_VERSION.to_le_bytes());
+    out.extend_from_slice(&boot);
+    out.extend_from_slice(&seq.to_le_bytes());
+    out.extend_from_slice(&class.to_le_bytes());
+    out.push(0);
+    out.extend_from_slice(&1u64.to_le_bytes());
+    match object {
+        Object::None => out.push(0),
+        Object::Domain(slot, generation) => {
+            out.push(1);
+            out.push(slot);
+            out.extend_from_slice(&generation.to_le_bytes());
+        },
+        Object::Endpoint(pool_index, generation) => {
+            out.push(2);
+            out.push(pool_index);
+            out.extend_from_slice(&generation.to_le_bytes());
+        },
+        Object::Capability(token, slot, generation, kind, object_token) => {
+            out.push(3);
+            out.extend_from_slice(&token.to_le_bytes());
+            out.push(slot);
+            out.extend_from_slice(&generation.to_le_bytes());
+            out.push(kind);
+            out.extend_from_slice(&object_token.to_le_bytes());
+        },
+    }
+    out.extend_from_slice(&rights.to_le_bytes());
+    out.extend_from_slice(&(payload.len() as u16).to_le_bytes());
+    out.extend_from_slice(payload);
+    match prev {
+        None => out.push(0),
+        Some(prev) => {
+            out.push(1);
+            out.extend_from_slice(&prev);
+        },
+    }
+    let mut framed = Vec::new();
+    framed.extend_from_slice(&((out.len()) as u32).to_le_bytes());
+    framed.extend_from_slice(&out);
+    framed
+}
+
+fn root_tag_bytes() -> Vec<u8> {
+    let mut prefix = Vec::new();
+    prefix.extend_from_slice(b"astrid.native-kernel.audit-root.v1");
+    prefix.extend_from_slice(b"BLAKE3-256");
+    prefix.extend_from_slice(&CODEC_VERSION.to_le_bytes());
+    prefix
+}
+
+fn expected_root(previous: [u8; 32], seq: u64, frame: &[u8]) -> [u8; 32] {
+    let mut hasher = Hasher::new();
+    hasher.update(&root_tag_bytes());
+    hasher.update(&BOOT);
+    hasher.update(&seq.to_le_bytes());
+    hasher.update(&previous);
+    hasher.update(frame);
+    hasher.finalize().into()
+}
+
+#[test]
+fn genesis_then_fold_matches_source_roots() {
+    let mut verifier = AuditVerifier::genesis(BOOT).unwrap();
+    let genesis = verifier.root();
+
+    let frame1 = body(BOOT, 1, 1, Object::None, 0, &[], None);
+    let root1 = expected_root(genesis, 1, &frame1);
+    assert_eq!(verifier.fold_with_root(&frame1, Some(root1)).unwrap(), 1);
+
+    let frame2 = body(
+        BOOT,
+        2,
+        16,
+        Object::Capability(9, 3, 4, 2, 11),
+        0b0101,
+        &[],
+        Some(root1),
+    );
+    let root2 = expected_root(root1, 2, &frame2);
+    assert_eq!(verifier.fold_with_root(&frame2, Some(root2)).unwrap(), 2);
+    assert_eq!(verifier.root(), root2);
+}
+
+#[test]
+fn claimed_root_mismatch_is_invalid() {
+    let mut verifier = AuditVerifier::genesis(BOOT).unwrap();
+    let frame = body(BOOT, 1, 1, Object::None, 0, &[], None);
+    let mut wrong = verifier.root();
+    wrong[0] ^= 1;
+    assert_eq!(
+        verifier.fold_with_root(&frame, Some(wrong)),
+        Err(FoldFailure::Invalid(InvalidReason::RootMismatch))
+    );
+}
+
+#[test]
+fn gap_is_incomplete_and_duplicate_is_invalid() {
+    let mut verifier = AuditVerifier::genesis(BOOT).unwrap();
+    let frame1 = body(BOOT, 1, 1, Object::None, 0, &[], None);
+    let frame3 = body(BOOT, 3, 3, Object::None, 0, &[], None);
+    verifier.fold(&frame1).unwrap();
+    assert_eq!(
+        verifier.fold(&frame3),
+        Err(FoldFailure::Incomplete(IncompleteReason::SequenceGap))
+    );
+    assert_eq!(
+        verifier.fold(&frame1),
+        Err(FoldFailure::Invalid(InvalidReason::DuplicateOrReorder))
+    );
+}
+
+#[test]
+fn denial_must_not_disclose_a_foreign_identity() {
+    let mut verifier = AuditVerifier::genesis(BOOT).unwrap();
+    let mut payload = vec![4, 0];
+    payload.extend_from_slice(&[9; 8]);
+    let denial = body(BOOT, 1, 80, Object::None, 0, &payload, None);
+    assert!(verifier.fold(&denial).is_ok());
+
+    let mut verifier = AuditVerifier::genesis(BOOT).unwrap();
+    let disclosing = body(BOOT, 1, 80, Object::Domain(1, 3), 0, &payload, None);
+    assert_eq!(
+        verifier.fold(&disclosing),
+        Err(FoldFailure::Invalid(InvalidReason::DenialDisclosure))
+    );
+}
+
+#[test]
+fn non_canonical_inputs_fail_closed() {
+    let valid = body(BOOT, 1, 1, Object::None, 0, &[], None);
+    let mut verifier = AuditVerifier::genesis(BOOT).unwrap();
+
+    assert!(matches!(
+        verifier.fold(&valid[..valid.len() - 1]),
+        Err(FoldFailure::Invalid(InvalidReason::Malformed))
+    ));
+    let mut slack = valid.clone();
+    slack.push(0);
+    assert!(matches!(
+        verifier.fold(&slack),
+        Err(FoldFailure::Invalid(InvalidReason::Malformed))
+    ));
+
+    let cases = [
+        body([0; 16], 1, 1, Object::None, 0, &[], None),
+        body(BOOT, 0, 1, Object::None, 0, &[], None),
+        body(BOOT, 1, 10, Object::None, 0, &[], None),
+        body(BOOT, 1, 1, Object::Domain(2, 1), 0, &[], None),
+        body(BOOT, 1, 1, Object::Domain(1, 0), 0, &[], None),
+        body(BOOT, 1, 1, Object::Endpoint(4, 1), 0, &[], None),
+        body(BOOT, 1, 1, Object::Capability(0, 1, 1, 1, 1), 0, &[], None),
+        body(BOOT, 1, 1, Object::Capability(1, 8, 1, 1, 1), 0, &[], None),
+        body(BOOT, 1, 1, Object::Capability(1, 1, 1, 7, 1), 0, &[], None),
+        body(BOOT, 1, 1, Object::None, 0x10, &[], None),
+        body(BOOT, 1, 1, Object::None, 0, &[0; 65], None),
+    ];
+    for case in cases {
+        let mut verifier = AuditVerifier::genesis(BOOT).unwrap();
+        assert!(matches!(
+            verifier.fold(&case),
+            Err(FoldFailure::Invalid(InvalidReason::Malformed))
+        ));
+    }
+
+    let mut bad_version = valid.clone();
+    bad_version[4..6].copy_from_slice(&2u16.to_le_bytes());
+    assert!(matches!(
+        verifier.fold(&bad_version),
+        Err(FoldFailure::Invalid(InvalidReason::Malformed))
+    ));
+}
+
+fn checkpoint_wire(
+    boot: [u8; 16],
+    seq: u64,
+    root: [u8; 32],
+    relay_generation: u64,
+    tag: [u8; 32],
+) -> Vec<u8> {
+    let mut body = Vec::new();
+    body.extend_from_slice(&CODEC_VERSION.to_le_bytes());
+    body.extend_from_slice(&boot);
+    body.extend_from_slice(&seq.to_le_bytes());
+    body.extend_from_slice(&root);
+    body.extend_from_slice(&relay_generation.to_le_bytes());
+    body.extend_from_slice(&tag);
+    let mut wire = Vec::new();
+    wire.extend_from_slice(&(body.len() as u32).to_le_bytes());
+    wire.extend_from_slice(&body);
+    wire
+}
+
+fn tag_for(boot: [u8; 16], seq: u64, root: [u8; 32], relay_generation: u64) -> [u8; 32] {
+    let mut hasher = Hasher::new();
+    hasher.update(b"astrid.native-kernel.audit-checkpoint.v1");
+    hasher.update(&CODEC_VERSION.to_le_bytes());
+    hasher.update(&boot);
+    hasher.update(&seq.to_le_bytes());
+    hasher.update(&root);
+    hasher.update(&relay_generation.to_le_bytes());
+    hasher.finalize().into()
+}
+
+#[test]
+fn checkpoint_restart_and_source_root_match() {
+    let genesis = AuditVerifier::genesis(BOOT).unwrap().root();
+    let start = checkpoint_wire(BOOT, 0, genesis, 1, tag_for(BOOT, 0, genesis, 1));
+    let mut verifier = AuditVerifier::from_checkpoint(&start).unwrap();
+    assert_eq!(verifier.root(), genesis);
+
+    let frame = body(BOOT, 1, 1, Object::None, 0, &[], Some(genesis));
+    let root1 = expected_root(genesis, 1, &frame);
+    verifier.fold_with_root(&frame, Some(root1)).unwrap();
+
+    let next = checkpoint_wire(BOOT, 1, root1, 1, tag_for(BOOT, 1, root1, 1));
+    assert_eq!(verifier.accept_checkpoint(&next), Ok(()));
+
+    let mut tampered = next.clone();
+    let last = tampered.len() - 1;
+    tampered[last] ^= 1;
+    assert!(matches!(
+        AuditVerifier::from_checkpoint(&tampered),
+        Err(VerifyFailure::CheckpointMismatch)
+    ));
+    assert_eq!(
+        verifier.accept_checkpoint(&tampered),
+        Err(VerifyFailure::CheckpointMismatch)
+    );
+
+    let mut wrong_root = root1;
+    wrong_root[0] ^= 1;
+    let mismatched = checkpoint_wire(BOOT, 1, wrong_root, 1, tag_for(BOOT, 1, wrong_root, 1));
+    assert_eq!(
+        verifier.accept_checkpoint(&mismatched),
+        Err(VerifyFailure::CheckpointMismatch)
+    );
+}
+
+#[test]
+fn zero_boot_genesis_is_rejected() {
+    assert!(matches!(
+        AuditVerifier::genesis([0; 16]),
+        Err(VerifyFailure::Malformed)
+    ));
+}

--- a/kernel/tools/native-audit-verifier/src/tests.rs
+++ b/kernel/tools/native-audit-verifier/src/tests.rs
@@ -5,8 +5,29 @@ use blake3::Hasher;
 
 const BOOT: [u8; 16] = [7; 16];
 
+fn trusted_key() -> [u8; 32] {
+    let mut hasher = Hasher::new();
+    hasher.update(b"native-audit-verifier-test-authority");
+    hasher.update(&BOOT);
+    hasher.update(&1u64.to_le_bytes());
+    hasher.finalize().into()
+}
+
 fn context() -> AuthContext {
-    AuthContext::mint(BOOT, 1)
+    AuthContext::from_trusted_anchor(1, BOOT, trusted_key()).unwrap()
+}
+
+/// Seals a genuine handoff for the test anchor. Only the byte layout is
+/// mirrored from the kernel; the tag comes from this crate's own keyed
+/// implementation, and kernel cross-checks bind the real layout.
+fn handoff() -> [u8; AUTHORITY_HANDOFF_BYTES] {
+    let mut bytes = [0; AUTHORITY_HANDOFF_BYTES];
+    bytes[..8].copy_from_slice(b"ASAUDCTX");
+    bytes[8..16].copy_from_slice(&1u64.to_le_bytes());
+    bytes[16..32].copy_from_slice(&BOOT);
+    let tag = verifier_handoff_tag(BOOT, 1, &trusted_key());
+    bytes[32..].copy_from_slice(&tag);
+    bytes
 }
 
 #[derive(Clone, Copy)]
@@ -84,7 +105,7 @@ fn expected_root(previous: [u8; 32], seq: u64, frame: &[u8]) -> [u8; 32] {
 
 #[test]
 fn genesis_fold_requires_boot_previous_root_and_source_root() {
-    let mut verifier = AuditVerifier::genesis(BOOT, context()).unwrap();
+    let mut verifier = AuditVerifier::genesis(BOOT, context(), &handoff()).unwrap();
     let genesis = verifier.root();
 
     let frame1 = body(BOOT, 1, 1, Object::None, 0, &[], Some(genesis));
@@ -107,7 +128,7 @@ fn genesis_fold_requires_boot_previous_root_and_source_root() {
 
 #[test]
 fn tamper_without_a_valid_claimed_root_is_invalid() {
-    let mut verifier = AuditVerifier::genesis(BOOT, context()).unwrap();
+    let mut verifier = AuditVerifier::genesis(BOOT, context(), &handoff()).unwrap();
     let frame = body(BOOT, 1, 1, Object::None, 0, &[], Some(verifier.root()));
     assert_eq!(
         verifier.fold(&frame, [0; 32]),
@@ -117,7 +138,7 @@ fn tamper_without_a_valid_claimed_root_is_invalid() {
 
 #[test]
 fn cross_boot_and_missing_previous_root_are_invalid() {
-    let mut verifier = AuditVerifier::genesis(BOOT, context()).unwrap();
+    let mut verifier = AuditVerifier::genesis(BOOT, context(), &handoff()).unwrap();
     let foreign = body([8; 16], 1, 1, Object::None, 0, &[], Some(verifier.root()));
     let foreign_root = expected_root(verifier.root(), 1, &foreign);
     assert_eq!(
@@ -135,7 +156,7 @@ fn cross_boot_and_missing_previous_root_are_invalid() {
 
 #[test]
 fn explicitly_mismatched_previous_root_is_invalid() {
-    let mut verifier = AuditVerifier::genesis(BOOT, context()).unwrap();
+    let mut verifier = AuditVerifier::genesis(BOOT, context(), &handoff()).unwrap();
     let wrong_previous = [0xAA; 32];
     let frame = body(BOOT, 1, 1, Object::None, 0, &[], Some(wrong_previous));
     let claimed = expected_root(wrong_previous, 1, &frame);
@@ -148,7 +169,9 @@ fn explicitly_mismatched_previous_root_is_invalid() {
 
 #[test]
 fn fold_overflow_is_fail_closed_without_state_change() {
-    let checkpoint_root = AuditVerifier::genesis(BOOT, context()).unwrap().root();
+    let checkpoint_root = AuditVerifier::genesis(BOOT, context(), &handoff())
+        .unwrap()
+        .root();
     let checkpoint = checkpoint_wire(
         BOOT,
         u64::MAX - 1,
@@ -156,7 +179,7 @@ fn fold_overflow_is_fail_closed_without_state_change() {
         1,
         sealed_tag(BOOT, u64::MAX - 1, checkpoint_root, 1),
     );
-    let mut verifier = AuditVerifier::from_checkpoint(&checkpoint, context()).unwrap();
+    let mut verifier = AuditVerifier::from_checkpoint(&checkpoint, context(), &handoff()).unwrap();
     let frame = body(
         BOOT,
         u64::MAX,
@@ -181,7 +204,7 @@ fn fold_overflow_is_fail_closed_without_state_change() {
 
 #[test]
 fn gap_is_incomplete_and_duplicate_is_invalid() {
-    let mut verifier = AuditVerifier::genesis(BOOT, context()).unwrap();
+    let mut verifier = AuditVerifier::genesis(BOOT, context(), &handoff()).unwrap();
     let genesis = verifier.root();
     let frame1 = body(BOOT, 1, 1, Object::None, 0, &[], Some(genesis));
     let root1 = expected_root(genesis, 1, &frame1);
@@ -200,7 +223,7 @@ fn gap_is_incomplete_and_duplicate_is_invalid() {
 
 #[test]
 fn denial_must_not_disclose_a_foreign_identity() {
-    let mut verifier = AuditVerifier::genesis(BOOT, context()).unwrap();
+    let mut verifier = AuditVerifier::genesis(BOOT, context(), &handoff()).unwrap();
     let mut payload = vec![4, 0];
     payload.extend_from_slice(&[9; 8]);
     let denial = body(
@@ -215,7 +238,7 @@ fn denial_must_not_disclose_a_foreign_identity() {
     let denial_root = expected_root(verifier.root(), 1, &denial);
     assert!(verifier.fold(&denial, denial_root).is_ok());
 
-    let mut verifier = AuditVerifier::genesis(BOOT, context()).unwrap();
+    let mut verifier = AuditVerifier::genesis(BOOT, context(), &handoff()).unwrap();
     let disclosing = body(
         BOOT,
         1,
@@ -234,7 +257,7 @@ fn denial_must_not_disclose_a_foreign_identity() {
 #[test]
 fn non_canonical_inputs_fail_closed() {
     let valid = body(BOOT, 1, 1, Object::None, 0, &[], Some(genesis_root(BOOT)));
-    let mut verifier = AuditVerifier::genesis(BOOT, context()).unwrap();
+    let mut verifier = AuditVerifier::genesis(BOOT, context(), &handoff()).unwrap();
 
     assert!(matches!(
         verifier.fold(&valid[..valid.len() - 1], [0; 32]),
@@ -351,7 +374,7 @@ fn non_canonical_inputs_fail_closed() {
         ),
     ];
     for case in cases {
-        let mut verifier = AuditVerifier::genesis(BOOT, context()).unwrap();
+        let mut verifier = AuditVerifier::genesis(BOOT, context(), &handoff()).unwrap();
         assert!(matches!(
             verifier.fold(&case, [0; 32]),
             Err(FoldFailure::Invalid(InvalidReason::Malformed))
@@ -405,9 +428,11 @@ fn unkeyed_tag(boot: [u8; 16], seq: u64, root: [u8; 32], relay_generation: u64) 
 
 #[test]
 fn checkpoint_restart_and_mandatory_source_root_match() {
-    let genesis = AuditVerifier::genesis(BOOT, context()).unwrap().root();
+    let genesis = AuditVerifier::genesis(BOOT, context(), &handoff())
+        .unwrap()
+        .root();
     let start = checkpoint_wire(BOOT, 0, genesis, 1, sealed_tag(BOOT, 0, genesis, 1));
-    let mut verifier = AuditVerifier::from_checkpoint(&start, context()).unwrap();
+    let mut verifier = AuditVerifier::from_checkpoint(&start, context(), &handoff()).unwrap();
     assert_eq!(verifier.root(), genesis);
 
     let frame = body(BOOT, 1, 1, Object::None, 0, &[], Some(genesis));
@@ -421,7 +446,7 @@ fn checkpoint_restart_and_mandatory_source_root_match() {
     let last = tampered.len() - 1;
     tampered[last] ^= 1;
     assert!(matches!(
-        AuditVerifier::from_checkpoint(&tampered, context()),
+        AuditVerifier::from_checkpoint(&tampered, context(), &handoff()),
         Err(VerifyFailure::CheckpointMismatch)
     ));
 
@@ -436,7 +461,9 @@ fn checkpoint_restart_and_mandatory_source_root_match() {
 
 #[test]
 fn host_minted_unkeyed_checkpoint_is_rejected() {
-    let genesis = AuditVerifier::genesis(BOOT, context()).unwrap().root();
+    let genesis = AuditVerifier::genesis(BOOT, context(), &handoff())
+        .unwrap()
+        .root();
     let mut forged = checkpoint_wire(BOOT, 0, genesis, 1, unkeyed_tag(BOOT, 0, genesis, 1));
     assert_eq!(
         verify_checkpoint(&forged, &context()),
@@ -447,14 +474,16 @@ fn host_minted_unkeyed_checkpoint_is_rejected() {
     let last = trusted.len() - 32;
     let (_, tail) = forged.split_at_mut(last);
     tail.copy_from_slice(&trusted[last..]);
-    assert!(AuditVerifier::from_checkpoint(&forged, context()).is_ok());
+    assert!(AuditVerifier::from_checkpoint(&forged, context(), &handoff()).is_ok());
 }
 
 #[test]
 fn stale_and_future_relay_generations_fail_closed() {
-    let genesis = AuditVerifier::genesis(BOOT, context()).unwrap().root();
+    let genesis = AuditVerifier::genesis(BOOT, context(), &handoff())
+        .unwrap()
+        .root();
     let start = checkpoint_wire(BOOT, 0, genesis, 1, sealed_tag(BOOT, 0, genesis, 1));
-    let mut verifier = AuditVerifier::from_checkpoint(&start, context()).unwrap();
+    let mut verifier = AuditVerifier::from_checkpoint(&start, context(), &handoff()).unwrap();
     let frame = body(BOOT, 1, 1, Object::None, 0, &[], Some(genesis));
     let root1 = expected_root(genesis, 1, &frame);
     verifier.fold(&frame, root1).unwrap();
@@ -475,21 +504,25 @@ fn stale_and_future_relay_generations_fail_closed() {
 
 #[test]
 fn zero_relay_generation_is_invalid_on_the_verifier() {
-    let genesis = AuditVerifier::genesis(BOOT, context()).unwrap().root();
+    let genesis = AuditVerifier::genesis(BOOT, context(), &handoff())
+        .unwrap()
+        .root();
     let checkpoint = checkpoint_wire(BOOT, 0, genesis, 0, sealed_tag(BOOT, 0, genesis, 0));
     assert_eq!(
         verify_checkpoint(&checkpoint, &context()),
         Err(VerifyFailure::Malformed)
     );
     assert!(matches!(
-        AuditVerifier::from_checkpoint(&checkpoint, context()),
+        AuditVerifier::from_checkpoint(&checkpoint, context(), &handoff()),
         Err(VerifyFailure::Malformed)
     ));
 }
 
 #[test]
 fn max_checkpoint_sequence_is_typed_fail_closed() {
-    let genesis = AuditVerifier::genesis(BOOT, context()).unwrap().root();
+    let genesis = AuditVerifier::genesis(BOOT, context(), &handoff())
+        .unwrap()
+        .root();
     let checkpoint = checkpoint_wire(
         BOOT,
         u64::MAX,
@@ -498,7 +531,7 @@ fn max_checkpoint_sequence_is_typed_fail_closed() {
         sealed_tag(BOOT, u64::MAX, genesis, 1),
     );
     assert!(matches!(
-        AuditVerifier::from_checkpoint(&checkpoint, context()),
+        AuditVerifier::from_checkpoint(&checkpoint, context(), &handoff()),
         Err(VerifyFailure::SequenceOverflow)
     ));
 }
@@ -506,7 +539,78 @@ fn max_checkpoint_sequence_is_typed_fail_closed() {
 #[test]
 fn zero_boot_genesis_is_rejected() {
     assert!(matches!(
-        AuditVerifier::genesis([0; 16], context()),
+        AuditVerifier::genesis([0; 16], context(), &handoff()),
         Err(VerifyFailure::Malformed)
+    ));
+}
+
+#[test]
+fn trusted_anchor_rejects_zero_material() {
+    assert_eq!(
+        AuthContext::from_trusted_anchor(0, BOOT, trusted_key()),
+        Err(VerifyFailure::Malformed)
+    );
+    assert_eq!(
+        AuthContext::from_trusted_anchor(1, [0; 16], trusted_key()),
+        Err(VerifyFailure::Malformed)
+    );
+    assert_eq!(
+        AuthContext::from_trusted_anchor(1, BOOT, [0; 32]),
+        Err(VerifyFailure::Malformed)
+    );
+}
+
+#[test]
+fn structurally_valid_self_authenticated_handoff_is_rejected() {
+    let anchor = context();
+    let genuine = handoff();
+    assert_eq!(anchor.bind_handoff(&genuine), Ok(()));
+
+    // Structurally valid: correct magic, the anchored identity, and a tag
+    // an attacker computed under a self-chosen key.
+    let mut forged = genuine;
+    let attacker_tag = verifier_handoff_tag(BOOT, anchor.authority_id, &[0xB0; 32]);
+    forged[32..].copy_from_slice(&attacker_tag);
+    assert_eq!(
+        anchor.bind_handoff(&forged),
+        Err(VerifyFailure::HandoffUnbound)
+    );
+    assert!(matches!(
+        AuditVerifier::genesis(BOOT, context(), &forged),
+        Err(VerifyFailure::HandoffUnbound)
+    ));
+
+    // A genuine tag replayed under a foreign identity also stays unbound.
+    let mut foreign = genuine;
+    foreign[16..32].copy_from_slice(&[8; 16]);
+    assert_eq!(
+        anchor.bind_handoff(&foreign),
+        Err(VerifyFailure::HandoffUnbound)
+    );
+
+    // A broken magic byte stays malformed.
+    let mut bad_magic = genuine;
+    bad_magic[0] = b'X';
+    assert_eq!(
+        anchor.bind_handoff(&bad_magic),
+        Err(VerifyFailure::Malformed)
+    );
+}
+
+#[test]
+fn checkpoint_under_forged_context_is_rejected() {
+    // Arbitrary attacker-chosen root and sequence sealed under an
+    // attacker-chosen key reusing only the public identity fields.
+    let forged = AuthContext::from_trusted_anchor(1, BOOT, [0xB0; 32]).unwrap();
+    let tag = checkpoint_tag(BOOT, 999, [0xAA; 32], 1, &forged);
+    let wire = checkpoint_wire(BOOT, 999, [0xAA; 32], 1, tag);
+
+    assert_eq!(
+        verify_checkpoint(&wire, &context()),
+        Err(VerifyFailure::CheckpointMismatch)
+    );
+    assert!(matches!(
+        AuditVerifier::from_checkpoint(&wire, context(), &handoff()),
+        Err(VerifyFailure::CheckpointMismatch)
     ));
 }

--- a/kernel/tools/native-audit-verifier/src/tests.rs
+++ b/kernel/tools/native-audit-verifier/src/tests.rs
@@ -5,8 +5,8 @@ use blake3::Hasher;
 
 const BOOT: [u8; 16] = [7; 16];
 
-fn key() -> CheckpointKey {
-    CheckpointKey::new([0x5a; 32]).unwrap()
+fn context() -> AuthContext {
+    AuthContext::mint(BOOT, 1)
 }
 
 #[derive(Clone, Copy)]
@@ -84,7 +84,7 @@ fn expected_root(previous: [u8; 32], seq: u64, frame: &[u8]) -> [u8; 32] {
 
 #[test]
 fn genesis_fold_requires_boot_previous_root_and_source_root() {
-    let mut verifier = AuditVerifier::genesis(BOOT, key()).unwrap();
+    let mut verifier = AuditVerifier::genesis(BOOT, context()).unwrap();
     let genesis = verifier.root();
 
     let frame1 = body(BOOT, 1, 1, Object::None, 0, &[], Some(genesis));
@@ -107,7 +107,7 @@ fn genesis_fold_requires_boot_previous_root_and_source_root() {
 
 #[test]
 fn tamper_without_a_valid_claimed_root_is_invalid() {
-    let mut verifier = AuditVerifier::genesis(BOOT, key()).unwrap();
+    let mut verifier = AuditVerifier::genesis(BOOT, context()).unwrap();
     let frame = body(BOOT, 1, 1, Object::None, 0, &[], Some(verifier.root()));
     assert_eq!(
         verifier.fold(&frame, [0; 32]),
@@ -117,7 +117,7 @@ fn tamper_without_a_valid_claimed_root_is_invalid() {
 
 #[test]
 fn cross_boot_and_missing_previous_root_are_invalid() {
-    let mut verifier = AuditVerifier::genesis(BOOT, key()).unwrap();
+    let mut verifier = AuditVerifier::genesis(BOOT, context()).unwrap();
     let foreign = body([8; 16], 1, 1, Object::None, 0, &[], Some(verifier.root()));
     let foreign_root = expected_root(verifier.root(), 1, &foreign);
     assert_eq!(
@@ -135,7 +135,7 @@ fn cross_boot_and_missing_previous_root_are_invalid() {
 
 #[test]
 fn explicitly_mismatched_previous_root_is_invalid() {
-    let mut verifier = AuditVerifier::genesis(BOOT, key()).unwrap();
+    let mut verifier = AuditVerifier::genesis(BOOT, context()).unwrap();
     let wrong_previous = [0xAA; 32];
     let frame = body(BOOT, 1, 1, Object::None, 0, &[], Some(wrong_previous));
     let claimed = expected_root(wrong_previous, 1, &frame);
@@ -148,7 +148,7 @@ fn explicitly_mismatched_previous_root_is_invalid() {
 
 #[test]
 fn fold_overflow_is_fail_closed_without_state_change() {
-    let checkpoint_root = AuditVerifier::genesis(BOOT, key()).unwrap().root();
+    let checkpoint_root = AuditVerifier::genesis(BOOT, context()).unwrap().root();
     let checkpoint = checkpoint_wire(
         BOOT,
         u64::MAX - 1,
@@ -156,7 +156,7 @@ fn fold_overflow_is_fail_closed_without_state_change() {
         1,
         sealed_tag(BOOT, u64::MAX - 1, checkpoint_root, 1),
     );
-    let mut verifier = AuditVerifier::from_checkpoint(&checkpoint, key()).unwrap();
+    let mut verifier = AuditVerifier::from_checkpoint(&checkpoint, context()).unwrap();
     let frame = body(
         BOOT,
         u64::MAX,
@@ -181,7 +181,7 @@ fn fold_overflow_is_fail_closed_without_state_change() {
 
 #[test]
 fn gap_is_incomplete_and_duplicate_is_invalid() {
-    let mut verifier = AuditVerifier::genesis(BOOT, key()).unwrap();
+    let mut verifier = AuditVerifier::genesis(BOOT, context()).unwrap();
     let genesis = verifier.root();
     let frame1 = body(BOOT, 1, 1, Object::None, 0, &[], Some(genesis));
     let root1 = expected_root(genesis, 1, &frame1);
@@ -200,7 +200,7 @@ fn gap_is_incomplete_and_duplicate_is_invalid() {
 
 #[test]
 fn denial_must_not_disclose_a_foreign_identity() {
-    let mut verifier = AuditVerifier::genesis(BOOT, key()).unwrap();
+    let mut verifier = AuditVerifier::genesis(BOOT, context()).unwrap();
     let mut payload = vec![4, 0];
     payload.extend_from_slice(&[9; 8]);
     let denial = body(
@@ -215,7 +215,7 @@ fn denial_must_not_disclose_a_foreign_identity() {
     let denial_root = expected_root(verifier.root(), 1, &denial);
     assert!(verifier.fold(&denial, denial_root).is_ok());
 
-    let mut verifier = AuditVerifier::genesis(BOOT, key()).unwrap();
+    let mut verifier = AuditVerifier::genesis(BOOT, context()).unwrap();
     let disclosing = body(
         BOOT,
         1,
@@ -234,7 +234,7 @@ fn denial_must_not_disclose_a_foreign_identity() {
 #[test]
 fn non_canonical_inputs_fail_closed() {
     let valid = body(BOOT, 1, 1, Object::None, 0, &[], Some(genesis_root(BOOT)));
-    let mut verifier = AuditVerifier::genesis(BOOT, key()).unwrap();
+    let mut verifier = AuditVerifier::genesis(BOOT, context()).unwrap();
 
     assert!(matches!(
         verifier.fold(&valid[..valid.len() - 1], [0; 32]),
@@ -351,7 +351,7 @@ fn non_canonical_inputs_fail_closed() {
         ),
     ];
     for case in cases {
-        let mut verifier = AuditVerifier::genesis(BOOT, key()).unwrap();
+        let mut verifier = AuditVerifier::genesis(BOOT, context()).unwrap();
         assert!(matches!(
             verifier.fold(&case, [0; 32]),
             Err(FoldFailure::Invalid(InvalidReason::Malformed))
@@ -379,6 +379,7 @@ fn checkpoint_wire(
     body.extend_from_slice(&seq.to_le_bytes());
     body.extend_from_slice(&root);
     body.extend_from_slice(&relay_generation.to_le_bytes());
+    body.extend_from_slice(&context().authority_id.to_le_bytes());
     body.extend_from_slice(&tag);
     let mut wire = Vec::new();
     wire.extend_from_slice(&(body.len() as u32).to_le_bytes());
@@ -387,7 +388,7 @@ fn checkpoint_wire(
 }
 
 fn sealed_tag(boot: [u8; 16], seq: u64, root: [u8; 32], relay_generation: u64) -> [u8; 32] {
-    checkpoint_tag(boot, seq, root, relay_generation, key())
+    checkpoint_tag(boot, seq, root, relay_generation, &context())
 }
 
 fn unkeyed_tag(boot: [u8; 16], seq: u64, root: [u8; 32], relay_generation: u64) -> [u8; 32] {
@@ -398,14 +399,15 @@ fn unkeyed_tag(boot: [u8; 16], seq: u64, root: [u8; 32], relay_generation: u64) 
     hasher.update(&seq.to_le_bytes());
     hasher.update(&root);
     hasher.update(&relay_generation.to_le_bytes());
+    hasher.update(&context().authority_id.to_le_bytes());
     hasher.finalize().into()
 }
 
 #[test]
 fn checkpoint_restart_and_mandatory_source_root_match() {
-    let genesis = AuditVerifier::genesis(BOOT, key()).unwrap().root();
+    let genesis = AuditVerifier::genesis(BOOT, context()).unwrap().root();
     let start = checkpoint_wire(BOOT, 0, genesis, 1, sealed_tag(BOOT, 0, genesis, 1));
-    let mut verifier = AuditVerifier::from_checkpoint(&start, key()).unwrap();
+    let mut verifier = AuditVerifier::from_checkpoint(&start, context()).unwrap();
     assert_eq!(verifier.root(), genesis);
 
     let frame = body(BOOT, 1, 1, Object::None, 0, &[], Some(genesis));
@@ -419,7 +421,7 @@ fn checkpoint_restart_and_mandatory_source_root_match() {
     let last = tampered.len() - 1;
     tampered[last] ^= 1;
     assert!(matches!(
-        AuditVerifier::from_checkpoint(&tampered, key()),
+        AuditVerifier::from_checkpoint(&tampered, context()),
         Err(VerifyFailure::CheckpointMismatch)
     ));
 
@@ -434,10 +436,10 @@ fn checkpoint_restart_and_mandatory_source_root_match() {
 
 #[test]
 fn host_minted_unkeyed_checkpoint_is_rejected() {
-    let genesis = AuditVerifier::genesis(BOOT, key()).unwrap().root();
+    let genesis = AuditVerifier::genesis(BOOT, context()).unwrap().root();
     let mut forged = checkpoint_wire(BOOT, 0, genesis, 1, unkeyed_tag(BOOT, 0, genesis, 1));
     assert_eq!(
-        verify_checkpoint(&forged, key()),
+        verify_checkpoint(&forged, &context()),
         Err(VerifyFailure::CheckpointMismatch)
     );
 
@@ -445,14 +447,14 @@ fn host_minted_unkeyed_checkpoint_is_rejected() {
     let last = trusted.len() - 32;
     let (_, tail) = forged.split_at_mut(last);
     tail.copy_from_slice(&trusted[last..]);
-    assert!(AuditVerifier::from_checkpoint(&forged, key()).is_ok());
+    assert!(AuditVerifier::from_checkpoint(&forged, context()).is_ok());
 }
 
 #[test]
 fn stale_and_future_relay_generations_fail_closed() {
-    let genesis = AuditVerifier::genesis(BOOT, key()).unwrap().root();
+    let genesis = AuditVerifier::genesis(BOOT, context()).unwrap().root();
     let start = checkpoint_wire(BOOT, 0, genesis, 1, sealed_tag(BOOT, 0, genesis, 1));
-    let mut verifier = AuditVerifier::from_checkpoint(&start, key()).unwrap();
+    let mut verifier = AuditVerifier::from_checkpoint(&start, context()).unwrap();
     let frame = body(BOOT, 1, 1, Object::None, 0, &[], Some(genesis));
     let root1 = expected_root(genesis, 1, &frame);
     verifier.fold(&frame, root1).unwrap();
@@ -473,21 +475,21 @@ fn stale_and_future_relay_generations_fail_closed() {
 
 #[test]
 fn zero_relay_generation_is_invalid_on_the_verifier() {
-    let genesis = AuditVerifier::genesis(BOOT, key()).unwrap().root();
+    let genesis = AuditVerifier::genesis(BOOT, context()).unwrap().root();
     let checkpoint = checkpoint_wire(BOOT, 0, genesis, 0, sealed_tag(BOOT, 0, genesis, 0));
     assert_eq!(
-        verify_checkpoint(&checkpoint, key()),
+        verify_checkpoint(&checkpoint, &context()),
         Err(VerifyFailure::Malformed)
     );
     assert!(matches!(
-        AuditVerifier::from_checkpoint(&checkpoint, key()),
+        AuditVerifier::from_checkpoint(&checkpoint, context()),
         Err(VerifyFailure::Malformed)
     ));
 }
 
 #[test]
 fn max_checkpoint_sequence_is_typed_fail_closed() {
-    let genesis = AuditVerifier::genesis(BOOT, key()).unwrap().root();
+    let genesis = AuditVerifier::genesis(BOOT, context()).unwrap().root();
     let checkpoint = checkpoint_wire(
         BOOT,
         u64::MAX,
@@ -496,7 +498,7 @@ fn max_checkpoint_sequence_is_typed_fail_closed() {
         sealed_tag(BOOT, u64::MAX, genesis, 1),
     );
     assert!(matches!(
-        AuditVerifier::from_checkpoint(&checkpoint, key()),
+        AuditVerifier::from_checkpoint(&checkpoint, context()),
         Err(VerifyFailure::SequenceOverflow)
     ));
 }
@@ -504,7 +506,7 @@ fn max_checkpoint_sequence_is_typed_fail_closed() {
 #[test]
 fn zero_boot_genesis_is_rejected() {
     assert!(matches!(
-        AuditVerifier::genesis([0; 16], key()),
+        AuditVerifier::genesis([0; 16], context()),
         Err(VerifyFailure::Malformed)
     ));
 }

--- a/kernel/tools/native-audit-verifier/src/tests.rs
+++ b/kernel/tools/native-audit-verifier/src/tests.rs
@@ -89,7 +89,7 @@ fn genesis_fold_requires_boot_previous_root_and_source_root() {
 
     let frame1 = body(BOOT, 1, 1, Object::None, 0, &[], Some(genesis));
     let root1 = expected_root(genesis, 1, &frame1);
-    assert_eq!(verifier.fold(&frame1, root1).unwrap(), 1);
+    assert_eq!(verifier.fold(&frame1, root1).unwrap().seq(), 1);
 
     let frame2 = body(
         BOOT,
@@ -101,7 +101,7 @@ fn genesis_fold_requires_boot_previous_root_and_source_root() {
         Some(root1),
     );
     let root2 = expected_root(root1, 2, &frame2);
-    assert_eq!(verifier.fold(&frame2, root2).unwrap(), 2);
+    assert_eq!(verifier.fold(&frame2, root2).unwrap().seq(), 2);
     assert_eq!(verifier.root(), root2);
 }
 
@@ -131,6 +131,52 @@ fn cross_boot_and_missing_previous_root_are_invalid() {
         verifier.fold(&missing_previous, missing_root),
         Err(FoldFailure::Invalid(InvalidReason::PreviousRootMismatch))
     );
+}
+
+#[test]
+fn explicitly_mismatched_previous_root_is_invalid() {
+    let mut verifier = AuditVerifier::genesis(BOOT, key()).unwrap();
+    let wrong_previous = [0xAA; 32];
+    let frame = body(BOOT, 1, 1, Object::None, 0, &[], Some(wrong_previous));
+    let claimed = expected_root(wrong_previous, 1, &frame);
+    assert_eq!(
+        verifier.fold(&frame, claimed),
+        Err(FoldFailure::Invalid(InvalidReason::PreviousRootMismatch))
+    );
+    assert_eq!(verifier.next_seq(), 1);
+}
+
+#[test]
+fn fold_overflow_is_fail_closed_without_state_change() {
+    let checkpoint_root = AuditVerifier::genesis(BOOT, key()).unwrap().root();
+    let checkpoint = checkpoint_wire(
+        BOOT,
+        u64::MAX - 1,
+        checkpoint_root,
+        1,
+        sealed_tag(BOOT, u64::MAX - 1, checkpoint_root, 1),
+    );
+    let mut verifier = AuditVerifier::from_checkpoint(&checkpoint, key()).unwrap();
+    let frame = body(
+        BOOT,
+        u64::MAX,
+        1,
+        Object::None,
+        0,
+        &[],
+        Some(checkpoint_root),
+    );
+    let claimed = expected_root(checkpoint_root, u64::MAX, &frame);
+    let before = (verifier.next_seq(), verifier.root());
+    assert_eq!(
+        verifier.fold(&frame, claimed),
+        Err(FoldFailure::SequenceOverflow)
+    );
+    assert_eq!(
+        verifier.fold(&frame, claimed),
+        Err(FoldFailure::SequenceOverflow)
+    );
+    assert_eq!((verifier.next_seq(), verifier.root()), before);
 }
 
 #[test]
@@ -423,6 +469,20 @@ fn stale_and_future_relay_generations_fail_closed() {
         verifier.accept_resync_checkpoint(&future),
         Err(VerifyFailure::CheckpointMismatch)
     );
+}
+
+#[test]
+fn zero_relay_generation_is_invalid_on_the_verifier() {
+    let genesis = AuditVerifier::genesis(BOOT, key()).unwrap().root();
+    let checkpoint = checkpoint_wire(BOOT, 0, genesis, 0, sealed_tag(BOOT, 0, genesis, 0));
+    assert_eq!(
+        verify_checkpoint(&checkpoint, key()),
+        Err(VerifyFailure::Malformed)
+    );
+    assert!(matches!(
+        AuditVerifier::from_checkpoint(&checkpoint, key()),
+        Err(VerifyFailure::Malformed)
+    ));
 }
 
 #[test]

--- a/kernel/tools/native-audit-verifier/src/tests.rs
+++ b/kernel/tools/native-audit-verifier/src/tests.rs
@@ -5,6 +5,10 @@ use blake3::Hasher;
 
 const BOOT: [u8; 16] = [7; 16];
 
+fn key() -> CheckpointKey {
+    CheckpointKey::new([0x5a; 32]).unwrap()
+}
+
 #[derive(Clone, Copy)]
 enum Object {
     None,
@@ -61,22 +65,16 @@ fn body(
         },
     }
     let mut framed = Vec::new();
-    framed.extend_from_slice(&((out.len()) as u32).to_le_bytes());
+    framed.extend_from_slice(&(out.len() as u32).to_le_bytes());
     framed.extend_from_slice(&out);
     framed
 }
 
-fn root_tag_bytes() -> Vec<u8> {
-    let mut prefix = Vec::new();
-    prefix.extend_from_slice(b"astrid.native-kernel.audit-root.v1");
-    prefix.extend_from_slice(b"BLAKE3-256");
-    prefix.extend_from_slice(&CODEC_VERSION.to_le_bytes());
-    prefix
-}
-
 fn expected_root(previous: [u8; 32], seq: u64, frame: &[u8]) -> [u8; 32] {
     let mut hasher = Hasher::new();
-    hasher.update(&root_tag_bytes());
+    hasher.update(ROOT_DOMAIN_TAG);
+    hasher.update(ROOT_ALGORITHM_ID);
+    hasher.update(&CODEC_VERSION.to_le_bytes());
     hasher.update(&BOOT);
     hasher.update(&seq.to_le_bytes());
     hasher.update(&previous);
@@ -85,13 +83,13 @@ fn expected_root(previous: [u8; 32], seq: u64, frame: &[u8]) -> [u8; 32] {
 }
 
 #[test]
-fn genesis_then_fold_matches_source_roots() {
-    let mut verifier = AuditVerifier::genesis(BOOT).unwrap();
+fn genesis_fold_requires_boot_previous_root_and_source_root() {
+    let mut verifier = AuditVerifier::genesis(BOOT, key()).unwrap();
     let genesis = verifier.root();
 
-    let frame1 = body(BOOT, 1, 1, Object::None, 0, &[], None);
+    let frame1 = body(BOOT, 1, 1, Object::None, 0, &[], Some(genesis));
     let root1 = expected_root(genesis, 1, &frame1);
-    assert_eq!(verifier.fold_with_root(&frame1, Some(root1)).unwrap(), 1);
+    assert_eq!(verifier.fold(&frame1, root1).unwrap(), 1);
 
     let frame2 = body(
         BOOT,
@@ -103,87 +101,213 @@ fn genesis_then_fold_matches_source_roots() {
         Some(root1),
     );
     let root2 = expected_root(root1, 2, &frame2);
-    assert_eq!(verifier.fold_with_root(&frame2, Some(root2)).unwrap(), 2);
+    assert_eq!(verifier.fold(&frame2, root2).unwrap(), 2);
     assert_eq!(verifier.root(), root2);
 }
 
 #[test]
-fn claimed_root_mismatch_is_invalid() {
-    let mut verifier = AuditVerifier::genesis(BOOT).unwrap();
-    let frame = body(BOOT, 1, 1, Object::None, 0, &[], None);
-    let mut wrong = verifier.root();
-    wrong[0] ^= 1;
+fn tamper_without_a_valid_claimed_root_is_invalid() {
+    let mut verifier = AuditVerifier::genesis(BOOT, key()).unwrap();
+    let frame = body(BOOT, 1, 1, Object::None, 0, &[], Some(verifier.root()));
     assert_eq!(
-        verifier.fold_with_root(&frame, Some(wrong)),
+        verifier.fold(&frame, [0; 32]),
         Err(FoldFailure::Invalid(InvalidReason::RootMismatch))
     );
 }
 
 #[test]
-fn gap_is_incomplete_and_duplicate_is_invalid() {
-    let mut verifier = AuditVerifier::genesis(BOOT).unwrap();
-    let frame1 = body(BOOT, 1, 1, Object::None, 0, &[], None);
-    let frame3 = body(BOOT, 3, 3, Object::None, 0, &[], None);
-    verifier.fold(&frame1).unwrap();
+fn cross_boot_and_missing_previous_root_are_invalid() {
+    let mut verifier = AuditVerifier::genesis(BOOT, key()).unwrap();
+    let foreign = body([8; 16], 1, 1, Object::None, 0, &[], Some(verifier.root()));
+    let foreign_root = expected_root(verifier.root(), 1, &foreign);
     assert_eq!(
-        verifier.fold(&frame3),
+        verifier.fold(&foreign, foreign_root),
+        Err(FoldFailure::Invalid(InvalidReason::ForeignBoot))
+    );
+
+    let missing_previous = body(BOOT, 1, 1, Object::None, 0, &[], None);
+    let missing_root = expected_root(verifier.root(), 1, &missing_previous);
+    assert_eq!(
+        verifier.fold(&missing_previous, missing_root),
+        Err(FoldFailure::Invalid(InvalidReason::PreviousRootMismatch))
+    );
+}
+
+#[test]
+fn gap_is_incomplete_and_duplicate_is_invalid() {
+    let mut verifier = AuditVerifier::genesis(BOOT, key()).unwrap();
+    let genesis = verifier.root();
+    let frame1 = body(BOOT, 1, 1, Object::None, 0, &[], Some(genesis));
+    let root1 = expected_root(genesis, 1, &frame1);
+    let frame3 = body(BOOT, 3, 3, Object::None, 0, &[], Some(root1));
+    let root3 = expected_root(root1, 3, &frame3);
+    verifier.fold(&frame1, root1).unwrap();
+    assert_eq!(
+        verifier.fold(&frame3, root3),
         Err(FoldFailure::Incomplete(IncompleteReason::SequenceGap))
     );
     assert_eq!(
-        verifier.fold(&frame1),
+        verifier.fold(&frame1, root1),
         Err(FoldFailure::Invalid(InvalidReason::DuplicateOrReorder))
     );
 }
 
 #[test]
 fn denial_must_not_disclose_a_foreign_identity() {
-    let mut verifier = AuditVerifier::genesis(BOOT).unwrap();
+    let mut verifier = AuditVerifier::genesis(BOOT, key()).unwrap();
     let mut payload = vec![4, 0];
     payload.extend_from_slice(&[9; 8]);
-    let denial = body(BOOT, 1, 80, Object::None, 0, &payload, None);
-    assert!(verifier.fold(&denial).is_ok());
+    let denial = body(
+        BOOT,
+        1,
+        80,
+        Object::None,
+        0,
+        &payload,
+        Some(verifier.root()),
+    );
+    let denial_root = expected_root(verifier.root(), 1, &denial);
+    assert!(verifier.fold(&denial, denial_root).is_ok());
 
-    let mut verifier = AuditVerifier::genesis(BOOT).unwrap();
-    let disclosing = body(BOOT, 1, 80, Object::Domain(1, 3), 0, &payload, None);
+    let mut verifier = AuditVerifier::genesis(BOOT, key()).unwrap();
+    let disclosing = body(
+        BOOT,
+        1,
+        80,
+        Object::Domain(1, 3),
+        0,
+        &payload,
+        Some(verifier.root()),
+    );
     assert_eq!(
-        verifier.fold(&disclosing),
+        verifier.fold(&disclosing, [0; 32]),
         Err(FoldFailure::Invalid(InvalidReason::DenialDisclosure))
     );
 }
 
 #[test]
 fn non_canonical_inputs_fail_closed() {
-    let valid = body(BOOT, 1, 1, Object::None, 0, &[], None);
-    let mut verifier = AuditVerifier::genesis(BOOT).unwrap();
+    let valid = body(BOOT, 1, 1, Object::None, 0, &[], Some(genesis_root(BOOT)));
+    let mut verifier = AuditVerifier::genesis(BOOT, key()).unwrap();
 
     assert!(matches!(
-        verifier.fold(&valid[..valid.len() - 1]),
+        verifier.fold(&valid[..valid.len() - 1], [0; 32]),
         Err(FoldFailure::Invalid(InvalidReason::Malformed))
     ));
     let mut slack = valid.clone();
     slack.push(0);
     assert!(matches!(
-        verifier.fold(&slack),
+        verifier.fold(&slack, [0; 32]),
         Err(FoldFailure::Invalid(InvalidReason::Malformed))
     ));
 
     let cases = [
-        body([0; 16], 1, 1, Object::None, 0, &[], None),
-        body(BOOT, 0, 1, Object::None, 0, &[], None),
-        body(BOOT, 1, 10, Object::None, 0, &[], None),
-        body(BOOT, 1, 1, Object::Domain(2, 1), 0, &[], None),
-        body(BOOT, 1, 1, Object::Domain(1, 0), 0, &[], None),
-        body(BOOT, 1, 1, Object::Endpoint(4, 1), 0, &[], None),
-        body(BOOT, 1, 1, Object::Capability(0, 1, 1, 1, 1), 0, &[], None),
-        body(BOOT, 1, 1, Object::Capability(1, 8, 1, 1, 1), 0, &[], None),
-        body(BOOT, 1, 1, Object::Capability(1, 1, 1, 7, 1), 0, &[], None),
-        body(BOOT, 1, 1, Object::None, 0x10, &[], None),
-        body(BOOT, 1, 1, Object::None, 0, &[0; 65], None),
+        body(
+            [0; 16],
+            1,
+            1,
+            Object::None,
+            0,
+            &[],
+            Some(genesis_root(BOOT)),
+        ),
+        body(BOOT, 0, 1, Object::None, 0, &[], Some(genesis_root(BOOT))),
+        body(BOOT, 1, 10, Object::None, 0, &[], Some(genesis_root(BOOT))),
+        body(
+            BOOT,
+            1,
+            1,
+            Object::Domain(2, 1),
+            0,
+            &[],
+            Some(genesis_root(BOOT)),
+        ),
+        body(
+            BOOT,
+            1,
+            1,
+            Object::Domain(1, 0),
+            0,
+            &[],
+            Some(genesis_root(BOOT)),
+        ),
+        body(
+            BOOT,
+            1,
+            1,
+            Object::Endpoint(4, 1),
+            0,
+            &[],
+            Some(genesis_root(BOOT)),
+        ),
+        body(
+            BOOT,
+            1,
+            1,
+            Object::Capability(1, 1, 1, 1, 1),
+            0,
+            &[],
+            Some(genesis_root(BOOT)),
+        ),
+        body(
+            BOOT,
+            1,
+            1,
+            Object::Capability(0, 1, 1, 2, 1),
+            0,
+            &[],
+            Some(genesis_root(BOOT)),
+        ),
+        body(
+            BOOT,
+            1,
+            1,
+            Object::Capability(1, 8, 1, 2, 1),
+            0,
+            &[],
+            Some(genesis_root(BOOT)),
+        ),
+        body(
+            BOOT,
+            1,
+            1,
+            Object::Capability(1, 1, 0, 2, 1),
+            0,
+            &[],
+            Some(genesis_root(BOOT)),
+        ),
+        body(
+            BOOT,
+            1,
+            1,
+            Object::Capability(1, 1, 1, 2, 0),
+            0,
+            &[],
+            Some(genesis_root(BOOT)),
+        ),
+        body(
+            BOOT,
+            1,
+            1,
+            Object::None,
+            0x10,
+            &[],
+            Some(genesis_root(BOOT)),
+        ),
+        body(
+            BOOT,
+            1,
+            1,
+            Object::None,
+            0,
+            &[0; 65],
+            Some(genesis_root(BOOT)),
+        ),
     ];
     for case in cases {
-        let mut verifier = AuditVerifier::genesis(BOOT).unwrap();
+        let mut verifier = AuditVerifier::genesis(BOOT, key()).unwrap();
         assert!(matches!(
-            verifier.fold(&case),
+            verifier.fold(&case, [0; 32]),
             Err(FoldFailure::Invalid(InvalidReason::Malformed))
         ));
     }
@@ -191,7 +315,7 @@ fn non_canonical_inputs_fail_closed() {
     let mut bad_version = valid.clone();
     bad_version[4..6].copy_from_slice(&2u16.to_le_bytes());
     assert!(matches!(
-        verifier.fold(&bad_version),
+        verifier.fold(&bad_version, [0; 32]),
         Err(FoldFailure::Invalid(InvalidReason::Malformed))
     ));
 }
@@ -216,9 +340,13 @@ fn checkpoint_wire(
     wire
 }
 
-fn tag_for(boot: [u8; 16], seq: u64, root: [u8; 32], relay_generation: u64) -> [u8; 32] {
+fn sealed_tag(boot: [u8; 16], seq: u64, root: [u8; 32], relay_generation: u64) -> [u8; 32] {
+    checkpoint_tag(boot, seq, root, relay_generation, key())
+}
+
+fn unkeyed_tag(boot: [u8; 16], seq: u64, root: [u8; 32], relay_generation: u64) -> [u8; 32] {
     let mut hasher = Hasher::new();
-    hasher.update(b"astrid.native-kernel.audit-checkpoint.v1");
+    hasher.update(CHECKPOINT_DOMAIN_TAG);
     hasher.update(&CODEC_VERSION.to_le_bytes());
     hasher.update(&boot);
     hasher.update(&seq.to_le_bytes());
@@ -228,34 +356,30 @@ fn tag_for(boot: [u8; 16], seq: u64, root: [u8; 32], relay_generation: u64) -> [
 }
 
 #[test]
-fn checkpoint_restart_and_source_root_match() {
-    let genesis = AuditVerifier::genesis(BOOT).unwrap().root();
-    let start = checkpoint_wire(BOOT, 0, genesis, 1, tag_for(BOOT, 0, genesis, 1));
-    let mut verifier = AuditVerifier::from_checkpoint(&start).unwrap();
+fn checkpoint_restart_and_mandatory_source_root_match() {
+    let genesis = AuditVerifier::genesis(BOOT, key()).unwrap().root();
+    let start = checkpoint_wire(BOOT, 0, genesis, 1, sealed_tag(BOOT, 0, genesis, 1));
+    let mut verifier = AuditVerifier::from_checkpoint(&start, key()).unwrap();
     assert_eq!(verifier.root(), genesis);
 
     let frame = body(BOOT, 1, 1, Object::None, 0, &[], Some(genesis));
     let root1 = expected_root(genesis, 1, &frame);
-    verifier.fold_with_root(&frame, Some(root1)).unwrap();
+    verifier.fold(&frame, root1).unwrap();
 
-    let next = checkpoint_wire(BOOT, 1, root1, 1, tag_for(BOOT, 1, root1, 1));
+    let next = checkpoint_wire(BOOT, 1, root1, 1, sealed_tag(BOOT, 1, root1, 1));
     assert_eq!(verifier.accept_checkpoint(&next), Ok(()));
 
     let mut tampered = next.clone();
     let last = tampered.len() - 1;
     tampered[last] ^= 1;
     assert!(matches!(
-        AuditVerifier::from_checkpoint(&tampered),
+        AuditVerifier::from_checkpoint(&tampered, key()),
         Err(VerifyFailure::CheckpointMismatch)
     ));
-    assert_eq!(
-        verifier.accept_checkpoint(&tampered),
-        Err(VerifyFailure::CheckpointMismatch)
-    );
 
     let mut wrong_root = root1;
     wrong_root[0] ^= 1;
-    let mismatched = checkpoint_wire(BOOT, 1, wrong_root, 1, tag_for(BOOT, 1, wrong_root, 1));
+    let mismatched = checkpoint_wire(BOOT, 1, wrong_root, 1, sealed_tag(BOOT, 1, wrong_root, 1));
     assert_eq!(
         verifier.accept_checkpoint(&mismatched),
         Err(VerifyFailure::CheckpointMismatch)
@@ -263,9 +387,64 @@ fn checkpoint_restart_and_source_root_match() {
 }
 
 #[test]
+fn host_minted_unkeyed_checkpoint_is_rejected() {
+    let genesis = AuditVerifier::genesis(BOOT, key()).unwrap().root();
+    let mut forged = checkpoint_wire(BOOT, 0, genesis, 1, unkeyed_tag(BOOT, 0, genesis, 1));
+    assert_eq!(
+        verify_checkpoint(&forged, key()),
+        Err(VerifyFailure::CheckpointMismatch)
+    );
+
+    let trusted = checkpoint_wire(BOOT, 0, genesis, 1, sealed_tag(BOOT, 0, genesis, 1));
+    let last = trusted.len() - 32;
+    let (_, tail) = forged.split_at_mut(last);
+    tail.copy_from_slice(&trusted[last..]);
+    assert!(AuditVerifier::from_checkpoint(&forged, key()).is_ok());
+}
+
+#[test]
+fn stale_and_future_relay_generations_fail_closed() {
+    let genesis = AuditVerifier::genesis(BOOT, key()).unwrap().root();
+    let start = checkpoint_wire(BOOT, 0, genesis, 1, sealed_tag(BOOT, 0, genesis, 1));
+    let mut verifier = AuditVerifier::from_checkpoint(&start, key()).unwrap();
+    let frame = body(BOOT, 1, 1, Object::None, 0, &[], Some(genesis));
+    let root1 = expected_root(genesis, 1, &frame);
+    verifier.fold(&frame, root1).unwrap();
+
+    let resync = checkpoint_wire(BOOT, 1, root1, 2, sealed_tag(BOOT, 1, root1, 2));
+    assert_eq!(verifier.accept_resync_checkpoint(&resync), Ok(()));
+    let stale = checkpoint_wire(BOOT, 1, root1, 1, sealed_tag(BOOT, 1, root1, 1));
+    assert_eq!(
+        verifier.accept_checkpoint(&stale),
+        Err(VerifyFailure::StaleRelayGeneration)
+    );
+    let future = checkpoint_wire(BOOT, 1, root1, 4, sealed_tag(BOOT, 1, root1, 4));
+    assert_eq!(
+        verifier.accept_resync_checkpoint(&future),
+        Err(VerifyFailure::CheckpointMismatch)
+    );
+}
+
+#[test]
+fn max_checkpoint_sequence_is_typed_fail_closed() {
+    let genesis = AuditVerifier::genesis(BOOT, key()).unwrap().root();
+    let checkpoint = checkpoint_wire(
+        BOOT,
+        u64::MAX,
+        genesis,
+        1,
+        sealed_tag(BOOT, u64::MAX, genesis, 1),
+    );
+    assert!(matches!(
+        AuditVerifier::from_checkpoint(&checkpoint, key()),
+        Err(VerifyFailure::SequenceOverflow)
+    ));
+}
+
+#[test]
 fn zero_boot_genesis_is_rejected() {
     assert!(matches!(
-        AuditVerifier::genesis([0; 16]),
+        AuditVerifier::genesis([0; 16], key()),
         Err(VerifyFailure::Malformed)
     ));
 }

--- a/kernel/tools/native-audit-verifier/src/wire.rs
+++ b/kernel/tools/native-audit-verifier/src/wire.rs
@@ -1,0 +1,190 @@
+//! Independent strict decoder for the frozen canonical frame wire format.
+//! Mirrors the kernel codec byte-for-byte; any drift fails loudly here.
+
+/// Wire-level decode errors for one frame.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WireError {
+    Malformed,
+    DenialDisclosure,
+}
+
+/// Minimal view the fold needs: sequence plus denial-projection checks.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FrameView {
+    pub seq: u64,
+    pub class: u16,
+    pub has_object: bool,
+}
+
+const CLASS_DISCRIMINANTS: &[u16] = &[
+    1, 2, 3, 4, 5, 6, 7, 8, 9, 16, 17, 18, 32, 33, 34, 35, 48, 49, 50, 64, 65, 66, 80,
+];
+
+const DENIAL_CLASS: u16 = 80;
+const LANDED_RIGHTS_MASK: u16 = 0b1111;
+const MAX_PAYLOAD: usize = 64;
+
+/// Strict canonical decode with the same fail-closed rules as the kernel.
+pub fn decode_frame(bytes: &[u8]) -> Result<FrameView, WireError> {
+    let mut reader = Reader::new(bytes).ok_or(WireError::Malformed)?;
+    let total = reader.u32().ok_or(WireError::Malformed)? as usize;
+    if bytes.len() - 4 != total {
+        return Err(WireError::Malformed);
+    }
+    let codec_version = reader.u16().ok_or(WireError::Malformed)?;
+    if codec_version != super::CODEC_VERSION {
+        return Err(WireError::Malformed);
+    }
+    let boot = reader.bytes(16).ok_or(WireError::Malformed)?;
+    if boot.iter().all(|byte| *byte == 0) {
+        return Err(WireError::Malformed);
+    }
+    let seq = reader.u64().ok_or(WireError::Malformed)?;
+    if seq == 0 {
+        return Err(WireError::Malformed);
+    }
+    let class = reader.u16().ok_or(WireError::Malformed)?;
+    if !CLASS_DISCRIMINANTS.contains(&class) {
+        return Err(WireError::Malformed);
+    }
+    let subject_slot = reader.u8().ok_or(WireError::Malformed)? as usize;
+    if subject_slot >= 2 {
+        return Err(WireError::Malformed);
+    }
+    let subject_generation = reader.u64().ok_or(WireError::Malformed)?;
+    if subject_generation == 0 {
+        return Err(WireError::Malformed);
+    }
+    let has_object = match reader.u8().ok_or(WireError::Malformed)? {
+        0 => false,
+        1 => {
+            if reader.u8().ok_or(WireError::Malformed)? as usize >= 2 {
+                return Err(WireError::Malformed);
+            }
+            if reader.u64().ok_or(WireError::Malformed)? == 0 {
+                return Err(WireError::Malformed);
+            }
+            true
+        },
+        2 => {
+            if reader.u8().ok_or(WireError::Malformed)? as usize >= 4 {
+                return Err(WireError::Malformed);
+            }
+            if reader.u64().ok_or(WireError::Malformed)? == 0 {
+                return Err(WireError::Malformed);
+            }
+            true
+        },
+        3 => {
+            if reader.u64().ok_or(WireError::Malformed)? == 0 {
+                return Err(WireError::Malformed);
+            }
+            if reader.u8().ok_or(WireError::Malformed)? as usize >= 8 {
+                return Err(WireError::Malformed);
+            }
+            if reader.u64().ok_or(WireError::Malformed)? == 0 {
+                return Err(WireError::Malformed);
+            }
+            let kind = reader.u8().ok_or(WireError::Malformed)?;
+            if kind != 1 && kind != 2 {
+                return Err(WireError::Malformed);
+            }
+            if reader.u64().ok_or(WireError::Malformed)? == 0 {
+                return Err(WireError::Malformed);
+            }
+            true
+        },
+        _ => return Err(WireError::Malformed),
+    };
+    let rights = reader.u16().ok_or(WireError::Malformed)?;
+    if rights & !LANDED_RIGHTS_MASK != 0 {
+        return Err(WireError::Malformed);
+    }
+    let payload_len = reader.u16().ok_or(WireError::Malformed)? as usize;
+    if payload_len > MAX_PAYLOAD {
+        return Err(WireError::Malformed);
+    }
+    let payload_start = reader.pos();
+    reader.skip(payload_len).ok_or(WireError::Malformed)?;
+    match reader.u8().ok_or(WireError::Malformed)? {
+        0 => {},
+        1 => {
+            reader.skip(32).ok_or(WireError::Malformed)?;
+        },
+        _ => return Err(WireError::Malformed),
+    }
+    if reader.remaining() != 0 {
+        return Err(WireError::Malformed);
+    }
+    if class == DENIAL_CLASS {
+        if has_object {
+            return Err(WireError::DenialDisclosure);
+        }
+        let payload = &bytes[payload_start..payload_start + payload_len];
+        let denial_ok =
+            payload.len() == 10 && matches!(u16::from_le_bytes([payload[0], payload[1]]), 1..=6);
+        if !denial_ok {
+            return Err(WireError::Malformed);
+        }
+    }
+    Ok(FrameView {
+        seq,
+        class,
+        has_object,
+    })
+}
+
+pub struct Reader<'a> {
+    bytes: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Reader<'a> {
+    pub fn new(bytes: &'a [u8]) -> Option<Self> {
+        if bytes.len() < 4 {
+            return None;
+        }
+        Some(Self { bytes, pos: 0 })
+    }
+
+    pub fn remaining(&self) -> usize {
+        self.bytes.len() - self.pos
+    }
+
+    pub fn pos(&self) -> usize {
+        self.pos
+    }
+
+    pub fn skip(&mut self, len: usize) -> Option<()> {
+        if self.remaining() < len {
+            return None;
+        }
+        self.pos += len;
+        Some(())
+    }
+
+    pub fn bytes(&mut self, len: usize) -> Option<&'a [u8]> {
+        if self.remaining() < len {
+            return None;
+        }
+        let start = self.pos;
+        self.pos += len;
+        Some(&self.bytes[start..self.pos])
+    }
+
+    pub fn u8(&mut self) -> Option<u8> {
+        Some(self.bytes(1)?[0])
+    }
+
+    pub fn u16(&mut self) -> Option<u16> {
+        Some(u16::from_le_bytes(self.bytes(2)?.try_into().ok()?))
+    }
+
+    pub fn u32(&mut self) -> Option<u32> {
+        Some(u32::from_le_bytes(self.bytes(4)?.try_into().ok()?))
+    }
+
+    pub fn u64(&mut self) -> Option<u64> {
+        Some(u64::from_le_bytes(self.bytes(8)?.try_into().ok()?))
+    }
+}

--- a/kernel/tools/native-audit-verifier/src/wire.rs
+++ b/kernel/tools/native-audit-verifier/src/wire.rs
@@ -11,9 +11,11 @@ pub enum WireError {
 /// Minimal view the fold needs: sequence plus denial-projection checks.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct FrameView {
+    pub boot: [u8; 16],
     pub seq: u64,
     pub class: u16,
     pub has_object: bool,
+    pub prev_root: Option<[u8; 32]>,
 }
 
 const CLASS_DISCRIMINANTS: &[u16] = &[
@@ -35,7 +37,11 @@ pub fn decode_frame(bytes: &[u8]) -> Result<FrameView, WireError> {
     if codec_version != super::CODEC_VERSION {
         return Err(WireError::Malformed);
     }
-    let boot = reader.bytes(16).ok_or(WireError::Malformed)?;
+    let boot: [u8; 16] = reader
+        .bytes(16)
+        .ok_or(WireError::Malformed)?
+        .try_into()
+        .map_err(|_| WireError::Malformed)?;
     if boot.iter().all(|byte| *byte == 0) {
         return Err(WireError::Malformed);
     }
@@ -86,7 +92,7 @@ pub fn decode_frame(bytes: &[u8]) -> Result<FrameView, WireError> {
                 return Err(WireError::Malformed);
             }
             let kind = reader.u8().ok_or(WireError::Malformed)?;
-            if kind != 1 && kind != 2 {
+            if kind != 2 {
                 return Err(WireError::Malformed);
             }
             if reader.u64().ok_or(WireError::Malformed)? == 0 {
@@ -106,13 +112,17 @@ pub fn decode_frame(bytes: &[u8]) -> Result<FrameView, WireError> {
     }
     let payload_start = reader.pos();
     reader.skip(payload_len).ok_or(WireError::Malformed)?;
-    match reader.u8().ok_or(WireError::Malformed)? {
-        0 => {},
-        1 => {
-            reader.skip(32).ok_or(WireError::Malformed)?;
-        },
+    let prev_root = match reader.u8().ok_or(WireError::Malformed)? {
+        0 => None,
+        1 => Some(
+            reader
+                .bytes(32)
+                .ok_or(WireError::Malformed)?
+                .try_into()
+                .map_err(|_| WireError::Malformed)?,
+        ),
         _ => return Err(WireError::Malformed),
-    }
+    };
     if reader.remaining() != 0 {
         return Err(WireError::Malformed);
     }
@@ -128,9 +138,11 @@ pub fn decode_frame(bytes: &[u8]) -> Result<FrameView, WireError> {
         }
     }
     Ok(FrameView {
+        boot,
         seq,
         class,
         has_object,
+        prev_root,
     })
 }
 


### PR DESCRIPTION
## Linked Issue

Tracking #1759

Project Evidence: Accepted

## Summary

Integrates the accepted private native-audit authority fix on a trunk-first signed merge at `20157a38b2446b2b92cd1c257cff9569f2c32a1c`. The first parent is the live `origin/os/universal` head `43f6d97fc4beee219af42ed7212bd11c0d7389cd`; the second parent is the accepted fix `c15fe0b8eae8bde932d149a3696bf978870adaba`. Authority-id and checkpoint verification-key derivation now consume opaque kernel-held entropy in addition to the live boot/session identity. The entropy is a zero-rejecting crate-private newtype with erasure on drop and is absent from canonical frames, checkpoint wire, and the untrusted verifier handoff. The verifier's modeled independently trusted out-of-band anchor remains the only path for verification material.

This integration preserves the frozen frame, checkpoint, relay, replay/order, retirement, and tamper behavior established by the audit slice. It carries the accepted authority input boundary and decisive public-derivation forgery regression onto the live trunk without unrelated resolution edits; the merge completed with no conflicts.

## Changes

- Introduce a narrow kernel-held secret entropy newtype that rejects zero and erases on drop.
- Mix that typed entropy into both authority-id and verification-key derivation; remove derivation from boot identity alone.
- Add a typed verification-key newtype and keep raw key bytes out of the handoff wire.
- Require the secret when an audit chain or authority is minted; retain fail-closed construction.
- Add a regression that reconstructs the superseded public-only derivation from the boot and authority id observable in a handoff, then proves forged handoff, checkpoint, and acknowledgement material are rejected under the genuine trusted anchor.
- Preserve all prior layout, binding, replay/order, checkpoint, retirement, and tamper invariants.
- Update the changelog fragment with the security boundary and explicit production-key residuals.

## Verification

Exact-head provenance on the isolated integration checkout:

- Before mutation, `origin/os/universal` was exactly `43f6d97fc4beee219af42ed7212bd11c0d7389cd` and `origin/codex/1759-native-audit-root` was exactly `c15fe0b8eae8bde932d149a3696bf978870adaba`.
- The accepted commit's parent is `3bda7554b466f81412e6319fafeb459a39532d71`; its GPG signature is valid for Joshua J. Bouw and its `Signed-off-by` trailer is present.
- The signed no-ff integration commit is `20157a38b2446b2b92cd1c257cff9569f2c32a1c` with parent order `(43f6d97fc4beee219af42ed7212bd11c0d7389cd, c15fe0b8eae8bde932d149a3696bf978870adaba)`.
- `GIT_NO_REPLACE_OBJECTS=1 git merge-tree --write-tree 43f6d97fc4beee219af42ed7212bd11c0d7389cd c15fe0b8eae8bde932d149a3696bf978870adaba` produced tree `6acceb6d27092c15f82f36eb199ae0801d3cd8bc`, exactly matching the integration `HEAD^{tree}`.
- The trunk-to-integration delta is limited to the accepted changelog, native-kernel audit implementation, verifier tool, and required kernel manifests/lockfile (16 paths); the merge introduced no unrelated resolution paths. `git diff --check` is clean and no exact conflict markers are present.
- The topic branch was pushed by normal fast-forward from `c15fe0b8eae8bde932d149a3696bf978870adaba` to `20157a38b2446b2b92cd1c257cff9569f2c32a1c` after re-fetching and reconfirming both exact remote refs.

Exact-head tests and checks from the integration commit:

- `CARGO_TARGET_DIR=/private/tmp/astrid-pr1771-integration.AL0RrN/target-cargo cargo test -p astrid-native-kernel --lib --locked audit -- --quiet`: 22 passed
- `CARGO_TARGET_DIR=/private/tmp/astrid-pr1771-integration.AL0RrN/target-cargo cargo test -p native-audit-verifier --locked -- --quiet`: 17 passed
- `CARGO_TARGET_DIR=/private/tmp/astrid-pr1771-integration.AL0RrN/target-cargo cargo test -p astrid-native-kernel --lib --locked -- --quiet`: 69 passed
- `CARGO_TARGET_DIR=/private/tmp/astrid-pr1771-integration.AL0RrN/target-cargo cargo check -p astrid-native-kernel --target x86_64-unknown-none --locked`: clean
- `CARGO_TARGET_DIR=/private/tmp/astrid-pr1771-integration.AL0RrN/target-cargo cargo clippy -p astrid-native-kernel --target x86_64-unknown-none --locked -- -D warnings`: clean
- `CARGO_TARGET_DIR=/private/tmp/astrid-pr1771-integration.AL0RrN/target-cargo cargo clippy -p native-audit-verifier --all-targets --locked -- -D warnings`: clean
- `cargo fmt -p astrid-native-kernel -p native-audit-verifier -- --check`: clean
- `CARGO_TARGET_DIR=/private/tmp/astrid-pr1771-integration.AL0RrN/target-cargo ./kernel/check.sh x86`: PASS (the repository's native x86 split checks, including target clippy and kimage checks)
- `git verify-commit 20157a38b2446b2b92cd1c257cff9569f2c32a1c`: good signature from Joshua J. Bouw using key `7CD32E7697286B11593246B9FA53358CB4127512`; merge commit includes `Signed-off-by: Joshua J. Bouw <jjb@unicity-labs.com>`

The broad `cargo fmt --all -- --check` invocation reports only pre-existing formatting differences in vendored bootloader sources outside this change; scoped kernel and verifier formatting is clean. Terminal GitHub checks for this exact pushed head are running.

## AI / Tool Assistance

Assisted-by: Automated coding tool

Affected areas: native-kernel audit authority input derivation, its decisive forgery regression, and the changelog fragment. The implementation and validation were reviewed in an isolated exact-parent worktree before the signed trunk-first integration commit.

## Claim Boundary

This slice makes no production secret provisioning, delivery, custody, rotation, live observer/serial wiring, public WIT, hosted audit, cross-boot durability, or q35 production-behavior claim. The verifier trust anchor remains a modeled out-of-band channel for this unwired slice. The linked issue remains open for production key delivery and live wiring.

## Checklist

- [x] Tracking issue linked without merge claim
- [x] Changelog fragment updated under `changes/1759.added.md`
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
