### PR TITLE
feat(native): preserve exact completed running-stop evidence

### DIFF
--- a/changes/1774.added.md
+++ b/changes/1774.added.md
@@ -1,6 +1,3 @@
 Added an exact-identity Running-stop lifecycle that arms atomically with the
 domain's Running transition, consumes only a qualifying guest timer trap, and
 reclaims through the existing same-lock terminal path.
-After the reclaimed slot preserves a completed stop ticket, a crate-private
-read-only observation returns one typed cancelled-stop evidence copy for that
-exact handle, manifest, component, and scenario.

--- a/changes/1774.added.md
+++ b/changes/1774.added.md
@@ -1,3 +1,6 @@
 Added an exact-identity Running-stop lifecycle that arms atomically with the
 domain's Running transition, consumes only a qualifying guest timer trap, and
 reclaims through the existing same-lock terminal path.
+After the reclaimed slot preserves a completed stop ticket, a crate-private
+read-only observation returns one typed cancelled-stop evidence copy for that
+exact handle, manifest, component, and scenario.

--- a/changes/1774.changed.md
+++ b/changes/1774.changed.md
@@ -1,0 +1,3 @@
+After the reclaimed slot preserves a completed stop ticket, a crate-private
+read-only observation returns one typed cancelled-stop evidence copy for that
+exact handle, manifest, component, and scenario.

--- a/kernel/crates/astrid-native-kernel/src/domains/harness.rs
+++ b/kernel/crates/astrid-native-kernel/src/domains/harness.rs
@@ -531,6 +531,33 @@ fn ipc_cancel_guest_done() -> ! {
     start_domain(stop, Scenario::RunningStop);
 }
 
+fn completed_stop_is_current_guarded(stop: DomainHandle) -> bool {
+    let current = &manager::CURRENT;
+    let expected = authenticated_component_id();
+
+    current.active.store(true, Ordering::SeqCst);
+    let active_observed =
+        stop::observe_completed_stop(stop, expected, Scenario::RunningStop).is_none();
+    current.active.store(false, Ordering::SeqCst);
+
+    current.root.store(1, Ordering::SeqCst);
+    let root_observed =
+        stop::observe_completed_stop(stop, expected, Scenario::RunningStop).is_none();
+    current.root.store(0, Ordering::SeqCst);
+
+    current.root_flags.store(1, Ordering::SeqCst);
+    let flags_observed =
+        stop::observe_completed_stop(stop, expected, Scenario::RunningStop).is_none();
+    current.root_flags.store(0, Ordering::SeqCst);
+
+    active_observed
+        && root_observed
+        && flags_observed
+        && !current.active.load(Ordering::SeqCst)
+        && current.root.load(Ordering::SeqCst) == 0
+        && current.root_flags.load(Ordering::SeqCst) == 0
+}
+
 fn running_stop_done() -> ! {
     let stop = handle(&IPC_SERVER_HANDLE);
     let passed = manager::is_stale(stop)
@@ -539,6 +566,7 @@ fn running_stop_done() -> ! {
     let stale = DomainHandle::new(stop.id(), DomainGeneration(stop.generation().0 + 1));
     let foreign_slot = DomainHandle::new(DomainId((stop.id().0 + 1) % 2), stop.generation());
     let substituted_component = ContentId::from_payload(b"running-stop-substitution");
+    let suppression_ok = completed_stop_is_current_guarded(stop);
     let exact =
         stop::observe_completed_stop(stop, authenticated_component_id(), Scenario::RunningStop);
     let repeated =
@@ -564,7 +592,7 @@ fn running_stop_done() -> ! {
                 && observation.scenario() == Scenario::RunningStop
                 && observation.outcome() == Outcome::Cancelled
         });
-    if !observation_ok || !exact_ok {
+    if !suppression_ok || !observation_ok || !exact_ok {
         fail("running_stop_observation_rejected");
     }
     RUNNING_STOP_OK.store(report(RUNNING_STOP_GATE, passed), Ordering::SeqCst);

--- a/kernel/crates/astrid-native-kernel/src/domains/harness.rs
+++ b/kernel/crates/astrid-native-kernel/src/domains/harness.rs
@@ -8,6 +8,7 @@ use astrid_system_generation::emulator_fixture::EMULATOR_COMPONENT_LEN;
 use super::admission;
 use super::manager::{self, CancelError, DomainIdentity, PrepareError};
 use super::stage;
+use super::stop;
 use super::types::{BindError, ComponentImage, DomainGeneration, DomainHandle, DomainId};
 use super::types::{Outcome, Scenario};
 use crate::closure::{authenticated_component, authenticated_component_id};
@@ -518,7 +519,13 @@ fn ipc_cancel_guest_done() -> ! {
         fail("running_guest_ipc_cancel_rejected");
     }
     let (raw, expected) = authenticated();
+    if stop::observe_completed_stop(server, expected, Scenario::RunningStop).is_some() {
+        fail("stale_running_stop_was_observable");
+    }
     let stop = prepare_domain(&raw, expected, Scenario::RunningStop);
+    if stop::observe_completed_stop(stop, expected, Scenario::RunningStop).is_some() {
+        fail("prepared_running_stop_was_observable");
+    }
     store_handle(&IPC_SERVER_HANDLE, stop);
     set_phase(PHASE_RUNNING_STOP_PREPARE);
     start_domain(stop, Scenario::RunningStop);
@@ -529,6 +536,37 @@ fn running_stop_done() -> ! {
     let passed = manager::is_stale(stop)
         && manager::outstanding_frames() == 0
         && manager::kernel_cr3_restored();
+    let stale = DomainHandle::new(stop.id(), DomainGeneration(stop.generation().0 + 1));
+    let foreign_slot = DomainHandle::new(DomainId((stop.id().0 + 1) % 2), stop.generation());
+    let substituted_component = ContentId::from_payload(b"running-stop-substitution");
+    let exact =
+        stop::observe_completed_stop(stop, authenticated_component_id(), Scenario::RunningStop);
+    let repeated =
+        stop::observe_completed_stop(stop, authenticated_component_id(), Scenario::RunningStop);
+    let observation_ok =
+        stop::observe_completed_stop(stale, authenticated_component_id(), Scenario::RunningStop)
+            .is_none()
+            && stop::observe_completed_stop(
+                foreign_slot,
+                authenticated_component_id(),
+                Scenario::RunningStop,
+            )
+            .is_none()
+            && stop::observe_completed_stop(stop, substituted_component, Scenario::RunningStop)
+                .is_none()
+            && stop::observe_completed_stop(stop, authenticated_component_id(), Scenario::Exit)
+                .is_none();
+    let exact_ok = exact.is_some()
+        && exact == repeated
+        && exact.as_ref().is_some_and(|observation| {
+            observation.handle() == stop
+                && *observation.component_id() == authenticated_component_id()
+                && observation.scenario() == Scenario::RunningStop
+                && observation.outcome() == Outcome::Cancelled
+        });
+    if !observation_ok || !exact_ok {
+        fail("running_stop_observation_rejected");
+    }
     RUNNING_STOP_OK.store(report(RUNNING_STOP_GATE, passed), Ordering::SeqCst);
     if !passed {
         fail("running_timer_stop_not_terminal");

--- a/kernel/crates/astrid-native-kernel/src/domains/manager/mod.rs
+++ b/kernel/crates/astrid-native-kernel/src/domains/manager/mod.rs
@@ -15,7 +15,7 @@ use x86_64::structures::paging::{PhysFrame, Size4KiB};
 
 #[cfg(not(test))]
 use super::paging::AddressSpace;
-use super::stop::DomainStop;
+use super::stop::{DomainStop, HostManifestIdentity};
 use super::types::{
     BindError, DomainGeneration, DomainHandle, DomainId, DomainPagingError, Outcome, SLOT_CAPACITY,
     Scenario,
@@ -27,7 +27,6 @@ use crate::ipc;
 use crate::memory::FRAME_SIZE;
 #[cfg(not(test))]
 use crate::serial;
-#[cfg(not(test))]
 use astrid_system_generation::ContentId;
 
 #[cfg(test)]
@@ -618,6 +617,24 @@ impl Manager {
             return Err(super::stop::StopError::StateMismatch);
         }
         domain.stop.take_timer(handle, scenario)
+    }
+
+    pub(in crate::domains) fn completed_running_stop(
+        &self,
+        handle: DomainHandle,
+        component_id: ContentId,
+        scenario: Scenario,
+    ) -> Option<super::stop::StopObservation<HostManifestIdentity, ContentId>> {
+        let domain = self
+            .slots
+            .get(handle.id().0 as usize)
+            .and_then(Option::as_ref)
+            .filter(|domain| {
+                domain.generation == handle.generation().0 && domain.state == DomainState::Reclaimed
+            })?;
+        domain
+            .stop
+            .completed_observation_for(handle, component_id, scenario)
     }
 
     fn slot_is_preparable(domain: Option<&Domain>) -> bool {

--- a/kernel/crates/astrid-native-kernel/src/domains/manager/stop_tests.rs
+++ b/kernel/crates/astrid-native-kernel/src/domains/manager/stop_tests.rs
@@ -2,6 +2,7 @@ use super::{ADMISSION_RELEASES, RELATION_RELEASE_FAILURE, ReclaimStats, SPACE_RE
 use super::{Domain, DomainState, DomainStop, Manager, Scenario};
 use crate::domains::types::{DomainGeneration, DomainHandle, DomainId};
 use crate::ipc::{DomainToken, prepare_domain};
+use astrid_system_generation::ContentId;
 use core::sync::atomic::Ordering;
 use spin::{Mutex, MutexGuard};
 
@@ -15,6 +16,10 @@ fn handle() -> DomainHandle {
     DomainHandle::new(DomainId(0), DomainGeneration(12))
 }
 
+fn release_component_id() -> ContentId {
+    ContentId::from_payload(b"manager-stop-release-failure")
+}
+
 fn reset_release_fixture() {
     RELATION_RELEASE_FAILURE.store(false, Ordering::SeqCst);
     SPACE_RELEASE_FAILURE.store(0, Ordering::SeqCst);
@@ -24,8 +29,7 @@ fn reset_release_fixture() {
 
 fn install_taken_domain(space: Option<()>) -> spin::MutexGuard<'static, Manager> {
     let handle = handle();
-    let component_id =
-        astrid_system_generation::ContentId::from_payload(b"manager-stop-release-failure");
+    let component_id = release_component_id();
     let mut stop = DomainStop::stage(handle, (), component_id, Scenario::RunningStop)
         .unwrap()
         .into_armed(handle, (), component_id, Scenario::RunningStop)
@@ -65,6 +69,11 @@ fn relation_release_failure_fails_closed_and_forbids_reuse() {
     }
     assert_eq!(ADMISSION_RELEASES.load(Ordering::SeqCst), 0);
     assert!(!Manager::slot_is_preparable(manager.slots[0].as_ref()));
+    assert!(
+        manager
+            .completed_running_stop(handle(), release_component_id(), Scenario::RunningStop)
+            .is_none()
+    );
 
     manager.slots[0] = None;
     RELATION_RELEASE_FAILURE.store(false, Ordering::SeqCst);
@@ -92,6 +101,11 @@ fn missing_space_fails_taken_stop_without_accounting_release() {
     }
     assert_eq!(ADMISSION_RELEASES.load(Ordering::SeqCst), 0);
     assert!(!Manager::slot_is_preparable(manager.slots[0].as_ref()));
+    assert!(
+        manager
+            .completed_running_stop(handle(), release_component_id(), Scenario::RunningStop)
+            .is_none()
+    );
 
     manager.slots[0] = None;
 }
@@ -119,6 +133,11 @@ fn cr3_restore_failure_finishes_aborted_and_keeps_accounting() {
     }
     assert_eq!(ADMISSION_RELEASES.load(Ordering::SeqCst), 0);
     assert!(!Manager::slot_is_preparable(manager.slots[0].as_ref()));
+    assert!(
+        manager
+            .completed_running_stop(handle(), release_component_id(), Scenario::RunningStop)
+            .is_none()
+    );
 
     manager.slots[0] = None;
     SPACE_RELEASE_FAILURE.store(0, Ordering::SeqCst);
@@ -147,6 +166,11 @@ fn reclaim_blocked_fails_taken_stop_and_keeps_accounting() {
     }
     assert_eq!(ADMISSION_RELEASES.load(Ordering::SeqCst), 0);
     assert!(!Manager::slot_is_preparable(manager.slots[0].as_ref()));
+    assert!(
+        manager
+            .completed_running_stop(handle(), release_component_id(), Scenario::RunningStop)
+            .is_none()
+    );
 
     manager.slots[0] = None;
     SPACE_RELEASE_FAILURE.store(0, Ordering::SeqCst);
@@ -173,5 +197,122 @@ fn successful_stop_reclaims_once_releases_admission_and_frees_slot() {
     assert_eq!(ADMISSION_RELEASES.load(Ordering::SeqCst), 1);
     assert!(Manager::slot_is_preparable(manager.slots[0].as_ref()));
 
+    let exact = manager
+        .completed_running_stop(handle(), release_component_id(), Scenario::RunningStop)
+        .unwrap();
+    let repeated = manager
+        .completed_running_stop(handle(), release_component_id(), Scenario::RunningStop)
+        .unwrap();
+    assert_eq!(exact, repeated);
+    assert_eq!(exact.handle(), handle());
+    assert_eq!(exact.manifest_identity(), &());
+    assert_eq!(exact.component_id(), &release_component_id());
+    assert_eq!(exact.scenario(), Scenario::RunningStop);
+    assert_eq!(exact.outcome(), crate::domains::types::Outcome::Cancelled);
+
+    let wrong_generation = DomainHandle::new(DomainId(0), DomainGeneration(13));
+    let wrong_slot = DomainHandle::new(DomainId(1), DomainGeneration(12));
+    let substituted_component =
+        astrid_system_generation::ContentId::from_payload(b"substituted-stop-release");
+    assert!(
+        manager
+            .completed_running_stop(
+                wrong_generation,
+                release_component_id(),
+                Scenario::RunningStop
+            )
+            .is_none()
+    );
+    assert!(
+        manager
+            .completed_running_stop(wrong_slot, release_component_id(), Scenario::RunningStop)
+            .is_none()
+    );
+    assert!(
+        manager
+            .completed_running_stop(handle(), substituted_component, Scenario::RunningStop)
+            .is_none()
+    );
+    assert!(
+        manager
+            .completed_running_stop(handle(), release_component_id(), Scenario::Exit)
+            .is_none()
+    );
+
     manager.slots[0] = None;
+}
+
+#[test]
+fn releasing_state_forbids_completed_observation() {
+    let _fixture = lock_fixture();
+    let mut manager = install_taken_domain(Some(()));
+    if let Some(domain) = manager.slots[0].as_mut() {
+        domain.state = DomainState::Releasing;
+    }
+
+    assert!(
+        manager
+            .completed_running_stop(handle(), release_component_id(), Scenario::RunningStop)
+            .is_none()
+    );
+    assert_eq!(
+        manager.slots[0].as_ref().unwrap().state,
+        DomainState::Releasing
+    );
+    manager.slots[0] = None;
+}
+
+#[test]
+fn same_slot_fresh_generation_hides_old_completed_observation() {
+    let _fixture = lock_fixture();
+    let old_component = ContentId::from_payload(b"manager-stop-old-generation");
+    let fresh_component = ContentId::from_payload(b"manager-stop-fresh-generation");
+    let mut manager = super::MANAGER.lock();
+    manager.slots[0] = Some(Domain {
+        generation: 12,
+        state: DomainState::Reclaimed,
+        scenario: Scenario::RunningStop,
+        quota_ticks: 0,
+        space: None,
+        ipc_enabled: false,
+        stop: completed_stop(handle(), old_component),
+    });
+
+    assert!(
+        manager
+            .completed_running_stop(handle(), old_component, Scenario::RunningStop)
+            .is_some()
+    );
+
+    let fresh = DomainHandle::new(DomainId(0), DomainGeneration(13));
+    manager.slots[0] = Some(Domain {
+        generation: 13,
+        state: DomainState::Reclaimed,
+        scenario: Scenario::RunningStop,
+        quota_ticks: 0,
+        space: None,
+        ipc_enabled: false,
+        stop: completed_stop(fresh, fresh_component),
+    });
+    assert!(
+        manager
+            .completed_running_stop(handle(), old_component, Scenario::RunningStop)
+            .is_none()
+    );
+    let observation = manager
+        .completed_running_stop(fresh, fresh_component, Scenario::RunningStop)
+        .unwrap();
+    assert_eq!(observation.handle(), fresh);
+    assert_eq!(observation.component_id(), &fresh_component);
+    manager.slots[0] = None;
+}
+
+fn completed_stop(handle: DomainHandle, component_id: ContentId) -> DomainStop {
+    let mut stop = DomainStop::stage(handle, (), component_id, Scenario::RunningStop)
+        .unwrap()
+        .into_armed(handle, (), component_id, Scenario::RunningStop)
+        .unwrap();
+    stop.take_timer(handle, Scenario::RunningStop).unwrap();
+    stop.finish(handle, true).unwrap();
+    stop
 }

--- a/kernel/crates/astrid-native-kernel/src/domains/stop/mod.rs
+++ b/kernel/crates/astrid-native-kernel/src/domains/stop/mod.rs
@@ -1,6 +1,6 @@
 //! Private identity-bound Running-stop scheduler handoff.
 
-use super::types::{DomainHandle, Scenario};
+use super::types::{DomainHandle, Outcome, Scenario};
 use astrid_system_generation::ContentId;
 #[cfg(not(test))]
 use astrid_system_generation::ManifestIdentity;
@@ -11,9 +11,9 @@ use super::manager::{CURRENT, MANAGER, fail_terminal};
 use crate::serial;
 
 #[cfg(not(test))]
-type HostManifestIdentity = ManifestIdentity;
+pub(in crate::domains) type HostManifestIdentity = ManifestIdentity;
 #[cfg(test)]
-type HostManifestIdentity = ();
+pub(in crate::domains) type HostManifestIdentity = ();
 
 pub(crate) type DomainStop = StopLifecycle<HostManifestIdentity, ContentId>;
 
@@ -54,6 +54,38 @@ pub(crate) struct StopTicket<G, C> {
     scenario: Scenario,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct StopObservation<G, C> {
+    handle: DomainHandle,
+    manifest_identity: G,
+    component_id: C,
+    scenario: Scenario,
+    outcome: Outcome,
+}
+
+impl<G, C> StopObservation<G, C> {
+    pub(in crate::domains) const fn handle(&self) -> DomainHandle {
+        self.handle
+    }
+
+    #[cfg(test)]
+    pub(in crate::domains) const fn manifest_identity(&self) -> &G {
+        &self.manifest_identity
+    }
+
+    pub(in crate::domains) const fn component_id(&self) -> &C {
+        &self.component_id
+    }
+
+    pub(in crate::domains) const fn scenario(&self) -> Scenario {
+        self.scenario
+    }
+
+    pub(in crate::domains) const fn outcome(&self) -> Outcome {
+        self.outcome
+    }
+}
+
 impl<G, C> StopTicket<G, C>
 where
     G: Copy + PartialEq,
@@ -79,6 +111,56 @@ where
             return Err(StopError::ScenarioMismatch);
         }
         Ok(())
+    }
+}
+
+impl<G, C> StopLifecycle<G, C>
+where
+    G: Copy + PartialEq,
+    C: Copy + PartialEq,
+{
+    #[cfg(test)]
+    pub(in crate::domains) fn completed_observation(
+        &self,
+        handle: DomainHandle,
+        manifest_identity: G,
+        component_id: C,
+        scenario: Scenario,
+    ) -> Option<StopObservation<G, C>> {
+        let Self::Completed(ticket) = self else {
+            return None;
+        };
+        ticket
+            .verify(handle, manifest_identity, component_id, scenario)
+            .ok()?;
+        (ticket.scenario == Scenario::RunningStop).then_some(StopObservation {
+            handle: ticket.handle,
+            manifest_identity: ticket.manifest_identity,
+            component_id: ticket.component_id,
+            scenario: ticket.scenario,
+            outcome: Outcome::Cancelled,
+        })
+    }
+
+    pub(in crate::domains) fn completed_observation_for(
+        &self,
+        handle: DomainHandle,
+        component_id: C,
+        scenario: Scenario,
+    ) -> Option<StopObservation<G, C>> {
+        let Self::Completed(ticket) = self else {
+            return None;
+        };
+        ticket
+            .verify(handle, ticket.manifest_identity, component_id, scenario)
+            .ok()?;
+        (ticket.scenario == Scenario::RunningStop).then_some(StopObservation {
+            handle: ticket.handle,
+            manifest_identity: ticket.manifest_identity,
+            component_id: ticket.component_id,
+            scenario: ticket.scenario,
+            outcome: Outcome::Cancelled,
+        })
     }
 }
 
@@ -239,4 +321,23 @@ pub(crate) fn abort_for_terminal(handle: DomainHandle) -> bool {
     } else {
         !domain.stop.is_taken()
     }
+}
+
+#[cfg(not(test))]
+pub(in crate::domains) fn observe_completed_stop(
+    handle: DomainHandle,
+    component_id: ContentId,
+    scenario: Scenario,
+) -> Option<StopObservation<HostManifestIdentity, ContentId>> {
+    if CURRENT.active.load(core::sync::atomic::Ordering::SeqCst)
+        || CURRENT.root.load(core::sync::atomic::Ordering::SeqCst) != 0
+        || CURRENT
+            .root_flags
+            .load(core::sync::atomic::Ordering::SeqCst)
+            != 0
+    {
+        return None;
+    }
+    let manager = MANAGER.lock();
+    manager.completed_running_stop(handle, component_id, scenario)
 }

--- a/kernel/crates/astrid-native-kernel/src/domains/stop/tests.rs
+++ b/kernel/crates/astrid-native-kernel/src/domains/stop/tests.rs
@@ -46,6 +46,12 @@ fn taken(slot: u64, generation: u64) -> StopLifecycle<TestManifest, TestComponen
     stop
 }
 
+fn completed(slot: u64, generation: u64) -> StopLifecycle<TestManifest, TestComponent> {
+    let mut stop = taken(slot, generation);
+    stop.finish(handle(slot, generation), true).unwrap();
+    stop
+}
+
 fn installed_armed_with_state(
     state: DomainState,
 ) -> spin::MutexGuard<'static, super::super::manager::Manager> {
@@ -301,4 +307,67 @@ fn inactive_stale_and_completed_reject_armed_take() {
         Err(StopError::HandleMismatch)
     );
     assert!(matches!(stale, StopLifecycle::Staged(_)));
+}
+
+#[test]
+fn completed_observation_requires_exact_taken_success() {
+    let handle = handle(0, 3);
+    for stop in [staged(0, 3), armed(0, 3), taken(0, 3), {
+        let mut aborted = taken(0, 3);
+        aborted.finish(handle, false).unwrap();
+        aborted
+    }] {
+        assert!(
+            stop.completed_observation(handle, MANIFEST, COMPONENT, Scenario::RunningStop)
+                .is_none()
+        );
+    }
+
+    let stop = completed(0, 3);
+    let observation = stop
+        .completed_observation(handle, MANIFEST, COMPONENT, Scenario::RunningStop)
+        .unwrap();
+    assert_eq!(observation.handle(), handle);
+    assert_eq!(observation.manifest_identity(), &MANIFEST);
+    assert_eq!(observation.component_id(), &COMPONENT);
+    assert_eq!(observation.scenario(), Scenario::RunningStop);
+    assert_eq!(
+        observation.outcome(),
+        crate::domains::types::Outcome::Cancelled
+    );
+}
+
+#[test]
+fn completed_observation_rejects_substituted_evidence() {
+    let stop = completed(0, 3);
+    assert!(
+        stop.completed_observation(handle(1, 3), MANIFEST, COMPONENT, Scenario::RunningStop)
+            .is_none()
+    );
+    assert!(
+        stop.completed_observation(handle(0, 4), MANIFEST, COMPONENT, Scenario::RunningStop)
+            .is_none()
+    );
+    assert!(
+        stop.completed_observation(
+            handle(0, 3),
+            TestManifest(8),
+            COMPONENT,
+            Scenario::RunningStop
+        )
+        .is_none()
+    );
+    assert!(
+        stop.completed_observation(
+            handle(0, 3),
+            MANIFEST,
+            TestComponent(12),
+            Scenario::RunningStop
+        )
+        .is_none()
+    );
+    assert!(
+        stop.completed_observation(handle(0, 3), MANIFEST, COMPONENT, Scenario::Exit)
+            .is_none()
+    );
 }


### PR DESCRIPTION
## Linked Issue

Refs #1774

## Summary

After a Running-domain stop reaches terminal completion, retain its completed ticket in the reclaimed slot and make one exact, read-only copy of the resulting cancelled-stop evidence available to the private scheduler consumer. Observation remains bound to the original handle generation, manifest identity, component, and RunningStop scenario.

## Changes

- Add a private typed observation of a completed Running stop with a cancelled outcome.
- Permit observation only after exact reclaim, accounting release, terminal completion, and inactive-root conditions are satisfied.
- Keep repeated observation idempotent while making stale handles and reused slots fail closed.
- Extend lifecycle and scheduler-harness tests for early, substituted, stale, and post-completion observation.
- Add a q35 harness falsifier that independently proves each CURRENT inactive-root condition suppresses a Completed observation, restoring each condition immediately.
- Preserve the existing added fragment and record the observation behavior in a newly added changed fragment.

## Verification

- `cargo fmt -p astrid-native-kernel -- --check` passes.
- `cargo test -p astrid-native-kernel --lib --locked`: 103 passed.
- `cargo test -p ktest --locked`: 33 passed.
- `cargo clippy -p astrid-native-kernel --target x86_64-unknown-none --locked -- -D warnings` passes.
- `cargo clippy -p ktest --all-targets --locked -- -D warnings` passes.
- Fresh q35/UEFI explicit-TCG positive boot: 237 events, exact terminal-stop order, assertions PASS, packaging determinism PASS, QEMU exit 33.
- Loader-tamper input fails before kernel entry; ring-0 plan mismatch exits 35 as expected.
- `python3 scripts/changelog.py check --base af092a72517bd09575e15e19442cda0af2f3254d --head HEAD --labels ""` passes.
- This evidence is q35/TCG emulator evidence only; it does not establish physical, native production, reboot, publication, or hardware-topology behavior. Full split-check CI for successor `1af9f81aea29710ce5f0f55e917c2c942fb4e901` remains pending.

## AI / Tool Assistance

Assisted-by: code-assistant tooling: Rust implementation and tests. Reviewed against the private lifecycle design and validated with the checks and emulator runs above.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/{issue}.{kind}.md`
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.