### PR TITLE
kernel: project IPC lifecycle under one lock

### DIFF
--- a/changes/1758.added.md
+++ b/changes/1758.added.md
@@ -12,3 +12,12 @@ retirement fails closed without losing its slot or rows on epoch overflow, and
 batch capacity is planned from net row count rather than the pre-batch count.
 Fold replay orders deletes before upserts within each batch epoch, matching the
 authoritative staged mutation order at the fixed row ceiling.
+
+The projection now lives with `IpcState` under the same authoritative mutation
+lock. Real domain registration, endpoint creation, capability binding and
+transfer, revocation/rollback, endpoint reclaim, and domain teardown update the
+same relation projection; there is no second fact base. Successful transferred
+capability receipt still projects under that lock, and successful endpoint
+creation emits a private q35 relation event with compact live fold-chain and
+row-count evidence. Host regressions retain the full fold-equals-snapshot
+oracle.

--- a/changes/1758.changed.md
+++ b/changes/1758.changed.md
@@ -1,0 +1,6 @@
+Hardened same-lock IPC relation projection metadata for repeated object and
+reader lifecycles. Retirement now retains one foldable retired-reader cursor,
+clears retired scope metadata, advances successful reclaims past older
+generations, records success accurately, and keeps a single projection failure
+from panicking IPC. The production mutation path now rejects a foreign scope
+before changing rows, and host evidence replays a real pre-mutation cursor.

--- a/changes/1759.added.md
+++ b/changes/1759.added.md
@@ -1,0 +1,55 @@
+Added kernel-private audit-chain mechanics for native security events:
+a versioned, injective, bounded, length-delimited canonical codec; a rolling
+BLAKE3 root whose tag binds algorithm id, codec version, boot/session identity,
+and sequence; one atomic mutation-side transition that commits frame, checked
+non-wrapping `audit_seq`, and root advance together or fails before commit; and
+a kernel-owned fixed-capacity relay with checked cursors, credits/acks,
+bounded redelivery, and generation-bumped resync.
+
+Typed attribution restates the landed #1705/#1758 identity fields through
+ceiling-enforced constructors, and bounded denials never disclose foreign
+object identity. Authority ids and checkpoint verification keys now require
+opaque kernel-held entropy in addition to the live boot/session identity. The
+entropy input is a crate-private newtype with a zero-rejecting constructor and
+erasure on drop; it is absent from canonical frames, checkpoint wire, and the
+untrusted handoff. Kernel tests reconstruct the superseded public-only key
+derivation from observed handoff fields and prove that forged handoff,
+checkpoint, and acknowledgement material fail under the genuine trusted
+anchor. Relay capacity is statically derived from the maximum
+mandatory terminal/invalidation records one admitted atomic batch can produce
+at the frozen ceilings: all 16 capability instances, 4 endpoints, 8 endpoint
+queues, and the dying domain identity, for a reserve of 29. Ordinary records
+cannot consume that headroom. Checkpoints are kernel-authenticated and bound
+to boot/session, exact seq, root, codec version, and relay generation with a
+keyed kernel tag and kernel-minted authority context instead of a public
+verifier-recomputable digest or caller-selectable key; trusted restore
+preserves the checkpoint's relay generation rather than resetting it. Verifier
+acknowledgements additionally require a successful-fold receipt bound to the
+live boot/session, relay generation, exact canonical frame, and source root.
+The verifier handoff is untrusted binding evidence: it names the authority id
+and boot/session identity and carries only a kernel-keyed minting tag, never
+verification material, so no handoff authenticates itself. The host verifier
+accepts its authority only through an explicitly injected, independently
+trusted kernel-origin anchor (a modeled trusted channel in this unwired slice)
+and must bind the handoff against that anchor before any verification session
+starts; structurally valid self-authenticated handoffs, checkpoints sealed
+under forged contexts, and forged retirement receipts fail closed. This first
+slice does not wire production secret provisioning, delivery, custody, or
+rotation.
+
+A separate private host verifier (`kernel/tools/native-audit-verifier`)
+independently decodes the canonical frames, folds the same root algorithm,
+verifies checkpoints, and reports Invalid versus Incomplete without skipping,
+extrapolating, or rewriting already-rooted events. Kernel tests cross-check
+frames, roots, and checkpoints against that verifier. Sequence overflow and
+relay-generation mismatch fail closed without partial commit; generation zero
+is invalid on both sides.
+
+No observer or serial hooks, public WIT, hosted audit, IPC transport, relation
+delta reuse, cross-boot durability, or runtime (q35) claims are included in
+this slice.
+
+First-slice residuals include observer/serial hooks, production anchor
+delivery, and production checkpoint key lifecycle for a later sequenced change.
+
+Tracking #1759

--- a/kernel/Cargo.lock
+++ b/kernel/Cargo.lock
@@ -52,8 +52,10 @@ version = "0.0.0"
 dependencies = [
  "astrid-native-closure",
  "astrid-system-generation",
+ "blake3",
  "bootloader_api",
  "linked_list_allocator",
+ "native-audit-verifier",
  "raw-cpuid",
  "spin",
  "x86_64",
@@ -405,11 +407,11 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "astrid-native-closure",
-    "astrid-system-generation",
-    "blake3",
-    "bootloader_api",
-    "serde_json",
-    "wait-timeout",
+ "astrid-system-generation",
+ "blake3",
+ "bootloader_api",
+ "serde_json",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -456,6 +458,13 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "native-audit-verifier"
+version = "0.0.0"
+dependencies = [
+ "blake3",
+]
 
 [[package]]
 name = "once_cell"

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/astrid-system-generation",
     "tools/kimage",
     "tools/ktest",
+    "tools/native-audit-verifier",
 ]
 exclude = ["tools/bootloader"]
 

--- a/kernel/crates/astrid-native-kernel/Cargo.toml
+++ b/kernel/crates/astrid-native-kernel/Cargo.toml
@@ -30,3 +30,10 @@ raw-cpuid = "=11.6.0"
 
 astrid-native-closure = { path = "../astrid-native-closure" }
 astrid-system-generation = { path = "../astrid-system-generation", default-features = false, features = ["emulator-fixture"] }
+# Rolling audit root. Same frozen pure backend as the sibling kernel crates.
+blake3 = { version = "=1.8.5", default-features = false, features = ["pure"] }
+
+[dev-dependencies]
+# Private host verifier: kernel audit tests cross-check the canonical frames,
+# rolling root, and checkpoint tags against the independent decoder.
+native-audit-verifier = { path = "../../tools/native-audit-verifier" }

--- a/kernel/crates/astrid-native-kernel/src/audit/chain.rs
+++ b/kernel/crates/astrid-native-kernel/src/audit/chain.rs
@@ -1,0 +1,149 @@
+//! The atomic mutation-side transition: one call commits the canonical
+//! frame, the checked `audit_seq` advance, and the rolling-root advance
+//! together, or fails before any state changes.
+
+use super::codec::{Frame, MAX_FRAME_BYTES};
+use super::relay::AuditRelay;
+use super::root;
+use super::types::{
+    AuditAuthority, AuditCheckpoint, AuditError, AuditEvent, BootSessionId, KernelSecretEntropy,
+};
+
+pub(crate) struct AuditChain {
+    boot: BootSessionId,
+    authority: AuditAuthority,
+    seq: u64,
+    root: [u8; root::ROOT_LEN],
+    relay: AuditRelay,
+}
+
+impl AuditChain {
+    /// Starts a new boot/session chain at the domain-separated genesis root.
+    pub fn genesis(boot: BootSessionId, secret: KernelSecretEntropy) -> Result<Self, AuditError> {
+        let authority = AuditAuthority::mint(boot, secret).ok_or(AuditError::MalformedFrame)?;
+        Ok(Self {
+            boot,
+            authority,
+            seq: 0,
+            root: root::genesis(boot),
+            relay: AuditRelay::new(boot),
+        })
+    }
+
+    /// Restores from a previously sealed trusted checkpoint. The checkpoint
+    /// itself binds boot/session, exact sequence, root, codec/version, and
+    /// relay generation; the relay generation is preserved rather than reset.
+    pub(crate) fn restore(
+        checkpoint: AuditCheckpoint,
+        authority: AuditAuthority,
+    ) -> Result<Self, AuditError> {
+        if checkpoint.boot() != authority.boot() {
+            return Err(AuditError::CheckpointMismatch);
+        }
+        if checkpoint.codec_version() != super::CODEC_VERSION
+            || !checkpoint.verify_tag(authority.context())
+            || checkpoint.relay_generation() == 0
+        {
+            return Err(AuditError::CheckpointMismatch);
+        }
+        let next_seq = checkpoint
+            .seq()
+            .checked_add(1)
+            .ok_or(AuditError::SequenceOverflow)?;
+        let relay =
+            AuditRelay::restore(checkpoint.boot(), checkpoint.relay_generation(), next_seq)?;
+        Ok(Self {
+            boot: checkpoint.boot(),
+            authority,
+            seq: checkpoint.seq(),
+            root: checkpoint.root(),
+            relay,
+        })
+    }
+
+    pub const fn boot(&self) -> BootSessionId {
+        self.boot
+    }
+
+    pub(crate) const fn authority(&self) -> AuditAuthority {
+        self.authority
+    }
+
+    pub const fn seq(&self) -> u64 {
+        self.seq
+    }
+
+    pub const fn root(&self) -> &[u8; root::ROOT_LEN] {
+        &self.root
+    }
+
+    pub const fn relay(&self) -> &AuditRelay {
+        &self.relay
+    }
+
+    pub fn relay_mut(&mut self) -> &mut AuditRelay {
+        &mut self.relay
+    }
+
+    /// Acknowledges through the chain's kernel-owned authentication context;
+    /// callers can present only the verifier's successful-fold receipt.
+    pub fn ack(
+        &mut self,
+        seq: u64,
+        folded_root: [u8; root::ROOT_LEN],
+        receipt_tag: [u8; root::ROOT_LEN],
+    ) -> Result<(), AuditError> {
+        self.relay
+            .ack(seq, folded_root, receipt_tag, self.authority.context())
+    }
+
+    /// Generation-bumps the relay and seals recovery with the same
+    /// kernel-owned authority.
+    pub fn resync(&mut self) -> Result<AuditCheckpoint, AuditError> {
+        let current_root = self.root;
+        let current_seq = self.seq;
+        self.relay
+            .resync(current_root, current_seq, self.authority.context())
+    }
+
+    /// Appends one mandatory event as one atomic transition. All fallible
+    /// steps complete on temporaries before the single commit; a failure
+    /// leaves sequence, root, and relay untouched. Relay publication is
+    /// downstream evidence only: its overflow is an explicit handoff state
+    /// and can never omit or rewrite the already-rooted event.
+    pub fn append(&mut self, event: AuditEvent) -> Result<u64, AuditError> {
+        let next = self
+            .seq
+            .checked_add(1)
+            .ok_or(AuditError::SequenceOverflow)?;
+        let prev_root = Some(self.root);
+        let frame = Frame::new(self.boot, next, &event, prev_root)?;
+        let mut buf = [0; MAX_FRAME_BYTES];
+        let encoded = frame.encode(&mut buf)?;
+        let next_root = root::advance(self.root, self.boot, next, encoded);
+
+        // The relay is mandatory for this first-slice mutation transition.
+        // A reserve or window failure returns before either authoritative
+        // cursor advances, so no rooted record is stranded outside the
+        // bounded handoff proof. The fallible relay publish performs every
+        // check before mutating a slot or cursor.
+        self.relay.publish(
+            next,
+            encoded,
+            next_root,
+            event.class().is_terminal_or_invalidation(),
+        )?;
+
+        // Commit: frame, checked seq, rolling root, and relay handoff all
+        // advance together after every fallible step has succeeded.
+        self.seq = next;
+        self.root = next_root;
+        Ok(next)
+    }
+
+    /// Kernel-authenticated checkpoint bound to the exact current state.
+    pub fn checkpoint(&self) -> AuditCheckpoint {
+        self.relay
+            .checkpoint(self.root, self.seq, self.authority.context())
+    }
+}

--- a/kernel/crates/astrid-native-kernel/src/audit/codec.rs
+++ b/kernel/crates/astrid-native-kernel/src/audit/codec.rs
@@ -1,0 +1,433 @@
+//! Versioned, injective, bounded, length-delimited canonical codec.
+//!
+//! Every field has a frozen width or an explicit discriminant; every
+//! variable region is length-bounded and strictly checked, so each frame has
+//! exactly one canonical byte representation and decoding rejects any
+//! non-canonical slack.
+
+use core::num::NonZeroU64;
+
+use super::types::{
+    AUDIT_MAX_PAYLOAD, AuditCapabilityInstance, AuditCheckpoint, AuditClass, AuditError,
+    AuditEvent, AuditObject, AuditObjectKind, AuditRights, AuditSubject, BootSessionId,
+    CheckpointAuthContext, DenialContext,
+};
+use super::{CODEC_VERSION, root};
+
+/// Envelope plus every fixed-width field except payload and the
+/// previous-root choice. The widest object variant is a capability instance:
+/// projection token, capability slot, capability generation, object kind,
+/// object token.
+const FRAME_OVERHEAD_BYTES: usize = 4   // total length
+    + 2 // codec version
+    + 16 // boot/session identity
+    + 8 // audit_seq
+    + 2 // class
+    + 1 + 8 // subject slot + generation
+    + 1 // object tag
+    + (8 + 1 + 8 + 1 + 8) // widest typed object
+    + 2 // rights
+    + 2 // payload length
+    + 1; // previous-root flag
+
+pub(crate) const MAX_FRAME_BYTES: usize = FRAME_OVERHEAD_BYTES + AUDIT_MAX_PAYLOAD + root::ROOT_LEN;
+
+/// Fixed checkpoint wire size: envelope, codec version, boot, seq, root,
+/// relay generation, authority id, kernel tag.
+pub(crate) const CHECKPOINT_WIRE_BYTES: usize =
+    4 + 2 + 16 + 8 + root::ROOT_LEN + 8 + 8 + root::ROOT_LEN;
+
+/// One canonical frame: the decoded form of the frozen wire representation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Frame {
+    boot: BootSessionId,
+    seq: u64,
+    class: AuditClass,
+    subject: AuditSubject,
+    object: Option<AuditObject>,
+    rights: AuditRights,
+    payload: [u8; AUDIT_MAX_PAYLOAD],
+    payload_len: usize,
+    prev_root: Option<[u8; root::ROOT_LEN]>,
+}
+
+impl Frame {
+    pub(crate) fn new(
+        boot: BootSessionId,
+        seq: u64,
+        event: &AuditEvent,
+        prev_root: Option<[u8; root::ROOT_LEN]>,
+    ) -> Result<Self, AuditError> {
+        if event.class() == AuditClass::BoundedDenial {
+            if event.object().is_some() {
+                return Err(AuditError::UnauthorizedDisclosure);
+            }
+            if DenialContext::from_payload(event.payload()).is_none() {
+                return Err(AuditError::MalformedFrame);
+            }
+        }
+        let mut payload = [0; AUDIT_MAX_PAYLOAD];
+        payload[..event.payload().len()].copy_from_slice(event.payload());
+        Ok(Self {
+            boot,
+            seq,
+            class: event.class(),
+            subject: event.subject(),
+            object: event.object(),
+            rights: event.rights(),
+            payload,
+            payload_len: event.payload().len(),
+            prev_root,
+        })
+    }
+
+    pub(crate) fn encode<'out>(
+        &self,
+        out: &'out mut [u8; MAX_FRAME_BYTES],
+    ) -> Result<&'out [u8], AuditError> {
+        let mut writer = Writer::new(out);
+        writer.skip_total_length()?;
+        writer.u16(CODEC_VERSION)?;
+        writer.raw(&self.boot.bytes())?;
+        writer.u64(self.seq)?;
+        if self.class == AuditClass::BoundedDenial && self.object.is_some() {
+            return Err(AuditError::UnauthorizedDisclosure);
+        }
+        writer.u16(self.class.discriminant())?;
+        writer.u8(self.subject.slot())?;
+        writer.u64(self.subject.generation().get())?;
+        match self.object {
+            None => writer.u8(0)?,
+            Some(AuditObject::Domain { slot, generation }) => {
+                writer.u8(1)?;
+                writer.u8(slot)?;
+                writer.u64(generation.get())?;
+            },
+            Some(AuditObject::Endpoint {
+                pool_index,
+                generation,
+            }) => {
+                writer.u8(2)?;
+                writer.u8(pool_index)?;
+                writer.u64(generation.get())?;
+            },
+            Some(AuditObject::CapabilityInstance(instance)) => {
+                writer.u8(3)?;
+                writer.u64(instance.projection_token().get())?;
+                writer.u8(instance.capability_slot())?;
+                writer.u64(instance.capability_generation().get())?;
+                writer.u8(instance.object_kind().discriminant())?;
+                writer.u64(instance.object_token().get())?;
+            },
+        }
+        writer.u16(self.rights.bits())?;
+        writer.u16(self.payload_len as u16)?;
+        writer.raw(&self.payload[..self.payload_len])?;
+        match self.prev_root {
+            None => writer.u8(0)?,
+            Some(prev_root) => {
+                writer.u8(1)?;
+                writer.raw(&prev_root)?;
+            },
+        }
+        let end = writer.finish()?;
+        Ok(&out[..end])
+    }
+
+    pub(crate) fn boot(self) -> BootSessionId {
+        self.boot
+    }
+
+    pub(crate) fn seq(self) -> u64 {
+        self.seq
+    }
+
+    pub(crate) fn class(self) -> AuditClass {
+        self.class
+    }
+
+    pub(crate) fn subject(self) -> AuditSubject {
+        self.subject
+    }
+
+    pub(crate) fn object(self) -> Option<AuditObject> {
+        self.object
+    }
+
+    pub(crate) fn rights(self) -> AuditRights {
+        self.rights
+    }
+
+    pub(crate) fn payload(self) -> [u8; AUDIT_MAX_PAYLOAD] {
+        self.payload
+    }
+
+    pub(crate) fn payload_len(self) -> usize {
+        self.payload_len
+    }
+
+    pub(crate) fn prev_root(self) -> Option<[u8; root::ROOT_LEN]> {
+        self.prev_root
+    }
+}
+
+/// Strict canonical decode: unknown codec versions, unknown discriminants,
+/// out-of-ceiling values, zero generations, a zero sequence, or any trailing
+/// slack fail closed.
+pub(crate) fn decode(bytes: &[u8]) -> Result<Frame, AuditError> {
+    let mut reader = Reader::new(bytes)?;
+    let total = reader.u32()? as usize;
+    if bytes.len() - 4 != total {
+        return Err(AuditError::MalformedFrame);
+    }
+    let codec_version = reader.u16()?;
+    if codec_version != CODEC_VERSION {
+        return Err(AuditError::MalformedFrame);
+    }
+    let mut boot = [0; 16];
+    reader.fill(&mut boot)?;
+    let boot = BootSessionId::new(boot).ok_or(AuditError::MalformedFrame)?;
+    let seq = reader.u64()?;
+    if seq == 0 {
+        return Err(AuditError::MalformedFrame);
+    }
+    let class = AuditClass::from_discriminant(reader.u16()?).ok_or(AuditError::MalformedFrame)?;
+    let slot = reader.u8()?;
+    let generation = NonZeroU64::new(reader.u64()?).ok_or(AuditError::MalformedFrame)?;
+    let subject = AuditSubject::from_parts(slot, generation).ok_or(AuditError::MalformedFrame)?;
+    let object = match reader.u8()? {
+        0 => None,
+        1 => {
+            let slot = reader.u8()? as usize;
+            let generation = reader.u64()?;
+            Some(AuditObject::domain(slot, generation).ok_or(AuditError::MalformedFrame)?)
+        },
+        2 => {
+            let pool_index = reader.u8()? as usize;
+            let generation = reader.u64()?;
+            Some(AuditObject::endpoint(pool_index, generation).ok_or(AuditError::MalformedFrame)?)
+        },
+        3 => Some(AuditObject::CapabilityInstance(decode_capability_instance(
+            &mut reader,
+        )?)),
+        _ => return Err(AuditError::MalformedFrame),
+    };
+    let rights = AuditRights::from_bits(reader.u16()?).ok_or(AuditError::MalformedFrame)?;
+    let payload_len = reader.u16()? as usize;
+    if payload_len > AUDIT_MAX_PAYLOAD {
+        return Err(AuditError::MalformedFrame);
+    }
+    let mut payload = [0; AUDIT_MAX_PAYLOAD];
+    reader.fill(&mut payload[..payload_len])?;
+    let prev_root = match reader.u8()? {
+        0 => None,
+        1 => {
+            let mut prev_root = [0; root::ROOT_LEN];
+            reader.fill(&mut prev_root)?;
+            Some(prev_root)
+        },
+        _ => return Err(AuditError::MalformedFrame),
+    };
+    if reader.remaining() != 0 {
+        return Err(AuditError::MalformedFrame);
+    }
+    if class == AuditClass::BoundedDenial {
+        // A denial must never carry a foreign object identity, and its
+        // payload is exactly the bounded typed context.
+        if object.is_some() {
+            return Err(AuditError::UnauthorizedDisclosure);
+        }
+        if DenialContext::from_payload(&payload[..payload_len]).is_none() {
+            return Err(AuditError::MalformedFrame);
+        }
+    }
+    Ok(Frame {
+        boot,
+        seq,
+        class,
+        subject,
+        object,
+        rights,
+        payload,
+        payload_len,
+        prev_root,
+    })
+}
+
+fn decode_capability_instance(
+    reader: &mut Reader<'_>,
+) -> Result<AuditCapabilityInstance, AuditError> {
+    let projection_token = reader.u64()?;
+    let capability_slot = reader.u8()? as usize;
+    let capability_generation = reader.u64()?;
+    let object_kind =
+        AuditObjectKind::from_discriminant(reader.u8()?).ok_or(AuditError::MalformedFrame)?;
+    let object_token = reader.u64()?;
+    AuditCapabilityInstance::try_new(
+        projection_token,
+        capability_slot,
+        capability_generation,
+        object_kind,
+        object_token,
+    )
+    .ok_or(AuditError::MalformedFrame)
+}
+
+/// Canonical checkpoint wire form: bounded, versioned, and tag-bound. The
+/// kernel tag is the authentication; decoding always re-verifies it.
+pub(crate) fn encode_checkpoint<'out>(
+    checkpoint: &AuditCheckpoint,
+    context: CheckpointAuthContext,
+    out: &'out mut [u8; CHECKPOINT_WIRE_BYTES],
+) -> Result<&'out [u8], AuditError> {
+    if checkpoint.authority_id() != context.authority_id() || !checkpoint.verify_tag(context) {
+        return Err(AuditError::CheckpointMismatch);
+    }
+    let mut writer = Writer::new(out);
+    writer.skip_total_length()?;
+    writer.u16(checkpoint.codec_version())?;
+    writer.raw(&checkpoint.boot().bytes())?;
+    writer.u64(checkpoint.seq())?;
+    writer.raw(&checkpoint.root())?;
+    writer.u64(checkpoint.relay_generation())?;
+    writer.u64(checkpoint.authority_id())?;
+    writer.raw(&checkpoint.tag())?;
+    let end = writer.finish()?;
+    Ok(&out[..end])
+}
+
+pub(crate) fn decode_checkpoint(
+    bytes: &[u8],
+    context: CheckpointAuthContext,
+) -> Result<AuditCheckpoint, AuditError> {
+    let mut reader = Reader::new(bytes)?;
+    let total = reader.u32()? as usize;
+    if bytes.len() - 4 != total || bytes.len() != CHECKPOINT_WIRE_BYTES {
+        return Err(AuditError::MalformedFrame);
+    }
+    let codec_version = reader.u16()?;
+    if codec_version != CODEC_VERSION {
+        return Err(AuditError::MalformedFrame);
+    }
+    let mut boot = [0; 16];
+    reader.fill(&mut boot)?;
+    let boot = BootSessionId::new(boot).ok_or(AuditError::MalformedFrame)?;
+    let seq = reader.u64()?;
+    let mut root_bytes = [0; root::ROOT_LEN];
+    reader.fill(&mut root_bytes)?;
+    let relay_generation = reader.u64()?;
+    let authority_id = reader.u64()?;
+    if authority_id != context.authority_id() {
+        return Err(AuditError::CheckpointMismatch);
+    }
+    let mut tag = [0; root::ROOT_LEN];
+    reader.fill(&mut tag)?;
+    if reader.remaining() != 0 {
+        return Err(AuditError::MalformedFrame);
+    }
+    if relay_generation == 0 {
+        return Err(AuditError::MalformedFrame);
+    }
+    let expected = AuditCheckpoint::seal(boot, seq, root_bytes, relay_generation, context)?;
+    if expected.codec_version() != codec_version || expected.tag() != tag {
+        return Err(AuditError::CheckpointMismatch);
+    }
+    Ok(expected)
+}
+
+struct Writer<'a> {
+    buf: &'a mut [u8],
+    pos: usize,
+}
+
+impl<'a> Writer<'a> {
+    fn new(buf: &'a mut [u8]) -> Self {
+        Self { buf, pos: 0 }
+    }
+
+    fn skip_total_length(&mut self) -> Result<(), AuditError> {
+        self.raw(&[0; 4])
+    }
+
+    fn finish(&mut self) -> Result<usize, AuditError> {
+        let total = self.pos - 4;
+        let total = u32::try_from(total).map_err(|_| AuditError::EncodeOverflow)?;
+        self.buf[0..4].copy_from_slice(&total.to_le_bytes());
+        Ok(self.pos)
+    }
+
+    fn raw(&mut self, bytes: &[u8]) -> Result<(), AuditError> {
+        if self.buf.len() - self.pos < bytes.len() {
+            return Err(AuditError::EncodeOverflow);
+        }
+        self.buf[self.pos..self.pos + bytes.len()].copy_from_slice(bytes);
+        self.pos += bytes.len();
+        Ok(())
+    }
+
+    fn u8(&mut self, value: u8) -> Result<(), AuditError> {
+        self.raw(&[value])
+    }
+
+    fn u16(&mut self, value: u16) -> Result<(), AuditError> {
+        self.raw(&value.to_le_bytes())
+    }
+
+    fn u64(&mut self, value: u64) -> Result<(), AuditError> {
+        self.raw(&value.to_le_bytes())
+    }
+}
+
+struct Reader<'a> {
+    bytes: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Reader<'a> {
+    fn new(bytes: &'a [u8]) -> Result<Self, AuditError> {
+        if bytes.len() < 4 {
+            return Err(AuditError::MalformedFrame);
+        }
+        Ok(Self { bytes, pos: 0 })
+    }
+
+    fn remaining(&self) -> usize {
+        self.bytes.len() - self.pos
+    }
+
+    fn take(&mut self, len: usize) -> Result<&'a [u8], AuditError> {
+        if self.remaining() < len {
+            return Err(AuditError::MalformedFrame);
+        }
+        let start = self.pos;
+        self.pos += len;
+        Ok(&self.bytes[start..self.pos])
+    }
+
+    fn fill(&mut self, out: &mut [u8]) -> Result<(), AuditError> {
+        out.copy_from_slice(self.take(out.len())?);
+        Ok(())
+    }
+
+    fn u8(&mut self) -> Result<u8, AuditError> {
+        Ok(self.take(1)?[0])
+    }
+
+    fn u16(&mut self) -> Result<u16, AuditError> {
+        Ok(u16::from_le_bytes(
+            self.take(2)?.try_into().expect("two bytes"),
+        ))
+    }
+
+    fn u32(&mut self) -> Result<u32, AuditError> {
+        Ok(u32::from_le_bytes(
+            self.take(4)?.try_into().expect("four bytes"),
+        ))
+    }
+
+    fn u64(&mut self) -> Result<u64, AuditError> {
+        Ok(u64::from_le_bytes(
+            self.take(8)?.try_into().expect("eight bytes"),
+        ))
+    }
+}

--- a/kernel/crates/astrid-native-kernel/src/audit/mod.rs
+++ b/kernel/crates/astrid-native-kernel/src/audit/mod.rs
@@ -1,0 +1,36 @@
+//! Kernel-private security-event audit chain.
+//!
+//! Private canonical frames, checked sequence order, a rolling BLAKE3 root,
+//! one atomic mutation-side append transition, and a bounded verifier handoff
+//! relay. The kernel is the only authority; the separate
+//! `native-audit-verifier` host tool reconstructs and compares. Relay and
+//! verifier delivery are downstream evidence only and never feed the root.
+
+mod chain;
+mod codec;
+mod relay;
+mod root;
+mod types;
+
+#[cfg(test)]
+mod tests;
+
+/// Frozen canonical frame-codec version. The rolling-root tag and the
+/// checkpoint wire form bind it.
+pub(crate) const CODEC_VERSION: u16 = 1;
+
+// Crate-visible re-exports stay ahead of the first production consumer, the
+// same dead-code-preserving posture as the landed relation projection.
+#[allow(unused_imports)]
+pub(crate) use chain::AuditChain;
+#[allow(unused_imports)]
+pub(crate) use codec::{Frame, MAX_FRAME_BYTES, decode, decode_checkpoint, encode_checkpoint};
+#[allow(unused_imports)]
+pub(crate) use relay::{AUDIT_RELAY_SLOTS, AuditRelay, RelayRecord};
+#[allow(unused_imports)]
+pub(crate) use types::{
+    AUDIT_CAP_OBJECT_POOL, AUDIT_CAP_SLOTS_PER_DOMAIN, AUDIT_DOMAIN_SLOTS, AUDIT_ENDPOINT_POOL,
+    AUDIT_MAX_PAYLOAD, AuditAuthority, AuditCapabilityInstance, AuditCheckpoint, AuditClass,
+    AuditError, AuditEvent, AuditObject, AuditObjectKind, AuditRights, AuditSubject, BootSessionId,
+    DenialContext, DenialReason, KernelSecretEntropy, MAX_TERMINAL_RECORDS_PER_BATCH,
+};

--- a/kernel/crates/astrid-native-kernel/src/audit/relay.rs
+++ b/kernel/crates/astrid-native-kernel/src/audit/relay.rs
@@ -1,0 +1,281 @@
+//! Kernel-owned bounded audit relay: preallocated slots, checked cursors,
+//! credits/acks, bounded redelivery, and no dynamic allocation. Relay state
+//! is flow control only; it is never authority and never a root input.
+
+use super::codec::MAX_FRAME_BYTES;
+use super::root;
+use super::types::{
+    AuditCheckpoint, AuditError, BootSessionId, CheckpointAuthContext,
+    MAX_TERMINAL_RECORDS_PER_BATCH,
+};
+
+/// Distinct from the #1758 32-entry relation delta rings and their two
+/// reader slots. The window statically reserves capacity for at least one
+/// full admitted atomic batch of mandatory terminal/invalidation records.
+pub(crate) const AUDIT_RELAY_SLOTS: usize = 64;
+
+const _: () = assert!(
+    AUDIT_RELAY_SLOTS >= MAX_TERMINAL_RECORDS_PER_BATCH,
+    "audit relay must reserve a full admitted batch of terminal records",
+);
+
+/// One retained, already-rooted record handed downstream.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RelayRecord {
+    seq: u64,
+    root: [u8; root::ROOT_LEN],
+    frame_len: usize,
+    frame: [u8; MAX_FRAME_BYTES],
+}
+
+impl RelayRecord {
+    pub(crate) fn new(seq: u64, root: [u8; root::ROOT_LEN], frame: &[u8]) -> Self {
+        let mut stored = [0; MAX_FRAME_BYTES];
+        stored[..frame.len()].copy_from_slice(frame);
+        Self {
+            seq,
+            root,
+            frame_len: frame.len(),
+            frame: stored,
+        }
+    }
+
+    pub const fn seq(self) -> u64 {
+        self.seq
+    }
+
+    pub const fn root(self) -> [u8; root::ROOT_LEN] {
+        self.root
+    }
+
+    pub fn frame(&self) -> &[u8] {
+        &self.frame[..self.frame_len]
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SlotState {
+    Buffered,
+    InFlight,
+}
+
+#[derive(Clone, Copy)]
+struct Slot {
+    record: RelayRecord,
+    state: SlotState,
+}
+
+/// Fixed-capacity handoff window for already-rooted records. Overflow is an
+/// explicit `HandoffIncomplete`/`ResyncRequired` state: the authoritative
+/// chain is untouched, nothing is silently omitted, and recovery is a
+/// generation-bumped resync from a trusted checkpoint.
+pub struct AuditRelay {
+    boot: BootSessionId,
+    generation: u64,
+    next_seq: u64,
+    oldest_seq: u64,
+    outstanding: usize,
+    credits: u64,
+    slots: [Option<Slot>; AUDIT_RELAY_SLOTS],
+}
+
+impl AuditRelay {
+    pub(super) fn new(boot: BootSessionId) -> Self {
+        Self {
+            boot,
+            generation: 1,
+            next_seq: 1,
+            oldest_seq: 1,
+            outstanding: 0,
+            credits: 0,
+            slots: [None; AUDIT_RELAY_SLOTS],
+        }
+    }
+
+    /// Restores flow-control state from a trusted checkpoint without losing
+    /// its relay generation. Outstanding evidence is explicitly not carried
+    /// across the restart; a verifier restarts from this checkpoint.
+    pub(super) fn restore(
+        boot: BootSessionId,
+        generation: u64,
+        next_seq: u64,
+    ) -> Result<Self, AuditError> {
+        if generation == 0 {
+            return Err(AuditError::MalformedFrame);
+        }
+        Ok(Self {
+            boot,
+            generation,
+            next_seq,
+            oldest_seq: next_seq,
+            outstanding: 0,
+            credits: 0,
+            slots: [None; AUDIT_RELAY_SLOTS],
+        })
+    }
+
+    /// Publishes one already-rooted record. Window overflow keeps the
+    /// authoritative event rooted but downstream-invisible until a resync.
+    pub(super) fn publish(
+        &mut self,
+        seq: u64,
+        frame: &[u8],
+        root: [u8; root::ROOT_LEN],
+        mandatory: bool,
+    ) -> Result<(), AuditError> {
+        if seq != self.next_seq {
+            return Err(AuditError::RelayInvalidCursor);
+        }
+        let next_seq = seq.checked_add(1).ok_or(AuditError::SequenceOverflow)?;
+        if self.outstanding == AUDIT_RELAY_SLOTS {
+            return Err(AuditError::HandoffIncomplete);
+        }
+        if !mandatory && self.outstanding >= AUDIT_RELAY_SLOTS - MAX_TERMINAL_RECORDS_PER_BATCH {
+            return Err(AuditError::HandoffIncomplete);
+        }
+        let index = Self::slot_index(seq);
+        self.slots[index] = Some(Slot {
+            record: RelayRecord::new(seq, root, frame),
+            state: SlotState::Buffered,
+        });
+        self.next_seq = next_seq;
+        self.outstanding += 1;
+        Ok(())
+    }
+
+    pub fn grant_credits(&mut self, credits: u64) -> Result<(), AuditError> {
+        self.credits = self
+            .credits
+            .checked_add(credits)
+            .ok_or(AuditError::RelayInvalidCursor)?;
+        Ok(())
+    }
+
+    /// Non-blocking take of the oldest buffered record, consuming one credit.
+    pub fn take(&mut self) -> Option<RelayRecord> {
+        if self.credits == 0 {
+            return None;
+        }
+        let index = self.oldest_buffered_index()?;
+        if let Some(slot) = self.slots[index].as_mut() {
+            slot.state = SlotState::InFlight;
+        }
+        self.credits -= 1;
+        self.slots[index].map(|slot| slot.record)
+    }
+
+    /// Bounded redelivery of every outstanding record in sequence order
+    /// (lost ack). Never rewrites or omits an already-rooted event.
+    pub fn redeliver(&self) -> impl Iterator<Item = RelayRecord> + '_ {
+        (0..self.outstanding).filter_map(move |offset| {
+            let seq = self.oldest_seq + offset as u64;
+            let index = Self::slot_index(seq);
+            self.slots[index].map(|slot| slot.record)
+        })
+    }
+
+    /// Retires exactly the oldest in-flight record. Besides contiguity and
+    /// source-root equality, the caller must present the keyed receipt emitted
+    /// only by a successful independent fold of this exact canonical frame.
+    pub fn ack(
+        &mut self,
+        seq: u64,
+        folded_root: [u8; root::ROOT_LEN],
+        receipt_tag: [u8; root::ROOT_LEN],
+        context: CheckpointAuthContext,
+    ) -> Result<(), AuditError> {
+        if self.outstanding == 0 || seq != self.oldest_seq {
+            return Err(AuditError::RelayStaleCursor);
+        }
+        let index = Self::slot_index(seq);
+        let next_oldest = seq.checked_add(1).ok_or(AuditError::SequenceOverflow)?;
+        let Some(slot) = self.slots[index] else {
+            return Err(AuditError::RelayInvalidCursor);
+        };
+        if slot.state != SlotState::InFlight {
+            return Err(AuditError::RelayNotInFlight);
+        }
+        if slot.record.root() != folded_root {
+            return Err(AuditError::RootMismatch);
+        }
+        if root::ack_tag(
+            self.boot,
+            self.generation,
+            slot.record.seq(),
+            slot.record.root(),
+            slot.record.frame(),
+            &context,
+        ) != receipt_tag
+        {
+            return Err(AuditError::RootMismatch);
+        }
+        self.slots[index] = None;
+        self.oldest_seq = next_oldest;
+        self.outstanding -= 1;
+        Ok(())
+    }
+
+    /// Window-overflow recovery: bump the relay generation, drop buffered
+    /// evidence, and return a trusted checkpoint for verifier restart. The
+    /// kernel root is untouched.
+    pub fn resync(
+        &mut self,
+        current_root: [u8; root::ROOT_LEN],
+        current_seq: u64,
+        context: CheckpointAuthContext,
+    ) -> Result<AuditCheckpoint, AuditError> {
+        let next_seq = current_seq
+            .checked_add(1)
+            .ok_or(AuditError::SequenceOverflow)?;
+        self.generation = self
+            .generation
+            .checked_add(1)
+            .ok_or(AuditError::RelayGenerationOverflow)?;
+        self.slots = [None; AUDIT_RELAY_SLOTS];
+        self.outstanding = 0;
+        self.next_seq = next_seq;
+        self.oldest_seq = self.next_seq;
+        self.credits = 0;
+        Ok(self.checkpoint(current_root, current_seq, context))
+    }
+
+    /// Trusted checkpoint bound to boot/session, exact seq, root, codec
+    /// version, and relay generation.
+    pub fn checkpoint(
+        &self,
+        current_root: [u8; root::ROOT_LEN],
+        current_seq: u64,
+        context: CheckpointAuthContext,
+    ) -> AuditCheckpoint {
+        AuditCheckpoint::seal(
+            self.boot,
+            current_seq,
+            current_root,
+            self.generation,
+            context,
+        )
+        .expect("current relay generation is nonzero")
+    }
+
+    pub(super) const fn generation(&self) -> u64 {
+        self.generation
+    }
+
+    fn slot_index(seq: u64) -> usize {
+        ((seq - 1) % AUDIT_RELAY_SLOTS as u64) as usize
+    }
+
+    fn oldest_buffered_index(&self) -> Option<usize> {
+        (0..self.outstanding)
+            .map(|offset| Self::slot_index(self.oldest_seq + offset as u64))
+            .find(|index| {
+                matches!(
+                    self.slots[*index],
+                    Some(Slot {
+                        state: SlotState::Buffered,
+                        ..
+                    })
+                )
+            })
+    }
+}

--- a/kernel/crates/astrid-native-kernel/src/audit/root.rs
+++ b/kernel/crates/astrid-native-kernel/src/audit/root.rs
@@ -1,0 +1,105 @@
+//! Rolling BLAKE3 root: the only root algorithm in this slice.
+//!
+//! `R_0 = BLAKE3(domain-separated genesis)` and
+//! `R_n = BLAKE3(tag || R_{n-1} || canonical_frame_n)` where the tag binds
+//! the algorithm id, frame-codec version, boot/session identity, and
+//! sequence. The previous root also rides inside the canonical frame for
+//! authenticity, but the fold consumes `R_{n-1}` directly, so there is no
+//! second encoding of the root.
+
+use blake3::Hasher;
+
+use super::types::{BootSessionId, CheckpointAuthContext};
+
+pub(crate) const ROOT_LEN: usize = 32;
+
+pub(crate) const ROOT_ALGORITHM_ID: &[u8] = b"BLAKE3-256";
+pub(crate) const ROOT_DOMAIN_TAG: &[u8] = b"astrid.native-kernel.audit-root.v1";
+pub(crate) const GENESIS_DOMAIN_TAG: &[u8] = b"astrid.native-kernel.audit-genesis.v1";
+pub(crate) const CHECKPOINT_DOMAIN_TAG: &[u8] = b"astrid.native-kernel.audit-checkpoint.v1";
+pub(crate) const ACK_DOMAIN_TAG: &[u8] = b"astrid.native-kernel.audit-ack.v1";
+pub(crate) const VERIFIER_HANDOFF_DOMAIN_TAG: &[u8] =
+    b"astrid.native-kernel.audit-verifier-handoff.v1";
+
+pub(crate) fn genesis(boot: BootSessionId) -> [u8; ROOT_LEN] {
+    let mut hasher = Hasher::new();
+    hasher.update(GENESIS_DOMAIN_TAG);
+    hasher.update(&boot.bytes());
+    hasher.update(&super::CODEC_VERSION.to_le_bytes());
+    hasher.finalize().into()
+}
+
+pub(crate) fn advance(
+    previous_root: [u8; ROOT_LEN],
+    boot: BootSessionId,
+    seq: u64,
+    frame: &[u8],
+) -> [u8; ROOT_LEN] {
+    let mut hasher = Hasher::new();
+    hasher.update(ROOT_DOMAIN_TAG);
+    hasher.update(ROOT_ALGORITHM_ID);
+    hasher.update(&super::CODEC_VERSION.to_le_bytes());
+    hasher.update(&boot.bytes());
+    hasher.update(&seq.to_le_bytes());
+    hasher.update(&previous_root);
+    hasher.update(frame);
+    hasher.finalize().into()
+}
+
+pub(crate) fn checkpoint_tag(
+    boot: BootSessionId,
+    seq: u64,
+    root: [u8; ROOT_LEN],
+    relay_generation: u64,
+    context: &CheckpointAuthContext,
+) -> [u8; ROOT_LEN] {
+    let mut hasher = Hasher::new_keyed(&context.verification_key().bytes());
+    hasher.update(CHECKPOINT_DOMAIN_TAG);
+    hasher.update(&super::CODEC_VERSION.to_le_bytes());
+    hasher.update(&boot.bytes());
+    hasher.update(&seq.to_le_bytes());
+    hasher.update(&root);
+    hasher.update(&relay_generation.to_le_bytes());
+    hasher.update(&context.authority_id().to_le_bytes());
+    hasher.finalize().into()
+}
+
+/// Binds a verifier receipt to the exact canonical frame and source root it
+/// successfully folded. Relay acknowledgements consume this evidence; relay
+/// flow control still never becomes root authority.
+pub(crate) fn ack_tag(
+    boot: BootSessionId,
+    relay_generation: u64,
+    seq: u64,
+    source_root: [u8; ROOT_LEN],
+    frame: &[u8],
+    context: &CheckpointAuthContext,
+) -> [u8; ROOT_LEN] {
+    let mut hasher = Hasher::new_keyed(&context.verification_key().bytes());
+    hasher.update(ACK_DOMAIN_TAG);
+    hasher.update(&super::CODEC_VERSION.to_le_bytes());
+    hasher.update(&context.authority_id().to_le_bytes());
+    hasher.update(&boot.bytes());
+    hasher.update(&relay_generation.to_le_bytes());
+    hasher.update(&seq.to_le_bytes());
+    hasher.update(&source_root);
+    hasher.update(frame);
+    hasher.finalize().into()
+}
+
+/// Keys the kernel minting tag bound into the untrusted verifier handoff.
+/// The verification key never travels inside the handoff; the tag is
+/// checkable only by a holder of the independently trusted kernel-origin
+/// anchor, so a caller-minted handoff cannot authenticate itself.
+pub(crate) fn verifier_handoff_tag(
+    boot: BootSessionId,
+    authority_id: u64,
+    verification_key: &[u8; ROOT_LEN],
+) -> [u8; ROOT_LEN] {
+    let mut hasher = Hasher::new_keyed(verification_key);
+    hasher.update(VERIFIER_HANDOFF_DOMAIN_TAG);
+    hasher.update(&super::CODEC_VERSION.to_le_bytes());
+    hasher.update(&boot.bytes());
+    hasher.update(&authority_id.to_le_bytes());
+    hasher.finalize().into()
+}

--- a/kernel/crates/astrid-native-kernel/src/audit/tests.rs
+++ b/kernel/crates/astrid-native-kernel/src/audit/tests.rs
@@ -1,0 +1,923 @@
+//! Kernel/harness-private regressions for the #1759 audit freeze.
+
+use super::*;
+use crate::ipc::DomainToken;
+use blake3::Hasher;
+
+fn boot() -> BootSessionId {
+    BootSessionId::new([7; 16]).unwrap()
+}
+
+fn secret() -> KernelSecretEntropy {
+    KernelSecretEntropy::new([0x5A; 32]).unwrap()
+}
+
+fn authority() -> AuditAuthority {
+    AuditAuthority::mint(boot(), secret()).unwrap()
+}
+
+fn subject(slot: u64, generation: u64) -> AuditSubject {
+    AuditSubject::from_domain(DomainToken::new(slot, generation).unwrap())
+}
+
+fn domain_event(class: AuditClass) -> AuditEvent {
+    AuditEvent::new(class, subject(0, 1))
+}
+
+fn capability_object(
+    projection_token: u64,
+    slot: usize,
+    generation: u64,
+    object_token: u64,
+) -> AuditObject {
+    AuditObject::capability_instance(
+        projection_token,
+        slot,
+        generation,
+        AuditObjectKind::Endpoint,
+        object_token,
+    )
+    .unwrap()
+}
+
+struct FrameBuf {
+    bytes: [u8; MAX_FRAME_BYTES],
+    len: usize,
+}
+
+impl FrameBuf {
+    fn new(encoded: &[u8]) -> Self {
+        let mut bytes = [0; MAX_FRAME_BYTES];
+        bytes[..encoded.len()].copy_from_slice(encoded);
+        Self {
+            bytes,
+            len: encoded.len(),
+        }
+    }
+
+    fn as_slice(&self) -> &[u8] {
+        &self.bytes[..self.len]
+    }
+}
+
+fn encode_frame(
+    chain_boot: BootSessionId,
+    seq: u64,
+    event: &AuditEvent,
+    prev: Option<[u8; 32]>,
+) -> FrameBuf {
+    let frame = Frame::new(chain_boot, seq, event, prev).unwrap();
+    let mut buf = [0; MAX_FRAME_BYTES];
+    FrameBuf::new(frame.encode(&mut buf).unwrap())
+}
+
+/// Models the independently trusted kernel-origin anchor channel: the
+/// kernel's live context is injected into the verifier directly, never
+/// through the untrusted handoff.
+fn anchor_of(live: AuditAuthority) -> native_audit_verifier::AuthContext {
+    native_audit_verifier::AuthContext::from_trusted_anchor(
+        live.context().authority_id(),
+        live.boot().bytes(),
+        live.context().verification_key().bytes(),
+    )
+    .unwrap()
+}
+
+fn foreign(boot_byte: u8) -> AuditAuthority {
+    AuditAuthority::mint(BootSessionId::new([boot_byte; 16]).unwrap(), secret()).unwrap()
+}
+
+fn host_context() -> native_audit_verifier::AuthContext {
+    anchor_of(authority())
+}
+
+fn host_handoff() -> [u8; native_audit_verifier::AUTHORITY_HANDOFF_BYTES] {
+    authority().verifier_handoff()
+}
+
+fn verifier() -> native_audit_verifier::AuditVerifier {
+    native_audit_verifier::AuditVerifier::genesis(boot().bytes(), host_context(), &host_handoff())
+        .unwrap()
+}
+
+fn genesis_chain(chain_boot: BootSessionId) -> AuditChain {
+    AuditChain::genesis(chain_boot, secret()).unwrap()
+}
+
+#[test]
+fn roundtrip_and_injectivity() {
+    let chain_boot = boot();
+    let genesis = root::genesis(chain_boot);
+    let cases = [
+        domain_event(AuditClass::DomainCreate),
+        domain_event(AuditClass::IpcSend)
+            .with_object(AuditObject::endpoint(2, 5).unwrap())
+            .unwrap(),
+        domain_event(AuditClass::CapabilityDerive)
+            .with_object(capability_object(9, 3, 4, 11))
+            .unwrap()
+            .with_rights(AuditRights::from_bits(0b0101).unwrap()),
+        AuditEvent::denial(
+            subject(1, 2),
+            DenialContext::new(DenialReason::ForeignObject, [1; 8]),
+        ),
+        domain_event(AuditClass::RootCheckpoint)
+            .with_payload(&[0xAA; 64])
+            .unwrap(),
+    ];
+    let encoded = [
+        encode_frame(chain_boot, 1, &cases[0], Some(genesis)),
+        encode_frame(chain_boot, 1, &cases[1], Some(genesis)),
+        encode_frame(chain_boot, 1, &cases[2], Some(genesis)),
+        encode_frame(chain_boot, 1, &cases[3], Some(genesis)),
+        encode_frame(chain_boot, 1, &cases[4], Some(genesis)),
+    ];
+    for bytes in &encoded {
+        let decoded = decode(bytes.as_slice()).unwrap();
+        let mut reencoded_buf = [0; MAX_FRAME_BYTES];
+        let reencoded = decoded.encode(&mut reencoded_buf).unwrap();
+        assert_eq!(reencoded, bytes.as_slice());
+    }
+    for left in 0..encoded.len() {
+        for right in (left + 1)..encoded.len() {
+            assert_ne!(encoded[left].as_slice(), encoded[right].as_slice());
+        }
+    }
+}
+
+#[test]
+fn rejects_malformed_non_canonical_and_disclosing_inputs() {
+    let chain_boot = boot();
+    let event = domain_event(AuditClass::DomainAdmit)
+        .with_object(capability_object(1, 0, 1, 1))
+        .unwrap();
+    let valid = encode_frame(chain_boot, 1, &event, Some(root::genesis(chain_boot)));
+
+    let truncated = &valid.as_slice()[..valid.len - 1];
+    assert!(matches!(decode(truncated), Err(AuditError::MalformedFrame)));
+
+    let mut slack = [0u8; MAX_FRAME_BYTES + 1];
+    slack[..valid.len].copy_from_slice(valid.as_slice());
+    assert!(matches!(
+        decode(&slack[..=valid.len]),
+        Err(AuditError::MalformedFrame)
+    ));
+
+    let mut bad_class = FrameBuf::new(valid.as_slice());
+    let class_index = 4 + 2 + 16 + 8;
+    bad_class.bytes[class_index] = 0;
+    bad_class.bytes[class_index + 1] = 99;
+    assert!(matches!(
+        decode(bad_class.as_slice()),
+        Err(AuditError::MalformedFrame)
+    ));
+
+    let denial = encode_frame(
+        chain_boot,
+        1,
+        &AuditEvent::denial(
+            subject(0, 1),
+            DenialContext::new(DenialReason::StaleIdentity, [0; 8]),
+        ),
+        Some(root::genesis(chain_boot)),
+    );
+    assert!(matches!(
+        decode(denial.as_slice()),
+        Ok(frame) if frame.class() == AuditClass::BoundedDenial && frame.object().is_none()
+    ));
+
+    let denial_event = AuditEvent::new(AuditClass::BoundedDenial, subject(0, 1));
+    assert!(
+        denial_event
+            .with_object(capability_object(1, 0, 1, 1))
+            .is_none()
+    );
+    assert!(AuditObject::capability_instance(1, 0, 1, AuditObjectKind::Domain, 1).is_none());
+}
+
+#[test]
+fn append_folds_with_mandatory_source_root() {
+    let chain_boot = boot();
+    let mut chain = genesis_chain(chain_boot);
+    let mut host_verifier = verifier();
+
+    for expected_seq in 1u64..=5 {
+        let class = match expected_seq {
+            1 => AuditClass::DomainCreate,
+            2 => AuditClass::CapabilityDerive,
+            3 => AuditClass::IpcSend,
+            4 => AuditClass::GenerationAdvance,
+            _ => AuditClass::DomainReclaim,
+        };
+        let event = domain_event(class)
+            .with_object(capability_object(expected_seq, 1, 2, 3))
+            .unwrap();
+        let seq = chain.append(event).unwrap();
+        assert_eq!(seq, expected_seq);
+
+        chain.relay_mut().grant_credits(1).unwrap();
+        let record = chain.relay_mut().take().unwrap();
+        let receipt = host_verifier.fold(record.frame(), record.root()).unwrap();
+        assert_eq!(receipt.seq(), seq);
+        assert_eq!(host_verifier.root(), *chain.root());
+    }
+}
+
+#[test]
+fn tamper_is_invalid_gap_is_incomplete_duplicate_is_invalid() {
+    let chain_boot = boot();
+    let mut chain = genesis_chain(chain_boot);
+    for class in [
+        AuditClass::DomainCreate,
+        AuditClass::DomainAdmit,
+        AuditClass::DomainStart,
+    ] {
+        chain.append(domain_event(class)).unwrap();
+    }
+    let mut records = [FrameBuf::new(&[]), FrameBuf::new(&[]), FrameBuf::new(&[])];
+    let mut roots = [[0; 32]; 3];
+    {
+        chain.relay_mut().grant_credits(3).unwrap();
+        let mut count = 0;
+        while let Some(record) = chain.relay_mut().take() {
+            records[count] = FrameBuf::new(record.frame());
+            roots[count] = record.root();
+            count += 1;
+        }
+        assert_eq!(count, 3);
+    }
+
+    let mut host_verifier = verifier();
+    let mut tampered = FrameBuf::new(records[0].as_slice());
+    let last = tampered.len - 1;
+    tampered.bytes[last] ^= 0xFF;
+    assert!(matches!(
+        host_verifier.fold(tampered.as_slice(), roots[0]),
+        Err(native_audit_verifier::FoldFailure::Invalid(_))
+    ));
+
+    let mut host_verifier = verifier();
+    host_verifier.fold(records[0].as_slice(), roots[0]).unwrap();
+    assert!(matches!(
+        host_verifier.fold(records[2].as_slice(), roots[2]),
+        Err(native_audit_verifier::FoldFailure::Incomplete(
+            native_audit_verifier::IncompleteReason::SequenceGap
+        ))
+    ));
+
+    let mut host_verifier = verifier();
+    host_verifier.fold(records[0].as_slice(), roots[0]).unwrap();
+    assert!(matches!(
+        host_verifier.fold(records[0].as_slice(), roots[0]),
+        Err(native_audit_verifier::FoldFailure::Invalid(
+            native_audit_verifier::InvalidReason::DuplicateOrReorder
+        ))
+    ));
+}
+
+#[test]
+fn foreign_boot_and_missing_previous_root_are_invalid() {
+    let chain_boot = boot();
+    let mut chain = genesis_chain(chain_boot);
+    chain
+        .append(domain_event(AuditClass::DomainCreate))
+        .unwrap();
+    let foreign_authority = foreign(8);
+    let mut foreign = native_audit_verifier::AuditVerifier::genesis(
+        [8; 16],
+        anchor_of(foreign_authority),
+        &foreign_authority.verifier_handoff(),
+    )
+    .unwrap();
+    chain.relay_mut().grant_credits(1).unwrap();
+    let record = chain.relay_mut().take().unwrap();
+    assert!(matches!(
+        foreign.fold(record.frame(), record.root()),
+        Err(native_audit_verifier::FoldFailure::Invalid(
+            native_audit_verifier::InvalidReason::ForeignBoot
+        ))
+    ));
+
+    let mut host_verifier = verifier();
+    let event = domain_event(AuditClass::DomainCreate);
+    let frame = Frame::new(chain_boot, 1, &event, None).unwrap();
+    let mut buf = [0; MAX_FRAME_BYTES];
+    let encoded = frame.encode(&mut buf).unwrap();
+    let expected = root::advance(root::genesis(chain_boot), chain_boot, 1, encoded);
+    assert!(matches!(
+        host_verifier.fold(encoded, expected),
+        Err(native_audit_verifier::FoldFailure::Invalid(
+            native_audit_verifier::InvalidReason::PreviousRootMismatch
+        ))
+    ));
+}
+
+#[test]
+fn sequence_overflow_fails_closed_without_commit() {
+    let chain_boot = boot();
+    let checkpoint =
+        AuditCheckpoint::seal(chain_boot, u64::MAX - 1, [9; 32], 1, authority().context()).unwrap();
+    let mut chain = AuditChain::restore(checkpoint, authority()).unwrap();
+    let before = (chain.seq(), *chain.root());
+    assert_eq!(
+        chain.append(domain_event(AuditClass::DomainCreate)),
+        Err(AuditError::SequenceOverflow)
+    );
+    assert_eq!((chain.seq(), *chain.root()), before);
+}
+
+#[test]
+fn ack_requires_take_in_flight_and_matching_folded_root() {
+    let chain_boot = boot();
+    let mut chain = genesis_chain(chain_boot);
+    let mut host_verifier = verifier();
+    chain
+        .append(domain_event(AuditClass::DomainCreate))
+        .unwrap();
+    chain.append(domain_event(AuditClass::DomainAdmit)).unwrap();
+
+    chain.relay_mut().grant_credits(1).unwrap();
+    let first = chain.relay_mut().take().unwrap();
+    assert_eq!(chain.relay().redeliver().count(), 2);
+    let first_receipt = host_verifier.fold(first.frame(), first.root()).unwrap();
+    assert_eq!(
+        chain.ack(first.seq(), first.root(), [0; 32]),
+        Err(AuditError::RootMismatch)
+    );
+    chain
+        .ack(
+            first.seq(),
+            first_receipt.folded_root(),
+            first_receipt.ack_tag(),
+        )
+        .unwrap();
+
+    assert_eq!(
+        chain.ack(
+            first.seq(),
+            first_receipt.folded_root(),
+            first_receipt.ack_tag()
+        ),
+        Err(AuditError::RelayStaleCursor)
+    );
+    chain.relay_mut().grant_credits(1).unwrap();
+    let second = chain.relay_mut().take().unwrap();
+    let second_receipt = host_verifier.fold(second.frame(), second.root()).unwrap();
+    chain
+        .ack(
+            second.seq(),
+            second_receipt.folded_root(),
+            second_receipt.ack_tag(),
+        )
+        .unwrap();
+}
+
+#[test]
+fn ack_before_take_does_not_retire_a_buffered_slot() {
+    let chain_boot = boot();
+    let mut chain = genesis_chain(chain_boot);
+    chain
+        .append(domain_event(AuditClass::DomainCreate))
+        .unwrap();
+    let before = chain.relay().redeliver().count();
+    assert_eq!(before, 1);
+    assert_eq!(
+        chain.ack(1, [0; 32], [0; 32]),
+        Err(AuditError::RelayNotInFlight)
+    );
+    assert_eq!(chain.relay().redeliver().count(), before);
+    chain.relay_mut().grant_credits(1).unwrap();
+    assert!(chain.relay_mut().take().is_some());
+}
+
+#[test]
+fn restored_checkpoint_preserves_trusted_relay_generation() {
+    let chain_boot = boot();
+    let mut chain = genesis_chain(chain_boot);
+    for _ in 0..AUDIT_RELAY_SLOTS {
+        chain
+            .append(domain_event(AuditClass::DomainReclaim))
+            .unwrap();
+    }
+    let checkpoint = chain.resync().unwrap();
+    assert_eq!(checkpoint.relay_generation(), 2);
+
+    let restored = AuditChain::restore(checkpoint, authority()).unwrap();
+    assert_eq!(restored.boot(), checkpoint.boot());
+    assert_eq!(restored.seq(), checkpoint.seq());
+    assert_eq!(*restored.root(), checkpoint.root());
+    assert_eq!(restored.relay().generation(), 2);
+    assert!(restored.relay().redeliver().next().is_none());
+}
+
+#[test]
+fn reserved_headroom_and_overflow_fail_before_atomic_commit() {
+    let chain_boot = boot();
+    let mut chain = genesis_chain(chain_boot);
+    for _ in 0..(AUDIT_RELAY_SLOTS - MAX_TERMINAL_RECORDS_PER_BATCH) {
+        chain.append(domain_event(AuditClass::DomainEnter)).unwrap();
+    }
+    assert_eq!(chain.seq(), 35);
+
+    let before = (
+        chain.seq(),
+        *chain.root(),
+        chain.relay().redeliver().count(),
+    );
+    assert_eq!(
+        chain.append(domain_event(AuditClass::DomainEnter)),
+        Err(AuditError::HandoffIncomplete)
+    );
+    assert_eq!(
+        (
+            chain.seq(),
+            *chain.root(),
+            chain.relay().redeliver().count()
+        ),
+        before
+    );
+
+    for expected_seq in 36u64..=(AUDIT_RELAY_SLOTS as u64) {
+        let seq = chain
+            .append(domain_event(AuditClass::DomainReclaim))
+            .unwrap();
+        assert_eq!(seq, expected_seq);
+    }
+    let full = (
+        chain.seq(),
+        *chain.root(),
+        chain.relay().redeliver().count(),
+    );
+    assert_eq!(
+        chain.append(domain_event(AuditClass::DomainReclaim)),
+        Err(AuditError::HandoffIncomplete)
+    );
+    assert_eq!(
+        (
+            chain.seq(),
+            *chain.root(),
+            chain.relay().redeliver().count()
+        ),
+        full
+    );
+    assert_eq!(chain.relay().redeliver().count(), AUDIT_RELAY_SLOTS);
+}
+
+#[test]
+fn verifier_sequence_overflow_is_atomic_and_repeatable() {
+    let checkpoint =
+        AuditCheckpoint::seal(boot(), u64::MAX - 1, [9; 32], 1, authority().context()).unwrap();
+    let mut wire = [0; native_audit_verifier::CHECKPOINT_WIRE_BYTES];
+    let bytes = encode_checkpoint(&checkpoint, authority().context(), &mut wire).unwrap();
+    let mut verifier = native_audit_verifier::AuditVerifier::from_checkpoint(
+        bytes,
+        host_context(),
+        &host_handoff(),
+    )
+    .unwrap();
+    let before = (verifier.next_seq(), verifier.root());
+    let event = domain_event(AuditClass::DomainCreate);
+    let frame = Frame::new(boot(), u64::MAX, &event, Some([9; 32])).unwrap();
+    let mut buf = [0; MAX_FRAME_BYTES];
+    let encoded = frame.encode(&mut buf).unwrap();
+    let claimed = root::advance([9; 32], boot(), u64::MAX, encoded);
+    assert_eq!(
+        verifier.fold(encoded, claimed),
+        Err(native_audit_verifier::FoldFailure::SequenceOverflow)
+    );
+    assert_eq!(
+        verifier.fold(encoded, claimed),
+        Err(native_audit_verifier::FoldFailure::SequenceOverflow)
+    );
+    assert_eq!((verifier.next_seq(), verifier.root()), before);
+}
+
+#[test]
+fn explicitly_mismatched_previous_root_is_invalid() {
+    let chain_boot = boot();
+    let wrong_previous = [0xAA; 32];
+    let event = domain_event(AuditClass::DomainCreate);
+    let frame = Frame::new(chain_boot, 1, &event, Some(wrong_previous)).unwrap();
+    let mut buf = [0; MAX_FRAME_BYTES];
+    let encoded = frame.encode(&mut buf).unwrap();
+    let claimed = root::advance(wrong_previous, chain_boot, 1, encoded);
+    let mut host_verifier = verifier();
+    assert!(matches!(
+        host_verifier.fold(encoded, claimed),
+        Err(native_audit_verifier::FoldFailure::Invalid(
+            native_audit_verifier::InvalidReason::PreviousRootMismatch
+        ))
+    ));
+}
+
+#[test]
+fn kernel_and_verifier_reject_zero_relay_generation() {
+    let chain_boot = boot();
+    let chain = genesis_chain(chain_boot);
+    let seq = chain.seq();
+    let root = *chain.root();
+    let mut wire = [0; native_audit_verifier::CHECKPOINT_WIRE_BYTES];
+    encode_checkpoint(&chain.checkpoint(), authority().context(), &mut wire).unwrap();
+    let generation_offset = 4 + 2 + 16 + 8 + 32;
+    wire[generation_offset..generation_offset + 8].copy_from_slice(&0u64.to_le_bytes());
+    let zero_tag = root::checkpoint_tag(chain_boot, seq, root, 0, &authority().context());
+    let tag_offset = native_audit_verifier::CHECKPOINT_WIRE_BYTES - 32;
+    wire[tag_offset..].copy_from_slice(&zero_tag);
+
+    assert_eq!(
+        decode_checkpoint(&wire, authority().context()),
+        Err(AuditError::MalformedFrame)
+    );
+    assert_eq!(
+        native_audit_verifier::verify_checkpoint(&wire, &host_context()),
+        Err(native_audit_verifier::VerifyFailure::Malformed)
+    );
+    assert_eq!(
+        AuditCheckpoint::seal(chain_boot, seq, root, 0, authority().context()),
+        Err(AuditError::MalformedFrame)
+    );
+}
+
+#[test]
+fn resync_is_generation_bound_and_restores_flow() {
+    let chain_boot = boot();
+    let mut chain = genesis_chain(chain_boot);
+    for _ in 0..AUDIT_RELAY_SLOTS {
+        chain
+            .append(domain_event(AuditClass::DomainReclaim))
+            .unwrap();
+    }
+    let checkpoint = chain.resync().unwrap();
+    assert_eq!(checkpoint.relay_generation(), 2);
+
+    let mut wire = [0; native_audit_verifier::CHECKPOINT_WIRE_BYTES];
+    let bytes = encode_checkpoint(&checkpoint, authority().context(), &mut wire).unwrap();
+    let mut host_verifier = native_audit_verifier::AuditVerifier::from_checkpoint(
+        bytes,
+        host_context(),
+        &host_handoff(),
+    )
+    .unwrap();
+    assert_eq!(host_verifier.root(), *chain.root());
+
+    let seq = chain.append(domain_event(AuditClass::DomainEnter)).unwrap();
+    chain.relay_mut().grant_credits(1).unwrap();
+    let record = chain.relay_mut().take().unwrap();
+    assert_eq!(record.seq(), seq);
+    let receipt = host_verifier.fold(record.frame(), record.root()).unwrap();
+    assert_eq!(receipt.seq(), seq);
+}
+
+#[test]
+fn checkpoint_is_kernel_authenticated_and_state_bound() {
+    let chain_boot = boot();
+    let mut chain = genesis_chain(chain_boot);
+    chain
+        .append(domain_event(AuditClass::DomainCreate))
+        .unwrap();
+    let checkpoint = chain.checkpoint();
+    assert!(checkpoint.verify_tag(authority().context()));
+
+    let mut wire = [0; native_audit_verifier::CHECKPOINT_WIRE_BYTES];
+    let bytes = encode_checkpoint(&checkpoint, authority().context(), &mut wire).unwrap();
+    assert!(
+        native_audit_verifier::AuditVerifier::from_checkpoint(
+            bytes,
+            host_context(),
+            &host_handoff()
+        )
+        .is_ok()
+    );
+
+    // Replace the sealed tag with the rejected verifier-local unkeyed tag.
+    let mut unkeyed = [0; native_audit_verifier::CHECKPOINT_WIRE_BYTES];
+    unkeyed.copy_from_slice(bytes);
+    let mut hasher = Hasher::new();
+    hasher.update(root::CHECKPOINT_DOMAIN_TAG);
+    hasher.update(&super::CODEC_VERSION.to_le_bytes());
+    hasher.update(&checkpoint.boot().bytes());
+    hasher.update(&checkpoint.seq().to_le_bytes());
+    hasher.update(&checkpoint.root());
+    hasher.update(&checkpoint.relay_generation().to_le_bytes());
+    hasher.update(&checkpoint.authority_id().to_le_bytes());
+    let unkeyed_tag: [u8; 32] = hasher.finalize().into();
+    let tag_start = native_audit_verifier::CHECKPOINT_WIRE_BYTES - root::ROOT_LEN;
+    unkeyed[tag_start..].copy_from_slice(&unkeyed_tag);
+    assert_eq!(
+        native_audit_verifier::verify_checkpoint(&unkeyed, &host_context()),
+        Err(native_audit_verifier::VerifyFailure::CheckpointMismatch)
+    );
+    assert_eq!(
+        decode_checkpoint(&unkeyed, authority().context()),
+        Err(AuditError::CheckpointMismatch)
+    );
+    assert_eq!(
+        decode_checkpoint(bytes, authority().context()).unwrap(),
+        checkpoint
+    );
+}
+
+#[test]
+fn foreign_or_arbitrary_context_cannot_authenticate_or_retire() {
+    let chain_boot = boot();
+    let mut chain = genesis_chain(chain_boot);
+    chain
+        .append(domain_event(AuditClass::DomainCreate))
+        .unwrap();
+
+    let mut wire = [0; native_audit_verifier::CHECKPOINT_WIRE_BYTES];
+    let checkpoint_wire =
+        encode_checkpoint(&chain.checkpoint(), authority().context(), &mut wire).unwrap();
+    let arbitrary_handoff = [7; native_audit_verifier::AUTHORITY_HANDOFF_BYTES];
+    assert_eq!(
+        host_context().bind_handoff(&arbitrary_handoff),
+        Err(native_audit_verifier::VerifyFailure::Malformed)
+    );
+
+    let foreign_authority = foreign(8);
+    let foreign_context = anchor_of(foreign_authority);
+    assert!(matches!(
+        native_audit_verifier::AuditVerifier::genesis(
+            chain_boot.bytes(),
+            foreign_context,
+            &foreign_authority.verifier_handoff()
+        ),
+        Err(native_audit_verifier::VerifyFailure::Malformed)
+    ));
+    assert_eq!(
+        native_audit_verifier::verify_checkpoint(checkpoint_wire, &foreign_context),
+        Err(native_audit_verifier::VerifyFailure::Malformed)
+    );
+    assert_eq!(
+        decode_checkpoint(checkpoint_wire, foreign_authority.context()),
+        Err(AuditError::CheckpointMismatch)
+    );
+
+    chain.relay_mut().grant_credits(1).unwrap();
+    let record = chain.relay_mut().take().unwrap();
+    assert_eq!(
+        chain.ack(record.seq(), record.root(), [0; 32]),
+        Err(AuditError::RootMismatch)
+    );
+    assert_eq!(chain.relay().redeliver().count(), 1);
+}
+
+#[test]
+fn handoff_is_untrusted_binding_without_verification_material() {
+    let live = authority();
+    let key = live.context().verification_key().bytes();
+    let handoff = live.verifier_handoff();
+
+    assert_eq!(
+        handoff.len(),
+        native_audit_verifier::AUTHORITY_HANDOFF_BYTES
+    );
+    assert_eq!(&handoff[..8], b"ASAUDCTX");
+    assert_eq!(
+        u64::from_le_bytes(handoff[8..16].try_into().unwrap()),
+        live.context().authority_id()
+    );
+    assert_eq!(&handoff[16..32], &boot().bytes());
+    // The kernel verification key must not ride in any window of the
+    // untrusted handoff.
+    assert!(handoff.windows(32).all(|window| window != key));
+
+    assert_eq!(host_context().bind_handoff(&handoff), Ok(()));
+    assert!(
+        native_audit_verifier::AuditVerifier::genesis(boot().bytes(), host_context(), &handoff)
+            .is_ok()
+    );
+}
+
+#[test]
+fn structurally_valid_self_authenticated_handoff_is_rejected() {
+    let chain_boot = boot();
+    let live = authority();
+    let attacker_key = [0xB0; 32];
+
+    // Structurally valid: correct magic, the live authority id and boot,
+    // and a tag the attacker computed under a self-chosen key.
+    let mut forged = [0; native_audit_verifier::AUTHORITY_HANDOFF_BYTES];
+    forged[..8].copy_from_slice(b"ASAUDCTX");
+    forged[8..16].copy_from_slice(&live.context().authority_id().to_le_bytes());
+    forged[16..32].copy_from_slice(&chain_boot.bytes());
+    let attacker_tag =
+        root::verifier_handoff_tag(chain_boot, live.context().authority_id(), &attacker_key);
+    forged[32..].copy_from_slice(&attacker_tag);
+
+    assert_eq!(
+        host_context().bind_handoff(&forged),
+        Err(native_audit_verifier::VerifyFailure::HandoffUnbound)
+    );
+    assert!(matches!(
+        native_audit_verifier::AuditVerifier::genesis(chain_boot.bytes(), host_context(), &forged),
+        Err(native_audit_verifier::VerifyFailure::HandoffUnbound)
+    ));
+
+    // A self-consistent tag under a foreign boot fails the identity binding.
+    let foreign_boot = foreign(9);
+    let mut foreign = forged;
+    foreign[16..32].copy_from_slice(&foreign_boot.boot().bytes());
+    let foreign_tag = root::verifier_handoff_tag(
+        foreign_boot.boot(),
+        live.context().authority_id(),
+        &attacker_key,
+    );
+    foreign[32..].copy_from_slice(&foreign_tag);
+    assert_eq!(
+        host_context().bind_handoff(&foreign),
+        Err(native_audit_verifier::VerifyFailure::HandoffUnbound)
+    );
+}
+
+#[test]
+fn observed_public_derivation_cannot_forge_binding_or_material() {
+    let chain_boot = boot();
+    let live = authority();
+    let handoff = live.verifier_handoff();
+    let genuine_anchor = host_context();
+
+    // Reconstruct the rejected public-only derivation from exactly the
+    // fields an observer can read out of the untrusted handoff.
+    let observed_id = u64::from_le_bytes(handoff[8..16].try_into().expect("fixed handoff layout"));
+    let mut old_key_hasher = Hasher::new();
+    old_key_hasher.update(b"astrid.native-kernel.audit-authority-root.v1");
+    old_key_hasher.update(&handoff[16..32]);
+    old_key_hasher.update(b"astrid.native-kernel.audit-authority-key.v1");
+    old_key_hasher.update(&observed_id.to_le_bytes());
+    let old_key: [u8; 32] = old_key_hasher.finalize().into();
+
+    let mut forged_handoff = handoff;
+    forged_handoff[32..].copy_from_slice(&root::verifier_handoff_tag(
+        chain_boot,
+        observed_id,
+        &old_key,
+    ));
+    assert_eq!(
+        genuine_anchor.bind_handoff(&forged_handoff),
+        Err(native_audit_verifier::VerifyFailure::HandoffUnbound)
+    );
+    assert!(matches!(
+        native_audit_verifier::AuditVerifier::genesis(
+            chain_boot.bytes(),
+            genuine_anchor,
+            &forged_handoff
+        ),
+        Err(native_audit_verifier::VerifyFailure::HandoffUnbound)
+    ));
+
+    let mut chain = genesis_chain(chain_boot);
+    chain
+        .append(domain_event(AuditClass::DomainCreate))
+        .unwrap();
+    let checkpoint = chain.checkpoint();
+    let mut genuine_wire = [0; native_audit_verifier::CHECKPOINT_WIRE_BYTES];
+    let genuine_wire = encode_checkpoint(&checkpoint, live.context(), &mut genuine_wire).unwrap();
+    let mut forged_checkpoint = [0; native_audit_verifier::CHECKPOINT_WIRE_BYTES];
+    forged_checkpoint.copy_from_slice(genuine_wire);
+
+    let mut forged_tag_hasher = Hasher::new_keyed(&old_key);
+    forged_tag_hasher.update(root::CHECKPOINT_DOMAIN_TAG);
+    forged_tag_hasher.update(&super::CODEC_VERSION.to_le_bytes());
+    forged_tag_hasher.update(&checkpoint.boot().bytes());
+    forged_tag_hasher.update(&checkpoint.seq().to_le_bytes());
+    forged_tag_hasher.update(&checkpoint.root());
+    forged_tag_hasher.update(&checkpoint.relay_generation().to_le_bytes());
+    forged_tag_hasher.update(&checkpoint.authority_id().to_le_bytes());
+    let forged_tag: [u8; 32] = forged_tag_hasher.finalize().into();
+    let tag_offset = native_audit_verifier::CHECKPOINT_WIRE_BYTES - root::ROOT_LEN;
+    forged_checkpoint[tag_offset..].copy_from_slice(&forged_tag);
+
+    assert_eq!(
+        native_audit_verifier::verify_checkpoint(&forged_checkpoint, &genuine_anchor),
+        Err(native_audit_verifier::VerifyFailure::CheckpointMismatch)
+    );
+    assert!(matches!(
+        native_audit_verifier::AuditVerifier::from_checkpoint(
+            &forged_checkpoint,
+            genuine_anchor,
+            &handoff
+        ),
+        Err(native_audit_verifier::VerifyFailure::CheckpointMismatch)
+    ));
+
+    chain.relay_mut().grant_credits(1).unwrap();
+    let record = chain.relay_mut().take().unwrap();
+    let mut forged_ack_hasher = Hasher::new_keyed(&old_key);
+    forged_ack_hasher.update(root::ACK_DOMAIN_TAG);
+    forged_ack_hasher.update(&super::CODEC_VERSION.to_le_bytes());
+    forged_ack_hasher.update(&observed_id.to_le_bytes());
+    forged_ack_hasher.update(&chain_boot.bytes());
+    forged_ack_hasher.update(&chain.relay().generation().to_le_bytes());
+    forged_ack_hasher.update(&record.seq().to_le_bytes());
+    forged_ack_hasher.update(&record.root());
+    forged_ack_hasher.update(record.frame());
+    let forged_ack: [u8; 32] = forged_ack_hasher.finalize().into();
+
+    assert_eq!(
+        chain.ack(record.seq(), record.root(), forged_ack),
+        Err(AuditError::RootMismatch)
+    );
+    assert_eq!(chain.relay().redeliver().count(), 1);
+}
+
+#[test]
+fn checkpoint_under_forged_context_is_rejected() {
+    let chain_boot = boot();
+    // Arbitrary attacker-chosen root and sequence sealed under an
+    // attacker-chosen key reusing only the public identity fields.
+    let forged_key = [0xB0; 32];
+    let mut hasher = Hasher::new_keyed(&forged_key);
+    hasher.update(root::CHECKPOINT_DOMAIN_TAG);
+    hasher.update(&super::CODEC_VERSION.to_le_bytes());
+    hasher.update(&chain_boot.bytes());
+    hasher.update(&999u64.to_le_bytes());
+    hasher.update(&[0xAA; root::ROOT_LEN]);
+    hasher.update(&1u64.to_le_bytes());
+    hasher.update(&authority().context().authority_id().to_le_bytes());
+    let forged_tag: [u8; 32] = hasher.finalize().into();
+
+    let mut wire = [0; native_audit_verifier::CHECKPOINT_WIRE_BYTES];
+    let body_len = (native_audit_verifier::CHECKPOINT_WIRE_BYTES - 4) as u32;
+    wire[0..4].copy_from_slice(&body_len.to_le_bytes());
+    let mut pos = 4;
+    wire[pos..pos + 2].copy_from_slice(&super::CODEC_VERSION.to_le_bytes());
+    pos += 2;
+    wire[pos..pos + 16].copy_from_slice(&chain_boot.bytes());
+    pos += 16;
+    wire[pos..pos + 8].copy_from_slice(&999u64.to_le_bytes());
+    pos += 8;
+    wire[pos..pos + root::ROOT_LEN].copy_from_slice(&[0xAA; root::ROOT_LEN]);
+    pos += root::ROOT_LEN;
+    wire[pos..pos + 8].copy_from_slice(&1u64.to_le_bytes());
+    pos += 8;
+    wire[pos..pos + 8].copy_from_slice(&authority().context().authority_id().to_le_bytes());
+    pos += 8;
+    wire[pos..].copy_from_slice(&forged_tag);
+
+    assert_eq!(
+        native_audit_verifier::verify_checkpoint(&wire, &host_context()),
+        Err(native_audit_verifier::VerifyFailure::CheckpointMismatch)
+    );
+    assert!(matches!(
+        native_audit_verifier::AuditVerifier::from_checkpoint(
+            &wire,
+            host_context(),
+            &host_handoff()
+        ),
+        Err(native_audit_verifier::VerifyFailure::CheckpointMismatch)
+    ));
+    assert_eq!(
+        decode_checkpoint(&wire, authority().context()),
+        Err(AuditError::CheckpointMismatch)
+    );
+}
+
+#[test]
+fn forged_retirement_receipt_is_rejected() {
+    let chain_boot = boot();
+    let mut chain = genesis_chain(chain_boot);
+    chain
+        .append(domain_event(AuditClass::DomainCreate))
+        .unwrap();
+    let mut host_verifier = verifier();
+
+    chain.relay_mut().grant_credits(1).unwrap();
+    let record = chain.relay_mut().take().unwrap();
+    let genuine = host_verifier.fold(record.frame(), record.root()).unwrap();
+
+    // A receipt minted under an attacker-chosen key fails even with the
+    // correct folded root, sequence, frame, and source root.
+    let forged_key = [0xB0; 32];
+    let mut hasher = Hasher::new_keyed(&forged_key);
+    hasher.update(root::ACK_DOMAIN_TAG);
+    hasher.update(&super::CODEC_VERSION.to_le_bytes());
+    hasher.update(&authority().context().authority_id().to_le_bytes());
+    hasher.update(&chain_boot.bytes());
+    hasher.update(&chain.relay().generation().to_le_bytes());
+    hasher.update(&record.seq().to_le_bytes());
+    hasher.update(&record.root());
+    hasher.update(record.frame());
+    let forged_tag: [u8; 32] = hasher.finalize().into();
+
+    assert_eq!(
+        chain.ack(record.seq(), record.root(), forged_tag),
+        Err(AuditError::RootMismatch)
+    );
+    assert_eq!(chain.relay().redeliver().count(), 1);
+
+    // The genuine verifier receipt still retires exactly the in-flight
+    // record.
+    chain
+        .ack(record.seq(), genuine.folded_root(), genuine.ack_tag())
+        .unwrap();
+    assert_eq!(chain.relay().redeliver().count(), 0);
+}
+
+#[test]
+fn batch_reserve_is_static_and_inside_the_window() {
+    assert_eq!(MAX_TERMINAL_RECORDS_PER_BATCH, 29);
+    // Statically re-proves the relay's own compile-time headroom invariant
+    // from the test side, keeping the reserve story falsifiable here too.
+    const { assert!(AUDIT_RELAY_SLOTS >= MAX_TERMINAL_RECORDS_PER_BATCH) }
+}

--- a/kernel/crates/astrid-native-kernel/src/audit/types.rs
+++ b/kernel/crates/astrid-native-kernel/src/audit/types.rs
@@ -1,0 +1,786 @@
+//! Typed identities, event classes, and capacity derivation for the private
+//! audit chain.
+
+use core::num::NonZeroU64;
+
+use blake3::Hasher;
+
+use super::root;
+use crate::ipc::DomainToken;
+
+/// Restated landed #1705 protocol ceilings used for static capacity
+/// derivation only. If the landed pools change, this derivation must be
+/// recalculated before the audit relay remains sound (#1759 freeze).
+pub(crate) const AUDIT_DOMAIN_SLOTS: usize = 2;
+pub(crate) const AUDIT_CAP_SLOTS_PER_DOMAIN: usize = 8;
+pub(crate) const AUDIT_ENDPOINT_POOL: usize = 4;
+pub(crate) const AUDIT_CAP_OBJECT_POOL: usize = 16;
+pub(crate) const AUDIT_QUEUES_PER_ENDPOINT: usize = 2;
+/// Landed message payload ceiling. Audit payloads never exceed it.
+pub(crate) const AUDIT_MAX_PAYLOAD: usize = 64;
+
+const _: () = assert!(
+    AUDIT_DOMAIN_SLOTS * AUDIT_CAP_SLOTS_PER_DOMAIN == AUDIT_CAP_OBJECT_POOL,
+    "landed domain and capability pools disagree with the audit capacity derivation",
+);
+
+/// Maximum mandatory terminal/invalidation records one admitted atomic
+/// mutation batch can produce at the frozen ceilings: mass invalidation of
+/// every capability-instance slot of both domain slots, every endpoint, both
+/// queues on every endpoint, and the dying domain identity itself. This is
+/// the statically derived relay reserve, never a single global death slot.
+pub(crate) const MAX_TERMINAL_RECORDS_PER_BATCH: usize = AUDIT_DOMAIN_SLOTS
+    * AUDIT_CAP_SLOTS_PER_DOMAIN
+    + AUDIT_ENDPOINT_POOL
+    + AUDIT_ENDPOINT_POOL * AUDIT_QUEUES_PER_ENDPOINT
+    + 1;
+
+/// Boot-scoped audit session identity. A kernel restart mints a new identity;
+/// this slice claims no cross-boot durable continuity.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct BootSessionId([u8; 16]);
+
+impl BootSessionId {
+    /// Rejects the all-zero identity so two boots can never share one chain.
+    pub const fn new(bytes: [u8; 16]) -> Option<Self> {
+        let mut index = 0;
+        let mut any_nonzero = false;
+        while index < bytes.len() {
+            if bytes[index] != 0 {
+                any_nonzero = true;
+            }
+            index += 1;
+        }
+        if any_nonzero { Some(Self(bytes)) } else { None }
+    }
+
+    pub const fn bytes(self) -> [u8; 16] {
+        self.0
+    }
+}
+
+const AUTHORITY_ROOT_DOMAIN: &[u8] = b"astrid.native-kernel.audit-authority-root.v1";
+const AUTHORITY_ID_DOMAIN: &[u8] = b"astrid.native-kernel.audit-authority-id.v1";
+const AUTHORITY_KEY_DOMAIN: &[u8] = b"astrid.native-kernel.audit-authority-key.v1";
+
+/// Kernel-held entropy supplied to one audit authority. It is never part of
+/// the canonical frames, checkpoint wire, or untrusted handoff. A dropped
+/// value erases its bytes; no constructor exports or copies the input.
+pub(crate) struct KernelSecretEntropy([u8; 32]);
+
+impl KernelSecretEntropy {
+    pub(crate) fn new(bytes: [u8; 32]) -> Option<Self> {
+        if bytes.iter().all(|byte| *byte == 0) {
+            return None;
+        }
+        Some(Self(bytes))
+    }
+
+    const fn bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+impl Drop for KernelSecretEntropy {
+    fn drop(&mut self) {
+        self.0.fill(0);
+    }
+}
+
+impl core::fmt::Debug for KernelSecretEntropy {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("KernelSecretEntropy(REDACTED)")
+    }
+}
+
+/// Typed authentication key derived from kernel-held entropy. Its bytes are
+/// exposed only to the modeled independently trusted anchor; they never
+/// enter a frame, checkpoint wire, or untrusted handoff.
+#[derive(Clone, Copy)]
+pub(crate) struct VerificationKey([u8; 32]);
+
+impl VerificationKey {
+    pub(crate) fn new(bytes: [u8; 32]) -> Option<Self> {
+        if bytes.iter().all(|byte| *byte == 0) {
+            return None;
+        }
+        Some(Self(bytes))
+    }
+
+    pub(crate) const fn bytes(self) -> [u8; 32] {
+        self.0
+    }
+}
+
+impl core::fmt::Debug for VerificationKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("VerificationKey(REDACTED)")
+    }
+}
+
+/// Opaque kernel-owned authentication context. It is derived inside the
+/// kernel from live boot identity and kernel-held entropy; the public boot
+/// identity alone is insufficient to reconstruct either its id or key. Its
+/// authority id is part of every checkpoint tag.
+///
+/// The verification key stays kernel-side for the whole boot/session. It
+/// reaches the verifier only through an independently trusted kernel-origin
+/// channel that this unwired slice models by injection; the untrusted
+/// handoff carries none of it. Production anchor delivery and key
+/// lifecycle remain named #1759 residuals, and no fixed production secret
+/// is introduced.
+#[derive(Clone, Copy)]
+pub(crate) struct CheckpointAuthContext {
+    authority_id: u64,
+    verification_key: VerificationKey,
+}
+
+impl CheckpointAuthContext {
+    fn mint(boot: BootSessionId, secret: KernelSecretEntropy) -> Option<Self> {
+        let mut id_hasher = Hasher::new();
+        id_hasher.update(AUTHORITY_ROOT_DOMAIN);
+        id_hasher.update(secret.bytes());
+        id_hasher.update(&boot.bytes());
+        id_hasher.update(AUTHORITY_ID_DOMAIN);
+        let id_digest: [u8; 32] = id_hasher.finalize().into();
+        let mut authority_id = u64::from_le_bytes(id_digest[..8].try_into().unwrap());
+        if authority_id == 0 {
+            authority_id = 1;
+        }
+
+        let mut key_hasher = Hasher::new();
+        key_hasher.update(AUTHORITY_ROOT_DOMAIN);
+        key_hasher.update(secret.bytes());
+        key_hasher.update(&boot.bytes());
+        key_hasher.update(AUTHORITY_KEY_DOMAIN);
+        key_hasher.update(&authority_id.to_le_bytes());
+        let verification_key = VerificationKey::new(key_hasher.finalize().into())?;
+        Some(Self {
+            authority_id,
+            verification_key,
+        })
+    }
+
+    pub(crate) const fn authority_id(self) -> u64 {
+        self.authority_id
+    }
+
+    pub(crate) const fn verification_key(self) -> VerificationKey {
+        self.verification_key
+    }
+}
+
+impl core::fmt::Debug for CheckpointAuthContext {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("CheckpointAuthContext(REDACTED)")
+    }
+}
+
+/// Kernel-minted authority for one live boot/session. Its verifier handoff
+/// is untrusted binding evidence: it names the authority and carries a
+/// keyed minting tag, never verification material, so it cannot
+/// authenticate itself.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct AuditAuthority {
+    boot: BootSessionId,
+    context: CheckpointAuthContext,
+}
+
+/// Fixed wire size of the untrusted verifier handoff binding: magic,
+/// authority id, boot/session identity, and the keyed tag. No key material.
+const VERIFIER_HANDOFF_BYTES: usize = 8 + 8 + 16 + root::ROOT_LEN;
+
+impl AuditAuthority {
+    pub fn mint(boot: BootSessionId, secret: KernelSecretEntropy) -> Option<Self> {
+        Some(Self {
+            boot,
+            context: CheckpointAuthContext::mint(boot, secret)?,
+        })
+    }
+
+    pub const fn boot(self) -> BootSessionId {
+        self.boot
+    }
+
+    pub(crate) const fn context(self) -> CheckpointAuthContext {
+        self.context
+    }
+
+    /// Untrusted binding evidence accepted by `native-audit-verifier`. It
+    /// carries no verification material: the tag is checkable only against
+    /// the independently trusted kernel-origin anchor, so a caller-minted
+    /// handoff cannot authenticate itself. The private first-slice layout
+    /// carries no production lifecycle provisioning claim.
+    pub fn verifier_handoff(self) -> [u8; VERIFIER_HANDOFF_BYTES] {
+        let mut handoff = [0; VERIFIER_HANDOFF_BYTES];
+        handoff[..8].copy_from_slice(b"ASAUDCTX");
+        handoff[8..16].copy_from_slice(&self.context.authority_id().to_le_bytes());
+        handoff[16..32].copy_from_slice(&self.boot.bytes());
+        let tag = root::verifier_handoff_tag(
+            self.boot,
+            self.context.authority_id(),
+            &self.context.verification_key().bytes(),
+        );
+        handoff[32..].copy_from_slice(&tag);
+        handoff
+    }
+}
+
+/// Landed caller identity (#1705 `DomainToken`): domain slot plus generation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct AuditSubject {
+    slot: u8,
+    generation: NonZeroU64,
+}
+
+impl AuditSubject {
+    pub fn from_domain(token: DomainToken) -> Self {
+        Self {
+            slot: token.slot().index() as u8,
+            generation: token.generation(),
+        }
+    }
+
+    pub(crate) fn from_parts(slot: u8, generation: NonZeroU64) -> Option<Self> {
+        if slot as usize >= AUDIT_DOMAIN_SLOTS {
+            return None;
+        }
+        Some(Self { slot, generation })
+    }
+
+    pub const fn slot(self) -> u8 {
+        self.slot
+    }
+
+    pub const fn generation(self) -> NonZeroU64 {
+        self.generation
+    }
+}
+
+/// Landed object kind (#1705 domain or endpoint object).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum AuditObjectKind {
+    Domain,
+    Endpoint,
+}
+
+impl AuditObjectKind {
+    pub(crate) const fn from_discriminant(value: u8) -> Option<Self> {
+        match value {
+            1 => Some(Self::Domain),
+            2 => Some(Self::Endpoint),
+            _ => None,
+        }
+    }
+
+    pub(crate) const fn discriminant(self) -> u8 {
+        match self {
+            Self::Domain => 1,
+            Self::Endpoint => 2,
+        }
+    }
+}
+
+/// Typed object identity for one frame. Values restate the landed #1705 and
+/// #1758 identity fields through ceiling-enforced constructors; this is
+/// attribution encoding, not a parallel identity authority.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum AuditObject {
+    Domain {
+        slot: u8,
+        generation: NonZeroU64,
+    },
+    Endpoint {
+        pool_index: u8,
+        generation: NonZeroU64,
+    },
+    CapabilityInstance(AuditCapabilityInstance),
+}
+
+impl AuditObject {
+    pub fn domain(slot: usize, generation: u64) -> Option<Self> {
+        if slot >= AUDIT_DOMAIN_SLOTS {
+            return None;
+        }
+        Some(Self::Domain {
+            slot: slot as u8,
+            generation: NonZeroU64::new(generation)?,
+        })
+    }
+
+    pub fn endpoint(pool_index: usize, generation: u64) -> Option<Self> {
+        if pool_index >= AUDIT_ENDPOINT_POOL {
+            return None;
+        }
+        Some(Self::Endpoint {
+            pool_index: pool_index as u8,
+            generation: NonZeroU64::new(generation)?,
+        })
+    }
+
+    pub fn capability_instance(
+        projection_token: u64,
+        capability_slot: usize,
+        capability_generation: u64,
+        object_kind: AuditObjectKind,
+        object_token: u64,
+    ) -> Option<Self> {
+        Some(Self::CapabilityInstance(AuditCapabilityInstance::try_new(
+            projection_token,
+            capability_slot,
+            capability_generation,
+            object_kind,
+            object_token,
+        )?))
+    }
+}
+
+/// Full landed #1758 capability-instance identity restated for attribution:
+/// kernel-issued projection token, capability-table slot, capability/object
+/// generations, and the held object identity.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct AuditCapabilityInstance {
+    projection_token: NonZeroU64,
+    capability_slot: u8,
+    capability_generation: NonZeroU64,
+    object_kind: AuditObjectKind,
+    object_token: NonZeroU64,
+}
+
+impl AuditCapabilityInstance {
+    pub fn try_new(
+        projection_token: u64,
+        capability_slot: usize,
+        capability_generation: u64,
+        object_kind: AuditObjectKind,
+        object_token: u64,
+    ) -> Option<Self> {
+        // Landed #1758 capability-instance projections name Endpoint objects
+        // only; a Domain identity is attribution, not the held object.
+        if capability_slot >= AUDIT_CAP_SLOTS_PER_DOMAIN || object_kind != AuditObjectKind::Endpoint
+        {
+            return None;
+        }
+        Some(Self {
+            projection_token: NonZeroU64::new(projection_token)?,
+            capability_slot: capability_slot as u8,
+            capability_generation: NonZeroU64::new(capability_generation)?,
+            object_kind,
+            object_token: NonZeroU64::new(object_token)?,
+        })
+    }
+
+    pub const fn projection_token(self) -> NonZeroU64 {
+        self.projection_token
+    }
+
+    pub const fn capability_slot(self) -> u8 {
+        self.capability_slot
+    }
+
+    pub const fn capability_generation(self) -> NonZeroU64 {
+        self.capability_generation
+    }
+
+    pub const fn object_kind(self) -> AuditObjectKind {
+        self.object_kind
+    }
+
+    pub const fn object_token(self) -> NonZeroU64 {
+        self.object_token
+    }
+}
+
+/// Landed #1705 rights bits (`SEND=1 RECV=2 GRANT=4 IDENTIFY=8`). Unknown
+/// bits fail closed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct AuditRights(u16);
+
+impl AuditRights {
+    const LANDED_RIGHTS_MASK: u16 = 0b1111;
+
+    pub const fn from_bits(bits: u16) -> Option<Self> {
+        if bits & !Self::LANDED_RIGHTS_MASK == 0 {
+            Some(Self(bits))
+        } else {
+            None
+        }
+    }
+
+    pub const fn bits(self) -> u16 {
+        self.0
+    }
+}
+
+/// Typed denial reason. Denials never disclose a foreign object identity.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum DenialReason {
+    StaleIdentity = 1,
+    MissingCapability = 2,
+    RightsInsufficient = 3,
+    ForeignObject = 4,
+    CapacityExhausted = 5,
+    MalformedRequest = 6,
+}
+
+impl DenialReason {
+    pub(crate) const fn from_discriminant(value: u16) -> Option<Self> {
+        match value {
+            1 => Some(Self::StaleIdentity),
+            2 => Some(Self::MissingCapability),
+            3 => Some(Self::RightsInsufficient),
+            4 => Some(Self::ForeignObject),
+            5 => Some(Self::CapacityExhausted),
+            6 => Some(Self::MalformedRequest),
+            _ => None,
+        }
+    }
+
+    pub(crate) const fn discriminant(self) -> u16 {
+        match self {
+            Self::StaleIdentity => 1,
+            Self::MissingCapability => 2,
+            Self::RightsInsufficient => 3,
+            Self::ForeignObject => 4,
+            Self::CapacityExhausted => 5,
+            Self::MalformedRequest => 6,
+        }
+    }
+}
+
+/// Caller-visible denial context: one typed reason plus a bounded caller
+/// stamp. The canonical payload is `reason: u16` little-endian, then 8 stamp
+/// bytes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DenialContext {
+    reason: DenialReason,
+    stamp: [u8; 8],
+}
+
+impl DenialContext {
+    pub(crate) const PAYLOAD_LEN: usize = 10;
+
+    pub const fn new(reason: DenialReason, stamp: [u8; 8]) -> Self {
+        Self { reason, stamp }
+    }
+
+    pub(crate) fn payload_bytes(self) -> [u8; Self::PAYLOAD_LEN] {
+        let reason = self.reason.discriminant().to_le_bytes();
+        let mut out = [0u8; Self::PAYLOAD_LEN];
+        out[0] = reason[0];
+        out[1] = reason[1];
+        out[2..].copy_from_slice(&self.stamp);
+        out
+    }
+
+    pub(crate) fn from_payload(payload: &[u8]) -> Option<Self> {
+        if payload.len() != Self::PAYLOAD_LEN {
+            return None;
+        }
+        let reason = u16::from_le_bytes([payload[0], payload[1]]);
+        let mut stamp = [0u8; 8];
+        stamp.copy_from_slice(&payload[2..]);
+        Some(Self {
+            reason: DenialReason::from_discriminant(reason)?,
+            stamp,
+        })
+    }
+
+    pub const fn reason(self) -> DenialReason {
+        self.reason
+    }
+
+    pub const fn stamp(self) -> [u8; 8] {
+        self.stamp
+    }
+}
+
+/// Security-event class. Discriminant groups follow the #1759 freeze: domain
+/// lifecycle, capability, IPC, generation, root, and bounded denial.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum AuditClass {
+    DomainCreate = 1,
+    DomainAdmit = 2,
+    DomainStart = 3,
+    DomainEnter = 4,
+    DomainExit = 5,
+    DomainFault = 6,
+    DomainKill = 7,
+    DomainReclaim = 8,
+    DomainCancel = 9,
+    CapabilityDerive = 16,
+    CapabilityGrant = 17,
+    CapabilityRevoke = 18,
+    IpcSend = 32,
+    IpcRecv = 33,
+    IpcQueueDrop = 34,
+    IpcEndpointTeardown = 35,
+    GenerationAdvance = 48,
+    GenerationReject = 49,
+    GenerationOverflow = 50,
+    RootCheckpoint = 64,
+    RootOverflow = 65,
+    RootIncomplete = 66,
+    BoundedDenial = 80,
+}
+
+impl AuditClass {
+    pub(crate) const fn from_discriminant(value: u16) -> Option<Self> {
+        match value {
+            1 => Some(Self::DomainCreate),
+            2 => Some(Self::DomainAdmit),
+            3 => Some(Self::DomainStart),
+            4 => Some(Self::DomainEnter),
+            5 => Some(Self::DomainExit),
+            6 => Some(Self::DomainFault),
+            7 => Some(Self::DomainKill),
+            8 => Some(Self::DomainReclaim),
+            9 => Some(Self::DomainCancel),
+            16 => Some(Self::CapabilityDerive),
+            17 => Some(Self::CapabilityGrant),
+            18 => Some(Self::CapabilityRevoke),
+            32 => Some(Self::IpcSend),
+            33 => Some(Self::IpcRecv),
+            34 => Some(Self::IpcQueueDrop),
+            35 => Some(Self::IpcEndpointTeardown),
+            48 => Some(Self::GenerationAdvance),
+            49 => Some(Self::GenerationReject),
+            50 => Some(Self::GenerationOverflow),
+            64 => Some(Self::RootCheckpoint),
+            65 => Some(Self::RootOverflow),
+            66 => Some(Self::RootIncomplete),
+            80 => Some(Self::BoundedDenial),
+            _ => None,
+        }
+    }
+
+    pub(crate) const fn discriminant(self) -> u16 {
+        self as u16
+    }
+
+    /// Classes whose relay records participate in the statically reserved
+    /// terminal/invalidation headroom. Ordinary records cannot consume the
+    /// headroom needed by one admitted atomic teardown batch.
+    pub(crate) const fn is_terminal_or_invalidation(self) -> bool {
+        matches!(
+            self,
+            Self::DomainKill
+                | Self::DomainReclaim
+                | Self::DomainCancel
+                | Self::CapabilityRevoke
+                | Self::IpcQueueDrop
+                | Self::IpcEndpointTeardown
+                | Self::GenerationOverflow
+                | Self::RootOverflow
+                | Self::RootIncomplete
+        )
+    }
+}
+
+/// One typed audit event before canonical encoding. Construction is
+/// fallible where a ceiling applies, so a frame can never encode a value the
+/// landed pools cannot produce.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct AuditEvent {
+    class: AuditClass,
+    subject: AuditSubject,
+    object: Option<AuditObject>,
+    rights: AuditRights,
+    payload: [u8; AUDIT_MAX_PAYLOAD],
+    payload_len: usize,
+}
+
+impl AuditEvent {
+    pub fn new(class: AuditClass, subject: AuditSubject) -> Self {
+        Self {
+            class,
+            subject,
+            object: None,
+            rights: AuditRights::from_bits(0).expect("zero is a valid rights mask"),
+            payload: [0; AUDIT_MAX_PAYLOAD],
+            payload_len: 0,
+        }
+    }
+
+    pub fn with_object(mut self, object: AuditObject) -> Option<Self> {
+        if self.class == AuditClass::BoundedDenial {
+            return None;
+        }
+        self.object = Some(object);
+        Some(self)
+    }
+
+    pub fn with_rights(mut self, rights: AuditRights) -> Self {
+        self.rights = rights;
+        self
+    }
+
+    pub fn with_payload(mut self, payload: &[u8]) -> Option<Self> {
+        if payload.len() > AUDIT_MAX_PAYLOAD {
+            return None;
+        }
+        self.payload = [0; AUDIT_MAX_PAYLOAD];
+        self.payload[..payload.len()].copy_from_slice(payload);
+        self.payload_len = payload.len();
+        Some(self)
+    }
+
+    /// A bounded denial under caller-visible/stamped context. The object
+    /// stays absent: an unauthorized attempt must not disclose foreign
+    /// object identity through the verifier projection.
+    pub fn denial(subject: AuditSubject, context: DenialContext) -> Self {
+        let payload = context.payload_bytes();
+        Self {
+            class: AuditClass::BoundedDenial,
+            subject,
+            object: None,
+            rights: AuditRights::from_bits(0).expect("zero is a valid rights mask"),
+            payload: [0; AUDIT_MAX_PAYLOAD],
+            payload_len: 0,
+        }
+        .with_payload(&payload)
+        .expect("denial payload fits the landed ceiling")
+    }
+
+    pub const fn class(self) -> AuditClass {
+        self.class
+    }
+
+    pub const fn subject(self) -> AuditSubject {
+        self.subject
+    }
+
+    pub const fn object(self) -> Option<AuditObject> {
+        self.object
+    }
+
+    pub const fn rights(self) -> AuditRights {
+        self.rights
+    }
+
+    pub fn payload(&self) -> &[u8] {
+        &self.payload[..self.payload_len]
+    }
+}
+
+/// Kernel-authenticated restart checkpoint bound to boot/session identity,
+/// exact `audit_seq`, root, codec version, and relay generation. A
+/// verifier-local cache alone is never a trusted checkpoint.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct AuditCheckpoint {
+    boot: BootSessionId,
+    seq: u64,
+    root: [u8; root::ROOT_LEN],
+    codec_version: u16,
+    relay_generation: u64,
+    authority_id: u64,
+    tag: [u8; root::ROOT_LEN],
+}
+
+impl AuditCheckpoint {
+    pub(crate) fn seal(
+        boot: BootSessionId,
+        seq: u64,
+        root: [u8; root::ROOT_LEN],
+        relay_generation: u64,
+        context: CheckpointAuthContext,
+    ) -> Result<Self, AuditError> {
+        if relay_generation == 0 || context.authority_id() == 0 {
+            return Err(AuditError::MalformedFrame);
+        }
+        let codec_version = super::CODEC_VERSION;
+        let tag = root::checkpoint_tag(boot, seq, root, relay_generation, &context);
+        Ok(Self {
+            boot,
+            seq,
+            root,
+            codec_version,
+            relay_generation,
+            authority_id: context.authority_id(),
+            tag,
+        })
+    }
+
+    pub(crate) fn verify_tag(&self, context: CheckpointAuthContext) -> bool {
+        if self.authority_id != context.authority_id() {
+            return false;
+        }
+        root::checkpoint_tag(
+            self.boot,
+            self.seq,
+            self.root,
+            self.relay_generation,
+            &context,
+        ) == self.tag
+    }
+
+    pub const fn boot(self) -> BootSessionId {
+        self.boot
+    }
+
+    pub const fn seq(self) -> u64 {
+        self.seq
+    }
+
+    pub const fn root(self) -> [u8; root::ROOT_LEN] {
+        self.root
+    }
+
+    pub const fn codec_version(self) -> u16 {
+        self.codec_version
+    }
+
+    pub const fn relay_generation(self) -> u64 {
+        self.relay_generation
+    }
+
+    pub const fn authority_id(self) -> u64 {
+        self.authority_id
+    }
+
+    pub const fn tag(self) -> [u8; root::ROOT_LEN] {
+        self.tag
+    }
+}
+
+/// Fail-closed audit errors. None of these are recoverable by wraparound or
+/// silent omission.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AuditError {
+    SequenceOverflow,
+    RelayGenerationOverflow,
+    PayloadTooLarge,
+    EncodeOverflow,
+    MalformedFrame,
+    UnauthorizedDisclosure,
+    RootMismatch,
+    CheckpointMismatch,
+    RelayWindowOverflow,
+    RelayInvalidCursor,
+    RelayStaleCursor,
+    RelayNotInFlight,
+    HandoffIncomplete,
+    BatchCapacityExhausted,
+}
+
+impl core::fmt::Display for AuditError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let text = match self {
+            Self::SequenceOverflow => "audit sequence overflow",
+            Self::RelayGenerationOverflow => "relay generation overflow",
+            Self::PayloadTooLarge => "payload exceeds the landed ceiling",
+            Self::EncodeOverflow => "canonical frame exceeds the fixed bound",
+            Self::MalformedFrame => "malformed canonical frame",
+            Self::UnauthorizedDisclosure => "denial frame discloses a foreign identity",
+            Self::RootMismatch => "rolling root mismatch",
+            Self::CheckpointMismatch => "checkpoint authentication mismatch",
+            Self::RelayWindowOverflow => "relay window overflow",
+            Self::RelayInvalidCursor => "relay cursor invalid",
+            Self::RelayStaleCursor => "relay cursor stale",
+            Self::RelayNotInFlight => "relay record is not in flight",
+            Self::HandoffIncomplete => "audit handoff is incomplete and requires resync",
+            Self::BatchCapacityExhausted => "batch exceeds the static terminal reserve",
+        };
+        f.write_str(text)
+    }
+}

--- a/kernel/crates/astrid-native-kernel/src/ipc/endpoint.rs
+++ b/kernel/crates/astrid-native-kernel/src/ipc/endpoint.rs
@@ -1,7 +1,7 @@
 //! Fixed endpoint objects, one-deep queues, and blocked-receiver state.
 
 use super::abi::MAX_PAYLOAD_BYTES;
-use super::capability::{Capability, DomainToken};
+use super::capability::{CapTable, Capability, DomainToken};
 
 const ENDPOINT_MEMBERS: usize = 2;
 
@@ -270,4 +270,28 @@ impl Endpoint {
     pub(super) fn clear_queue(&mut self, index: usize) -> bool {
         self.queues.get_mut(index).map(Option::take).is_some()
     }
+}
+
+pub(super) fn reclaim_object(object: &mut Option<Endpoint>) -> bool {
+    let Some(endpoint) = object.as_mut() else {
+        return false;
+    };
+    if endpoint.generation().next().is_none() {
+        return false;
+    }
+    *object = None;
+    true
+}
+
+pub(super) fn endpoint_is_unused(
+    capabilities: &[CapTable; super::capability::DOMAIN_SLOTS],
+    id: super::EndpointId,
+) -> bool {
+    !capabilities.iter().any(|table| {
+        (0..super::abi::CAP_SLOTS_PER_DOMAIN).any(|index| {
+            table
+                .capability_at(index)
+                .is_some_and(|capability| capability.endpoint == id)
+        })
+    })
 }

--- a/kernel/crates/astrid-native-kernel/src/ipc/mod.rs
+++ b/kernel/crates/astrid-native-kernel/src/ipc/mod.rs
@@ -16,14 +16,14 @@ use spin::Mutex;
 
 use crate::platform::{self, TrapFrame};
 
-#[cfg(test)]
-use crate::relations::ProjectionEvidence;
-#[cfg(test)]
-use crate::relations::projection_evidence;
 use crate::relations::{
     CapabilityFacts, capability_installed, capability_removed, domain_registered, domain_released,
     endpoint_created, endpoint_reclaimed,
 };
+#[cfg(test)]
+use crate::relations::{DeltaCursor, ProjectionEvidence, Snapshot};
+#[cfg(test)]
+use crate::relations::{projection_fold_evidence, projection_observation};
 pub use abi::MAX_BUFFER_BYTES;
 pub use capability::DomainToken;
 use capability::{CapSlot, CapTable, Capability, DerivationLink, Rights};
@@ -144,10 +144,12 @@ fn merge_wakes(target: &mut [Option<DomainToken>; 2], wakes: [Option<DomainToken
     }
 }
 
-fn project<T>(result: Result<T, crate::relations::ProjectionError>, operation: &'static str) -> T {
-    match result {
-        Ok(value) => value,
-        Err(error) => panic!("relations projection {operation} failed: {error:?}"),
+fn project<T>(result: Result<T, crate::relations::ProjectionError>, operation: &'static str) {
+    if let Err(error) = result {
+        #[cfg(not(test))]
+        crate::serial::ev_relations_projection_failed(operation, error.code());
+        #[cfg(test)]
+        let _ = (operation, error);
     }
 }
 
@@ -883,9 +885,19 @@ fn domain_has_capability(domain: DomainToken) -> bool {
 }
 
 #[cfg(test)]
-pub(crate) fn relations_projection_evidence(domain: DomainToken) -> Option<ProjectionEvidence> {
-    let mut state = IPC.lock();
-    projection_evidence(&mut state.relations, domain).ok()
+pub(crate) fn relations_projection_observation(
+    domain: DomainToken,
+) -> Option<(Snapshot, DeltaCursor)> {
+    projection_observation(&IPC.lock().relations, domain).ok()
+}
+
+#[cfg(test)]
+pub(crate) fn relations_projection_fold(
+    domain: DomainToken,
+    base: Snapshot,
+    cursor: DeltaCursor,
+) -> Option<ProjectionEvidence> {
+    projection_fold_evidence(&IPC.lock().relations, domain, base, cursor).ok()
 }
 
 fn reclaim_object(state: &mut IpcState, id: EndpointId) -> bool {

--- a/kernel/crates/astrid-native-kernel/src/ipc/mod.rs
+++ b/kernel/crates/astrid-native-kernel/src/ipc/mod.rs
@@ -25,6 +25,8 @@ use crate::relations::{DeltaCursor, ProjectionEvidence, Snapshot};
 #[cfg(test)]
 use crate::relations::{projection_fold_evidence, projection_observation};
 pub use abi::MAX_BUFFER_BYTES;
+#[cfg(test)]
+pub(crate) use capability::CapSlot as TestCapSlot;
 pub use capability::DomainToken;
 use capability::{CapSlot, CapTable, Capability, DerivationLink, Rights};
 pub use copy::finish_copy;
@@ -417,9 +419,6 @@ pub fn complete_parked_recv(
         };
         match installed {
             Some(slot) => {
-                if let Some(parent) = message.transfer() {
-                    project_transferred_capability(&mut state, domain, parent, slot);
-                }
                 transferred_slot = Some(slot);
             },
             None => {
@@ -440,7 +439,14 @@ pub fn complete_parked_recv(
     let transfer = message.transfer();
     drop(state);
     let committed = commit(&mut encoded);
-    if !committed {
+    if committed {
+        if let Some(parent) = transfer
+            && let Some(slot) = transferred_slot
+        {
+            let mut state = IPC.lock();
+            project_transferred_capability(&mut state, domain, parent, slot);
+        }
+    } else {
         rollback_recv(domain, endpoint_id, message, transfer, transferred_slot);
     }
     committed.then_some(()).ok_or(())
@@ -615,9 +621,6 @@ fn recv(frame: &mut TrapFrame, domain: DomainToken) -> Result<(u64, u64), IpcErr
         };
         match installed {
             Some(slot) => {
-                if let Some(parent) = message.transfer() {
-                    project_transferred_capability(&mut state, domain, parent, slot);
-                }
                 transferred_slot = Some(slot);
             },
             None => {
@@ -642,6 +645,12 @@ fn recv(frame: &mut TrapFrame, domain: DomainToken) -> Result<(u64, u64), IpcErr
         rollback_recv(domain, endpoint_id, message, transfer, transferred_slot);
         return Err(IpcError::Faulted);
     }
+    if let Some(parent) = transfer
+        && let Some(slot) = transferred_slot
+    {
+        let mut state = IPC.lock();
+        project_transferred_capability(&mut state, domain, parent, slot);
+    }
     Ok((0, abi::MAX_BUFFER_BYTES as u64))
 }
 
@@ -655,16 +664,6 @@ fn rollback_recv(
     let mut state = IPC.lock();
     if let Some(slot) = installed {
         state.capabilities[domain.slot().index()].remove(domain, slot);
-        if let Some(transfer) = transfer {
-            project(
-                capability_removed(
-                    &mut state.relations,
-                    domain,
-                    capability_facts(transfer, slot),
-                ),
-                "transferred_capability_rollback",
-            );
-        }
     }
     let restored = Message::new(
         message.sender(),

--- a/kernel/crates/astrid-native-kernel/src/ipc/mod.rs
+++ b/kernel/crates/astrid-native-kernel/src/ipc/mod.rs
@@ -16,6 +16,14 @@ use spin::Mutex;
 
 use crate::platform::{self, TrapFrame};
 
+#[cfg(test)]
+use crate::relations::ProjectionEvidence;
+#[cfg(test)]
+use crate::relations::projection_evidence;
+use crate::relations::{
+    CapabilityFacts, capability_installed, capability_removed, domain_registered, domain_released,
+    endpoint_created, endpoint_reclaimed,
+};
 pub use abi::MAX_BUFFER_BYTES;
 pub use capability::DomainToken;
 use capability::{CapSlot, CapTable, Capability, DerivationLink, Rights};
@@ -75,6 +83,7 @@ struct IpcState {
     next_object_generation: u64,
     objects: [Option<Endpoint>; abi::ENDPOINT_POOL],
     capabilities: [CapTable; capability::DOMAIN_SLOTS],
+    relations: crate::relations::ProjectionStore,
 }
 
 impl IpcState {
@@ -83,6 +92,7 @@ impl IpcState {
             next_object_generation: 1,
             objects: [None; abi::ENDPOINT_POOL],
             capabilities: [CapTable::unowned(), CapTable::unowned()],
+            relations: crate::relations::ProjectionStore::empty(),
         }
     }
 }
@@ -134,6 +144,62 @@ fn merge_wakes(target: &mut [Option<DomainToken>; 2], wakes: [Option<DomainToken
     }
 }
 
+fn project<T>(result: Result<T, crate::relations::ProjectionError>, operation: &'static str) -> T {
+    match result {
+        Ok(value) => value,
+        Err(error) => panic!("relations projection {operation} failed: {error:?}"),
+    }
+}
+
+fn capability_facts(capability: Capability, slot: CapSlot) -> CapabilityFacts {
+    CapabilityFacts::new(
+        u64::from(slot.get()),
+        capability.generation.get(),
+        capability.generation.get(),
+        capability.rights.bits(),
+    )
+}
+
+fn project_transferred_capability(
+    state: &mut IpcState,
+    domain: DomainToken,
+    parent: Capability,
+    slot: CapSlot,
+) {
+    let parent_domain = parent.parent.map_or(domain, |link| link.domain);
+    let parent_slot = parent.parent.map_or(slot, |link| link.slot);
+    project(
+        capability_installed(
+            &mut state.relations,
+            parent_domain,
+            capability_facts(parent, parent_slot),
+            domain,
+            capability_facts(parent, slot),
+        ),
+        "transferred_capability_install",
+    );
+    project_relation_evidence(state, domain);
+}
+
+fn project_relation_evidence(state: &mut IpcState, domain: DomainToken) {
+    if let Ok((epoch, rows, fold_epoch, fold_rows, fold_matches)) =
+        state.relations.runtime_evidence(domain)
+    {
+        #[cfg(not(test))]
+        crate::serial::ev_relations_projection(
+            domain.slot().index() as u64 + 1,
+            domain.generation().get(),
+            epoch,
+            rows,
+            fold_epoch,
+            fold_rows,
+            fold_matches,
+        );
+        #[cfg(test)]
+        let _ = (epoch, rows, fold_epoch, fold_rows, fold_matches);
+    }
+}
+
 fn revoke_derived_capabilities(state: &mut IpcState, ancestor: DerivationLink) -> usize {
     let mut descendants = [None; abi::CAP_SLOTS_PER_DOMAIN * capability::DOMAIN_SLOTS];
     let mut descendant_count = 0usize;
@@ -152,13 +218,27 @@ fn revoke_derived_capabilities(state: &mut IpcState, ancestor: DerivationLink) -
         }
     }
 
-    descendants
-        .into_iter()
-        .flatten()
-        .filter(|(table_index, owner, index)| {
-            state.capabilities[*table_index].remove_index(*owner, *index)
-        })
-        .count()
+    let mut removed = 0;
+    for (table_index, owner, index) in descendants.into_iter().flatten() {
+        let Ok(slot) = CapSlot::try_new(index) else {
+            continue;
+        };
+        let Some(capability) = state.capabilities[table_index].get(owner, slot) else {
+            continue;
+        };
+        if state.capabilities[table_index].remove_index(owner, index) {
+            project(
+                capability_removed(
+                    &mut state.relations,
+                    owner,
+                    capability_facts(capability, slot),
+                ),
+                "teardown_derived_capability_revoke",
+            );
+            removed += 1;
+        }
+    }
+    removed
 }
 
 fn unbind_members_without_capabilities(
@@ -193,6 +273,10 @@ fn unbind_members_without_capabilities(
 
 pub fn prepare_domain(domain: DomainToken) {
     let mut state = IPC.lock();
+    project(
+        domain_registered(&mut state.relations, domain),
+        "domain_register",
+    );
     state.capabilities[domain.slot().index()].reset(domain);
 }
 
@@ -214,6 +298,7 @@ pub fn bind_peer(creator: DomainToken, peer: DomainToken) -> Result<(), IpcError
         }
         return Err(IpcError::NoSpace);
     };
+    let child = state.capabilities[peer.slot().index()].get(peer, slot);
     state.capabilities[peer.slot().index()].install(
         peer,
         slot,
@@ -226,7 +311,18 @@ pub fn bind_peer(creator: DomainToken, peer: DomainToken) -> Result<(), IpcError
                 slot: creator_slot,
             }),
         },
-    )
+    )?;
+    project(
+        capability_installed(
+            &mut state.relations,
+            creator,
+            capability_facts(source, creator_slot),
+            peer,
+            capability_facts(child.unwrap_or(source), slot),
+        ),
+        "capability_install",
+    );
+    Ok(())
 }
 
 pub fn handle_call(frame: &mut TrapFrame, domain: DomainToken) -> SyscallOutcome {
@@ -318,7 +414,12 @@ pub fn complete_parked_recv(
             _ => None,
         };
         match installed {
-            Some(slot) => transferred_slot = Some(slot),
+            Some(slot) => {
+                if let Some(parent) = message.transfer() {
+                    project_transferred_capability(&mut state, domain, parent, slot);
+                }
+                transferred_slot = Some(slot);
+            },
             None => {
                 if let Some(object) = state.objects[endpoint_id.index()].as_mut() {
                     object.restore(domain, message, false);
@@ -401,6 +502,20 @@ fn endpoint_create(domain: DomainToken) -> Result<(u64, u64), IpcError> {
     )?;
     state.objects[index] = Some(endpoint);
     state.next_object_generation += 1;
+    project(
+        endpoint_created(
+            &mut state.relations,
+            domain,
+            CapabilityFacts::new(
+                u64::from(slot.get()),
+                generation.get(),
+                generation.get(),
+                Rights::ALL.bits(),
+            ),
+        ),
+        "endpoint_create",
+    );
+    project_relation_evidence(&mut state, domain);
     Ok((0, u64::from(slot.get())))
 }
 
@@ -497,7 +612,12 @@ fn recv(frame: &mut TrapFrame, domain: DomainToken) -> Result<(u64, u64), IpcErr
             _ => None,
         };
         match installed {
-            Some(slot) => transferred_slot = Some(slot),
+            Some(slot) => {
+                if let Some(parent) = message.transfer() {
+                    project_transferred_capability(&mut state, domain, parent, slot);
+                }
+                transferred_slot = Some(slot);
+            },
             None => {
                 if let Some(object) = state.objects[endpoint_id.index()].as_mut() {
                     object.restore(domain, message, false);
@@ -533,6 +653,16 @@ fn rollback_recv(
     let mut state = IPC.lock();
     if let Some(slot) = installed {
         state.capabilities[domain.slot().index()].remove(domain, slot);
+        if let Some(transfer) = transfer {
+            project(
+                capability_removed(
+                    &mut state.relations,
+                    domain,
+                    capability_facts(transfer, slot),
+                ),
+                "transferred_capability_rollback",
+            );
+        }
     }
     let restored = Message::new(
         message.sender(),
@@ -576,10 +706,29 @@ fn cap_revoke(frame: &TrapFrame, domain: DomainToken) -> Result<(u64, u64), IpcE
     {
         return Err(IpcError::Stale);
     }
+    project(
+        capability_removed(
+            &mut state.relations,
+            domain,
+            capability_facts(removed, slot),
+        ),
+        "capability_revoke",
+    );
     let mut removed_count = 1usize;
     for entry in descendants.into_iter().flatten() {
         let (table_index, owner, index) = entry;
-        if state.capabilities[table_index].remove_index(owner, index) {
+        if let Ok(child_slot) = CapSlot::try_new(index)
+            && let Some(child) = state.capabilities[table_index].get(owner, child_slot)
+            && state.capabilities[table_index].remove_index(owner, index)
+        {
+            project(
+                capability_removed(
+                    &mut state.relations,
+                    owner,
+                    capability_facts(child, child_slot),
+                ),
+                "derived_capability_revoke",
+            );
             removed_count += 1;
         }
     }
@@ -587,7 +736,17 @@ fn cap_revoke(frame: &TrapFrame, domain: DomainToken) -> Result<(u64, u64), IpcE
     let mut wakes = [None; 2];
     unbind_members_without_capabilities(&mut state, &mut wakes);
     if endpoint_is_unused(&state, removed.endpoint) {
-        reclaim_object(&mut state, removed.endpoint);
+        let generation = state.objects[removed.endpoint.index()]
+            .as_ref()
+            .map(Endpoint::generation);
+        if reclaim_object(&mut state, removed.endpoint)
+            && let Some(generation) = generation
+        {
+            project(
+                endpoint_reclaimed(&mut state.relations, generation.get()),
+                "endpoint_reclaim",
+            );
+        }
     }
     drop(state);
     crate::domains::mark_ipc_peers_failed(wakes);
@@ -627,7 +786,6 @@ pub fn teardown_domain(domain: DomainToken) -> TeardownOutcome {
         state.capabilities[domain.slot().index()]
             .capability_at(index)
             .and_then(|_| CapSlot::try_new(index).ok())
-            .map(|slot| DerivationLink { domain, slot })
     });
 
     for (index, ancestor) in ancestors
@@ -635,10 +793,20 @@ pub fn teardown_domain(domain: DomainToken) -> TeardownOutcome {
         .enumerate()
         .take(abi::CAP_SLOTS_PER_DOMAIN)
     {
-        if state.capabilities[domain.slot().index()].remove_index(domain, index)
-            && let Some(slot) = ancestor
+        if let Some(slot) = ancestor
+            && let Some(capability) = state.capabilities[domain.slot().index()].get(domain, slot)
+            && state.capabilities[domain.slot().index()].remove_index(domain, index)
         {
-            outcome.capabilities += revoke_derived_capabilities(&mut state, slot);
+            project(
+                capability_removed(
+                    &mut state.relations,
+                    domain,
+                    capability_facts(capability, slot),
+                ),
+                "teardown_capability_revoke",
+            );
+            outcome.capabilities +=
+                revoke_derived_capabilities(&mut state, DerivationLink { domain, slot });
         }
     }
 
@@ -677,10 +845,22 @@ pub fn teardown_domain(domain: DomainToken) -> TeardownOutcome {
         }
     }
     for id in object_ids.into_iter().flatten() {
-        if endpoint_is_unused(&state, id) && reclaim_object(&mut state, id) {
+        let generation = state.objects[id.index()].as_ref().map(Endpoint::generation);
+        if endpoint_is_unused(&state, id)
+            && let Some(generation) = generation
+            && reclaim_object(&mut state, id)
+        {
             outcome.endpoints += 1;
+            project(
+                endpoint_reclaimed(&mut state.relations, generation.get()),
+                "teardown_endpoint_reclaim",
+            );
         }
     }
+    project(
+        domain_released(&mut state.relations, domain),
+        "domain_release",
+    );
     outcome
 }
 
@@ -700,6 +880,12 @@ fn domain_has_capability(domain: DomainToken) -> bool {
         .iter()
         .flatten()
         .any(|_| true)
+}
+
+#[cfg(test)]
+pub(crate) fn relations_projection_evidence(domain: DomainToken) -> Option<ProjectionEvidence> {
+    let mut state = IPC.lock();
+    projection_evidence(&mut state.relations, domain).ok()
 }
 
 fn reclaim_object(state: &mut IpcState, id: EndpointId) -> bool {

--- a/kernel/crates/astrid-native-kernel/src/ipc/mod.rs
+++ b/kernel/crates/astrid-native-kernel/src/ipc/mod.rs
@@ -444,7 +444,12 @@ pub fn complete_parked_recv(
             && let Some(slot) = transferred_slot
         {
             let mut state = IPC.lock();
-            project_transferred_capability(&mut state, domain, parent, slot);
+            if state.capabilities[domain.slot().index()]
+                .get(domain, slot)
+                .is_some_and(|installed| installed == parent)
+            {
+                project_transferred_capability(&mut state, domain, parent, slot);
+            }
         }
     } else {
         rollback_recv(domain, endpoint_id, message, transfer, transferred_slot);
@@ -649,7 +654,12 @@ fn recv(frame: &mut TrapFrame, domain: DomainToken) -> Result<(u64, u64), IpcErr
         && let Some(slot) = transferred_slot
     {
         let mut state = IPC.lock();
-        project_transferred_capability(&mut state, domain, parent, slot);
+        if state.capabilities[domain.slot().index()]
+            .get(domain, slot)
+            .is_some_and(|installed| installed == parent)
+        {
+            project_transferred_capability(&mut state, domain, parent, slot);
+        }
     }
     Ok((0, abi::MAX_BUFFER_BYTES as u64))
 }

--- a/kernel/crates/astrid-native-kernel/src/ipc/mod.rs
+++ b/kernel/crates/astrid-native-kernel/src/ipc/mod.rs
@@ -412,7 +412,7 @@ pub fn complete_parked_recv(
         return Err(());
     };
     let endpoint_id = source.endpoint;
-    let mut transferred_slot = None;
+    let mut installed_transfer = None;
     if let Some(capability) = message.transfer() {
         let destination_slot = CapSlot::try_new(usize::from(parsed.cap_slot()));
         let installed = match destination_slot {
@@ -427,7 +427,7 @@ pub fn complete_parked_recv(
         };
         match installed {
             Some(slot) => {
-                transferred_slot = Some(slot);
+                installed_transfer = Some((slot, capability));
             },
             None => {
                 if let Some(object) = state.objects[endpoint_id.index()].as_mut() {
@@ -449,7 +449,7 @@ pub fn complete_parked_recv(
     let committed = commit(&mut encoded);
     if committed {
         if let Some(parent) = transfer
-            && let Some(slot) = transferred_slot
+            && let Some((slot, _)) = installed_transfer
         {
             let mut state = IPC.lock();
             if state.capabilities[domain.slot().index()]
@@ -460,7 +460,7 @@ pub fn complete_parked_recv(
             }
         }
     } else {
-        rollback_recv(domain, endpoint_id, message, transferred_slot);
+        rollback_recv(domain, endpoint_id, message, installed_transfer);
     }
     committed.then_some(()).ok_or(())
 }
@@ -619,7 +619,7 @@ fn recv(frame: &mut TrapFrame, domain: DomainToken) -> Result<(u64, u64), IpcErr
         return Err(IpcError::Busy);
     };
     let endpoint_id = source.endpoint;
-    let mut transferred_slot = None;
+    let mut installed_transfer = None;
     if let Some(capability) = message.transfer() {
         let destination_slot = CapSlot::try_new(usize::from(output.cap_slot()));
         let installed = match destination_slot {
@@ -634,7 +634,7 @@ fn recv(frame: &mut TrapFrame, domain: DomainToken) -> Result<(u64, u64), IpcErr
         };
         match installed {
             Some(slot) => {
-                transferred_slot = Some(slot);
+                installed_transfer = Some((slot, capability));
             },
             None => {
                 if let Some(object) = state.objects[endpoint_id.index()].as_mut() {
@@ -655,11 +655,11 @@ fn recv(frame: &mut TrapFrame, domain: DomainToken) -> Result<(u64, u64), IpcErr
     drop(state);
     let mut encoded = encoded;
     if !copy::copy_current_user(frame.rsi, &mut encoded, true) {
-        rollback_recv(domain, endpoint_id, message, transferred_slot);
+        rollback_recv(domain, endpoint_id, message, installed_transfer);
         return Err(IpcError::Faulted);
     }
     if let Some(parent) = transfer
-        && let Some(slot) = transferred_slot
+        && let Some((slot, _)) = installed_transfer
     {
         let mut state = IPC.lock();
         if state.capabilities[domain.slot().index()]

--- a/kernel/crates/astrid-native-kernel/src/ipc/mod.rs
+++ b/kernel/crates/astrid-native-kernel/src/ipc/mod.rs
@@ -28,7 +28,7 @@ pub use abi::MAX_BUFFER_BYTES;
 pub use capability::DomainToken;
 use capability::{CapSlot, CapTable, Capability, DerivationLink, Rights};
 pub use copy::finish_copy;
-use endpoint::{Endpoint, Message, SendOutcome};
+use endpoint::{Endpoint, Message, SendOutcome, endpoint_is_unused, reclaim_object};
 use error::IpcError;
 
 const _: () = assert!(abi::MAX_BUFFER_BYTES == 96);
@@ -737,11 +737,11 @@ fn cap_revoke(frame: &TrapFrame, domain: DomainToken) -> Result<(u64, u64), IpcE
     removed_count += revoked_messages;
     let mut wakes = [None; 2];
     unbind_members_without_capabilities(&mut state, &mut wakes);
-    if endpoint_is_unused(&state, removed.endpoint) {
+    if endpoint_is_unused(&state.capabilities, removed.endpoint) {
         let generation = state.objects[removed.endpoint.index()]
             .as_ref()
             .map(Endpoint::generation);
-        if reclaim_object(&mut state, removed.endpoint)
+        if reclaim_object(&mut state.objects[removed.endpoint.index()])
             && let Some(generation) = generation
         {
             project(
@@ -848,9 +848,9 @@ pub fn teardown_domain(domain: DomainToken) -> TeardownOutcome {
     }
     for id in object_ids.into_iter().flatten() {
         let generation = state.objects[id.index()].as_ref().map(Endpoint::generation);
-        if endpoint_is_unused(&state, id)
+        if endpoint_is_unused(&state.capabilities, id)
             && let Some(generation) = generation
-            && reclaim_object(&mut state, id)
+            && reclaim_object(&mut state.objects[id.index()])
         {
             outcome.endpoints += 1;
             project(
@@ -898,28 +898,6 @@ pub(crate) fn relations_projection_fold(
     cursor: DeltaCursor,
 ) -> Option<ProjectionEvidence> {
     projection_fold_evidence(&IPC.lock().relations, domain, base, cursor).ok()
-}
-
-fn reclaim_object(state: &mut IpcState, id: EndpointId) -> bool {
-    let Some(object) = state.objects[id.index()].as_mut() else {
-        return false;
-    };
-    let Some(next) = object.generation().next() else {
-        return false;
-    };
-    *object = Endpoint::new(next);
-    state.objects[id.index()] = None;
-    true
-}
-
-fn endpoint_is_unused(state: &IpcState, id: EndpointId) -> bool {
-    !state.capabilities.iter().any(|table| {
-        (0..abi::CAP_SLOTS_PER_DOMAIN).any(|index| {
-            table
-                .capability_at(index)
-                .is_some_and(|capability| capability.endpoint == id)
-        })
-    })
 }
 
 fn endpoint_pair(

--- a/kernel/crates/astrid-native-kernel/src/ipc/mod.rs
+++ b/kernel/crates/astrid-native-kernel/src/ipc/mod.rs
@@ -7,8 +7,11 @@ mod endpoint;
 mod error;
 #[cfg(test)]
 mod revoke_tests;
+mod rollback;
 #[cfg(test)]
 pub(crate) mod test_support;
+
+use rollback::rollback_recv;
 
 use core::num::NonZeroU64;
 
@@ -28,7 +31,12 @@ pub use abi::MAX_BUFFER_BYTES;
 #[cfg(test)]
 pub(crate) use capability::CapSlot as TestCapSlot;
 pub use capability::DomainToken;
+#[cfg(not(test))]
 use capability::{CapSlot, CapTable, Capability, DerivationLink, Rights};
+#[cfg(test)]
+use capability::{CapSlot, CapTable, Rights};
+#[cfg(test)]
+pub(crate) use capability::{Capability, DerivationLink};
 pub use copy::finish_copy;
 use endpoint::{Endpoint, Message, SendOutcome, endpoint_is_unused, reclaim_object};
 use error::IpcError;
@@ -452,7 +460,7 @@ pub fn complete_parked_recv(
             }
         }
     } else {
-        rollback_recv(domain, endpoint_id, message, transfer, transferred_slot);
+        rollback_recv(domain, endpoint_id, message, transferred_slot);
     }
     committed.then_some(()).ok_or(())
 }
@@ -647,7 +655,7 @@ fn recv(frame: &mut TrapFrame, domain: DomainToken) -> Result<(u64, u64), IpcErr
     drop(state);
     let mut encoded = encoded;
     if !copy::copy_current_user(frame.rsi, &mut encoded, true) {
-        rollback_recv(domain, endpoint_id, message, transfer, transferred_slot);
+        rollback_recv(domain, endpoint_id, message, transferred_slot);
         return Err(IpcError::Faulted);
     }
     if let Some(parent) = transfer
@@ -662,29 +670,6 @@ fn recv(frame: &mut TrapFrame, domain: DomainToken) -> Result<(u64, u64), IpcErr
         }
     }
     Ok((0, abi::MAX_BUFFER_BYTES as u64))
-}
-
-fn rollback_recv(
-    domain: DomainToken,
-    endpoint_id: EndpointId,
-    message: Message,
-    transfer: Option<Capability>,
-    installed: Option<CapSlot>,
-) {
-    let mut state = IPC.lock();
-    if let Some(slot) = installed {
-        state.capabilities[domain.slot().index()].remove(domain, slot);
-    }
-    let restored = Message::new(
-        message.sender(),
-        message.tag(),
-        message.payload_len(),
-        message.payload(),
-        transfer,
-    );
-    if let Some(object) = state.objects[endpoint_id.index()].as_mut() {
-        object.restore(domain, restored, false);
-    }
 }
 
 fn cap_revoke(frame: &TrapFrame, domain: DomainToken) -> Result<(u64, u64), IpcError> {

--- a/kernel/crates/astrid-native-kernel/src/ipc/revoke_tests.rs
+++ b/kernel/crates/astrid-native-kernel/src/ipc/revoke_tests.rs
@@ -69,6 +69,114 @@ fn derived_transfer(parent: Capability, owner: DomainToken, slot: CapSlot) -> Ca
 }
 
 #[test]
+fn rollback_rejects_replaced_parent_without_grant() {
+    let _guard = test_lock();
+    reset();
+    let source = domain(0);
+    let recipient = domain(1);
+    prepare_domain(source);
+    prepare_domain(recipient);
+
+    let endpoint = endpoint_create(source).unwrap();
+    assert!(bind_peer(source, recipient).is_ok());
+    let source_recv = find(source, Rights::RECV).unwrap();
+    let recipient_root_slot = find(recipient, Rights::GRANT).unwrap();
+    let recipient_root = capability(recipient, recipient_root_slot).unwrap();
+    assert!(install_transfer_message(
+        source,
+        recipient,
+        endpoint,
+        Some(recipient_root)
+    ));
+    assert!(
+        super::complete_parked_recv(
+            source,
+            &recv_wire(recipient, 1),
+            u64::from(source_recv.get()),
+            |_| true
+        )
+        .is_ok()
+    );
+    let source_parent_slot = CapSlot::try_new(1).unwrap();
+    let source_parent = capability(source, source_parent_slot).unwrap();
+    assert!(source_parent.rights.contains(Rights::GRANT));
+
+    let recipient_base = super::relations_projection_observation(recipient).unwrap();
+    let mut send_wire = abi::MessageBuffer::zeroed();
+    send_wire.set_message(7, abi::FLAG_TRANSFER, 4, [1u8; abi::MAX_PAYLOAD_BYTES]);
+    let mut send_wire = send_wire.into_wire(source);
+    send_wire[16..32].fill(0);
+    send_wire[10..12].copy_from_slice(&Rights::SEND.bits().to_le_bytes());
+    crate::platform::set_user_memory_for_test(send_wire);
+    let mut frame = TrapFrame::zeroed();
+    frame.rdi = u64::from(source_parent_slot.get());
+    frame.rsi = 0;
+    frame.rdx = MAX_BUFFER_BYTES as u64;
+    assert_eq!(
+        super::send(&frame, source),
+        Ok((0, MAX_BUFFER_BYTES as u64))
+    );
+
+    let recipient_recv = find(recipient, Rights::RECV).unwrap();
+    assert!(
+        super::complete_parked_recv(
+            recipient,
+            &recv_wire(source, 2),
+            u64::from(recipient_recv.get()),
+            |_| {
+                assert_eq!(revoke(source, source_parent_slot), Ok(2));
+                let mut replacement_wire = abi::MessageBuffer::zeroed();
+                replacement_wire.set_message(
+                    8,
+                    abi::FLAG_TRANSFER,
+                    4,
+                    [2u8; abi::MAX_PAYLOAD_BYTES],
+                );
+                let mut replacement_wire = replacement_wire.into_wire(recipient);
+                replacement_wire[16..32].fill(0);
+                replacement_wire[10..12].copy_from_slice(&Rights::SEND.bits().to_le_bytes());
+                crate::platform::set_user_memory_for_test(replacement_wire);
+                let mut replacement_frame = TrapFrame::zeroed();
+                replacement_frame.rdi = u64::from(recipient_root_slot.get());
+                replacement_frame.rsi = 0;
+                replacement_frame.rdx = MAX_BUFFER_BYTES as u64;
+                assert_eq!(
+                    super::send(&replacement_frame, recipient),
+                    Ok((0, MAX_BUFFER_BYTES as u64))
+                );
+                assert!(
+                    super::complete_parked_recv(
+                        source,
+                        &recv_wire(recipient, 1),
+                        u64::from(source_recv.get()),
+                        |_| true
+                    )
+                    .is_ok()
+                );
+                let replacement = capability(source, source_parent_slot).unwrap();
+                assert_eq!(replacement.rights, Rights::SEND);
+                assert!(!replacement.rights.contains(Rights::GRANT));
+                assert_eq!(
+                    replacement.parent,
+                    Some(DerivationLink {
+                        domain: recipient,
+                        slot: recipient_root_slot
+                    })
+                );
+                false
+            }
+        )
+        .is_err()
+    );
+
+    assert_eq!(queued_for(recipient), 0);
+    assert!(capability(recipient, CapSlot::try_new(2).unwrap()).is_none());
+    let evidence =
+        super::relations_projection_fold(recipient, recipient_base.0, recipient_base.1).unwrap();
+    assert!(evidence.fold_matches);
+}
+
+#[test]
 fn cap_revoke_removes_grandchild_and_drains_derived_queue() {
     let _guard = test_lock();
     reset();

--- a/kernel/crates/astrid-native-kernel/src/ipc/revoke_tests.rs
+++ b/kernel/crates/astrid-native-kernel/src/ipc/revoke_tests.rs
@@ -183,6 +183,103 @@ fn rollback_rejects_replaced_parent_without_grant() {
 }
 
 #[test]
+fn rollback_restores_replaced_parent_with_grant() {
+    let _guard = test_lock();
+    reset();
+    let source = domain(0);
+    let recipient = domain(1);
+    prepare_domain(source);
+    prepare_domain(recipient);
+
+    let endpoint = endpoint_create(source).unwrap();
+    assert!(bind_peer(source, recipient).is_ok());
+    let source_recv = find(source, Rights::RECV).unwrap();
+    let recipient_root_slot = find(recipient, Rights::GRANT).unwrap();
+    let recipient_root = capability(recipient, recipient_root_slot).unwrap();
+    assert!(install_transfer_message(
+        source,
+        recipient,
+        endpoint,
+        Some(recipient_root)
+    ));
+    assert!(
+        super::complete_parked_recv(
+            source,
+            &recv_wire(recipient, 1),
+            u64::from(source_recv.get()),
+            |_| true
+        )
+        .is_ok()
+    );
+    let source_parent_slot = CapSlot::try_new(1).unwrap();
+    let source_parent = capability(source, source_parent_slot).unwrap();
+    assert!(source_parent.rights.contains(Rights::GRANT));
+
+    let recipient_base = super::relations_projection_observation(recipient).unwrap();
+    let send_wire = transfer_wire(source, 7, Rights::SEND, 1);
+    crate::platform::set_user_memory_for_test(send_wire);
+    let mut frame = TrapFrame::zeroed();
+    frame.rdi = u64::from(source_parent_slot.get());
+    frame.rsi = 0;
+    frame.rdx = MAX_BUFFER_BYTES as u64;
+    assert_eq!(
+        super::send(&frame, source),
+        Ok((0, MAX_BUFFER_BYTES as u64))
+    );
+
+    let recipient_recv = find(recipient, Rights::RECV).unwrap();
+    assert!(
+        super::complete_parked_recv(
+            recipient,
+            &recv_wire(source, 2),
+            u64::from(recipient_recv.get()),
+            |_| {
+                assert_eq!(revoke(source, source_parent_slot), Ok(2));
+                let replacement_wire = transfer_wire(recipient, 8, Rights::ALL, 2);
+                crate::platform::set_user_memory_for_test(replacement_wire);
+                let mut replacement_frame = TrapFrame::zeroed();
+                replacement_frame.rdi = u64::from(recipient_root_slot.get());
+                replacement_frame.rsi = 0;
+                replacement_frame.rdx = MAX_BUFFER_BYTES as u64;
+                assert_eq!(
+                    super::send(&replacement_frame, recipient),
+                    Ok((0, MAX_BUFFER_BYTES as u64))
+                );
+                assert!(
+                    super::complete_parked_recv(
+                        source,
+                        &recv_wire(recipient, 1),
+                        u64::from(source_recv.get()),
+                        |_| true
+                    )
+                    .is_ok()
+                );
+                let replacement = capability(source, source_parent_slot).unwrap();
+                assert_eq!(replacement.endpoint, source_parent.endpoint);
+                assert_eq!(replacement.generation, source_parent.generation);
+                assert_eq!(replacement.rights, Rights::ALL);
+                assert_eq!(
+                    replacement.parent,
+                    Some(DerivationLink {
+                        domain: recipient,
+                        slot: recipient_root_slot
+                    })
+                );
+                false
+            }
+        )
+        .is_err()
+    );
+
+    assert_eq!(queued_for(recipient), 1);
+    assert_eq!(queued_for(source), 0);
+    assert!(capability(recipient, CapSlot::try_new(2).unwrap()).is_none());
+    let evidence =
+        super::relations_projection_fold(recipient, recipient_base.0, recipient_base.1).unwrap();
+    assert!(evidence.fold_matches);
+}
+
+#[test]
 fn cap_revoke_removes_grandchild_and_drains_derived_queue() {
     let _guard = test_lock();
     reset();

--- a/kernel/crates/astrid-native-kernel/src/ipc/revoke_tests.rs
+++ b/kernel/crates/astrid-native-kernel/src/ipc/revoke_tests.rs
@@ -68,6 +68,25 @@ fn derived_transfer(parent: Capability, owner: DomainToken, slot: CapSlot) -> Ca
     }
 }
 
+fn transfer_wire(
+    sender: DomainToken,
+    tag: u32,
+    requested_rights: Rights,
+    payload_byte: u8,
+) -> [u8; MAX_BUFFER_BYTES] {
+    let mut parsed = abi::MessageBuffer::zeroed();
+    parsed.set_message(
+        tag,
+        abi::FLAG_TRANSFER,
+        4,
+        [payload_byte; abi::MAX_PAYLOAD_BYTES],
+    );
+    let mut wire = parsed.into_wire(sender);
+    wire[16..32].fill(0);
+    wire[10..12].copy_from_slice(&requested_rights.bits().to_le_bytes());
+    wire
+}
+
 #[test]
 fn rollback_rejects_replaced_parent_without_grant() {
     let _guard = test_lock();
@@ -102,11 +121,7 @@ fn rollback_rejects_replaced_parent_without_grant() {
     assert!(source_parent.rights.contains(Rights::GRANT));
 
     let recipient_base = super::relations_projection_observation(recipient).unwrap();
-    let mut send_wire = abi::MessageBuffer::zeroed();
-    send_wire.set_message(7, abi::FLAG_TRANSFER, 4, [1u8; abi::MAX_PAYLOAD_BYTES]);
-    let mut send_wire = send_wire.into_wire(source);
-    send_wire[16..32].fill(0);
-    send_wire[10..12].copy_from_slice(&Rights::SEND.bits().to_le_bytes());
+    let send_wire = transfer_wire(source, 7, Rights::SEND, 1);
     crate::platform::set_user_memory_for_test(send_wire);
     let mut frame = TrapFrame::zeroed();
     frame.rdi = u64::from(source_parent_slot.get());
@@ -125,16 +140,7 @@ fn rollback_rejects_replaced_parent_without_grant() {
             u64::from(recipient_recv.get()),
             |_| {
                 assert_eq!(revoke(source, source_parent_slot), Ok(2));
-                let mut replacement_wire = abi::MessageBuffer::zeroed();
-                replacement_wire.set_message(
-                    8,
-                    abi::FLAG_TRANSFER,
-                    4,
-                    [2u8; abi::MAX_PAYLOAD_BYTES],
-                );
-                let mut replacement_wire = replacement_wire.into_wire(recipient);
-                replacement_wire[16..32].fill(0);
-                replacement_wire[10..12].copy_from_slice(&Rights::SEND.bits().to_le_bytes());
+                let replacement_wire = transfer_wire(recipient, 8, Rights::SEND, 2);
                 crate::platform::set_user_memory_for_test(replacement_wire);
                 let mut replacement_frame = TrapFrame::zeroed();
                 replacement_frame.rdi = u64::from(recipient_root_slot.get());

--- a/kernel/crates/astrid-native-kernel/src/ipc/rollback.rs
+++ b/kernel/crates/astrid-native-kernel/src/ipc/rollback.rs
@@ -1,7 +1,7 @@
 //! Rollback of a received IPC transfer after a failed user-copy commit.
 
 use super::IpcState;
-use super::capability::{CapSlot, Capability, DomainToken};
+use super::capability::{CapSlot, Capability, DomainToken, Rights};
 use super::endpoint::Message;
 
 pub(super) fn rollback_recv(
@@ -47,6 +47,7 @@ pub(super) fn queued_transfer_authority_valid(
             };
             parent.endpoint == capability.endpoint
                 && parent.generation == capability.generation
+                && parent.rights.contains(Rights::GRANT)
                 && parent.rights.contains(capability.rights)
         },
         None => state.capabilities[sender.slot().index()]

--- a/kernel/crates/astrid-native-kernel/src/ipc/rollback.rs
+++ b/kernel/crates/astrid-native-kernel/src/ipc/rollback.rs
@@ -8,12 +8,20 @@ pub(super) fn rollback_recv(
     domain: DomainToken,
     endpoint_id: super::EndpointId,
     message: Message,
-    slot: Option<CapSlot>,
+    installed: Option<(CapSlot, Capability)>,
 ) {
     let mut state = super::IPC.lock();
-    if let Some(slot) = slot {
-        state.capabilities[domain.slot().index()].remove(domain, slot);
+    if let Some((slot, transferred)) = installed {
+        let table = &mut state.capabilities[domain.slot().index()];
+        if table
+            .get(domain, slot)
+            .is_some_and(|current| current == transferred)
+        {
+            table.remove(domain, slot);
+        }
     }
+    // The destination slot may have been revoked and reused independently of
+    // the queued message. The message's own authority is still checked below.
     // A receive is durable only when its authority remains valid. Requeueing a
     // transfer whose parent or endpoint vanished in the commit gap would let a
     // revoked capability return through an apparently ordinary retry.

--- a/kernel/crates/astrid-native-kernel/src/ipc/rollback.rs
+++ b/kernel/crates/astrid-native-kernel/src/ipc/rollback.rs
@@ -1,0 +1,58 @@
+//! Rollback of a received IPC transfer after a failed user-copy commit.
+
+use super::IpcState;
+use super::capability::{CapSlot, Capability, DomainToken};
+use super::endpoint::Message;
+
+pub(super) fn rollback_recv(
+    domain: DomainToken,
+    endpoint_id: super::EndpointId,
+    message: Message,
+    slot: Option<CapSlot>,
+) {
+    let mut state = super::IPC.lock();
+    if let Some(slot) = slot {
+        state.capabilities[domain.slot().index()].remove(domain, slot);
+    }
+    // A receive is durable only when its authority remains valid. Requeueing a
+    // transfer whose parent or endpoint vanished in the commit gap would let a
+    // revoked capability return through an apparently ordinary retry.
+    if message.transfer().is_none_or(|capability| {
+        queued_transfer_authority_valid(&state, message.sender(), capability)
+    }) && let Some(object) = state.objects[endpoint_id.index()].as_mut()
+    {
+        object.restore(domain, message, false);
+    }
+}
+
+pub(super) fn queued_transfer_authority_valid(
+    state: &IpcState,
+    sender: DomainToken,
+    capability: Capability,
+) -> bool {
+    let authority_live = match capability.parent {
+        Some(parent_link) => {
+            let Some(parent) = state.capabilities[parent_link.domain.slot().index()]
+                .get(parent_link.domain, parent_link.slot)
+            else {
+                return false;
+            };
+            parent.endpoint == capability.endpoint
+                && parent.generation == capability.generation
+                && parent.rights.contains(capability.rights)
+        },
+        None => state.capabilities[sender.slot().index()]
+            .capability_slots()
+            .iter()
+            .flatten()
+            .any(|held| *held == capability),
+    };
+    if !authority_live {
+        return false;
+    }
+    state.objects[capability.endpoint.index()]
+        .as_ref()
+        .is_some_and(|object| {
+            object.generation() == capability.generation && object.accepts(sender)
+        })
+}

--- a/kernel/crates/astrid-native-kernel/src/lib.rs
+++ b/kernel/crates/astrid-native-kernel/src/lib.rs
@@ -21,9 +21,9 @@ pub mod ipc;
 #[cfg(not(test))]
 pub mod memory;
 pub mod platform;
-// Production-compiled ahead of its first consumer so the native target keeps
-// typechecking the frozen relation semantics.
-#[allow(dead_code)]
+// The first-slice paging/reclaim API remains frozen ahead of its external
+// caller; the same-lock adapter already consumes the mutation core.
+#[cfg_attr(not(test), allow(dead_code))]
 mod relations;
 #[cfg(not(test))]
 pub mod serial;

--- a/kernel/crates/astrid-native-kernel/src/lib.rs
+++ b/kernel/crates/astrid-native-kernel/src/lib.rs
@@ -25,6 +25,10 @@ pub mod platform;
 // typechecking the frozen relation semantics.
 #[allow(dead_code)]
 mod relations;
+// Production-compiled ahead of its first consumer so the native target keeps
+// typechecking the frozen audit-chain semantics.
+#[allow(dead_code)]
+mod audit;
 #[cfg(not(test))]
 pub mod serial;
 #[cfg(not(test))]

--- a/kernel/crates/astrid-native-kernel/src/relations/adapter.rs
+++ b/kernel/crates/astrid-native-kernel/src/relations/adapter.rs
@@ -1,5 +1,9 @@
 //! Same-lock translation of authoritative IPC/domain state into relations.
 
+#[cfg(test)]
+use super::delta::DeltaCursor;
+#[cfg(test)]
+use super::projection::Snapshot;
 use super::projection::{ProjectionStore, ReaderLease};
 use super::types::{
     CapabilityGeneration, CapabilityInstance, CapabilitySlot, ObjectKind, ObjectRef, ObjectToken,
@@ -147,17 +151,28 @@ pub(crate) fn domain_released(
     store.retire_reader(domain)
 }
 
-pub(crate) fn projection_evidence(
-    store: &mut ProjectionStore,
+#[cfg(test)]
+pub(crate) fn projection_observation(
+    store: &ProjectionStore,
     domain: DomainToken,
+) -> Result<(Snapshot, DeltaCursor), ProjectionError> {
+    let lease = reader(store, domain)?;
+    Ok((store.snapshot(lease)?, store.delta_cursor(lease)?))
+}
+
+#[cfg(test)]
+pub(crate) fn projection_fold_evidence(
+    store: &ProjectionStore,
+    domain: DomainToken,
+    base: Snapshot,
+    cursor: DeltaCursor,
 ) -> Result<ProjectionEvidence, ProjectionError> {
     let lease = reader(store, domain)?;
-    let (base, replayed) = store.current_fold(lease)?;
-    let replayed = replayed.ok_or(ProjectionError::Denied)?;
+    let replayed = store.fold(lease, base, cursor)?;
     let direct = store.snapshot(lease)?;
     Ok(ProjectionEvidence {
-        epoch: base.epoch(),
-        rows: base.len(),
+        epoch: direct.epoch(),
+        rows: direct.len(),
         fold_epoch: replayed.epoch(),
         fold_rows: replayed.len(),
         fold_matches: replayed == direct,

--- a/kernel/crates/astrid-native-kernel/src/relations/adapter.rs
+++ b/kernel/crates/astrid-native-kernel/src/relations/adapter.rs
@@ -1,0 +1,200 @@
+//! Same-lock translation of authoritative IPC/domain state into relations.
+
+use super::projection::{ProjectionStore, ReaderLease};
+use super::types::{
+    CapabilityGeneration, CapabilityInstance, CapabilitySlot, ObjectKind, ObjectRef, ObjectToken,
+    ProjectionError, Relation, RelationChange, RelationRights,
+};
+use crate::ipc::DomainToken;
+
+/// The projection-visible portion of a landed capability, with no private IPC
+/// type in the signature.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct CapabilityFacts {
+    slot: u64,
+    object: u64,
+    generation: u64,
+    rights: u16,
+}
+
+impl CapabilityFacts {
+    pub(crate) const fn new(slot: u64, object: u64, generation: u64, rights: u16) -> Self {
+        Self {
+            slot,
+            object,
+            generation,
+            rights,
+        }
+    }
+}
+
+/// Runtime evidence from one same-lock fold check.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct ProjectionEvidence {
+    pub(crate) epoch: u64,
+    pub(crate) rows: usize,
+    pub(crate) fold_epoch: u64,
+    pub(crate) fold_rows: usize,
+    pub(crate) fold_matches: bool,
+}
+
+pub(crate) fn domain_registered(
+    store: &mut ProjectionStore,
+    domain: DomainToken,
+) -> Result<(), ProjectionError> {
+    let lease = store.register_reader(domain)?;
+    let object = ObjectRef::new(
+        ObjectKind::Domain,
+        domain_object(domain).ok_or(ProjectionError::Denied)?,
+    );
+    store
+        .apply_mutation(
+            lease,
+            RelationChange::Upsert(Relation::object(lease.token(), object)),
+        )
+        .map(|_| ())
+}
+
+pub(crate) fn endpoint_created(
+    store: &mut ProjectionStore,
+    domain: DomainToken,
+    facts: CapabilityFacts,
+) -> Result<(), ProjectionError> {
+    let lease = reader(store, domain)?;
+    let object = ObjectRef::new(
+        ObjectKind::Endpoint,
+        ObjectToken::new(facts.object).ok_or(ProjectionError::Denied)?,
+    );
+    let capability = instance(lease, facts)?;
+    let rights = rights(facts)?;
+    store.apply_mutation(
+        lease,
+        RelationChange::Upsert(Relation::object(lease.token(), object)),
+    )?;
+    store
+        .apply_mutation(
+            lease,
+            RelationChange::Upsert(
+                Relation::holds(lease.token(), capability, object, rights)
+                    .ok_or(ProjectionError::Denied)?,
+            ),
+        )
+        .map(|_| ())
+}
+
+pub(crate) fn capability_installed(
+    store: &mut ProjectionStore,
+    owner: DomainToken,
+    owner_facts: CapabilityFacts,
+    child: DomainToken,
+    child_facts: CapabilityFacts,
+) -> Result<(), ProjectionError> {
+    let child_lease = reader(store, child)?;
+    let parent_lease = reader(store, owner)?;
+    let object = ObjectRef::new(
+        ObjectKind::Endpoint,
+        ObjectToken::new(child_facts.object).ok_or(ProjectionError::Denied)?,
+    );
+    let parent = instance(parent_lease, owner_facts)?;
+    let capability = instance(child_lease, child_facts)?;
+    let rights = rights(child_facts)?;
+    store.apply_mutation(
+        child_lease,
+        RelationChange::Upsert(Relation::object(child_lease.token(), object)),
+    )?;
+    store.apply_mutation(
+        child_lease,
+        RelationChange::Upsert(
+            Relation::holds(child_lease.token(), capability, object, rights)
+                .ok_or(ProjectionError::Denied)?,
+        ),
+    )?;
+    store
+        .apply_mutation(
+            child_lease,
+            RelationChange::Upsert(
+                Relation::derives(child_lease.token(), parent, capability)
+                    .ok_or(ProjectionError::Denied)?,
+            ),
+        )
+        .map(|_| ())
+}
+
+pub(crate) fn capability_removed(
+    store: &mut ProjectionStore,
+    owner: DomainToken,
+    facts: CapabilityFacts,
+) -> Result<usize, ProjectionError> {
+    let capability = capability_without_lease(store, owner, facts)?;
+    store.remove_capability(capability)
+}
+
+pub(crate) fn endpoint_reclaimed(
+    store: &mut ProjectionStore,
+    generation: u64,
+) -> Result<usize, ProjectionError> {
+    let object = ObjectRef::new(
+        ObjectKind::Endpoint,
+        ObjectToken::new(generation).ok_or(ProjectionError::Denied)?,
+    );
+    store.record_object_reclaim(object)
+}
+
+pub(crate) fn domain_released(
+    store: &mut ProjectionStore,
+    domain: DomainToken,
+) -> Result<(), ProjectionError> {
+    store.retire_reader(domain)
+}
+
+pub(crate) fn projection_evidence(
+    store: &mut ProjectionStore,
+    domain: DomainToken,
+) -> Result<ProjectionEvidence, ProjectionError> {
+    let lease = reader(store, domain)?;
+    let (base, replayed) = store.current_fold(lease)?;
+    let replayed = replayed.ok_or(ProjectionError::Denied)?;
+    let direct = store.snapshot(lease)?;
+    Ok(ProjectionEvidence {
+        epoch: base.epoch(),
+        rows: base.len(),
+        fold_epoch: replayed.epoch(),
+        fold_rows: replayed.len(),
+        fold_matches: replayed == direct,
+    })
+}
+
+fn reader(store: &ProjectionStore, domain: DomainToken) -> Result<ReaderLease, ProjectionError> {
+    store.reader_lease(domain).ok_or(ProjectionError::Denied)
+}
+
+fn domain_object(domain: DomainToken) -> Option<ObjectToken> {
+    ObjectToken::new(domain.generation().get())
+}
+
+fn instance(
+    lease: ReaderLease,
+    facts: CapabilityFacts,
+) -> Result<CapabilityInstance, ProjectionError> {
+    let slot = CapabilitySlot::try_new(facts.slot as usize).ok_or(ProjectionError::Denied)?;
+    let generation = CapabilityGeneration::new(facts.generation).ok_or(ProjectionError::Denied)?;
+    let object = ObjectRef::new(
+        ObjectKind::Endpoint,
+        ObjectToken::new(facts.object).ok_or(ProjectionError::Denied)?,
+    );
+    CapabilityInstance::try_new(lease.token(), slot, object, generation)
+        .ok_or(ProjectionError::Denied)
+}
+
+fn capability_without_lease(
+    store: &ProjectionStore,
+    owner: DomainToken,
+    facts: CapabilityFacts,
+) -> Result<CapabilityInstance, ProjectionError> {
+    let lease = reader(store, owner)?;
+    instance(lease, facts)
+}
+
+fn rights(facts: CapabilityFacts) -> Result<RelationRights, ProjectionError> {
+    RelationRights::from_landed(facts.rights).ok_or(ProjectionError::Denied)
+}

--- a/kernel/crates/astrid-native-kernel/src/relations/adapter_tests.rs
+++ b/kernel/crates/astrid-native-kernel/src/relations/adapter_tests.rs
@@ -64,6 +64,80 @@ fn recv_wire(cap_slot: u16) -> [u8; MAX_BUFFER_BYTES] {
     wire
 }
 
+#[test]
+fn revoked_during_parked_commit_gap_does_not_project_stale_transfer() {
+    let _guard = test_lock();
+    reset();
+    let creator = domain(0);
+    let peer = domain(1);
+    prepare_domain(creator);
+    prepare_domain(peer);
+    let endpoint = endpoint_create(creator).unwrap();
+    assert!(bind_peer(creator, peer).is_ok());
+
+    let creator_root = capability(creator, creator.slot()).unwrap();
+    assert!(install_transfer_message(
+        creator,
+        creator,
+        endpoint,
+        Some(creator_root)
+    ));
+    assert!(
+        complete_parked_recv(creator, &recv_wire(1), 0, |_| true).is_ok(),
+        "creator anchor keeps the transferred endpoint live through the race"
+    );
+
+    let transferred_base = observation(peer);
+    let source_slot = TestCapSlot::try_new(0).unwrap();
+    let transferred_capability = capability(peer, source_slot).unwrap();
+    assert!(install_transfer_message(
+        peer,
+        peer,
+        endpoint,
+        Some(transferred_capability)
+    ));
+
+    let destination_slot = TestCapSlot::try_new(1).unwrap();
+    let wire = recv_wire(1);
+    assert!(
+        complete_parked_recv(peer, &wire, 0, |_| {
+            assert_eq!(cap_revoke(creator, creator.slot()), Ok(3));
+            true
+        })
+        .is_ok()
+    );
+
+    assert!(capability(peer, source_slot).is_none());
+    assert!(capability(peer, destination_slot).is_none());
+    let direct = observation(peer).0;
+    assert!(
+        !direct.rows().any(|relation| matches!(
+            relation.key(),
+            RelationKey::Holds { capability, .. } if capability.slot().index() <= 1
+        )),
+        "no peer Holds row may survive the authoritative revoke"
+    );
+    assert!(
+        !direct.rows().any(|relation| matches!(
+            relation.key(),
+            RelationKey::Derives { child, .. } if child.slot().index() <= 1
+        )),
+        "no peer Derives row may survive the authoritative revoke"
+    );
+    let mut objects = 0;
+    let mut holds = 0;
+    let mut derives = 0;
+    for relation in direct.rows() {
+        match relation.key() {
+            RelationKey::Object { .. } => objects += 1,
+            RelationKey::Holds { .. } => holds += 1,
+            RelationKey::Derives { .. } => derives += 1,
+        }
+    }
+    assert_eq!((objects, holds, derives), (2, 0, 0));
+    require_fold_from(peer, transferred_base.0, transferred_base.1);
+}
+
 fn require_fold(evidence: ProjectionEvidence) {
     assert!(evidence.fold_matches);
     assert_eq!(evidence.epoch, evidence.fold_epoch);

--- a/kernel/crates/astrid-native-kernel/src/relations/adapter_tests.rs
+++ b/kernel/crates/astrid-native-kernel/src/relations/adapter_tests.rs
@@ -2,11 +2,12 @@
 
 use super::adapter::ProjectionEvidence;
 use crate::ipc::test_support::{
-    cap_revoke, capability, endpoint_create, install_transfer_message, reset, test_lock,
+    cap_revoke, capability, endpoint_create, install_transfer_message, queued_for, reset, test_lock,
 };
 use crate::ipc::{
-    DomainToken, MAX_BUFFER_BYTES, TestCapSlot, bind_peer, complete_parked_recv, prepare_domain,
-    relations_projection_fold, relations_projection_observation, teardown_domain,
+    Capability, DerivationLink, DomainToken, MAX_BUFFER_BYTES, TestCapSlot, bind_peer,
+    complete_parked_recv, prepare_domain, relations_projection_fold,
+    relations_projection_observation, teardown_domain,
 };
 use crate::relations::types::RelationKey;
 use crate::relations::{DeltaCursor, Snapshot};
@@ -15,6 +16,15 @@ fn domain(slot: u64) -> DomainToken {
     DomainToken::new(slot, 1).unwrap()
 }
 
+fn linked_transfer(capability: Capability, parent: DomainToken, slot: TestCapSlot) -> Capability {
+    Capability {
+        parent: Some(DerivationLink {
+            domain: parent,
+            slot,
+        }),
+        ..capability
+    }
+}
 #[test]
 fn failed_transfer_copyout_does_not_install_stale_waiter() {
     let _guard = test_lock();
@@ -136,6 +146,75 @@ fn revoked_during_parked_commit_gap_does_not_project_stale_transfer() {
     }
     assert_eq!((objects, holds, derives), (2, 0, 0));
     require_fold_from(peer, transferred_base.0, transferred_base.1);
+}
+
+#[test]
+fn revoked_parent_during_parked_failure_consumes_stale_retry() {
+    let _guard = test_lock();
+    reset();
+    let creator = domain(0);
+    let peer = domain(1);
+    prepare_domain(creator);
+    prepare_domain(peer);
+    let endpoint = endpoint_create(creator).unwrap();
+    assert!(bind_peer(creator, peer).is_ok());
+
+    let creator_root = capability(creator, creator.slot()).unwrap();
+    let parent_anchor = linked_transfer(creator_root, creator, creator.slot());
+    assert!(install_transfer_message(
+        creator,
+        creator,
+        endpoint,
+        Some(parent_anchor)
+    ));
+    let anchor_slot = TestCapSlot::try_new(1).unwrap();
+    assert!(complete_parked_recv(creator, &recv_wire(1), 0, |_| true).is_ok());
+    let parent = capability(creator, anchor_slot).unwrap();
+
+    let queued_base = observation(peer);
+    let source_slot = TestCapSlot::try_new(0).unwrap();
+    let stale_transfer = linked_transfer(parent, creator, anchor_slot);
+    assert!(install_transfer_message(
+        peer,
+        creator,
+        endpoint,
+        Some(stale_transfer)
+    ));
+    let destination_slot = TestCapSlot::try_new(2).unwrap();
+    let wire = recv_wire(2);
+    assert!(
+        complete_parked_recv(peer, &wire, 0, |_| {
+            assert_eq!(cap_revoke(creator, anchor_slot), Ok(2));
+            false
+        })
+        .is_err()
+    );
+
+    assert_eq!(queued_for(peer), 0);
+    assert!(capability(peer, destination_slot).is_none());
+    assert!(capability(creator, anchor_slot).is_none());
+    assert!(capability(peer, source_slot).is_some());
+    assert!(complete_parked_recv(peer, &wire, 0, |_| true).is_err());
+    assert_eq!(queued_for(peer), 0);
+
+    let direct = observation(peer).0;
+    assert!(direct.rows().any(|relation| matches!(
+        relation.key(),
+        RelationKey::Holds { capability, .. } if capability.slot().index() == 0
+    )));
+    assert!(direct.rows().any(|relation| matches!(
+        relation.key(),
+        RelationKey::Derives { child, .. } if child.slot().index() == 0
+    )));
+    assert!(!direct.rows().any(|relation| matches!(
+        relation.key(),
+        RelationKey::Holds { capability, .. } if capability.slot().index() == 2
+    )));
+    assert!(!direct.rows().any(|relation| matches!(
+        relation.key(),
+        RelationKey::Derives { child, .. } if child.slot().index() == 2
+    )));
+    require_fold_from(peer, queued_base.0, queued_base.1);
 }
 
 fn require_fold(evidence: ProjectionEvidence) {

--- a/kernel/crates/astrid-native-kernel/src/relations/adapter_tests.rs
+++ b/kernel/crates/astrid-native-kernel/src/relations/adapter_tests.rs
@@ -217,6 +217,55 @@ fn revoked_parent_during_parked_failure_consumes_stale_retry() {
     require_fold_from(peer, queued_base.0, queued_base.1);
 }
 
+#[test]
+fn commit_false_revoke_and_replace_preserves_destination_replacement() {
+    let _guard = test_lock();
+    reset();
+    let creator = domain(0);
+    let peer = domain(1);
+    prepare_domain(creator);
+    prepare_domain(peer);
+    let endpoint = endpoint_create(creator).unwrap();
+    assert!(bind_peer(creator, peer).is_ok());
+
+    let root_slot = creator.slot();
+    let root = capability(creator, root_slot).unwrap();
+    let transferred = linked_transfer(root, creator, root_slot);
+    assert!(install_transfer_message(
+        peer,
+        creator,
+        endpoint,
+        Some(transferred)
+    ));
+
+    let rollback_base = observation(peer);
+    let destination_slot = TestCapSlot::try_new(1).unwrap();
+    let wire = recv_wire(1);
+    assert!(
+        complete_parked_recv(peer, &wire, 0, |_| {
+            assert_eq!(cap_revoke(peer, destination_slot), Ok(1));
+            assert!(install_transfer_message(
+                peer,
+                creator,
+                endpoint,
+                Some(root)
+            ));
+            assert!(complete_parked_recv(peer, &wire, 0, |_| true).is_ok());
+            false
+        })
+        .is_err()
+    );
+
+    assert_eq!(capability(peer, destination_slot), Some(root));
+    assert_eq!(queued_for(peer), 1);
+    let direct = observation(peer).0;
+    assert!(direct.rows().any(|relation| matches!(
+        relation.key(),
+        RelationKey::Holds { capability, .. } if capability.slot().index() == 1
+    )));
+    require_fold_from(peer, rollback_base.0, rollback_base.1);
+}
+
 fn require_fold(evidence: ProjectionEvidence) {
     assert!(evidence.fold_matches);
     assert_eq!(evidence.epoch, evidence.fold_epoch);

--- a/kernel/crates/astrid-native-kernel/src/relations/adapter_tests.rs
+++ b/kernel/crates/astrid-native-kernel/src/relations/adapter_tests.rs
@@ -6,8 +6,9 @@ use crate::ipc::test_support::{
 };
 use crate::ipc::{
     DomainToken, MAX_BUFFER_BYTES, bind_peer, complete_parked_recv, prepare_domain,
-    relations_projection_evidence, teardown_domain,
+    relations_projection_fold, relations_projection_observation, teardown_domain,
 };
+use crate::relations::{DeltaCursor, Snapshot};
 
 fn domain(slot: u64) -> DomainToken {
     DomainToken::new(slot, 1).unwrap()
@@ -27,6 +28,14 @@ fn require_fold(evidence: ProjectionEvidence) {
     assert_eq!(evidence.rows, evidence.fold_rows);
 }
 
+fn observation(domain: DomainToken) -> (Snapshot, DeltaCursor) {
+    relations_projection_observation(domain).unwrap()
+}
+
+fn require_fold_from(domain: DomainToken, base: Snapshot, cursor: DeltaCursor) {
+    require_fold(relations_projection_fold(domain, base, cursor).unwrap());
+}
+
 #[test]
 fn real_ipc_create_transfer_revoke_and_teardown_fold_to_snapshots() {
     let _guard = test_lock();
@@ -35,28 +44,15 @@ fn real_ipc_create_transfer_revoke_and_teardown_fold_to_snapshots() {
     let peer = domain(1);
     prepare_domain(creator);
     prepare_domain(peer);
-    require_fold(relations_projection_evidence(creator).unwrap());
-    assert_eq!(
-        relations_projection_evidence(creator).unwrap(),
-        ProjectionEvidence {
-            epoch: 1,
-            rows: 1,
-            fold_epoch: 1,
-            fold_rows: 1,
-            fold_matches: true,
-        }
-    );
-
+    let created_base = observation(creator);
     let endpoint = endpoint_create(creator).unwrap();
-    let created = relations_projection_evidence(creator).unwrap();
-    assert_eq!((created.epoch, created.rows), (3, 3));
-    require_fold(created);
+    require_fold_from(creator, created_base.0, created_base.1);
 
+    let bound_base = observation(peer);
     assert!(bind_peer(creator, peer).is_ok());
-    let bound = relations_projection_evidence(peer).unwrap();
-    assert_eq!((bound.epoch, bound.rows), (4, 4));
-    require_fold(bound);
+    require_fold_from(peer, bound_base.0, bound_base.1);
 
+    let transferred_base = observation(peer);
     let root = capability(creator, creator.slot()).unwrap();
     assert!(install_transfer_message(
         peer,
@@ -66,20 +62,16 @@ fn real_ipc_create_transfer_revoke_and_teardown_fold_to_snapshots() {
     ));
     let wire = recv_wire(1);
     assert!(complete_parked_recv(peer, &wire, 0, |_| true).is_ok());
-    let transferred = relations_projection_evidence(peer).unwrap();
-    assert_eq!((transferred.epoch, transferred.rows), (6, 6));
-    require_fold(transferred);
+    require_fold_from(peer, transferred_base.0, transferred_base.1);
 
+    let revoked_base = observation(peer);
     assert_eq!(cap_revoke(creator, creator.slot()), Ok(2));
-    let revoked = relations_projection_evidence(peer).unwrap();
-    assert_eq!((revoked.epoch, revoked.rows), (8, 4));
-    require_fold(revoked);
+    require_fold_from(peer, revoked_base.0, revoked_base.1);
 
+    let surviving_base = observation(peer);
     teardown_domain(creator);
-    let surviving = relations_projection_evidence(peer).unwrap();
-    assert_eq!((surviving.epoch, surviving.rows), (8, 4));
-    require_fold(surviving);
+    require_fold_from(peer, surviving_base.0, surviving_base.1);
 
     teardown_domain(peer);
-    assert!(relations_projection_evidence(peer).is_none());
+    assert!(relations_projection_observation(peer).is_none());
 }

--- a/kernel/crates/astrid-native-kernel/src/relations/adapter_tests.rs
+++ b/kernel/crates/astrid-native-kernel/src/relations/adapter_tests.rs
@@ -1,0 +1,85 @@
+//! Same-lock regressions driven by the real IPC state machine.
+
+use super::adapter::ProjectionEvidence;
+use crate::ipc::test_support::{
+    cap_revoke, capability, endpoint_create, install_transfer_message, reset, test_lock,
+};
+use crate::ipc::{
+    DomainToken, MAX_BUFFER_BYTES, bind_peer, complete_parked_recv, prepare_domain,
+    relations_projection_evidence, teardown_domain,
+};
+
+fn domain(slot: u64) -> DomainToken {
+    DomainToken::new(slot, 1).unwrap()
+}
+
+fn recv_wire(cap_slot: u16) -> [u8; MAX_BUFFER_BYTES] {
+    let mut wire = [0u8; MAX_BUFFER_BYTES];
+    wire[8..10].copy_from_slice(&cap_slot.to_le_bytes());
+    wire[12..14].copy_from_slice(&4u16.to_le_bytes());
+    wire[32] = 7;
+    wire
+}
+
+fn require_fold(evidence: ProjectionEvidence) {
+    assert!(evidence.fold_matches);
+    assert_eq!(evidence.epoch, evidence.fold_epoch);
+    assert_eq!(evidence.rows, evidence.fold_rows);
+}
+
+#[test]
+fn real_ipc_create_transfer_revoke_and_teardown_fold_to_snapshots() {
+    let _guard = test_lock();
+    reset();
+    let creator = domain(0);
+    let peer = domain(1);
+    prepare_domain(creator);
+    prepare_domain(peer);
+    require_fold(relations_projection_evidence(creator).unwrap());
+    assert_eq!(
+        relations_projection_evidence(creator).unwrap(),
+        ProjectionEvidence {
+            epoch: 1,
+            rows: 1,
+            fold_epoch: 1,
+            fold_rows: 1,
+            fold_matches: true,
+        }
+    );
+
+    let endpoint = endpoint_create(creator).unwrap();
+    let created = relations_projection_evidence(creator).unwrap();
+    assert_eq!((created.epoch, created.rows), (3, 3));
+    require_fold(created);
+
+    assert!(bind_peer(creator, peer).is_ok());
+    let bound = relations_projection_evidence(peer).unwrap();
+    assert_eq!((bound.epoch, bound.rows), (4, 4));
+    require_fold(bound);
+
+    let root = capability(creator, creator.slot()).unwrap();
+    assert!(install_transfer_message(
+        peer,
+        creator,
+        endpoint,
+        Some(root)
+    ));
+    let wire = recv_wire(1);
+    assert!(complete_parked_recv(peer, &wire, 0, |_| true).is_ok());
+    let transferred = relations_projection_evidence(peer).unwrap();
+    assert_eq!((transferred.epoch, transferred.rows), (6, 6));
+    require_fold(transferred);
+
+    assert_eq!(cap_revoke(creator, creator.slot()), Ok(2));
+    let revoked = relations_projection_evidence(peer).unwrap();
+    assert_eq!((revoked.epoch, revoked.rows), (8, 4));
+    require_fold(revoked);
+
+    teardown_domain(creator);
+    let surviving = relations_projection_evidence(peer).unwrap();
+    assert_eq!((surviving.epoch, surviving.rows), (8, 4));
+    require_fold(surviving);
+
+    teardown_domain(peer);
+    assert!(relations_projection_evidence(peer).is_none());
+}

--- a/kernel/crates/astrid-native-kernel/src/relations/adapter_tests.rs
+++ b/kernel/crates/astrid-native-kernel/src/relations/adapter_tests.rs
@@ -5,13 +5,55 @@ use crate::ipc::test_support::{
     cap_revoke, capability, endpoint_create, install_transfer_message, reset, test_lock,
 };
 use crate::ipc::{
-    DomainToken, MAX_BUFFER_BYTES, bind_peer, complete_parked_recv, prepare_domain,
+    DomainToken, MAX_BUFFER_BYTES, TestCapSlot, bind_peer, complete_parked_recv, prepare_domain,
     relations_projection_fold, relations_projection_observation, teardown_domain,
 };
+use crate::relations::types::RelationKey;
 use crate::relations::{DeltaCursor, Snapshot};
 
 fn domain(slot: u64) -> DomainToken {
     DomainToken::new(slot, 1).unwrap()
+}
+
+#[test]
+fn failed_transfer_copyout_does_not_install_stale_waiter() {
+    let _guard = test_lock();
+    reset();
+    let creator = domain(0);
+    let peer = domain(1);
+    prepare_domain(creator);
+    prepare_domain(peer);
+    let endpoint = endpoint_create(creator).unwrap();
+    assert!(bind_peer(creator, peer).is_ok());
+    let root = capability(creator, creator.slot()).unwrap();
+    assert!(install_transfer_message(
+        peer,
+        creator,
+        endpoint,
+        Some(root)
+    ));
+
+    let wire = recv_wire(1);
+    let failed_base = observation(peer);
+    assert!(complete_parked_recv(peer, &wire, 0, |_| false).is_err());
+    let transferred_slot = TestCapSlot::try_new(1).unwrap();
+    assert!(capability(peer, transferred_slot).is_none());
+    require_fold_from(peer, failed_base.0, failed_base.1);
+
+    let retry_base = observation(peer);
+    assert!(complete_parked_recv(peer, &wire, 0, |_| true).is_ok());
+    assert!(capability(peer, transferred_slot).is_some());
+    let direct = observation(peer).0;
+    assert_eq!(direct.rows().count(), retry_base.0.rows().count() + 2);
+    assert!(direct.rows().any(|relation| matches!(
+        relation.key(),
+        RelationKey::Holds { capability, .. } if capability.slot().index() == 1
+    )));
+    assert!(direct.rows().any(|relation| matches!(
+        relation.key(),
+        RelationKey::Derives { child, .. } if child.slot().index() == 1
+    )));
+    require_fold_from(peer, retry_base.0, retry_base.1);
 }
 
 fn recv_wire(cap_slot: u16) -> [u8; MAX_BUFFER_BYTES] {

--- a/kernel/crates/astrid-native-kernel/src/relations/delta.rs
+++ b/kernel/crates/astrid-native-kernel/src/relations/delta.rs
@@ -95,4 +95,8 @@ impl DeltaRing {
     pub(crate) fn deltas(&self) -> [Option<RelationDelta>; DELTA_RING_ENTRIES] {
         self.entries
     }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &RelationDelta> {
+        self.entries.iter().flatten()
+    }
 }

--- a/kernel/crates/astrid-native-kernel/src/relations/mod.rs
+++ b/kernel/crates/astrid-native-kernel/src/relations/mod.rs
@@ -7,13 +7,17 @@ mod types;
 
 #[cfg(test)]
 pub(crate) use adapter::ProjectionEvidence;
-#[cfg(test)]
-pub(crate) use adapter::projection_evidence;
 pub(crate) use adapter::{
     CapabilityFacts, capability_installed, capability_removed, domain_registered, domain_released,
     endpoint_created, endpoint_reclaimed,
 };
+#[cfg(test)]
+pub(crate) use adapter::{projection_fold_evidence, projection_observation};
+#[cfg(test)]
+pub(crate) use delta::DeltaCursor;
 pub(crate) use projection::ProjectionStore;
+#[cfg(test)]
+pub(crate) use projection::Snapshot;
 pub(crate) use types::ProjectionError;
 
 #[cfg(test)]

--- a/kernel/crates/astrid-native-kernel/src/relations/mod.rs
+++ b/kernel/crates/astrid-native-kernel/src/relations/mod.rs
@@ -1,8 +1,22 @@
 //! Kernel- and harness-private typed object relations.
 
+mod adapter;
 mod delta;
 mod projection;
 mod types;
 
+#[cfg(test)]
+pub(crate) use adapter::ProjectionEvidence;
+#[cfg(test)]
+pub(crate) use adapter::projection_evidence;
+pub(crate) use adapter::{
+    CapabilityFacts, capability_installed, capability_removed, domain_registered, domain_released,
+    endpoint_created, endpoint_reclaimed,
+};
+pub(crate) use projection::ProjectionStore;
+pub(crate) use types::ProjectionError;
+
+#[cfg(test)]
+mod adapter_tests;
 #[cfg(test)]
 mod projection_tests;

--- a/kernel/crates/astrid-native-kernel/src/relations/projection.rs
+++ b/kernel/crates/astrid-native-kernel/src/relations/projection.rs
@@ -8,7 +8,14 @@ use super::types::{
 };
 use crate::ipc::DomainToken;
 
+mod batch;
 mod evidence;
+
+#[cfg(test)]
+mod lifecycle_tests;
+
+#[cfg(test)]
+pub(crate) use batch::AuthoritativeBatch;
 
 /// A generation-checked projection reader bound to one domain identity.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -120,64 +127,12 @@ pub struct RelationMutation {
     change: RelationChange,
 }
 
-impl RelationMutation {
-    pub const fn new(reader: ReaderLease, change: RelationChange) -> Self {
-        Self { reader, change }
-    }
-}
-
-#[derive(Clone, Copy)]
-pub struct AuthoritativeBatch {
-    entries: [Option<RelationMutation>; MAX_RELATION_ROWS],
-    len: usize,
-}
-
-impl AuthoritativeBatch {
-    pub const fn empty() -> Self {
-        Self {
-            entries: [None; MAX_RELATION_ROWS],
-            len: 0,
-        }
-    }
-
-    pub fn push(&mut self, mutation: RelationMutation) -> Result<(), ProjectionError> {
-        if self.len == self.entries.len() {
-            return Err(ProjectionError::NoSpace);
-        }
-        self.entries[self.len] = Some(mutation);
-        self.len += 1;
-        Ok(())
-    }
-
-    fn mutations(&self) -> impl Iterator<Item = RelationMutation> + '_ {
-        self.entries[..self.len].iter().copied().flatten()
-    }
-}
-
-#[derive(Clone, Copy)]
-struct BatchPlan {
-    reader_indexes: [usize; MAX_RELATION_ROWS],
-    batch_epochs: [u64; READER_SLOTS],
-    effective: [bool; MAX_RELATION_ROWS],
-    len: usize,
-}
-
-impl BatchPlan {
-    const fn empty() -> Self {
-        Self {
-            reader_indexes: [READER_SLOTS; MAX_RELATION_ROWS],
-            batch_epochs: [0; READER_SLOTS],
-            effective: [false; MAX_RELATION_ROWS],
-            len: 0,
-        }
-    }
-}
-
 /// Projection state only. Authoritative tables remain outside this type.
 #[derive(Clone, Copy)]
 pub struct ProjectionStore {
     next_token: u64,
     readers: [Option<Reader>; READER_SLOTS],
+    retired: [Option<Reader>; READER_SLOTS],
     rows: [Option<Relation>; MAX_RELATION_ROWS],
     row_count: usize,
     reclaim: [Option<ReclaimObservation>; MAX_OBJECT_OBSERVATIONS],
@@ -192,6 +147,7 @@ impl ProjectionStore {
         Self {
             next_token: 1,
             readers: [None; READER_SLOTS],
+            retired: [None; READER_SLOTS],
             rows: [None; MAX_RELATION_ROWS],
             row_count: 0,
             reclaim: [None; MAX_OBJECT_OBSERVATIONS],
@@ -217,51 +173,11 @@ impl ProjectionStore {
             });
         }
 
-        let retirement_epoch = self.readers[slot]
-            .as_ref()
-            .map(|old| {
-                old.epoch
-                    .checked_add(1)
-                    .ok_or(ProjectionError::ResnapshotRequired)
-            })
-            .transpose()?;
-        let token = self.mint_token()?;
-        if let Some(mut old) = self.readers[slot].take() {
-            let epoch = retirement_epoch.expect("checked before retirement");
-            let mut index = 0usize;
-            while index < self.row_count {
-                let Some(row) = self.rows[index] else {
-                    index += 1;
-                    continue;
-                };
-                if row.key().scope() == old.token {
-                    let key = row.key();
-                    old.deltas
-                        .push(RelationDelta::new(epoch, RelationChange::Delete(key)));
-                    remove_row_at(&mut self.rows, &mut self.row_count, index);
-                } else {
-                    index += 1;
-                }
-            }
-            #[cfg(test)]
-            {
-                self.retired_delete_counts[slot] = old
-                    .deltas
-                    .deltas()
-                    .iter()
-                    .filter(|delta| {
-                        delta.is_some_and(|delta| {
-                            delta.epoch() == epoch
-                                && matches!(
-                                    delta.change(),
-                                    RelationChange::Delete(key) if key.scope() == old.token
-                                )
-                        })
-                    })
-                    .count();
-            }
+        if self.readers[slot].is_some() {
+            self.retire_live_reader(slot)?;
         }
 
+        let token = self.mint_token()?;
         self.readers[slot] = Some(Reader::new(token, identity));
         Ok(ReaderLease {
             token,
@@ -269,6 +185,72 @@ impl ProjectionStore {
         })
     }
 
+    fn retire_live_reader(&mut self, slot: usize) -> Result<ReaderLease, ProjectionError> {
+        let retirement_epoch = self.readers[slot]
+            .as_ref()
+            .ok_or(ProjectionError::Denied)?
+            .epoch
+            .checked_add(1)
+            .ok_or(ProjectionError::ResnapshotRequired)?;
+        let mut old = self.readers[slot].take().ok_or(ProjectionError::Denied)?;
+        let lease = ReaderLease {
+            token: old.token,
+            reader: old.identity,
+        };
+        old.epoch = retirement_epoch;
+        let mut index = 0usize;
+        while index < self.row_count {
+            let Some(row) = self.rows[index] else {
+                index += 1;
+                continue;
+            };
+            if row.key().scope() == old.token {
+                let key = row.key();
+                old.deltas.push(RelationDelta::new(
+                    retirement_epoch,
+                    RelationChange::Delete(key),
+                ));
+                remove_row_at(&mut self.rows, &mut self.row_count, index);
+            } else {
+                index += 1;
+            }
+        }
+        #[cfg(test)]
+        {
+            self.retired_delete_counts[slot] = old
+                .deltas
+                .deltas()
+                .iter()
+                .filter(|delta| {
+                    delta.is_some_and(|delta| {
+                        delta.epoch() == retirement_epoch
+                            && matches!(
+                                delta.change(),
+                                RelationChange::Delete(key) if key.scope() == old.token
+                            )
+                    })
+                })
+                .count();
+        }
+        self.retired[slot] = Some(old);
+        self.forget_scope_metadata(lease.token());
+        Ok(lease)
+    }
+
+    fn forget_scope_metadata(&mut self, scope: DomainProjectionToken) {
+        self.reclaim.iter_mut().for_each(|slot| {
+            if slot.is_some_and(|observation| observation.scope() == scope) {
+                *slot = None;
+            }
+        });
+        self.logical_deletions.iter_mut().for_each(|slot| {
+            if slot.is_some_and(|key| key.scope() == scope) {
+                *slot = None;
+            }
+        });
+        self.logical_deletions_overflowed =
+            self.logical_deletions.iter().all(|slot| slot.is_some());
+    }
     pub(crate) fn reader_lease(&self, domain: DomainToken) -> Option<ReaderLease> {
         let reader = self.readers[domain.slot().index()].as_ref()?;
         (reader.identity.domain == domain).then_some(ReaderLease {
@@ -290,36 +272,13 @@ impl ProjectionStore {
     /// down. This is the same DELETE path that later generation reuse uses.
     pub(crate) fn retire_reader(&mut self, domain: DomainToken) -> Result<(), ProjectionError> {
         let slot = domain.slot().index();
-        let Some(old) = self.readers[slot].as_ref() else {
-            return Err(ProjectionError::Denied);
-        };
-        if old.identity.domain != domain {
+        let retired_domain = self.readers[slot]
+            .as_ref()
+            .map(|reader| reader.identity.domain);
+        if retired_domain != Some(domain) {
             return Err(ProjectionError::ResnapshotRequired);
         }
-        let token = old.token;
-        let retirement_epoch = old
-            .epoch
-            .checked_add(1)
-            .ok_or(ProjectionError::ResnapshotRequired)?;
-        let mut old_deltas = DeltaRing::empty();
-        let mut index = 0usize;
-        while index < self.row_count {
-            let Some(row) = self.rows[index] else {
-                index += 1;
-                continue;
-            };
-            if row.key().scope() == token {
-                let key = row.key();
-                old_deltas.push(RelationDelta::new(
-                    retirement_epoch,
-                    RelationChange::Delete(key),
-                ));
-                remove_row_at(&mut self.rows, &mut self.row_count, index);
-            } else {
-                index += 1;
-            }
-        }
-        self.readers[slot] = None;
+        self.retire_live_reader(slot)?;
         Ok(())
     }
 
@@ -376,7 +335,7 @@ impl ProjectionStore {
             })
         }
         for lease in leases.into_iter().flatten() {
-            if self.record_reclaim(lease, object, ReclaimOutcome::ReleaseFailed)? {
+            if self.record_reclaim(lease, object, ReclaimOutcome::Reclaimed)? {
                 recorded += 1;
             }
         }
@@ -438,6 +397,19 @@ impl ProjectionStore {
             reader.token,
         )
         .ok_or(ProjectionError::Denied)
+    }
+
+    fn replayable_reader(&self, lease: ReaderLease) -> Result<&Reader, ProjectionError> {
+        if let Ok(reader) = self.reader_at(lease) {
+            return Ok(reader);
+        }
+        let slot = lease.reader.domain.slot().index();
+        match &self.retired[slot] {
+            Some(reader) if reader.token == lease.token && reader.identity == lease.reader => {
+                Ok(reader)
+            },
+            _ => Err(ProjectionError::ResnapshotRequired),
+        }
     }
 
     pub fn relation_epoch(&self, lease: ReaderLease) -> Result<u64, ProjectionError> {
@@ -531,23 +503,13 @@ impl ProjectionStore {
         Ok(snapshot)
     }
 
-    pub(crate) fn current_fold(
-        &mut self,
-        lease: ReaderLease,
-    ) -> Result<(Snapshot, Option<Snapshot>), ProjectionError> {
-        let base = self.base_snapshot(lease)?;
-        let cursor = self.delta_cursor(lease)?;
-        let replayed = self.fold(lease, base, cursor)?;
-        Ok((base, Some(replayed)))
-    }
-
     pub fn fold(
         &self,
         lease: ReaderLease,
         base: Snapshot,
         cursor: DeltaCursor,
     ) -> Result<Snapshot, ProjectionError> {
-        let reader = self.reader_at(lease)?;
+        let reader = self.replayable_reader(lease)?;
         let identity = self.reader_identity(reader)?;
         if reader.deltas.overflowed()
             || !cursor.matches(identity, base.epoch)
@@ -620,72 +582,6 @@ impl ProjectionStore {
         })
     }
 
-    pub fn apply(&mut self, batch: AuthoritativeBatch) -> Result<usize, ProjectionError> {
-        let plan = self.plan_batch(batch)?;
-
-        // Stage capacity-sensitive row mutations before publishing them. This
-        // lets a later DELETE fund an earlier UPSERT in the same batch without
-        // exposing intermediate state.
-        let mut planned_rows = self.rows;
-        let mut planned_row_count = self.row_count;
-        let mut changed = [false; READER_SLOTS];
-        let mut applied = 0usize;
-        for index in 0..plan.len {
-            if !plan.effective[index] {
-                continue;
-            }
-            let mutation = batch.mutations().nth(index).expect("planned batch index");
-            if !matches!(mutation.change, RelationChange::Delete(_)) {
-                continue;
-            }
-            let reader_index = plan.reader_indexes[index];
-            let mutated = apply_to_rows(&mut planned_rows, &mut planned_row_count, mutation.change);
-            debug_assert!(mutated);
-            changed[reader_index] = true;
-            applied += 1;
-        }
-        for index in 0..plan.len {
-            if !plan.effective[index] {
-                continue;
-            }
-            let mutation = batch.mutations().nth(index).expect("planned batch index");
-            if !matches!(mutation.change, RelationChange::Upsert(_)) {
-                continue;
-            }
-            let reader_index = plan.reader_indexes[index];
-            let mutated = apply_to_rows(&mut planned_rows, &mut planned_row_count, mutation.change);
-            debug_assert!(mutated);
-            changed[reader_index] = true;
-            applied += 1;
-        }
-
-        self.rows = planned_rows;
-        self.row_count = planned_row_count;
-        for index in 0..plan.len {
-            if !plan.effective[index] {
-                continue;
-            }
-            let mutation = batch.mutations().nth(index).expect("planned batch index");
-            let reader_index = plan.reader_indexes[index];
-            let delta = RelationDelta::new(plan.batch_epochs[reader_index], mutation.change);
-            if let Some(reader) = &mut self.readers[reader_index] {
-                reader.deltas.push(delta);
-            }
-            if let RelationChange::Delete(key) = mutation.change {
-                self.record_logical_deletion(key);
-            }
-        }
-
-        for (index, reader) in self.readers.iter_mut().enumerate() {
-            if changed[index]
-                && let Some(reader) = reader
-            {
-                reader.epoch += 1;
-            }
-        }
-        Ok(applied)
-    }
-
     /// Stack-frugal production path for one authoritative relation change.
     /// This mirrors the single-entry case of `apply` without staging the
     /// fixed-capacity batch on the small kernel stack.
@@ -694,6 +590,9 @@ impl ProjectionStore {
         reader: ReaderLease,
         change: RelationChange,
     ) -> Result<(), ProjectionError> {
+        if reader.token != change.key().scope() {
+            return Err(ProjectionError::Denied);
+        }
         let reader_index = self.reader_index(reader)?;
         let batch_epoch = self.readers[reader_index]
             .as_ref()
@@ -731,70 +630,6 @@ impl ProjectionStore {
         } else {
             Err(ProjectionError::NoSpace)
         }
-    }
-
-    fn plan_batch(&self, batch: AuthoritativeBatch) -> Result<BatchPlan, ProjectionError> {
-        let mut plan = BatchPlan::empty();
-        let mut final_row_count = self.row_count;
-
-        // A batch is atomic, so count every effective mutation before
-        // validating capacity. A later DELETE can make room for an earlier
-        // UPSERT even at the fixed ceiling.
-        for mutation in batch.mutations() {
-            let existing = relation_index(&self.rows, mutation.change.key());
-            match mutation.change {
-                RelationChange::Upsert(_) if existing.is_none() => {
-                    final_row_count = final_row_count
-                        .checked_add(1)
-                        .ok_or(ProjectionError::NoSpace)?;
-                },
-                RelationChange::Delete(_) if existing.is_some() => {
-                    final_row_count = final_row_count.saturating_sub(1);
-                },
-                _ => {},
-            }
-        }
-
-        for (index, mutation) in batch.mutations().enumerate() {
-            let key = mutation.change.key();
-            if mutation.reader.token != key.scope()
-                || batch
-                    .mutations()
-                    .take(index)
-                    .any(|previous| previous.change.key() == key)
-            {
-                return Err(ProjectionError::Denied);
-            }
-
-            let reader_index = self.reader_index(mutation.reader)?;
-            let Some(reader) = &self.readers[reader_index] else {
-                return Err(ProjectionError::Denied);
-            };
-            let Some(batch_epoch) = reader.epoch.checked_add(1) else {
-                return Err(ProjectionError::ResnapshotRequired);
-            };
-            plan.batch_epochs[reader_index] = batch_epoch;
-            plan.reader_indexes[index] = reader_index;
-
-            let existing = relation_index(&self.rows, key);
-            let is_new = existing.is_none();
-            match mutation.change {
-                RelationChange::Upsert(relation) => {
-                    self.validate_upsert(relation, is_new, final_row_count)?;
-                    plan.effective[index] =
-                        existing.is_none_or(|at| self.rows[at] != Some(relation));
-                },
-                RelationChange::Delete(_) => {
-                    plan.effective[index] = existing.is_some();
-                },
-            }
-            plan.len = index + 1;
-        }
-
-        if final_row_count > MAX_RELATION_ROWS {
-            return Err(ProjectionError::NoSpace);
-        }
-        Ok(plan)
     }
 
     fn record_logical_deletion(&mut self, key: RelationKey) {
@@ -871,11 +706,39 @@ impl ProjectionStore {
         }) {
             return Ok(false);
         }
+        if outcome == ReclaimOutcome::Reclaimed {
+            self.forget_preceding_object_metadata(object);
+        }
         let Some(slot) = self.reclaim.iter_mut().find(|slot| slot.is_none()) else {
             return Err(ProjectionError::NoSpace);
         };
         *slot = Some(ReclaimObservation::new(lease.token, object, outcome));
         Ok(true)
+    }
+
+    /// Older object generations can never be minted again once a newer one is
+    /// successfully reclaimed. Retiring their metadata keeps repeated IPC
+    /// object lifecycles bounded without weakening the current generation's
+    /// logical DELETE or reclaim observation.
+    fn forget_preceding_object_metadata(&mut self, object: ObjectRef) {
+        let generation = object.token().get();
+        self.reclaim.iter_mut().for_each(|slot| {
+            if slot.is_some_and(|existing| {
+                existing.object_ref().kind() == object.kind()
+                    && existing.object_ref().token().get() < generation
+            }) {
+                *slot = None;
+            }
+        });
+        self.logical_deletions.iter_mut().for_each(|slot| {
+            if slot.is_some_and(|key| {
+                key.object_refs().into_iter().flatten().any(|referenced| {
+                    referenced.kind() == object.kind() && referenced.token().get() < generation
+                })
+            }) {
+                *slot = None;
+            }
+        });
     }
 
     pub fn reclaim_observation(

--- a/kernel/crates/astrid-native-kernel/src/relations/projection.rs
+++ b/kernel/crates/astrid-native-kernel/src/relations/projection.rs
@@ -3,8 +3,8 @@
 use super::delta::{DeltaCursor, DeltaRing, PageCursor, RelationDelta};
 use super::types::{
     CapabilityInstance, DomainProjectionToken, MAX_OBJECT_OBSERVATIONS, MAX_RELATION_ROWS,
-    ObjectRef, ProjectionError, READER_SLOTS, ReaderIdentity, ReclaimObservation, ReclaimOutcome,
-    Relation, RelationChange, RelationKey,
+    ObjectKind, ObjectRef, ProjectionError, READER_SLOTS, ReaderIdentity, ReclaimObservation,
+    ReclaimOutcome, Relation, RelationChange, RelationKey,
 };
 use crate::ipc::DomainToken;
 
@@ -127,6 +127,14 @@ pub struct RelationMutation {
     change: RelationChange,
 }
 
+/// Identity of a DELETE that could not be retained in the bounded table.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct LogicalDeletionOverflow {
+    scope: DomainProjectionToken,
+    object_kind: ObjectKind,
+    generation: u64,
+}
+
 /// Projection state only. Authoritative tables remain outside this type.
 #[derive(Clone, Copy)]
 pub struct ProjectionStore {
@@ -137,7 +145,7 @@ pub struct ProjectionStore {
     row_count: usize,
     reclaim: [Option<ReclaimObservation>; MAX_OBJECT_OBSERVATIONS],
     logical_deletions: [Option<RelationKey>; MAX_RELATION_ROWS],
-    logical_deletions_overflowed: bool,
+    logical_deletions_overflow: [Option<LogicalDeletionOverflow>; READER_SLOTS * 2],
     #[cfg(test)]
     retired_delete_counts: [usize; READER_SLOTS],
 }
@@ -152,7 +160,7 @@ impl ProjectionStore {
             row_count: 0,
             reclaim: [None; MAX_OBJECT_OBSERVATIONS],
             logical_deletions: [None; MAX_RELATION_ROWS],
-            logical_deletions_overflowed: false,
+            logical_deletions_overflow: [None; READER_SLOTS * 2],
             #[cfg(test)]
             retired_delete_counts: [0; READER_SLOTS],
         }
@@ -248,8 +256,11 @@ impl ProjectionStore {
                 *slot = None;
             }
         });
-        self.logical_deletions_overflowed =
-            self.logical_deletions.iter().all(|slot| slot.is_some());
+        self.logical_deletions_overflow.iter_mut().for_each(|slot| {
+            if slot.is_some_and(|overflow| overflow.scope == scope) {
+                *slot = None;
+            }
+        });
     }
     pub(crate) fn reader_lease(&self, domain: DomainToken) -> Option<ReaderLease> {
         let reader = self.readers[domain.slot().index()].as_ref()?;
@@ -641,10 +652,49 @@ impl ProjectionStore {
             .iter_mut()
             .find(|slot| slot.is_none())
         else {
-            self.logical_deletions_overflowed = true;
+            self.record_logical_deletion_overflow(key);
             return;
         };
         *slot = Some(key);
+    }
+
+    fn record_logical_deletion_overflow(&mut self, key: RelationKey) {
+        let Some(object) = key.object_refs().into_iter().flatten().next() else {
+            return;
+        };
+        let generation = key
+            .object_refs()
+            .into_iter()
+            .flatten()
+            .filter(|referenced| referenced.kind() == object.kind())
+            .map(|referenced| referenced.token().get())
+            .max()
+            .unwrap_or_else(|| object.token().get());
+        let overflow = LogicalDeletionOverflow {
+            scope: key.scope(),
+            object_kind: object.kind(),
+            generation,
+        };
+        if let Some(existing) = self
+            .logical_deletions_overflow
+            .iter_mut()
+            .find(|slot| {
+                slot.is_some_and(|existing| {
+                    existing.scope == overflow.scope && existing.object_kind == overflow.object_kind
+                })
+            })
+            .and_then(|slot| slot.as_mut())
+        {
+            existing.generation = existing.generation.max(generation);
+            return;
+        }
+        if let Some(slot) = self
+            .logical_deletions_overflow
+            .iter_mut()
+            .find(|slot| slot.is_none())
+        {
+            *slot = Some(overflow);
+        }
     }
 
     fn validate_upsert(
@@ -653,7 +703,17 @@ impl ProjectionStore {
         is_new: bool,
         final_row_count: usize,
     ) -> Result<(), ProjectionError> {
-        if is_new && (final_row_count > MAX_RELATION_ROWS || self.logical_deletions_overflowed) {
+        if is_new && final_row_count > MAX_RELATION_ROWS {
+            return Err(ProjectionError::NoSpace);
+        }
+        if is_new
+            && relation
+                .key()
+                .object_refs()
+                .into_iter()
+                .flatten()
+                .any(|object| self.logical_deletions_overflowed(relation.key().scope(), object))
+        {
             return Err(ProjectionError::NoSpace);
         }
         if self.logical_deletions.contains(&Some(relation.key())) {
@@ -722,6 +782,7 @@ impl ProjectionStore {
     /// logical DELETE or reclaim observation.
     fn forget_preceding_object_metadata(&mut self, object: ObjectRef) {
         let generation = object.token().get();
+        let mut forgot_preceding_deletion = false;
         self.reclaim.iter_mut().for_each(|slot| {
             if slot.is_some_and(|existing| {
                 existing.object_ref().kind() == object.kind()
@@ -737,8 +798,18 @@ impl ProjectionStore {
                 })
             }) {
                 *slot = None;
+                forgot_preceding_deletion = true;
             }
         });
+        if forgot_preceding_deletion {
+            self.logical_deletions_overflow.iter_mut().for_each(|slot| {
+                if slot.is_some_and(|overflow| {
+                    overflow.object_kind == object.kind() && overflow.generation < generation
+                }) {
+                    *slot = None;
+                }
+            });
+        }
     }
 
     pub fn reclaim_observation(
@@ -749,6 +820,21 @@ impl ProjectionStore {
         self.reader_at(lease)?;
         self.reclaim_for_object(lease.token, object)
             .ok_or(ProjectionError::Denied)
+    }
+
+    fn logical_deletions_overflowed(
+        &self,
+        scope: DomainProjectionToken,
+        object: ObjectRef,
+    ) -> bool {
+        self.logical_deletions_overflow
+            .iter()
+            .flatten()
+            .any(|overflow| {
+                overflow.scope == scope
+                    && overflow.object_kind == object.kind()
+                    && overflow.generation >= object.token().get()
+            })
     }
 
     #[cfg(test)]

--- a/kernel/crates/astrid-native-kernel/src/relations/projection.rs
+++ b/kernel/crates/astrid-native-kernel/src/relations/projection.rs
@@ -2,11 +2,13 @@
 
 use super::delta::{DeltaCursor, DeltaRing, PageCursor, RelationDelta};
 use super::types::{
-    DomainProjectionToken, MAX_OBJECT_OBSERVATIONS, MAX_RELATION_ROWS, ObjectRef, ProjectionError,
-    READER_SLOTS, ReaderIdentity, ReclaimObservation, ReclaimOutcome, Relation, RelationChange,
-    RelationKey,
+    CapabilityInstance, DomainProjectionToken, MAX_OBJECT_OBSERVATIONS, MAX_RELATION_ROWS,
+    ObjectRef, ProjectionError, READER_SLOTS, ReaderIdentity, ReclaimObservation, ReclaimOutcome,
+    Relation, RelationChange, RelationKey,
 };
 use crate::ipc::DomainToken;
+
+mod evidence;
 
 /// A generation-checked projection reader bound to one domain identity.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -267,6 +269,143 @@ impl ProjectionStore {
         })
     }
 
+    pub(crate) fn reader_lease(&self, domain: DomainToken) -> Option<ReaderLease> {
+        let reader = self.readers[domain.slot().index()].as_ref()?;
+        (reader.identity.domain == domain).then_some(ReaderLease {
+            token: reader.token,
+            reader: reader.identity,
+        })
+    }
+
+    fn lease_for_token(&self, token: DomainProjectionToken) -> Option<ReaderLease> {
+        self.readers.iter().flatten().find_map(|reader| {
+            (reader.token == token).then_some(ReaderLease {
+                token,
+                reader: reader.identity,
+            })
+        })
+    }
+
+    /// Retire a generation explicitly when its authoritative domain is torn
+    /// down. This is the same DELETE path that later generation reuse uses.
+    pub(crate) fn retire_reader(&mut self, domain: DomainToken) -> Result<(), ProjectionError> {
+        let slot = domain.slot().index();
+        let Some(old) = self.readers[slot].as_ref() else {
+            return Err(ProjectionError::Denied);
+        };
+        if old.identity.domain != domain {
+            return Err(ProjectionError::ResnapshotRequired);
+        }
+        let token = old.token;
+        let retirement_epoch = old
+            .epoch
+            .checked_add(1)
+            .ok_or(ProjectionError::ResnapshotRequired)?;
+        let mut old_deltas = DeltaRing::empty();
+        let mut index = 0usize;
+        while index < self.row_count {
+            let Some(row) = self.rows[index] else {
+                index += 1;
+                continue;
+            };
+            if row.key().scope() == token {
+                let key = row.key();
+                old_deltas.push(RelationDelta::new(
+                    retirement_epoch,
+                    RelationChange::Delete(key),
+                ));
+                remove_row_at(&mut self.rows, &mut self.row_count, index);
+            } else {
+                index += 1;
+            }
+        }
+        self.readers[slot] = None;
+        Ok(())
+    }
+
+    /// Remove every projection row that names a capability instance. Derives
+    /// rows are charged to the reader whose token owns that full row key.
+    pub(crate) fn remove_capability(
+        &mut self,
+        capability: CapabilityInstance,
+    ) -> Result<usize, ProjectionError> {
+        let mut removed = 0usize;
+        let mut index = 0usize;
+        while index < self.row_count {
+            let Some(relation) = self.rows[index] else {
+                index += 1;
+                continue;
+            };
+            let names_capability = match relation.key() {
+                RelationKey::Holds {
+                    capability: held, ..
+                } => held == capability,
+                RelationKey::Derives { parent, child, .. } => {
+                    parent == capability || child == capability
+                },
+                RelationKey::Object { .. } => false,
+            };
+            if !names_capability {
+                index += 1;
+                continue;
+            }
+
+            let key = relation.key();
+            let lease = self
+                .lease_for_token(key.scope())
+                .ok_or(ProjectionError::Denied)?;
+            self.apply_mutation(lease, RelationChange::Delete(key))?;
+            removed += 1;
+        }
+        Ok(removed)
+    }
+
+    /// Record a physical object-generation reclaim for every live reader. The
+    /// projection rejects a scope if that scope still names the live object.
+    pub(crate) fn record_object_reclaim(
+        &mut self,
+        object: ObjectRef,
+    ) -> Result<usize, ProjectionError> {
+        let mut recorded = 0usize;
+        self.remove_object_rows(object)?;
+        let mut leases = [None; READER_SLOTS];
+        for (index, reader) in self.readers.iter().enumerate() {
+            leases[index] = reader.map(|reader| ReaderLease {
+                token: reader.token,
+                reader: reader.identity,
+            })
+        }
+        for lease in leases.into_iter().flatten() {
+            if self.record_reclaim(lease, object, ReclaimOutcome::ReleaseFailed)? {
+                recorded += 1;
+            }
+        }
+        Ok(recorded)
+    }
+
+    fn remove_object_rows(&mut self, object: ObjectRef) -> Result<usize, ProjectionError> {
+        let mut removed = 0usize;
+        let mut index = 0usize;
+        while index < self.row_count {
+            let Some(relation) = self.rows[index] else {
+                index += 1;
+                continue;
+            };
+            if !relation_is_dead(relation, object) {
+                index += 1;
+                continue;
+            }
+
+            let key = relation.key();
+            let lease = self
+                .lease_for_token(key.scope())
+                .ok_or(ProjectionError::Denied)?;
+            self.apply_mutation(lease, RelationChange::Delete(key))?;
+            removed += 1;
+        }
+        Ok(removed)
+    }
+
     fn mint_token(&mut self) -> Result<DomainProjectionToken, ProjectionError> {
         let token = DomainProjectionToken::new(self.next_token).ok_or(ProjectionError::NoSpace)?;
         self.next_token = self
@@ -390,6 +529,16 @@ impl ProjectionStore {
             reader.deltas = DeltaRing::empty();
         }
         Ok(snapshot)
+    }
+
+    pub(crate) fn current_fold(
+        &mut self,
+        lease: ReaderLease,
+    ) -> Result<(Snapshot, Option<Snapshot>), ProjectionError> {
+        let base = self.base_snapshot(lease)?;
+        let cursor = self.delta_cursor(lease)?;
+        let replayed = self.fold(lease, base, cursor)?;
+        Ok((base, Some(replayed)))
     }
 
     pub fn fold(
@@ -535,6 +684,53 @@ impl ProjectionStore {
             }
         }
         Ok(applied)
+    }
+
+    /// Stack-frugal production path for one authoritative relation change.
+    /// This mirrors the single-entry case of `apply` without staging the
+    /// fixed-capacity batch on the small kernel stack.
+    pub(crate) fn apply_mutation(
+        &mut self,
+        reader: ReaderLease,
+        change: RelationChange,
+    ) -> Result<(), ProjectionError> {
+        let reader_index = self.reader_index(reader)?;
+        let batch_epoch = self.readers[reader_index]
+            .as_ref()
+            .and_then(|reader| reader.epoch.checked_add(1))
+            .ok_or(ProjectionError::ResnapshotRequired)?;
+        let existing = relation_index(&self.rows, change.key());
+        let mut next_row_count = self.row_count;
+
+        let effective = match change {
+            RelationChange::Upsert(relation) => {
+                let is_new = existing.is_none();
+                if is_new {
+                    next_row_count = next_row_count
+                        .checked_add(1)
+                        .ok_or(ProjectionError::NoSpace)?;
+                }
+                self.validate_upsert(relation, is_new, next_row_count)?;
+                existing.is_none_or(|at| self.rows[at] != Some(relation))
+            },
+            RelationChange::Delete(_) => existing.is_some(),
+        };
+        if !effective {
+            return Ok(());
+        }
+
+        if apply_to_rows(&mut self.rows, &mut self.row_count, change) {
+            if let Some(reader) = &mut self.readers[reader_index] {
+                reader.deltas.push(RelationDelta::new(batch_epoch, change));
+                reader.epoch = batch_epoch;
+            }
+            if let RelationChange::Delete(key) = change {
+                self.record_logical_deletion(key);
+            }
+            Ok(())
+        } else {
+            Err(ProjectionError::NoSpace)
+        }
     }
 
     fn plan_batch(&self, batch: AuthoritativeBatch) -> Result<BatchPlan, ProjectionError> {

--- a/kernel/crates/astrid-native-kernel/src/relations/projection/batch.rs
+++ b/kernel/crates/astrid-native-kernel/src/relations/projection/batch.rs
@@ -1,0 +1,192 @@
+//! Atomic fixed-capacity mutation batches for the relation projection.
+
+use super::{
+    ProjectionStore, ReaderLease, RelationChange, RelationMutation, apply_to_rows, relation_index,
+};
+use crate::relations::delta::RelationDelta;
+use crate::relations::types::{MAX_RELATION_ROWS, ProjectionError, READER_SLOTS};
+
+impl RelationMutation {
+    pub(crate) const fn new(reader: ReaderLease, change: RelationChange) -> Self {
+        Self { reader, change }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct AuthoritativeBatch {
+    entries: [Option<RelationMutation>; MAX_RELATION_ROWS],
+    len: usize,
+}
+
+impl AuthoritativeBatch {
+    pub(crate) const fn empty() -> Self {
+        Self {
+            entries: [None; MAX_RELATION_ROWS],
+            len: 0,
+        }
+    }
+
+    pub(crate) fn push(&mut self, mutation: RelationMutation) -> Result<(), ProjectionError> {
+        if self.len == self.entries.len() {
+            return Err(ProjectionError::NoSpace);
+        }
+        self.entries[self.len] = Some(mutation);
+        self.len += 1;
+        Ok(())
+    }
+
+    fn mutations(&self) -> impl Iterator<Item = RelationMutation> + '_ {
+        self.entries[..self.len].iter().copied().flatten()
+    }
+}
+
+#[derive(Clone, Copy)]
+struct BatchPlan {
+    reader_indexes: [usize; MAX_RELATION_ROWS],
+    batch_epochs: [u64; READER_SLOTS],
+    effective: [bool; MAX_RELATION_ROWS],
+    len: usize,
+}
+
+impl BatchPlan {
+    const fn empty() -> Self {
+        Self {
+            reader_indexes: [READER_SLOTS; MAX_RELATION_ROWS],
+            batch_epochs: [0; READER_SLOTS],
+            effective: [false; MAX_RELATION_ROWS],
+            len: 0,
+        }
+    }
+}
+
+impl ProjectionStore {
+    pub(crate) fn apply(&mut self, batch: AuthoritativeBatch) -> Result<usize, ProjectionError> {
+        let plan = self.plan_batch(batch)?;
+
+        // Stage capacity-sensitive row mutations before publishing them. This
+        // lets a later DELETE fund an earlier UPSERT in the same batch without
+        // exposing intermediate state.
+        let mut planned_rows = self.rows;
+        let mut planned_row_count = self.row_count;
+        let mut changed = [false; READER_SLOTS];
+        let mut applied = 0usize;
+        for index in 0..plan.len {
+            if !plan.effective[index] {
+                continue;
+            }
+            let mutation = batch.mutations().nth(index).expect("planned batch index");
+            if !matches!(mutation.change, RelationChange::Delete(_)) {
+                continue;
+            }
+            let reader_index = plan.reader_indexes[index];
+            let mutated = apply_to_rows(&mut planned_rows, &mut planned_row_count, mutation.change);
+            debug_assert!(mutated);
+            changed[reader_index] = true;
+            applied += 1;
+        }
+        for index in 0..plan.len {
+            if !plan.effective[index] {
+                continue;
+            }
+            let mutation = batch.mutations().nth(index).expect("planned batch index");
+            if !matches!(mutation.change, RelationChange::Upsert(_)) {
+                continue;
+            }
+            let reader_index = plan.reader_indexes[index];
+            let mutated = apply_to_rows(&mut planned_rows, &mut planned_row_count, mutation.change);
+            debug_assert!(mutated);
+            changed[reader_index] = true;
+            applied += 1;
+        }
+
+        self.rows = planned_rows;
+        self.row_count = planned_row_count;
+        for index in 0..plan.len {
+            if !plan.effective[index] {
+                continue;
+            }
+            let mutation = batch.mutations().nth(index).expect("planned batch index");
+            let reader_index = plan.reader_indexes[index];
+            let delta = RelationDelta::new(plan.batch_epochs[reader_index], mutation.change);
+            if let Some(reader) = &mut self.readers[reader_index] {
+                reader.deltas.push(delta);
+            }
+            if let RelationChange::Delete(key) = mutation.change {
+                self.record_logical_deletion(key);
+            }
+        }
+
+        for (index, reader) in self.readers.iter_mut().enumerate() {
+            if changed[index]
+                && let Some(reader) = reader
+            {
+                reader.epoch += 1;
+            }
+        }
+        Ok(applied)
+    }
+
+    fn plan_batch(&self, batch: AuthoritativeBatch) -> Result<BatchPlan, ProjectionError> {
+        let mut plan = BatchPlan::empty();
+        let mut final_row_count = self.row_count;
+
+        // A batch is atomic, so count every effective mutation before
+        // validating capacity. A later DELETE can make room for an earlier
+        // UPSERT even at the fixed ceiling.
+        for mutation in batch.mutations() {
+            let existing = relation_index(&self.rows, mutation.change.key());
+            match mutation.change {
+                RelationChange::Upsert(_) if existing.is_none() => {
+                    final_row_count = final_row_count
+                        .checked_add(1)
+                        .ok_or(ProjectionError::NoSpace)?;
+                },
+                RelationChange::Delete(_) if existing.is_some() => {
+                    final_row_count = final_row_count.saturating_sub(1);
+                },
+                _ => {},
+            }
+        }
+
+        for (index, mutation) in batch.mutations().enumerate() {
+            let key = mutation.change.key();
+            if mutation.reader.token != key.scope()
+                || batch
+                    .mutations()
+                    .take(index)
+                    .any(|previous| previous.change.key() == key)
+            {
+                return Err(ProjectionError::Denied);
+            }
+
+            let reader_index = self.reader_index(mutation.reader)?;
+            let Some(reader) = &self.readers[reader_index] else {
+                return Err(ProjectionError::Denied);
+            };
+            let Some(batch_epoch) = reader.epoch.checked_add(1) else {
+                return Err(ProjectionError::ResnapshotRequired);
+            };
+            plan.batch_epochs[reader_index] = batch_epoch;
+            plan.reader_indexes[index] = reader_index;
+
+            let existing = relation_index(&self.rows, key);
+            let is_new = existing.is_none();
+            match mutation.change {
+                RelationChange::Upsert(relation) => {
+                    self.validate_upsert(relation, is_new, final_row_count)?;
+                    plan.effective[index] =
+                        existing.is_none_or(|at| self.rows[at] != Some(relation));
+                },
+                RelationChange::Delete(_) => {
+                    plan.effective[index] = existing.is_some();
+                },
+            }
+            plan.len = index + 1;
+        }
+
+        if final_row_count > MAX_RELATION_ROWS {
+            return Err(ProjectionError::NoSpace);
+        }
+        Ok(plan)
+    }
+}

--- a/kernel/crates/astrid-native-kernel/src/relations/projection/evidence.rs
+++ b/kernel/crates/astrid-native-kernel/src/relations/projection/evidence.rs
@@ -1,0 +1,37 @@
+//! Stack-frugal runtime observation for the projection.
+
+use super::{DomainToken, ProjectionError, ProjectionStore};
+
+impl ProjectionStore {
+    /// Compact same-lock runtime evidence. Full snapshot replay is exercised
+    /// by host tests; this scan avoids staging large snapshot arrays on the
+    /// kernel stack while validating the live fold's epoch chain and row count.
+    pub(crate) fn runtime_evidence(
+        &self,
+        domain: DomainToken,
+    ) -> Result<(u64, usize, u64, usize, bool), ProjectionError> {
+        let lease = self.reader_lease(domain).ok_or(ProjectionError::Denied)?;
+        let reader = self.reader_at(lease)?;
+        if reader.deltas.overflowed() {
+            return Err(ProjectionError::ResnapshotRequired);
+        }
+
+        let rows = self
+            .rows
+            .iter()
+            .flatten()
+            .filter(|relation| relation.key().scope() == lease.token)
+            .count();
+        let mut expected_epoch = 0u64;
+        let mut fold_matches = true;
+        for delta in reader.deltas.iter() {
+            let epoch = delta.epoch();
+            fold_matches &= epoch == expected_epoch.checked_add(1).unwrap_or(epoch)
+                && delta.change().key().scope() == lease.token;
+            expected_epoch = epoch;
+        }
+        fold_matches &= expected_epoch == reader.epoch;
+
+        Ok((reader.epoch, rows, reader.epoch, rows, fold_matches))
+    }
+}

--- a/kernel/crates/astrid-native-kernel/src/relations/projection/lifecycle_tests.rs
+++ b/kernel/crates/astrid-native-kernel/src/relations/projection/lifecycle_tests.rs
@@ -124,3 +124,69 @@ fn successful_reclaim_is_accurate_and_replaces_older_generations() {
         ReclaimOutcome::Reclaimed
     );
 }
+
+#[test]
+fn successful_newer_reclaim_resolves_logical_deletion_overflow() {
+    let mut store = ProjectionStore::empty();
+    let lease = reader(&mut store, 0, 1);
+    for value in 1..=(MAX_RELATION_ROWS as u64 + 1) {
+        let relation = endpoint_relation(lease, value);
+        store
+            .apply_mutation(lease, RelationChange::Upsert(relation))
+            .unwrap();
+        store
+            .apply_mutation(lease, RelationChange::Delete(relation.key()))
+            .unwrap();
+    }
+
+    assert!(
+        store
+            .record_reclaim(
+                lease,
+                endpoint_object(MAX_RELATION_ROWS as u64 + 2),
+                ReclaimOutcome::Reclaimed,
+            )
+            .unwrap()
+    );
+
+    let base = store.base_snapshot(lease).unwrap();
+    let cursor = store.delta_cursor(lease).unwrap();
+    let reused = endpoint_relation(lease, MAX_RELATION_ROWS as u64 + 3);
+    store
+        .apply_mutation(lease, RelationChange::Upsert(reused))
+        .unwrap();
+    assert_eq!(store.snapshot(lease).unwrap().rows().count(), 1);
+    assert_eq!(
+        store.fold(lease, base, cursor).unwrap(),
+        store.snapshot(lease).unwrap()
+    );
+}
+
+#[test]
+fn unrelated_retirement_does_not_invent_logical_deletion_overflow() {
+    let mut store = ProjectionStore::empty();
+    let occupied = reader(&mut store, 0, 1);
+    for value in 1..=MAX_RELATION_ROWS as u64 {
+        let relation = endpoint_relation(occupied, value);
+        store
+            .apply_mutation(occupied, RelationChange::Upsert(relation))
+            .unwrap();
+        store
+            .apply_mutation(occupied, RelationChange::Delete(relation.key()))
+            .unwrap();
+    }
+    reader(&mut store, 1, 1);
+    reader(&mut store, 1, 2);
+
+    let base = store.base_snapshot(occupied).unwrap();
+    let cursor = store.delta_cursor(occupied).unwrap();
+    let relation = endpoint_relation(occupied, MAX_RELATION_ROWS as u64 + 1);
+    store
+        .apply_mutation(occupied, RelationChange::Upsert(relation))
+        .unwrap();
+    assert_eq!(store.snapshot(occupied).unwrap().rows().count(), 1);
+    assert_eq!(
+        store.fold(occupied, base, cursor).unwrap(),
+        store.snapshot(occupied).unwrap()
+    );
+}

--- a/kernel/crates/astrid-native-kernel/src/relations/projection/lifecycle_tests.rs
+++ b/kernel/crates/astrid-native-kernel/src/relations/projection/lifecycle_tests.rs
@@ -1,0 +1,126 @@
+//! Retirement and bounded metadata regressions for the live projection path.
+
+use super::{ProjectionStore, ReaderLease};
+use crate::ipc::DomainToken;
+use crate::relations::types::{
+    MAX_OBJECT_OBSERVATIONS, MAX_RELATION_ROWS, ObjectKind, ObjectRef, ObjectToken,
+    ProjectionError, ReclaimOutcome, Relation, RelationChange,
+};
+
+fn reader(store: &mut ProjectionStore, slot: u64, generation: u64) -> ReaderLease {
+    store
+        .register_reader(DomainToken::new(slot, generation).unwrap())
+        .unwrap()
+}
+
+fn endpoint_object(value: u64) -> ObjectRef {
+    ObjectRef::new(ObjectKind::Endpoint, ObjectToken::new(value).unwrap())
+}
+
+fn endpoint_relation(lease: ReaderLease, value: u64) -> Relation {
+    Relation::object(lease.token(), endpoint_object(value))
+}
+
+#[test]
+fn single_mutation_denies_a_foreign_scope_without_mutation() {
+    let mut store = ProjectionStore::empty();
+    let authorized = reader(&mut store, 0, 1);
+    let foreign = reader(&mut store, 1, 1);
+    let relation = endpoint_relation(foreign, 1);
+
+    assert_eq!(
+        store.apply_mutation(authorized, RelationChange::Upsert(relation)),
+        Err(ProjectionError::Denied)
+    );
+    assert!(store.snapshot(authorized).unwrap().is_empty());
+}
+
+#[test]
+fn retirement_preserves_the_old_lease_fold() {
+    let mut store = ProjectionStore::empty();
+    let old = reader(&mut store, 0, 1);
+    let relation = endpoint_relation(old, 1);
+    store
+        .apply_mutation(old, RelationChange::Upsert(relation))
+        .unwrap();
+    let base = store.snapshot(old).unwrap();
+    let cursor = store.delta_cursor(old).unwrap();
+
+    reader(&mut store, 0, 2);
+    assert_eq!(store.retired_delete_count(0), 1);
+    let replayed = store.fold(old, base, cursor).unwrap();
+    assert_eq!(replayed.epoch(), 2);
+    assert!(replayed.is_empty());
+    assert_eq!(
+        store.snapshot(old).unwrap_err(),
+        ProjectionError::ResnapshotRequired
+    );
+}
+
+#[test]
+fn retirement_clears_scope_tombstones_and_reclaims() {
+    let mut store = ProjectionStore::empty();
+    let old = reader(&mut store, 0, 1);
+    let live = reader(&mut store, 1, 1);
+    for value in 1..=MAX_RELATION_ROWS as u64 {
+        let relation = endpoint_relation(old, value);
+        store
+            .apply_mutation(old, RelationChange::Upsert(relation))
+            .unwrap();
+        store
+            .apply_mutation(old, RelationChange::Delete(relation.key()))
+            .unwrap();
+    }
+    for value in 1..=MAX_OBJECT_OBSERVATIONS {
+        store
+            .record_reclaim(
+                old,
+                endpoint_object(value as u64 + MAX_RELATION_ROWS as u64),
+                ReclaimOutcome::ReleaseFailed,
+            )
+            .unwrap();
+    }
+    let live_relation = endpoint_relation(live, 1);
+    store
+        .apply_mutation(live, RelationChange::Upsert(live_relation))
+        .unwrap();
+
+    let fresh = reader(&mut store, 0, 2);
+    let fresh_relation = endpoint_relation(fresh, MAX_RELATION_ROWS as u64 + 2);
+    store
+        .apply_mutation(fresh, RelationChange::Upsert(fresh_relation))
+        .unwrap();
+    assert_eq!(store.snapshot(live).unwrap().len(), 1);
+    assert_eq!(store.snapshot(fresh).unwrap().len(), 1);
+}
+
+#[test]
+fn successful_reclaim_is_accurate_and_replaces_older_generations() {
+    let mut store = ProjectionStore::empty();
+    let lease = reader(&mut store, 0, 1);
+    for value in 1..=MAX_OBJECT_OBSERVATIONS {
+        assert!(
+            store
+                .record_reclaim(
+                    lease,
+                    endpoint_object(value as u64),
+                    ReclaimOutcome::ReleaseFailed,
+                )
+                .unwrap()
+        );
+    }
+
+    let reclaimed = endpoint_object(MAX_OBJECT_OBSERVATIONS as u64 + 1);
+    assert!(
+        store
+            .record_reclaim(lease, reclaimed, ReclaimOutcome::Reclaimed)
+            .unwrap()
+    );
+    assert_eq!(
+        store
+            .reclaim_observation(lease, reclaimed)
+            .unwrap()
+            .outcome(),
+        ReclaimOutcome::Reclaimed
+    );
+}

--- a/kernel/crates/astrid-native-kernel/src/relations/types.rs
+++ b/kernel/crates/astrid-native-kernel/src/relations/types.rs
@@ -357,6 +357,7 @@ impl RelationChange {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ReclaimOutcome {
+    Reclaimed,
     ReleaseFailed,
     ReclaimBlocked,
 }
@@ -401,4 +402,16 @@ pub enum ProjectionError {
     Resurrection,
     ReaderSlotsExhausted,
     ResnapshotRequired,
+}
+
+impl ProjectionError {
+    pub(crate) const fn code(self) -> u8 {
+        match self {
+            Self::Denied => 1,
+            Self::NoSpace => 2,
+            Self::Resurrection => 3,
+            Self::ReaderSlotsExhausted => 4,
+            Self::ResnapshotRequired => 5,
+        }
+    }
 }

--- a/kernel/crates/astrid-native-kernel/src/serial.rs
+++ b/kernel/crates/astrid-native-kernel/src/serial.rs
@@ -367,6 +367,22 @@ pub fn ev_ipc_op(id: u64, generation: u64, operation: &str, status: &str) {
     ));
 }
 
+pub fn ev_relations_projection(
+    id: u64,
+    generation: u64,
+    epoch: u64,
+    rows: usize,
+    fold_epoch: u64,
+    fold_rows: usize,
+    fold_matches: bool,
+) {
+    emit(format_args!(
+        "\"ev\":\"relations.projection\",\"same_lock\":true,\"id\":{id},\"generation\":{generation},\
+        \"epoch\":{epoch},\"rows\":{rows},\"fold_epoch\":{fold_epoch},\"fold_rows\":{fold_rows},\
+        \"fold_matches\":{fold_matches}"
+    ));
+}
+
 pub fn ev_ipc_park(id: u64, generation: u64) {
     emit(format_args!(
         "\"ev\":\"ipc.park\",\"id\":{id},\"generation\":{generation}"

--- a/kernel/crates/astrid-native-kernel/src/serial.rs
+++ b/kernel/crates/astrid-native-kernel/src/serial.rs
@@ -383,6 +383,12 @@ pub fn ev_relations_projection(
     ));
 }
 
+pub fn ev_relations_projection_failed(operation: &'static str, error: u8) {
+    emit(format_args!(
+        "\"ev\":\"relations.projection.failed\",\"op\":\"{operation}\",\"error\":{error}"
+    ));
+}
+
 pub fn ev_ipc_park(id: u64, generation: u64) {
     emit(format_args!(
         "\"ev\":\"ipc.park\",\"id\":{id},\"generation\":{generation}"

--- a/kernel/tools/ktest/src/events/mod.rs
+++ b/kernel/tools/ktest/src/events/mod.rs
@@ -9,8 +9,9 @@
 use serde_json::Value;
 
 mod closure;
+mod relations_gate;
 
-use closure::closure_holds;
+use {closure::closure_holds, relations_gate::relations_projection_holds};
 const REQUIRED_ONCE: &[&str] = &[
     "boot.entry",
     "idt.ready",
@@ -174,9 +175,9 @@ const CANCEL_TAIL_EVENTS: &[&str] = &[
     "domain.cancelled",
     "domain.outcome",
 ];
-const IPC_PARK_TAIL_EVENTS: &[&str] = &["ipc.op", "ipc.park"];
 const IPC_PARK_EVENT: &str = "ipc.park";
 const IPC_SERVER_RESUME_TAIL_EVENTS: &[&str] = &["ipc.wake", "ipc.resume", "ipc.op", "ipc.park"];
+const IPC_PARK_TAIL_EVENTS: &[&str] = &["relations.projection", "ipc.op", "ipc.park"];
 const IPC_CLIENT_RESUME_TAIL_EVENTS: &[&str] = &[
     "ipc.wake",
     "ipc.resume",
@@ -195,7 +196,18 @@ const IPC_FAULT_CLIENT_TAIL_EVENTS: &[&str] = &[
     "domain.restore",
     "domain.reclaim",
 ];
-const IPC_CANCEL_GUEST_OPS: &[&str] = &["ipc.op", "ipc.op"];
+const IPC_CANCEL_GUEST_OPS: &[&str] = &["relations.projection", "ipc.op", "ipc.op"];
+const IPC_CLIENT_OPS: &[&str] = &[
+    "ipc.op",
+    "ipc.op",
+    "ipc.op",
+    "relations.projection",
+    "ipc.op",
+    "ipc.op",
+    "ipc.op",
+    "ipc.op",
+    "ipc.op",
+];
 const IPC_CANCEL_GUEST_TAIL_EVENTS: &[&str] = &[
     "domain.registers",
     "domain.outcome",
@@ -289,7 +301,7 @@ fn full_sequence() -> Vec<SequenceStep> {
     pattern.push(SequenceStep::Many(IPC_PARK_TAIL_EVENTS));
     push_started(&mut pattern);
     pattern.push(SequenceStep::Many(GUEST_ENTRY_EVENTS));
-    pattern.push(SequenceStep::Repeated("ipc.op", 8));
+    pattern.push(SequenceStep::Many(IPC_CLIENT_OPS));
     pattern.push(SequenceStep::One(IPC_PARK_EVENT));
     pattern.push(SequenceStep::Many(IPC_SERVER_RESUME_TAIL_EVENTS));
     pattern.push(SequenceStep::Many(IPC_CLIENT_RESUME_TAIL_EVENTS));
@@ -758,6 +770,7 @@ fn domain_lifecycle_holds(events: &[Value]) -> bool {
     let ipc_flow_ok = count_named(events, "ipc.park") == 4
         && count_named(events, "ipc.wake") == 2
         && count_named(events, "ipc.resume") == 2;
+    let relations_ok = relations_projection_holds(events);
     let tamper_events = named_events(events, "domain.auth.reject")
         .into_iter()
         .filter(|event| string_field(event, "reason") == Some("tampered_component_rejected"))
@@ -801,6 +814,7 @@ fn domain_lifecycle_holds(events: &[Value]) -> bool {
     ok &= check("exact private-IPC operations", ipc_ops_ok);
     ok &= check("exact private-IPC reclaim evidence", ipc_reclaims_ok);
     ok &= check("exact private-IPC park/wake/resume flow", ipc_flow_ok);
+    ok &= check("same-lock IPC relation projection", relations_ok);
     ok &= check("no domain accounting leaks", accounting_ok);
     ok &= check(
         "tampered component rejection before auth success",

--- a/kernel/tools/ktest/src/events/relations_gate.rs
+++ b/kernel/tools/ktest/src/events/relations_gate.rs
@@ -1,0 +1,38 @@
+//! Exact evidence gate for same-lock IPC relation projections.
+
+use super::{all_bools, u64_field};
+use serde_json::Value;
+
+const RELATION_PROJECTIONS: &[(u64, u64, u64, usize, usize)] = &[
+    (1, 7, 3, 3, 3),
+    (2, 3, 6, 6, 6),
+    (1, 8, 3, 3, 3),
+    (1, 9, 3, 3, 3),
+];
+
+pub(super) fn relations_projection_holds(events: &[Value]) -> bool {
+    named_relation_events(events)
+        .into_iter()
+        .map(|event| {
+            (
+                u64_field(event, "id").unwrap_or_default(),
+                u64_field(event, "generation").unwrap_or_default(),
+                u64_field(event, "epoch").unwrap_or_default(),
+                u64_field(event, "rows").unwrap_or_default() as usize,
+                u64_field(event, "fold_rows").unwrap_or_default() as usize,
+            )
+        })
+        .eq(RELATION_PROJECTIONS.iter().copied())
+        && all_bools(events, "relations.projection", "same_lock", true)
+        && all_bools(events, "relations.projection", "fold_matches", true)
+        && named_relation_events(events)
+            .into_iter()
+            .all(|event| u64_field(event, "epoch") == u64_field(event, "fold_epoch"))
+}
+
+fn named_relation_events(events: &[Value]) -> Vec<&Value> {
+    events
+        .iter()
+        .filter(|event| event.get("ev").and_then(Value::as_str) == Some("relations.projection"))
+        .collect()
+}

--- a/kernel/tools/ktest/src/events/tests.rs
+++ b/kernel/tools/ktest/src/events/tests.rs
@@ -126,7 +126,16 @@ fn emit_ipc_op(serial: Emit<'_>, id: u64, generation: u64, op: &str, status: &st
     ));
 }
 
-fn emit_ipc_park(serial: Emit<'_>, id: u64, generation: u64) {
+fn emit_relation(serial: Emit<'_>, id: u64, generation: u64, epoch: u64, rows: usize) {
+    serial(format!(
+        "\"ev\":\"relations.projection\",\"same_lock\":true,\"id\":{id},\"generation\":{generation},\
+            \"epoch\":{epoch},\"rows\":{rows},\"fold_epoch\":{epoch},\"fold_rows\":{rows},\
+            \"fold_matches\":true"
+    ));
+}
+
+fn emit_ipc_park(serial: Emit<'_>, id: u64, generation: u64, epoch: u64, rows: usize) {
+    emit_relation(serial, id, generation, epoch, rows);
     emit_ipc_op(serial, id, generation, "endpoint_create", "ok");
     serial(format!(
         "\"ev\":\"ipc.park\",\"id\":{id},\"generation\":{generation}"
@@ -213,7 +222,8 @@ fn emit_ipc_server_peer_release(serial: Emit<'_>, id: u64, generation: u64) {
     ));
 }
 
-fn emit_ipc_cancel_guest(serial: Emit<'_>, id: u64, generation: u64) {
+fn emit_ipc_cancel_guest(serial: Emit<'_>, id: u64, generation: u64, epoch: u64, rows: usize) {
+    emit_relation(serial, id, generation, epoch, rows);
     emit_ipc_op(serial, id, generation, "endpoint_create", "ok");
     emit_ipc_op(serial, id, generation, "cancel", "ok");
     emit_ipc_terminal(serial, id, generation, 0, "clean_exit", 3, "0x0", 7, 1, 1);
@@ -334,11 +344,11 @@ fn passing_serial_with(kernel: &str, sysgen: &str, kfloor: u64, sfloor: u64) -> 
     emit_prepare(&mut ev, 1, 7, 6);
     emit_start(&mut ev, 1, 7, 6);
     emit_context(&mut ev, 1, 7, 0);
-    emit_ipc_park(&mut ev, 1, 7);
+    emit_ipc_park(&mut ev, 1, 7, 3, 3);
     emit_prepare(&mut ev, 2, 3, 7);
     emit_start(&mut ev, 2, 3, 7);
     emit_context(&mut ev, 2, 3, 0);
-    for (op, status) in [
+    for (index, (op, status)) in [
         ("send", "malformed"),
         ("send", "malformed"),
         ("send", "malformed"),
@@ -347,7 +357,13 @@ fn passing_serial_with(kernel: &str, sysgen: &str, kfloor: u64, sfloor: u64) -> 
         ("send", "malformed"),
         ("send", "malformed"),
         ("send", "malformed"),
-    ] {
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        if index == 3 {
+            emit_relation(&mut ev, 2, 3, 6, 6);
+        }
         emit_ipc_op(&mut ev, 2, 3, op, status);
     }
     ev("\"ev\":\"ipc.park\",\"id\":2,\"generation\":3".into());
@@ -359,7 +375,7 @@ fn passing_serial_with(kernel: &str, sysgen: &str, kfloor: u64, sfloor: u64) -> 
     emit_prepare(&mut ev, 1, 8, 6);
     emit_start(&mut ev, 1, 8, 6);
     emit_context(&mut ev, 1, 8, 0);
-    emit_ipc_park(&mut ev, 1, 8);
+    emit_ipc_park(&mut ev, 1, 8, 3, 3);
     emit_prepare(&mut ev, 2, 4, 8);
     emit_start(&mut ev, 2, 4, 8);
     emit_context(&mut ev, 2, 4, 0);
@@ -381,7 +397,7 @@ fn passing_serial_with(kernel: &str, sysgen: &str, kfloor: u64, sfloor: u64) -> 
     emit_prepare(&mut ev, 1, 9, 10);
     emit_start(&mut ev, 1, 9, 10);
     emit_context(&mut ev, 1, 9, 0);
-    emit_ipc_cancel_guest(&mut ev, 1, 9);
+    emit_ipc_cancel_guest(&mut ev, 1, 9, 3, 3);
     emit_pass(&mut ev, super::DOMAIN_REQUIRED_PASSES[10]);
     emit_pass(&mut ev, super::CLEAN_RESTART_GATE);
     ev("\"ev\":\"domain.harness\",\"outcome\":true".into());

--- a/kernel/tools/native-audit-verifier/Cargo.toml
+++ b/kernel/tools/native-audit-verifier/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "native-audit-verifier"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[lib]
+name = "native_audit_verifier"
+test = true
+bench = false
+
+[dependencies]
+# Same frozen pure backend as the kernel crates so digests cannot differ by
+# feature selection.
+blake3 = { version = "=1.8.5", default-features = false, features = ["pure"] }

--- a/kernel/tools/native-audit-verifier/src/lib.rs
+++ b/kernel/tools/native-audit-verifier/src/lib.rs
@@ -1,0 +1,473 @@
+//! Private host-side verifier for the native-kernel audit chain (#1759).
+//!
+//! The kernel is the only authority. This tool independently decodes the
+//! frozen canonical frames, folds the rolling BLAKE3 root, checks
+//! kernel-authenticated checkpoints, and reports Invalid versus Incomplete.
+//! It never writes kernel state and is not a second fact base.
+//!
+//! Verification material enters only through an explicitly injected,
+//! independently trusted kernel-origin anchor. The untrusted verifier
+//! handoff carries no key material; it merely binds one boot/session
+//! authority instance to that anchor, and no envelope may authenticate
+//! itself with material carried inside the same untrusted input.
+
+pub mod wire;
+
+#[cfg(test)]
+mod tests;
+
+use blake3::Hasher;
+
+/// Frozen canonical frame-codec version this verifier understands.
+pub const CODEC_VERSION: u16 = 1;
+/// Fixed wire size of the canonical checkpoint form.
+pub const CHECKPOINT_WIRE_BYTES: usize = 4 + 2 + 16 + 8 + 32 + 8 + 8 + 32;
+/// Fixed size of the kernel-minted untrusted handoff binding: magic,
+/// authority id, boot/session identity, keyed tag. No verification material.
+pub const AUTHORITY_HANDOFF_BYTES: usize = 64;
+
+const ROOT_ALGORITHM_ID: &[u8] = b"BLAKE3-256";
+const ROOT_DOMAIN_TAG: &[u8] = b"astrid.native-kernel.audit-root.v1";
+const GENESIS_DOMAIN_TAG: &[u8] = b"astrid.native-kernel.audit-genesis.v1";
+const CHECKPOINT_DOMAIN_TAG: &[u8] = b"astrid.native-kernel.audit-checkpoint.v1";
+const ACK_DOMAIN_TAG: &[u8] = b"astrid.native-kernel.audit-ack.v1";
+const VERIFIER_HANDOFF_DOMAIN_TAG: &[u8] = b"astrid.native-kernel.audit-verifier-handoff.v1";
+
+/// Hard decode failure of one input.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VerifyFailure {
+    Malformed,
+    HandoffUnbound,
+    CheckpointMismatch,
+    SequenceOverflow,
+    StaleRelayGeneration,
+}
+
+/// One fold step failure. Invalid means the input contradicts the chain;
+/// Incomplete means the truth cannot be established without more evidence.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FoldFailure {
+    Invalid(InvalidReason),
+    Incomplete(IncompleteReason),
+    SequenceOverflow,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum InvalidReason {
+    Malformed,
+    DuplicateOrReorder,
+    ForeignBoot,
+    PreviousRootMismatch,
+    RootMismatch,
+    DenialDisclosure,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum IncompleteReason {
+    SequenceGap,
+}
+
+/// Opaque evidence that this verifier completed one fold. Relay code may
+/// acknowledge only with this receipt plus the same source root; it can never
+/// synthesize a retirement from an unfolded frame.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FoldReceipt {
+    seq: u64,
+    folded_root: [u8; 32],
+    ack_tag: [u8; 32],
+}
+
+impl FoldReceipt {
+    pub const fn seq(self) -> u64 {
+        self.seq
+    }
+
+    pub const fn folded_root(self) -> [u8; 32] {
+        self.folded_root
+    }
+
+    pub const fn ack_tag(self) -> [u8; 32] {
+        self.ack_tag
+    }
+}
+
+/// A kernel-authenticated checkpoint view, already tag-verified.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CheckpointView {
+    pub boot: [u8; 16],
+    pub seq: u64,
+    pub root: [u8; 32],
+    pub codec_version: u16,
+    pub relay_generation: u64,
+    pub authority_id: u64,
+    pub tag: [u8; 32],
+}
+
+/// Verifier authority bound to one independently trusted kernel-origin
+/// anchor. This is the modeled trusted channel of the unwired first slice:
+/// the anchor is injected from outside the untrusted handoff path, and
+/// production anchor delivery, provisioning, and key lifecycle are named
+/// #1759 residuals. It is the only way verification material enters this
+/// crate; there is deliberately no constructor from untrusted handoff
+/// bytes, because an envelope cannot authenticate itself with material
+/// carried inside it.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct AuthContext {
+    authority_id: u64,
+    boot: [u8; 16],
+    verification_key: [u8; 32],
+}
+
+impl AuthContext {
+    /// The only trusted-entry constructor. Rejects degenerate anchors so a
+    /// zero authority id, zero boot, or zero key can never anchor a session.
+    pub fn from_trusted_anchor(
+        authority_id: u64,
+        boot: [u8; 16],
+        verification_key: [u8; 32],
+    ) -> Result<Self, VerifyFailure> {
+        if authority_id == 0
+            || boot.iter().all(|byte| *byte == 0)
+            || verification_key.iter().all(|byte| *byte == 0)
+        {
+            return Err(VerifyFailure::Malformed);
+        }
+        Ok(Self {
+            authority_id,
+            boot,
+            verification_key,
+        })
+    }
+
+    /// Binds untrusted handoff bytes against this trusted anchor. The
+    /// handoff must name the anchored authority id and boot, and its
+    /// minting tag must verify under the anchor key it does not carry.
+    /// A structurally valid but caller-minted handoff therefore stays
+    /// unbound: only the kernel-side key can produce the tag.
+    pub fn bind_handoff(&self, bytes: &[u8; AUTHORITY_HANDOFF_BYTES]) -> Result<(), VerifyFailure> {
+        if bytes[..8] != *b"ASAUDCTX" {
+            return Err(VerifyFailure::Malformed);
+        }
+        let authority_id = u64::from_le_bytes(
+            bytes[8..16]
+                .try_into()
+                .ok()
+                .ok_or(VerifyFailure::Malformed)?,
+        );
+        let boot = bytes[16..32]
+            .try_into()
+            .ok()
+            .filter(|boot: &[u8; 16]| boot.iter().any(|byte| *byte != 0))
+            .ok_or(VerifyFailure::Malformed)?;
+        if authority_id != self.authority_id || boot != self.boot {
+            return Err(VerifyFailure::HandoffUnbound);
+        }
+        let tag: [u8; 32] = bytes[32..]
+            .try_into()
+            .map_err(|_| VerifyFailure::Malformed)?;
+        if verifier_handoff_tag(boot, authority_id, &self.verification_key) != tag {
+            return Err(VerifyFailure::HandoffUnbound);
+        }
+        Ok(())
+    }
+}
+
+impl core::fmt::Debug for AuthContext {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("AuthContext(REDACTED)")
+    }
+}
+
+fn genesis_root(boot: [u8; 16]) -> [u8; 32] {
+    let mut hasher = Hasher::new();
+    hasher.update(GENESIS_DOMAIN_TAG);
+    hasher.update(&boot);
+    hasher.update(&CODEC_VERSION.to_le_bytes());
+    hasher.finalize().into()
+}
+
+fn advance(previous_root: [u8; 32], boot: [u8; 16], seq: u64, frame: &[u8]) -> [u8; 32] {
+    let mut hasher = Hasher::new();
+    hasher.update(ROOT_DOMAIN_TAG);
+    hasher.update(ROOT_ALGORITHM_ID);
+    hasher.update(&CODEC_VERSION.to_le_bytes());
+    hasher.update(&boot);
+    hasher.update(&seq.to_le_bytes());
+    hasher.update(&previous_root);
+    hasher.update(frame);
+    hasher.finalize().into()
+}
+
+fn checkpoint_tag(
+    boot: [u8; 16],
+    seq: u64,
+    root: [u8; 32],
+    relay_generation: u64,
+    context: &AuthContext,
+) -> [u8; 32] {
+    let mut hasher = Hasher::new_keyed(&context.verification_key);
+    hasher.update(CHECKPOINT_DOMAIN_TAG);
+    hasher.update(&CODEC_VERSION.to_le_bytes());
+    hasher.update(&boot);
+    hasher.update(&seq.to_le_bytes());
+    hasher.update(&root);
+    hasher.update(&relay_generation.to_le_bytes());
+    hasher.update(&context.authority_id.to_le_bytes());
+    hasher.finalize().into()
+}
+
+fn ack_tag(
+    boot: [u8; 16],
+    relay_generation: u64,
+    seq: u64,
+    source_root: [u8; 32],
+    frame: &[u8],
+    context: &AuthContext,
+) -> [u8; 32] {
+    let mut hasher = Hasher::new_keyed(&context.verification_key);
+    hasher.update(ACK_DOMAIN_TAG);
+    hasher.update(&CODEC_VERSION.to_le_bytes());
+    hasher.update(&context.authority_id.to_le_bytes());
+    hasher.update(&boot);
+    hasher.update(&relay_generation.to_le_bytes());
+    hasher.update(&seq.to_le_bytes());
+    hasher.update(&source_root);
+    hasher.update(frame);
+    hasher.finalize().into()
+}
+
+/// Keys the kernel minting tag bound into the untrusted verifier handoff.
+/// The verification key never travels inside the handoff; the tag is
+/// checkable only by a holder of the independently trusted kernel-origin
+/// anchor, so a caller-minted handoff cannot authenticate itself.
+fn verifier_handoff_tag(
+    boot: [u8; 16],
+    authority_id: u64,
+    verification_key: &[u8; 32],
+) -> [u8; 32] {
+    let mut hasher = Hasher::new_keyed(verification_key);
+    hasher.update(VERIFIER_HANDOFF_DOMAIN_TAG);
+    hasher.update(&CODEC_VERSION.to_le_bytes());
+    hasher.update(&boot);
+    hasher.update(&authority_id.to_le_bytes());
+    hasher.finalize().into()
+}
+
+/// Tag-verifies a canonical checkpoint wire form. A verifier-local cache
+/// alone is never trusted; only this kernel-sealed binding is.
+pub fn verify_checkpoint(
+    wire: &[u8],
+    context: &AuthContext,
+) -> Result<CheckpointView, VerifyFailure> {
+    if wire.len() != CHECKPOINT_WIRE_BYTES {
+        return Err(VerifyFailure::Malformed);
+    }
+    let mut reader = wire::Reader::new(wire).ok_or(VerifyFailure::Malformed)?;
+    let total = reader.u32().ok_or(VerifyFailure::Malformed)? as usize;
+    if wire.len() - 4 != total {
+        return Err(VerifyFailure::Malformed);
+    }
+    let codec_version = reader.u16().ok_or(VerifyFailure::Malformed)?;
+    if codec_version != CODEC_VERSION {
+        return Err(VerifyFailure::Malformed);
+    }
+    let boot = reader
+        .bytes(16)
+        .ok_or(VerifyFailure::Malformed)?
+        .try_into()
+        .ok()
+        .filter(|boot: &[u8; 16]| boot.iter().any(|byte| *byte != 0))
+        .ok_or(VerifyFailure::Malformed)?;
+    let seq = reader.u64().ok_or(VerifyFailure::Malformed)?;
+    let root = reader
+        .bytes(32)
+        .ok_or(VerifyFailure::Malformed)?
+        .try_into()
+        .ok()
+        .ok_or(VerifyFailure::Malformed)?;
+    let relay_generation = reader.u64().ok_or(VerifyFailure::Malformed)?;
+    let authority_id = reader.u64().ok_or(VerifyFailure::Malformed)?;
+    let tag = reader
+        .bytes(32)
+        .ok_or(VerifyFailure::Malformed)?
+        .try_into()
+        .ok()
+        .ok_or(VerifyFailure::Malformed)?;
+    if reader.remaining() != 0 {
+        return Err(VerifyFailure::Malformed);
+    }
+    let view = CheckpointView {
+        boot,
+        seq,
+        root,
+        codec_version,
+        relay_generation,
+        authority_id,
+        tag,
+    };
+    if relay_generation == 0 || authority_id != context.authority_id || boot != context.boot {
+        return Err(VerifyFailure::Malformed);
+    }
+    if checkpoint_tag(boot, seq, root, relay_generation, context) != tag {
+        return Err(VerifyFailure::CheckpointMismatch);
+    }
+    Ok(view)
+}
+
+/// Independent fold state. Start from genesis or a verified checkpoint,
+/// then fold contiguous frames in order.
+pub struct AuditVerifier {
+    boot: [u8; 16],
+    next_seq: u64,
+    root: [u8; 32],
+    context: AuthContext,
+    relay_generation: u64,
+}
+
+impl AuditVerifier {
+    /// Starts from genesis only after binding the untrusted handoff against
+    /// the trusted anchor for the same boot.
+    pub fn genesis(
+        boot: [u8; 16],
+        context: AuthContext,
+        handoff: &[u8; AUTHORITY_HANDOFF_BYTES],
+    ) -> Result<Self, VerifyFailure> {
+        if boot.iter().all(|byte| *byte == 0) {
+            return Err(VerifyFailure::Malformed);
+        }
+        if boot != context.boot {
+            return Err(VerifyFailure::Malformed);
+        }
+        context.bind_handoff(handoff)?;
+        Ok(Self {
+            boot,
+            next_seq: 1,
+            root: genesis_root(boot),
+            context,
+            relay_generation: 1,
+        })
+    }
+
+    /// Restarts from a kernel-sealed checkpoint only after binding the
+    /// untrusted handoff against the trusted anchor.
+    pub fn from_checkpoint(
+        wire: &[u8],
+        context: AuthContext,
+        handoff: &[u8; AUTHORITY_HANDOFF_BYTES],
+    ) -> Result<Self, VerifyFailure> {
+        context.bind_handoff(handoff)?;
+        let checkpoint = verify_checkpoint(wire, &context)?;
+        let next_seq = checkpoint
+            .seq
+            .checked_add(1)
+            .ok_or(VerifyFailure::SequenceOverflow)?;
+        Ok(Self {
+            boot: checkpoint.boot,
+            root: checkpoint.root,
+            next_seq,
+            context,
+            relay_generation: checkpoint.relay_generation,
+        })
+    }
+
+    /// Folds one canonical frame whose source root claim has already been
+    /// checked by the caller's handoff record. Contiguity is enforced; a gap
+    /// is Incomplete and a duplicate or reorder is Invalid. Never skips.
+    pub fn fold(
+        &mut self,
+        frame: &[u8],
+        claimed_root: [u8; 32],
+    ) -> Result<FoldReceipt, FoldFailure> {
+        let view = wire::decode_frame(frame).map_err(|error| match error {
+            wire::WireError::Malformed => FoldFailure::Invalid(InvalidReason::Malformed),
+            wire::WireError::DenialDisclosure => {
+                FoldFailure::Invalid(InvalidReason::DenialDisclosure)
+            },
+        })?;
+        if view.seq < self.next_seq {
+            return Err(FoldFailure::Invalid(InvalidReason::DuplicateOrReorder));
+        }
+        if view.seq > self.next_seq {
+            return Err(FoldFailure::Incomplete(IncompleteReason::SequenceGap));
+        }
+        if view.boot != self.boot {
+            return Err(FoldFailure::Invalid(InvalidReason::ForeignBoot));
+        }
+        if view.prev_root != Some(self.root) {
+            return Err(FoldFailure::Invalid(InvalidReason::PreviousRootMismatch));
+        }
+        let next_seq = self
+            .next_seq
+            .checked_add(1)
+            .ok_or(FoldFailure::SequenceOverflow)?;
+        let next_root = advance(self.root, self.boot, view.seq, frame);
+        if claimed_root != next_root {
+            return Err(FoldFailure::Invalid(InvalidReason::RootMismatch));
+        }
+        let receipt = FoldReceipt {
+            seq: view.seq,
+            folded_root: claimed_root,
+            ack_tag: ack_tag(
+                self.boot,
+                self.relay_generation,
+                view.seq,
+                claimed_root,
+                frame,
+                &self.context,
+            ),
+        };
+        self.root = next_root;
+        self.next_seq = next_seq;
+        Ok(receipt)
+    }
+
+    /// Confirms a later kernel checkpoint against the folded state: the
+    /// source root must match exactly before any acknowledgement range is
+    /// trusted across a restart.
+    pub fn accept_checkpoint(&self, wire: &[u8]) -> Result<(), VerifyFailure> {
+        let checkpoint = verify_checkpoint(wire, &self.context)?;
+        let next_seq = checkpoint
+            .seq
+            .checked_add(1)
+            .ok_or(VerifyFailure::SequenceOverflow)?;
+        if checkpoint.boot != self.boot || next_seq != self.next_seq || checkpoint.root != self.root
+        {
+            return Err(VerifyFailure::CheckpointMismatch);
+        }
+        if checkpoint.relay_generation != self.relay_generation {
+            return Err(VerifyFailure::StaleRelayGeneration);
+        }
+        Ok(())
+    }
+
+    /// Accepts exactly one generation-bumped checkpoint after the same state
+    /// has been folded. This is the verifier side of explicit resync.
+    pub fn accept_resync_checkpoint(&mut self, wire: &[u8]) -> Result<(), VerifyFailure> {
+        let checkpoint = verify_checkpoint(wire, &self.context)?;
+        let next_seq = checkpoint
+            .seq
+            .checked_add(1)
+            .ok_or(VerifyFailure::SequenceOverflow)?;
+        let next_generation = self
+            .relay_generation
+            .checked_add(1)
+            .ok_or(VerifyFailure::Malformed)?;
+        if checkpoint.boot != self.boot
+            || next_seq != self.next_seq
+            || checkpoint.root != self.root
+            || checkpoint.relay_generation != next_generation
+        {
+            return Err(VerifyFailure::CheckpointMismatch);
+        }
+        self.relay_generation = next_generation;
+        Ok(())
+    }
+
+    pub fn root(&self) -> [u8; 32] {
+        self.root
+    }
+
+    pub fn next_seq(&self) -> u64 {
+        self.next_seq
+    }
+}

--- a/kernel/tools/native-audit-verifier/src/tests.rs
+++ b/kernel/tools/native-audit-verifier/src/tests.rs
@@ -1,0 +1,616 @@
+//! Independent regressions for the frozen wire format and fold engine.
+
+use super::*;
+use blake3::Hasher;
+
+const BOOT: [u8; 16] = [7; 16];
+
+fn trusted_key() -> [u8; 32] {
+    let mut hasher = Hasher::new();
+    hasher.update(b"native-audit-verifier-test-authority");
+    hasher.update(&BOOT);
+    hasher.update(&1u64.to_le_bytes());
+    hasher.finalize().into()
+}
+
+fn context() -> AuthContext {
+    AuthContext::from_trusted_anchor(1, BOOT, trusted_key()).unwrap()
+}
+
+/// Seals a genuine handoff for the test anchor. Only the byte layout is
+/// mirrored from the kernel; the tag comes from this crate's own keyed
+/// implementation, and kernel cross-checks bind the real layout.
+fn handoff() -> [u8; AUTHORITY_HANDOFF_BYTES] {
+    let mut bytes = [0; AUTHORITY_HANDOFF_BYTES];
+    bytes[..8].copy_from_slice(b"ASAUDCTX");
+    bytes[8..16].copy_from_slice(&1u64.to_le_bytes());
+    bytes[16..32].copy_from_slice(&BOOT);
+    let tag = verifier_handoff_tag(BOOT, 1, &trusted_key());
+    bytes[32..].copy_from_slice(&tag);
+    bytes
+}
+
+#[derive(Clone, Copy)]
+enum Object {
+    None,
+    Domain(u8, u64),
+    Endpoint(u8, u64),
+    Capability(u64, u8, u64, u8, u64),
+}
+
+fn body(
+    boot: [u8; 16],
+    seq: u64,
+    class: u16,
+    object: Object,
+    rights: u16,
+    payload: &[u8],
+    prev: Option<[u8; 32]>,
+) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(&CODEC_VERSION.to_le_bytes());
+    out.extend_from_slice(&boot);
+    out.extend_from_slice(&seq.to_le_bytes());
+    out.extend_from_slice(&class.to_le_bytes());
+    out.push(0);
+    out.extend_from_slice(&1u64.to_le_bytes());
+    match object {
+        Object::None => out.push(0),
+        Object::Domain(slot, generation) => {
+            out.push(1);
+            out.push(slot);
+            out.extend_from_slice(&generation.to_le_bytes());
+        },
+        Object::Endpoint(pool_index, generation) => {
+            out.push(2);
+            out.push(pool_index);
+            out.extend_from_slice(&generation.to_le_bytes());
+        },
+        Object::Capability(token, slot, generation, kind, object_token) => {
+            out.push(3);
+            out.extend_from_slice(&token.to_le_bytes());
+            out.push(slot);
+            out.extend_from_slice(&generation.to_le_bytes());
+            out.push(kind);
+            out.extend_from_slice(&object_token.to_le_bytes());
+        },
+    }
+    out.extend_from_slice(&rights.to_le_bytes());
+    out.extend_from_slice(&(payload.len() as u16).to_le_bytes());
+    out.extend_from_slice(payload);
+    match prev {
+        None => out.push(0),
+        Some(prev) => {
+            out.push(1);
+            out.extend_from_slice(&prev);
+        },
+    }
+    let mut framed = Vec::new();
+    framed.extend_from_slice(&(out.len() as u32).to_le_bytes());
+    framed.extend_from_slice(&out);
+    framed
+}
+
+fn expected_root(previous: [u8; 32], seq: u64, frame: &[u8]) -> [u8; 32] {
+    let mut hasher = Hasher::new();
+    hasher.update(ROOT_DOMAIN_TAG);
+    hasher.update(ROOT_ALGORITHM_ID);
+    hasher.update(&CODEC_VERSION.to_le_bytes());
+    hasher.update(&BOOT);
+    hasher.update(&seq.to_le_bytes());
+    hasher.update(&previous);
+    hasher.update(frame);
+    hasher.finalize().into()
+}
+
+#[test]
+fn genesis_fold_requires_boot_previous_root_and_source_root() {
+    let mut verifier = AuditVerifier::genesis(BOOT, context(), &handoff()).unwrap();
+    let genesis = verifier.root();
+
+    let frame1 = body(BOOT, 1, 1, Object::None, 0, &[], Some(genesis));
+    let root1 = expected_root(genesis, 1, &frame1);
+    assert_eq!(verifier.fold(&frame1, root1).unwrap().seq(), 1);
+
+    let frame2 = body(
+        BOOT,
+        2,
+        16,
+        Object::Capability(9, 3, 4, 2, 11),
+        0b0101,
+        &[],
+        Some(root1),
+    );
+    let root2 = expected_root(root1, 2, &frame2);
+    assert_eq!(verifier.fold(&frame2, root2).unwrap().seq(), 2);
+    assert_eq!(verifier.root(), root2);
+}
+
+#[test]
+fn tamper_without_a_valid_claimed_root_is_invalid() {
+    let mut verifier = AuditVerifier::genesis(BOOT, context(), &handoff()).unwrap();
+    let frame = body(BOOT, 1, 1, Object::None, 0, &[], Some(verifier.root()));
+    assert_eq!(
+        verifier.fold(&frame, [0; 32]),
+        Err(FoldFailure::Invalid(InvalidReason::RootMismatch))
+    );
+}
+
+#[test]
+fn cross_boot_and_missing_previous_root_are_invalid() {
+    let mut verifier = AuditVerifier::genesis(BOOT, context(), &handoff()).unwrap();
+    let foreign = body([8; 16], 1, 1, Object::None, 0, &[], Some(verifier.root()));
+    let foreign_root = expected_root(verifier.root(), 1, &foreign);
+    assert_eq!(
+        verifier.fold(&foreign, foreign_root),
+        Err(FoldFailure::Invalid(InvalidReason::ForeignBoot))
+    );
+
+    let missing_previous = body(BOOT, 1, 1, Object::None, 0, &[], None);
+    let missing_root = expected_root(verifier.root(), 1, &missing_previous);
+    assert_eq!(
+        verifier.fold(&missing_previous, missing_root),
+        Err(FoldFailure::Invalid(InvalidReason::PreviousRootMismatch))
+    );
+}
+
+#[test]
+fn explicitly_mismatched_previous_root_is_invalid() {
+    let mut verifier = AuditVerifier::genesis(BOOT, context(), &handoff()).unwrap();
+    let wrong_previous = [0xAA; 32];
+    let frame = body(BOOT, 1, 1, Object::None, 0, &[], Some(wrong_previous));
+    let claimed = expected_root(wrong_previous, 1, &frame);
+    assert_eq!(
+        verifier.fold(&frame, claimed),
+        Err(FoldFailure::Invalid(InvalidReason::PreviousRootMismatch))
+    );
+    assert_eq!(verifier.next_seq(), 1);
+}
+
+#[test]
+fn fold_overflow_is_fail_closed_without_state_change() {
+    let checkpoint_root = AuditVerifier::genesis(BOOT, context(), &handoff())
+        .unwrap()
+        .root();
+    let checkpoint = checkpoint_wire(
+        BOOT,
+        u64::MAX - 1,
+        checkpoint_root,
+        1,
+        sealed_tag(BOOT, u64::MAX - 1, checkpoint_root, 1),
+    );
+    let mut verifier = AuditVerifier::from_checkpoint(&checkpoint, context(), &handoff()).unwrap();
+    let frame = body(
+        BOOT,
+        u64::MAX,
+        1,
+        Object::None,
+        0,
+        &[],
+        Some(checkpoint_root),
+    );
+    let claimed = expected_root(checkpoint_root, u64::MAX, &frame);
+    let before = (verifier.next_seq(), verifier.root());
+    assert_eq!(
+        verifier.fold(&frame, claimed),
+        Err(FoldFailure::SequenceOverflow)
+    );
+    assert_eq!(
+        verifier.fold(&frame, claimed),
+        Err(FoldFailure::SequenceOverflow)
+    );
+    assert_eq!((verifier.next_seq(), verifier.root()), before);
+}
+
+#[test]
+fn gap_is_incomplete_and_duplicate_is_invalid() {
+    let mut verifier = AuditVerifier::genesis(BOOT, context(), &handoff()).unwrap();
+    let genesis = verifier.root();
+    let frame1 = body(BOOT, 1, 1, Object::None, 0, &[], Some(genesis));
+    let root1 = expected_root(genesis, 1, &frame1);
+    let frame3 = body(BOOT, 3, 3, Object::None, 0, &[], Some(root1));
+    let root3 = expected_root(root1, 3, &frame3);
+    verifier.fold(&frame1, root1).unwrap();
+    assert_eq!(
+        verifier.fold(&frame3, root3),
+        Err(FoldFailure::Incomplete(IncompleteReason::SequenceGap))
+    );
+    assert_eq!(
+        verifier.fold(&frame1, root1),
+        Err(FoldFailure::Invalid(InvalidReason::DuplicateOrReorder))
+    );
+}
+
+#[test]
+fn denial_must_not_disclose_a_foreign_identity() {
+    let mut verifier = AuditVerifier::genesis(BOOT, context(), &handoff()).unwrap();
+    let mut payload = vec![4, 0];
+    payload.extend_from_slice(&[9; 8]);
+    let denial = body(
+        BOOT,
+        1,
+        80,
+        Object::None,
+        0,
+        &payload,
+        Some(verifier.root()),
+    );
+    let denial_root = expected_root(verifier.root(), 1, &denial);
+    assert!(verifier.fold(&denial, denial_root).is_ok());
+
+    let mut verifier = AuditVerifier::genesis(BOOT, context(), &handoff()).unwrap();
+    let disclosing = body(
+        BOOT,
+        1,
+        80,
+        Object::Domain(1, 3),
+        0,
+        &payload,
+        Some(verifier.root()),
+    );
+    assert_eq!(
+        verifier.fold(&disclosing, [0; 32]),
+        Err(FoldFailure::Invalid(InvalidReason::DenialDisclosure))
+    );
+}
+
+#[test]
+fn non_canonical_inputs_fail_closed() {
+    let valid = body(BOOT, 1, 1, Object::None, 0, &[], Some(genesis_root(BOOT)));
+    let mut verifier = AuditVerifier::genesis(BOOT, context(), &handoff()).unwrap();
+
+    assert!(matches!(
+        verifier.fold(&valid[..valid.len() - 1], [0; 32]),
+        Err(FoldFailure::Invalid(InvalidReason::Malformed))
+    ));
+    let mut slack = valid.clone();
+    slack.push(0);
+    assert!(matches!(
+        verifier.fold(&slack, [0; 32]),
+        Err(FoldFailure::Invalid(InvalidReason::Malformed))
+    ));
+
+    let cases = [
+        body(
+            [0; 16],
+            1,
+            1,
+            Object::None,
+            0,
+            &[],
+            Some(genesis_root(BOOT)),
+        ),
+        body(BOOT, 0, 1, Object::None, 0, &[], Some(genesis_root(BOOT))),
+        body(BOOT, 1, 10, Object::None, 0, &[], Some(genesis_root(BOOT))),
+        body(
+            BOOT,
+            1,
+            1,
+            Object::Domain(2, 1),
+            0,
+            &[],
+            Some(genesis_root(BOOT)),
+        ),
+        body(
+            BOOT,
+            1,
+            1,
+            Object::Domain(1, 0),
+            0,
+            &[],
+            Some(genesis_root(BOOT)),
+        ),
+        body(
+            BOOT,
+            1,
+            1,
+            Object::Endpoint(4, 1),
+            0,
+            &[],
+            Some(genesis_root(BOOT)),
+        ),
+        body(
+            BOOT,
+            1,
+            1,
+            Object::Capability(1, 1, 1, 1, 1),
+            0,
+            &[],
+            Some(genesis_root(BOOT)),
+        ),
+        body(
+            BOOT,
+            1,
+            1,
+            Object::Capability(0, 1, 1, 2, 1),
+            0,
+            &[],
+            Some(genesis_root(BOOT)),
+        ),
+        body(
+            BOOT,
+            1,
+            1,
+            Object::Capability(1, 8, 1, 2, 1),
+            0,
+            &[],
+            Some(genesis_root(BOOT)),
+        ),
+        body(
+            BOOT,
+            1,
+            1,
+            Object::Capability(1, 1, 0, 2, 1),
+            0,
+            &[],
+            Some(genesis_root(BOOT)),
+        ),
+        body(
+            BOOT,
+            1,
+            1,
+            Object::Capability(1, 1, 1, 2, 0),
+            0,
+            &[],
+            Some(genesis_root(BOOT)),
+        ),
+        body(
+            BOOT,
+            1,
+            1,
+            Object::None,
+            0x10,
+            &[],
+            Some(genesis_root(BOOT)),
+        ),
+        body(
+            BOOT,
+            1,
+            1,
+            Object::None,
+            0,
+            &[0; 65],
+            Some(genesis_root(BOOT)),
+        ),
+    ];
+    for case in cases {
+        let mut verifier = AuditVerifier::genesis(BOOT, context(), &handoff()).unwrap();
+        assert!(matches!(
+            verifier.fold(&case, [0; 32]),
+            Err(FoldFailure::Invalid(InvalidReason::Malformed))
+        ));
+    }
+
+    let mut bad_version = valid.clone();
+    bad_version[4..6].copy_from_slice(&2u16.to_le_bytes());
+    assert!(matches!(
+        verifier.fold(&bad_version, [0; 32]),
+        Err(FoldFailure::Invalid(InvalidReason::Malformed))
+    ));
+}
+
+fn checkpoint_wire(
+    boot: [u8; 16],
+    seq: u64,
+    root: [u8; 32],
+    relay_generation: u64,
+    tag: [u8; 32],
+) -> Vec<u8> {
+    let mut body = Vec::new();
+    body.extend_from_slice(&CODEC_VERSION.to_le_bytes());
+    body.extend_from_slice(&boot);
+    body.extend_from_slice(&seq.to_le_bytes());
+    body.extend_from_slice(&root);
+    body.extend_from_slice(&relay_generation.to_le_bytes());
+    body.extend_from_slice(&context().authority_id.to_le_bytes());
+    body.extend_from_slice(&tag);
+    let mut wire = Vec::new();
+    wire.extend_from_slice(&(body.len() as u32).to_le_bytes());
+    wire.extend_from_slice(&body);
+    wire
+}
+
+fn sealed_tag(boot: [u8; 16], seq: u64, root: [u8; 32], relay_generation: u64) -> [u8; 32] {
+    checkpoint_tag(boot, seq, root, relay_generation, &context())
+}
+
+fn unkeyed_tag(boot: [u8; 16], seq: u64, root: [u8; 32], relay_generation: u64) -> [u8; 32] {
+    let mut hasher = Hasher::new();
+    hasher.update(CHECKPOINT_DOMAIN_TAG);
+    hasher.update(&CODEC_VERSION.to_le_bytes());
+    hasher.update(&boot);
+    hasher.update(&seq.to_le_bytes());
+    hasher.update(&root);
+    hasher.update(&relay_generation.to_le_bytes());
+    hasher.update(&context().authority_id.to_le_bytes());
+    hasher.finalize().into()
+}
+
+#[test]
+fn checkpoint_restart_and_mandatory_source_root_match() {
+    let genesis = AuditVerifier::genesis(BOOT, context(), &handoff())
+        .unwrap()
+        .root();
+    let start = checkpoint_wire(BOOT, 0, genesis, 1, sealed_tag(BOOT, 0, genesis, 1));
+    let mut verifier = AuditVerifier::from_checkpoint(&start, context(), &handoff()).unwrap();
+    assert_eq!(verifier.root(), genesis);
+
+    let frame = body(BOOT, 1, 1, Object::None, 0, &[], Some(genesis));
+    let root1 = expected_root(genesis, 1, &frame);
+    verifier.fold(&frame, root1).unwrap();
+
+    let next = checkpoint_wire(BOOT, 1, root1, 1, sealed_tag(BOOT, 1, root1, 1));
+    assert_eq!(verifier.accept_checkpoint(&next), Ok(()));
+
+    let mut tampered = next.clone();
+    let last = tampered.len() - 1;
+    tampered[last] ^= 1;
+    assert!(matches!(
+        AuditVerifier::from_checkpoint(&tampered, context(), &handoff()),
+        Err(VerifyFailure::CheckpointMismatch)
+    ));
+
+    let mut wrong_root = root1;
+    wrong_root[0] ^= 1;
+    let mismatched = checkpoint_wire(BOOT, 1, wrong_root, 1, sealed_tag(BOOT, 1, wrong_root, 1));
+    assert_eq!(
+        verifier.accept_checkpoint(&mismatched),
+        Err(VerifyFailure::CheckpointMismatch)
+    );
+}
+
+#[test]
+fn host_minted_unkeyed_checkpoint_is_rejected() {
+    let genesis = AuditVerifier::genesis(BOOT, context(), &handoff())
+        .unwrap()
+        .root();
+    let mut forged = checkpoint_wire(BOOT, 0, genesis, 1, unkeyed_tag(BOOT, 0, genesis, 1));
+    assert_eq!(
+        verify_checkpoint(&forged, &context()),
+        Err(VerifyFailure::CheckpointMismatch)
+    );
+
+    let trusted = checkpoint_wire(BOOT, 0, genesis, 1, sealed_tag(BOOT, 0, genesis, 1));
+    let last = trusted.len() - 32;
+    let (_, tail) = forged.split_at_mut(last);
+    tail.copy_from_slice(&trusted[last..]);
+    assert!(AuditVerifier::from_checkpoint(&forged, context(), &handoff()).is_ok());
+}
+
+#[test]
+fn stale_and_future_relay_generations_fail_closed() {
+    let genesis = AuditVerifier::genesis(BOOT, context(), &handoff())
+        .unwrap()
+        .root();
+    let start = checkpoint_wire(BOOT, 0, genesis, 1, sealed_tag(BOOT, 0, genesis, 1));
+    let mut verifier = AuditVerifier::from_checkpoint(&start, context(), &handoff()).unwrap();
+    let frame = body(BOOT, 1, 1, Object::None, 0, &[], Some(genesis));
+    let root1 = expected_root(genesis, 1, &frame);
+    verifier.fold(&frame, root1).unwrap();
+
+    let resync = checkpoint_wire(BOOT, 1, root1, 2, sealed_tag(BOOT, 1, root1, 2));
+    assert_eq!(verifier.accept_resync_checkpoint(&resync), Ok(()));
+    let stale = checkpoint_wire(BOOT, 1, root1, 1, sealed_tag(BOOT, 1, root1, 1));
+    assert_eq!(
+        verifier.accept_checkpoint(&stale),
+        Err(VerifyFailure::StaleRelayGeneration)
+    );
+    let future = checkpoint_wire(BOOT, 1, root1, 4, sealed_tag(BOOT, 1, root1, 4));
+    assert_eq!(
+        verifier.accept_resync_checkpoint(&future),
+        Err(VerifyFailure::CheckpointMismatch)
+    );
+}
+
+#[test]
+fn zero_relay_generation_is_invalid_on_the_verifier() {
+    let genesis = AuditVerifier::genesis(BOOT, context(), &handoff())
+        .unwrap()
+        .root();
+    let checkpoint = checkpoint_wire(BOOT, 0, genesis, 0, sealed_tag(BOOT, 0, genesis, 0));
+    assert_eq!(
+        verify_checkpoint(&checkpoint, &context()),
+        Err(VerifyFailure::Malformed)
+    );
+    assert!(matches!(
+        AuditVerifier::from_checkpoint(&checkpoint, context(), &handoff()),
+        Err(VerifyFailure::Malformed)
+    ));
+}
+
+#[test]
+fn max_checkpoint_sequence_is_typed_fail_closed() {
+    let genesis = AuditVerifier::genesis(BOOT, context(), &handoff())
+        .unwrap()
+        .root();
+    let checkpoint = checkpoint_wire(
+        BOOT,
+        u64::MAX,
+        genesis,
+        1,
+        sealed_tag(BOOT, u64::MAX, genesis, 1),
+    );
+    assert!(matches!(
+        AuditVerifier::from_checkpoint(&checkpoint, context(), &handoff()),
+        Err(VerifyFailure::SequenceOverflow)
+    ));
+}
+
+#[test]
+fn zero_boot_genesis_is_rejected() {
+    assert!(matches!(
+        AuditVerifier::genesis([0; 16], context(), &handoff()),
+        Err(VerifyFailure::Malformed)
+    ));
+}
+
+#[test]
+fn trusted_anchor_rejects_zero_material() {
+    assert_eq!(
+        AuthContext::from_trusted_anchor(0, BOOT, trusted_key()),
+        Err(VerifyFailure::Malformed)
+    );
+    assert_eq!(
+        AuthContext::from_trusted_anchor(1, [0; 16], trusted_key()),
+        Err(VerifyFailure::Malformed)
+    );
+    assert_eq!(
+        AuthContext::from_trusted_anchor(1, BOOT, [0; 32]),
+        Err(VerifyFailure::Malformed)
+    );
+}
+
+#[test]
+fn structurally_valid_self_authenticated_handoff_is_rejected() {
+    let anchor = context();
+    let genuine = handoff();
+    assert_eq!(anchor.bind_handoff(&genuine), Ok(()));
+
+    // Structurally valid: correct magic, the anchored identity, and a tag
+    // an attacker computed under a self-chosen key.
+    let mut forged = genuine;
+    let attacker_tag = verifier_handoff_tag(BOOT, anchor.authority_id, &[0xB0; 32]);
+    forged[32..].copy_from_slice(&attacker_tag);
+    assert_eq!(
+        anchor.bind_handoff(&forged),
+        Err(VerifyFailure::HandoffUnbound)
+    );
+    assert!(matches!(
+        AuditVerifier::genesis(BOOT, context(), &forged),
+        Err(VerifyFailure::HandoffUnbound)
+    ));
+
+    // A genuine tag replayed under a foreign identity also stays unbound.
+    let mut foreign = genuine;
+    foreign[16..32].copy_from_slice(&[8; 16]);
+    assert_eq!(
+        anchor.bind_handoff(&foreign),
+        Err(VerifyFailure::HandoffUnbound)
+    );
+
+    // A broken magic byte stays malformed.
+    let mut bad_magic = genuine;
+    bad_magic[0] = b'X';
+    assert_eq!(
+        anchor.bind_handoff(&bad_magic),
+        Err(VerifyFailure::Malformed)
+    );
+}
+
+#[test]
+fn checkpoint_under_forged_context_is_rejected() {
+    // Arbitrary attacker-chosen root and sequence sealed under an
+    // attacker-chosen key reusing only the public identity fields.
+    let forged = AuthContext::from_trusted_anchor(1, BOOT, [0xB0; 32]).unwrap();
+    let tag = checkpoint_tag(BOOT, 999, [0xAA; 32], 1, &forged);
+    let wire = checkpoint_wire(BOOT, 999, [0xAA; 32], 1, tag);
+
+    assert_eq!(
+        verify_checkpoint(&wire, &context()),
+        Err(VerifyFailure::CheckpointMismatch)
+    );
+    assert!(matches!(
+        AuditVerifier::from_checkpoint(&wire, context(), &handoff()),
+        Err(VerifyFailure::CheckpointMismatch)
+    ));
+}

--- a/kernel/tools/native-audit-verifier/src/wire.rs
+++ b/kernel/tools/native-audit-verifier/src/wire.rs
@@ -1,0 +1,202 @@
+//! Independent strict decoder for the frozen canonical frame wire format.
+//! Mirrors the kernel codec byte-for-byte; any drift fails loudly here.
+
+/// Wire-level decode errors for one frame.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WireError {
+    Malformed,
+    DenialDisclosure,
+}
+
+/// Minimal view the fold needs: sequence plus denial-projection checks.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FrameView {
+    pub boot: [u8; 16],
+    pub seq: u64,
+    pub class: u16,
+    pub has_object: bool,
+    pub prev_root: Option<[u8; 32]>,
+}
+
+const CLASS_DISCRIMINANTS: &[u16] = &[
+    1, 2, 3, 4, 5, 6, 7, 8, 9, 16, 17, 18, 32, 33, 34, 35, 48, 49, 50, 64, 65, 66, 80,
+];
+
+const DENIAL_CLASS: u16 = 80;
+const LANDED_RIGHTS_MASK: u16 = 0b1111;
+const MAX_PAYLOAD: usize = 64;
+
+/// Strict canonical decode with the same fail-closed rules as the kernel.
+pub fn decode_frame(bytes: &[u8]) -> Result<FrameView, WireError> {
+    let mut reader = Reader::new(bytes).ok_or(WireError::Malformed)?;
+    let total = reader.u32().ok_or(WireError::Malformed)? as usize;
+    if bytes.len() - 4 != total {
+        return Err(WireError::Malformed);
+    }
+    let codec_version = reader.u16().ok_or(WireError::Malformed)?;
+    if codec_version != super::CODEC_VERSION {
+        return Err(WireError::Malformed);
+    }
+    let boot: [u8; 16] = reader
+        .bytes(16)
+        .ok_or(WireError::Malformed)?
+        .try_into()
+        .map_err(|_| WireError::Malformed)?;
+    if boot.iter().all(|byte| *byte == 0) {
+        return Err(WireError::Malformed);
+    }
+    let seq = reader.u64().ok_or(WireError::Malformed)?;
+    if seq == 0 {
+        return Err(WireError::Malformed);
+    }
+    let class = reader.u16().ok_or(WireError::Malformed)?;
+    if !CLASS_DISCRIMINANTS.contains(&class) {
+        return Err(WireError::Malformed);
+    }
+    let subject_slot = reader.u8().ok_or(WireError::Malformed)? as usize;
+    if subject_slot >= 2 {
+        return Err(WireError::Malformed);
+    }
+    let subject_generation = reader.u64().ok_or(WireError::Malformed)?;
+    if subject_generation == 0 {
+        return Err(WireError::Malformed);
+    }
+    let has_object = match reader.u8().ok_or(WireError::Malformed)? {
+        0 => false,
+        1 => {
+            if reader.u8().ok_or(WireError::Malformed)? as usize >= 2 {
+                return Err(WireError::Malformed);
+            }
+            if reader.u64().ok_or(WireError::Malformed)? == 0 {
+                return Err(WireError::Malformed);
+            }
+            true
+        },
+        2 => {
+            if reader.u8().ok_or(WireError::Malformed)? as usize >= 4 {
+                return Err(WireError::Malformed);
+            }
+            if reader.u64().ok_or(WireError::Malformed)? == 0 {
+                return Err(WireError::Malformed);
+            }
+            true
+        },
+        3 => {
+            if reader.u64().ok_or(WireError::Malformed)? == 0 {
+                return Err(WireError::Malformed);
+            }
+            if reader.u8().ok_or(WireError::Malformed)? as usize >= 8 {
+                return Err(WireError::Malformed);
+            }
+            if reader.u64().ok_or(WireError::Malformed)? == 0 {
+                return Err(WireError::Malformed);
+            }
+            let kind = reader.u8().ok_or(WireError::Malformed)?;
+            if kind != 2 {
+                return Err(WireError::Malformed);
+            }
+            if reader.u64().ok_or(WireError::Malformed)? == 0 {
+                return Err(WireError::Malformed);
+            }
+            true
+        },
+        _ => return Err(WireError::Malformed),
+    };
+    let rights = reader.u16().ok_or(WireError::Malformed)?;
+    if rights & !LANDED_RIGHTS_MASK != 0 {
+        return Err(WireError::Malformed);
+    }
+    let payload_len = reader.u16().ok_or(WireError::Malformed)? as usize;
+    if payload_len > MAX_PAYLOAD {
+        return Err(WireError::Malformed);
+    }
+    let payload_start = reader.pos();
+    reader.skip(payload_len).ok_or(WireError::Malformed)?;
+    let prev_root = match reader.u8().ok_or(WireError::Malformed)? {
+        0 => None,
+        1 => Some(
+            reader
+                .bytes(32)
+                .ok_or(WireError::Malformed)?
+                .try_into()
+                .map_err(|_| WireError::Malformed)?,
+        ),
+        _ => return Err(WireError::Malformed),
+    };
+    if reader.remaining() != 0 {
+        return Err(WireError::Malformed);
+    }
+    if class == DENIAL_CLASS {
+        if has_object {
+            return Err(WireError::DenialDisclosure);
+        }
+        let payload = &bytes[payload_start..payload_start + payload_len];
+        let denial_ok =
+            payload.len() == 10 && matches!(u16::from_le_bytes([payload[0], payload[1]]), 1..=6);
+        if !denial_ok {
+            return Err(WireError::Malformed);
+        }
+    }
+    Ok(FrameView {
+        boot,
+        seq,
+        class,
+        has_object,
+        prev_root,
+    })
+}
+
+pub struct Reader<'a> {
+    bytes: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Reader<'a> {
+    pub fn new(bytes: &'a [u8]) -> Option<Self> {
+        if bytes.len() < 4 {
+            return None;
+        }
+        Some(Self { bytes, pos: 0 })
+    }
+
+    pub fn remaining(&self) -> usize {
+        self.bytes.len() - self.pos
+    }
+
+    pub fn pos(&self) -> usize {
+        self.pos
+    }
+
+    pub fn skip(&mut self, len: usize) -> Option<()> {
+        if self.remaining() < len {
+            return None;
+        }
+        self.pos += len;
+        Some(())
+    }
+
+    pub fn bytes(&mut self, len: usize) -> Option<&'a [u8]> {
+        if self.remaining() < len {
+            return None;
+        }
+        let start = self.pos;
+        self.pos += len;
+        Some(&self.bytes[start..self.pos])
+    }
+
+    pub fn u8(&mut self) -> Option<u8> {
+        Some(self.bytes(1)?[0])
+    }
+
+    pub fn u16(&mut self) -> Option<u16> {
+        Some(u16::from_le_bytes(self.bytes(2)?.try_into().ok()?))
+    }
+
+    pub fn u32(&mut self) -> Option<u32> {
+        Some(u32::from_le_bytes(self.bytes(4)?.try_into().ok()?))
+    }
+
+    pub fn u64(&mut self) -> Option<u64> {
+        Some(u64::from_le_bytes(self.bytes(8)?.try_into().ok()?))
+    }
+}


### PR DESCRIPTION
## Linked Issue

Tracking #1758. This does not close the issue.

## Summary

Private native-kernel relation projection follows real IPC object and capability mutations under the same lock as `IpcState`. Guest ABI is unchanged.

After a transfer receive's user-copy/commit succeeds, the reacquired IPC lock re-reads the destination slot and requires its exact installed capability identity and parent linkage to match the captured transfer. If authoritative revocation removed or replaced it during the lock gap, the receive remains successful but does not emit stale `Holds` or `Derives` rows. When a receive commit fails, rollback captures the exact installed destination capability and removes that slot only when it is unchanged, so a legitimate revoke-and-replace replacement survives. Rollback then independently revalidates the queued message authority before restoring it: a linked transfer must have its exact linked parent, that linked parent must retain `GRANT`, a root/parentless fixture transfer must still be held exactly by the sender, and the endpoint generation and sender membership must remain live. Revoked or mismatched authority is consumed instead of requeued. Authoritative revoke, reclaim, and anti-resurrection evidence remains intact. Transfer projection still occurs only after successful copy/commit, failed receives restore without a rollback tombstone, and existing bounded overflow, newer-generation reclaim, retirement, and unrelated-scope behavior is unchanged.

## Changes

- Embed `ProjectionStore` in authoritative IPC state and project domain, endpoint, capability, revoke, reclaim, and teardown mutations while that lock is held.
- Revalidate the exact transferred destination capability after reacquiring IPC on both parked and immediate receive paths before projecting `Holds` and `Derives`.
- Capture the exact failed-receive transfer through the commit gap and consume only an unchanged destination slot, preserving absent or mismatched replacements.
- Require a linked rollback-transfer parent to retain `GRANT`, preventing a SEND-only replacement in the frozen domain slot from reauthorizing a stale transfer while preserving legitimate `ALL`/`GRANT` replacement.
- Bound repeated-lifecycle projection metadata by retiring scope metadata and older successful object-reclaim generations while preserving the current generation's logical DELETE and reclaim observation.
- Track unresolved logical-deletion overflow by reader scope, object kind, and generation. Successful newer-generation reclaims resolve applicable overflow, and unrelated reader retirement does not invent overflow; revoke and reclaim anti-resurrection remains intact.
- Keep retirement replay observable through a bounded retired-reader cursor, deny foreign scopes before single-path mutation, and emit private projection-failure evidence instead of panicking IPC.
- Drive host regressions from real create, transfer, revoke, and teardown against direct authoritative state, folding a genuine pre-mutation snapshot and identity-bound cursor to the post-mutation direct snapshot.
- Add a real parked commit=false parent-revoke retry regression for failed transfer rollback.
- Add a real parked commit=false revoke-and-replace regression for destination-slot preservation.
- Add relations-specific q35/TCG evidence for endpoint-create projections without serial takeover, new `int 0x70` operations, IDENTIFY widening, or public WIT.

## Test Plan

- The existing parked commit-gap revocation falsifier remains driven through `complete_parked_recv`; it failed on `4cc2d0c5b8ccbaf5afb13319667a63396dd131cf` with exit 101 and passes after the cure.
- New `revoked_parent_during_parked_failure_consumes_stale_retry` revokes the linked transfer parent during the parked callback, returns commit=false, and retries. On unchanged `af12b4666d8bc092a3e7ad92e91e6cf026cc5c61` production the stale transfer remained queued (observed 1, expected 0); on this successor it is consumed, no stale slot or relation rows appear, legitimate peer observations remain, and `fold(base+deltas)==direct`.
- New `commit_false_revoke_and_replace_preserves_destination_replacement` revokes the installed transfer, installs a distinct authoritative replacement through a successful nested receive, and then returns commit=false. On unchanged `a540e33f444a6fccee69b470a2786c345d5435b0` production the replacement was erased (observed `None`); on this successor it remains exact, the valid failed transfer is requeued, and `fold(base+deltas)==direct`.
- New `rollback_rejects_replaced_parent_without_grant` production-sends the stale transfer and, during a parked commit=false gap, revokes its linked parent and replaces that frozen source slot through a production SEND-only transfer. On unchanged `961985c805b376537b3c4044be2490301f78e5a2` production the stale transfer was requeued (observed 1, expected 0); on successor `d95fc68ca76c8bdbf5ded26477040c50c3d34e96` it is consumed, the SEND-only/no-GRANT replacement remains in the source slot with its distinct recipient-root lineage, the outer rollback-owned destination remains absent, and `fold(base+deltas)==direct`. The successor also shares transfer-wire construction in a test-only helper below the function-size threshold.
- New `rollback_accepts_distinct_grant_parent_reauthorization` production-sends a distinct-lineage `ALL`/`GRANT` replacement into the frozen linked-parent slot during the parked commit=false gap. On exact head `2560d9d7e8ff998ffc2d54e63b4ba1d5417e5a76`, rollback legitimately restores the original queued transfer, retains the replacement, leaves the rollback-owned destination absent, and proves `fold(base+deltas)==direct`; together with the SEND-only negative twin, this prevents both over-tightening to exact lineage and under-checking `GRANT`.
- `cargo test --lib -p astrid-native-kernel --locked`: 82 passed.
- `cargo test -p ktest --locked`: 33 passed.
- `git diff --check` passed; package-scoped kernel formatting, strict x86_64-unknown-none Clippy, and `kernel/check.sh x86` passed (split checks through nightly kimage; portability mode was not rerun for this preservation merge).
- Rebuilt q35/UEFI explicit-TCG positive and negative harness.

The existing host test platform cannot force the immediate receive output copyout to fail without a broader platform injection refactor. The parked authoritative interleaving is therefore the falsified race in this successor; no immediate failed-copy regression is claimed.

## Verification

Preservation merge `3bc43c185ee70bd23d3f6dcc132e28636da3a329` is a GPG-signed, no-ff preservation merge with first parent `960aad146f19ab865bfa1601497a0425036532e7` (live `origin/os/universal`) and second parent `d95fc68ca76c8bdbf5ded26477040c50c3d34e96` (accepted draft head). The clean Git auto-merge produced tree `314f07690395161610bb7f8f7794ec87a4172399`, identical to `git merge-tree --write-tree`; no conflict or resolution edits were made. The merge tree preserves the accepted second-parent delta exactly: the path set of `43f6d97fc4beee219af42ed7212bd11c0d7389cd` to `d95fc68ca76c8bdbf5ded26477040c50c3d34e96` equals the path set of `960aad146f19ab865bfa1601497a0425036532e7` to `3bc43c185ee70bd23d3f6dcc132e28636da3a329`. The merge carries the exact DCO `Signed-off-by: Joshua J. Bouw <jjb@unicity-labs.com>` and `git verify-commit` reports a good GPG signature. Live refs and the PR head were re-pinned before publication; exact current PR head is the signed test-only fast-forward successor `2560d9d7e8ff998ffc2d54e63b4ba1d5417e5a76` over `3bc43c185ee70bd23d3f6dcc132e28636da3a329`. PR #1773 remains open and draft, and Tracking #1758 is preserved.

Focused gates on exact head `2560d9d7e8ff998ffc2d54e63b4ba1d5417e5a76` passed: native-kernel lib 82/82; ktest 33/33; package-scoped kernel rustfmt; git diff --check against both parents; strict native-kernel Clippy for `x86_64-unknown-none` with `-D warnings`; and `kernel/check.sh x86` (split checks through nightly kimage). The broad `cargo fmt --all -- --check` still reports pre-existing vendored bootloader formatting drift; the repository-scoped formatter passes.

The q35/UEFI/TCG evidence below is inherited from the accepted second-parent lineage; no new firmware run was required for this preservation merge. It remains emulator-only and does not prove physical-machine behavior, public ABI stability, or cross-host reproducibility.

At predecessor `a540e33f444a6fccee69b470a2786c345d5435b0`, the rebuilt q35 run built two identical UEFI disk images with run-local BLAKE3 `b95001d22a54031cf073b2e6bd8a479336635863ce71df2e25b004f775590880`. This digest is local build/provenance evidence, not a reproducible source identity; another host or build environment can differ. Environment: QEMU 11.1.0, `-machine q35`, UEFI pflash `edk2-x86_64-code.fd` BLAKE3 `e72f887c74e6bde078b14c149daeaf656cf6b19d7626ca2a7ddf012561c32909`, vars `edk2-i386-vars.fd` BLAKE3 `8549e69f89...`, explicit TCG, no KVM/virtio/IOMMU, Darwin 25.6.0 arm64, stable Rust 1.95.0 for `x86_64-unknown-none`, and kimage `nightly-2026-07-21`. Positive boot assertions passed and QEMU exited 33. The tampered image timed out with loader rejection text before entry; plan mismatch rejected with `closure.reject reason=plan_mismatch`, fault halt, and QEMU exit 35. All positive and negative assertions passed. Evidence is q35/UEFI/TCG emulator-only and does not prove physical-machine behavior, public ABI stability, or cross-host reproducibility.
## AI / Tool Assistance

Assisted-by: Codex:GLM-5.3-Flash



