### PR TITLE
feat(kernel): observe staged domain state

### DIFF
--- a/changes/1766.added.md
+++ b/changes/1766.added.md
@@ -1,0 +1,6 @@
+Staged native-domain starts can privately observe an admitted domain as
+Prepared, Running, or Blocked after revalidating the admitted handle,
+manifest identity, component identity, and scenario. Release and retirement
+states remain fail-closed with exact rejection reasons. This is observation
+evidence only, not readiness, publication, a returning lifecycle, or a
+Running stop. Tracking #1766

--- a/changes/1766.changed.admission-bound-observe.md
+++ b/changes/1766.changed.admission-bound-observe.md
@@ -1,0 +1,7 @@
+Staged native-domain starts can now observe an admitted domain as Prepared,
+Running, or Blocked through the exact admitted handle, manifest identity,
+component identity, and scenario. Non-live release states and admission
+substitution remain fail-closed with distinct rejection reasons. The production
+start path remains non-returning; this is admission-bound observation evidence
+only, not readiness, publication, a returning lifecycle, or a Running stop.
+Refs #1766

--- a/changes/1766.changed.admission-bound-observe.md
+++ b/changes/1766.changed.admission-bound-observe.md
@@ -1,7 +1,0 @@
-Staged native-domain starts can now observe an admitted domain as Prepared,
-Running, or Blocked through the exact admitted handle, manifest identity,
-component identity, and scenario. Non-live release states and admission
-substitution remain fail-closed with distinct rejection reasons. The production
-start path remains non-returning; this is admission-bound observation evidence
-only, not readiness, publication, a returning lifecycle, or a Running stop.
-Refs #1766

--- a/kernel/crates/astrid-native-kernel/src/domains/manager/start.rs
+++ b/kernel/crates/astrid-native-kernel/src/domains/manager/start.rs
@@ -53,12 +53,17 @@ impl StartContext {
 #[cfg(not(test))]
 pub(in crate::domains) fn staged_state(
     handle: DomainHandle,
-) -> Result<(DomainState, Scenario), PrepareError> {
+) -> Result<Option<(DomainState, Scenario)>, PrepareError> {
     let manager = MANAGER.lock();
-    let Some(domain) = manager.valid_domain(handle) else {
-        return Err(PrepareError::Bind(BindError::NotInstalled));
+    let Some(domain) = manager
+        .slots
+        .get(handle.id().0 as usize)
+        .and_then(Option::as_ref)
+        .filter(|domain| domain.generation == handle.generation().0)
+    else {
+        return Ok(None);
     };
-    Ok((domain.state, domain.scenario))
+    Ok(Some((domain.state, domain.scenario)))
 }
 
 #[cfg(not(test))]

--- a/kernel/crates/astrid-native-kernel/src/domains/stage.rs
+++ b/kernel/crates/astrid-native-kernel/src/domains/stage.rs
@@ -14,6 +14,8 @@ pub(crate) enum StageError {
     NotPrepared,
     ScenarioMismatch,
     StaleDomain,
+    Releasing,
+    ReleaseFailed,
 }
 
 impl StageError {
@@ -24,6 +26,8 @@ impl StageError {
             Self::NotPrepared => "domain_not_prepared",
             Self::ScenarioMismatch => "domain_scenario_mismatch",
             Self::StaleDomain => "staged_domain_stale",
+            Self::Releasing => "domain_releasing",
+            Self::ReleaseFailed => "domain_release_failed",
         }
     }
 }
@@ -44,13 +48,7 @@ where
     G: Copy + PartialEq,
     C: Copy + PartialEq,
 {
-    fn revalidate(
-        &self,
-        manifest_identity: G,
-        component_id: C,
-        state: DomainState,
-        scenario: Scenario,
-    ) -> Result<(), StageError> {
+    fn validate_identity(&self, manifest_identity: G, component_id: C) -> Result<(), StageError> {
         if manifest_identity != self.manifest_identity {
             return Err(StageError::Admission(
                 admission::AdmissionError::SubstitutedIdentity,
@@ -61,20 +59,38 @@ where
                 admission::AdmissionError::ComponentMismatch,
             ));
         }
+        Ok(())
+    }
+
+    fn validate_observation_state(
+        &self,
+        state: DomainState,
+        scenario: Scenario,
+    ) -> Result<DomainState, StageError> {
         match state {
-            DomainState::Prepared => {
+            DomainState::Prepared | DomainState::Running | DomainState::Blocked => {
                 if scenario != self.scenario {
                     return Err(StageError::ScenarioMismatch);
                 }
+                Ok(state)
             },
-            DomainState::Running | DomainState::Blocked | DomainState::Releasing => {
-                return Err(StageError::NotPrepared);
-            },
-            DomainState::Reclaimed | DomainState::ReleaseFailed => {
-                return Err(StageError::StaleDomain);
-            },
+            DomainState::Releasing => Err(StageError::Releasing),
+            DomainState::Reclaimed => Err(StageError::StaleDomain),
+            DomainState::ReleaseFailed => Err(StageError::ReleaseFailed),
         }
-        Ok(())
+    }
+
+    fn revalidate(
+        &self,
+        manifest_identity: G,
+        component_id: C,
+        state: DomainState,
+        scenario: Scenario,
+    ) -> Result<(), StageError> {
+        match self.validate_observation_state(state, scenario)? {
+            DomainState::Prepared => self.validate_identity(manifest_identity, component_id),
+            _ => Err(StageError::NotPrepared),
+        }
     }
 
     fn authorize_dispatch(
@@ -92,6 +108,37 @@ where
             )));
         }
         Ok(context)
+    }
+}
+
+#[cfg(not(test))]
+impl StagedStart<ManifestIdentity, ContentId> {
+    #[cfg(not(test))]
+    pub(crate) fn observe(&self) -> Result<DomainState, StageError> {
+        let (state, scenario) = match manager::staged_state(self.handle) {
+            Ok(observed) => observed,
+            Err(_) => {
+                // staged_state classifies only live domains; this second
+                // snapshot preserves exact release-state evidence instead.
+                let manager = manager::MANAGER.lock();
+                let Some(domain) = manager
+                    .slots
+                    .get(self.handle.id().0 as usize)
+                    .and_then(Option::as_ref)
+                    .filter(|domain| domain.generation == self.handle.generation().0)
+                else {
+                    return Err(StageError::Domain(manager::PrepareError::Bind(
+                        BindError::NotInstalled,
+                    )));
+                };
+                (domain.state, domain.scenario)
+            },
+        };
+        let observed = self.validate_observation_state(state, scenario)?;
+        let manifest_identity = admission::confirm_start(self.handle, self.component_id)
+            .map_err(StageError::Admission)?;
+        self.validate_identity(manifest_identity, self.component_id)?;
+        Ok(observed)
     }
 }
 
@@ -117,19 +164,24 @@ pub(crate) fn stage_start(
 pub(crate) fn dispatch_start(
     staged: StagedStart<ManifestIdentity, ContentId>,
 ) -> Result<(), StageError> {
-    let manifest_identity = admission::confirm_start(staged.handle, staged.component_id)
-        .map_err(StageError::Admission)?;
-    let (state, scenario) = manager::staged_state(staged.handle).map_err(StageError::Domain)?;
+    if staged.observe()? != DomainState::Prepared {
+        return Err(StageError::NotPrepared);
+    }
     let context =
         manager::stage_context(staged.handle, staged.scenario).map_err(StageError::Domain)?;
-    let context = staged.authorize_dispatch(
-        manifest_identity,
+    staged.authorize_dispatch(
+        staged.manifest_identity,
         staged.component_id,
-        state,
-        scenario,
+        DomainState::Prepared,
+        staged.scenario,
         context,
     )?;
     manager::start_running(staged.handle, context).map_err(StageError::Domain)?;
+    if staged.observe()? != DomainState::Running {
+        return Err(StageError::Domain(manager::PrepareError::Bind(
+            BindError::Malformed,
+        )));
+    }
     manager::enter_running(staged.handle, context)
 }
 
@@ -210,18 +262,107 @@ mod tests {
     }
 
     #[test]
-    fn non_prepared_or_mismatched_dispatch_state_fails() {
+    fn observation_accepts_only_authorized_live_states() {
         let staged = staged(Scenario::Exit);
-        for state in [
-            DomainState::Running,
-            DomainState::Blocked,
-            DomainState::Releasing,
+        for (state, expected) in [
+            (DomainState::Prepared, DomainState::Prepared),
+            (DomainState::Running, DomainState::Running),
+            (DomainState::Blocked, DomainState::Blocked),
         ] {
             assert_eq!(
-                staged.revalidate(GENERATION, COMPONENT, state, Scenario::Exit),
+                staged.validate_observation_state(state, Scenario::Exit),
+                Ok(expected)
+            );
+        }
+    }
+
+    #[test]
+    fn release_observation_failure_reasons_are_exact() {
+        let staged = staged(Scenario::Exit);
+        assert_eq!(
+            staged.validate_observation_state(DomainState::Releasing, Scenario::Exit),
+            Err(StageError::Releasing)
+        );
+        assert_eq!(
+            staged.validate_observation_state(DomainState::Reclaimed, Scenario::Exit),
+            Err(StageError::StaleDomain)
+        );
+        assert_eq!(
+            staged.validate_observation_state(DomainState::ReleaseFailed, Scenario::Exit),
+            Err(StageError::ReleaseFailed)
+        );
+    }
+
+    #[test]
+    fn observation_scenario_mismatch_fails() {
+        let staged = staged(Scenario::Exit);
+        for state in [
+            DomainState::Prepared,
+            DomainState::Running,
+            DomainState::Blocked,
+        ] {
+            assert_eq!(
+                staged.validate_observation_state(state, Scenario::PageFault),
+                Err(StageError::ScenarioMismatch)
+            );
+        }
+    }
+
+    #[test]
+    fn observation_identity_equality_is_required() {
+        let staged = staged(Scenario::Exit);
+        assert_eq!(
+            staged.validate_identity(SUBSTITUTED, COMPONENT),
+            Err(StageError::Admission(AdmissionError::SubstitutedIdentity))
+        );
+        assert_eq!(
+            staged.validate_identity(GENERATION, MISMATCHED),
+            Err(StageError::Admission(AdmissionError::ComponentMismatch))
+        );
+        assert_eq!(staged.validate_identity(GENERATION, COMPONENT), Ok(()));
+    }
+
+    #[test]
+    fn dispatch_running_or_blocked_is_not_prepared() {
+        let staged = staged(Scenario::Exit);
+        for state in [DomainState::Running, DomainState::Blocked] {
+            assert_eq!(
+                staged.authorize_dispatch(
+                    GENERATION,
+                    COMPONENT,
+                    state,
+                    Scenario::Exit,
+                    context(Scenario::Exit),
+                ),
                 Err(StageError::NotPrepared)
             );
         }
+    }
+
+    #[test]
+    fn dispatch_release_states_fail_before_transition() {
+        let staged = staged(Scenario::Exit);
+        for (state, expected) in [
+            (DomainState::Releasing, StageError::Releasing),
+            (DomainState::Reclaimed, StageError::StaleDomain),
+            (DomainState::ReleaseFailed, StageError::ReleaseFailed),
+        ] {
+            assert_eq!(
+                staged.authorize_dispatch(
+                    GENERATION,
+                    COMPONENT,
+                    state,
+                    Scenario::Exit,
+                    context(Scenario::Exit),
+                ),
+                Err(expected)
+            );
+        }
+    }
+
+    #[test]
+    fn mismatched_dispatch_scenario_fails() {
+        let staged = staged(Scenario::Exit);
         assert_eq!(
             staged.revalidate(
                 GENERATION,
@@ -236,12 +377,24 @@ mod tests {
     #[test]
     fn reclaimed_dispatch_state_is_stale() {
         let staged = staged(Scenario::Exit);
-        for state in [DomainState::Reclaimed, DomainState::ReleaseFailed] {
-            assert_eq!(
-                staged.revalidate(GENERATION, COMPONENT, state, Scenario::Exit),
-                Err(StageError::StaleDomain)
-            );
-        }
+        assert_eq!(
+            staged.revalidate(
+                GENERATION,
+                COMPONENT,
+                DomainState::Reclaimed,
+                Scenario::Exit
+            ),
+            Err(StageError::StaleDomain)
+        );
+        assert_eq!(
+            staged.revalidate(
+                GENERATION,
+                COMPONENT,
+                DomainState::ReleaseFailed,
+                Scenario::Exit
+            ),
+            Err(StageError::ReleaseFailed)
+        );
     }
 
     #[test]

--- a/kernel/crates/astrid-native-kernel/src/domains/stage.rs
+++ b/kernel/crates/astrid-native-kernel/src/domains/stage.rs
@@ -115,30 +115,33 @@ where
 impl StagedStart<ManifestIdentity, ContentId> {
     #[cfg(not(test))]
     pub(crate) fn observe(&self) -> Result<DomainState, StageError> {
-        let (state, scenario) = match manager::staged_state(self.handle) {
-            Ok(observed) => observed,
-            Err(_) => {
-                // staged_state classifies only live domains; this second
-                // snapshot preserves exact release-state evidence instead.
-                let manager = manager::MANAGER.lock();
-                let Some(domain) = manager
-                    .slots
-                    .get(self.handle.id().0 as usize)
-                    .and_then(Option::as_ref)
-                    .filter(|domain| domain.generation == self.handle.generation().0)
-                else {
-                    return Err(StageError::Domain(manager::PrepareError::Bind(
-                        BindError::NotInstalled,
-                    )));
-                };
-                (domain.state, domain.scenario)
-            },
-        };
-        let observed = self.validate_observation_state(state, scenario)?;
+        let observed = manager::staged_state(self.handle).map_err(StageError::Domain)?;
         let manifest_identity = admission::confirm_start(self.handle, self.component_id)
-            .map_err(StageError::Admission)?;
+            .map_err(|error| self.classify_admission_error(error, observed))?;
         self.validate_identity(manifest_identity, self.component_id)?;
-        Ok(observed)
+        let Some((state, scenario)) = observed else {
+            return Err(StageError::Admission(
+                admission::AdmissionError::StaleDomain,
+            ));
+        };
+        self.validate_observation_state(state, scenario)
+    }
+
+    #[cfg(not(test))]
+    fn classify_admission_error(
+        &self,
+        error: admission::AdmissionError,
+        observed: Option<(DomainState, Scenario)>,
+    ) -> StageError {
+        match (error, observed) {
+            (admission::AdmissionError::StaleDomain, Some((DomainState::Releasing, _))) => {
+                StageError::Releasing
+            },
+            (admission::AdmissionError::StaleDomain, Some((DomainState::ReleaseFailed, _))) => {
+                StageError::ReleaseFailed
+            },
+            (error, _) => StageError::Admission(error),
+        }
     }
 }
 


### PR DESCRIPTION
## Linked Issue

Tracking #1766. Does not close it.

## Summary

Adds private admission-bound observation for staged native-domain starts. The observer revalidates the admitted DomainHandle and generation, ManifestIdentity, component ContentId, and scenario, then reports Prepared, Running, or Blocked from one manager snapshot. Live-state admission is reconfirmed through `confirm_start`.

## Changes

- Added private staged-state observation with exact live-state and scenario revalidation.
- Preserved staged admission failure labels for unverified, unknown, substituted, mismatched, stale, releasing, reclaimed, and release-failed states.
- Composed existing staging with dispatch, observing Prepared before the sole Running transition and Running before guest entry.
- Added focused admission and dispatch falsifiers and a changelog fragment.

## Verification

- `cargo fmt -p astrid-native-kernel`
- `cargo clippy -p astrid-native-kernel --target x86_64-unknown-none --locked -- -D warnings`
- `cargo test -p astrid-native-kernel --lib --locked`: 47 passed.
- Focused mutation checks: removing scenario revalidation and manifest identity equality each failed the new focused tests; the tree was restored afterward.
- Full q35/TCG `kernel/run.sh`: deterministic images, all boot and domain serial assertions passed, QEMU exit 33; tampered image failed before entry; plan mismatch failed with QEMU exit 35.

This is admission-bound observation evidence only. It is not readiness, a returning lifecycle, a Running stop, publication, persistence, native PIO, ServiceDriver, registry, WIT, or service-identity evidence.

## Test Plan

Native-kernel CI must run on this PR. Reviewers should rerun the focused stage tests and `kernel/run.sh`, then independently remove either observation state validation or identity equality and confirm the focused tests fail.

## AI / Tool Assistance

Assisted-by: Codex: GLM-5.3-Flash