### PR TITLE
Return running domains to scheduler control

### DIFF
--- a/changes/1774.changed.md
+++ b/changes/1774.changed.md
@@ -1,1 +1,3 @@
-Running domains now return to the scheduler through a private, identity-bound execution-control lease before a one-shot stop request is accepted. The universal stop path still performs relation retirement, exact reclamation, admission release, and completion evidence, while a returned domain never becomes ready or terminal. Tracking #1774.
+After the reclaimed slot preserves a completed stop ticket, a crate-private
+read-only observation returns one typed cancelled-stop evidence copy for that
+exact handle, manifest, component, and scenario.

--- a/changes/1774.changed.md
+++ b/changes/1774.changed.md
@@ -1,3 +1,1 @@
-After the reclaimed slot preserves a completed stop ticket, a crate-private
-read-only observation returns one typed cancelled-stop evidence copy for that
-exact handle, manifest, component, and scenario.
+Running domains now return to the scheduler through a private, identity-bound execution-control lease before a one-shot stop request is accepted. The universal stop path still performs relation retirement, exact reclamation, admission release, and completion evidence, while a returned domain never becomes ready or terminal. Tracking #1774.

--- a/changes/1774.fixed.md
+++ b/changes/1774.fixed.md
@@ -1,0 +1,1 @@
+- Native running-stop returns validate the admitted user-stack context before retaining scheduler control. One-shot stop requests now distinguish a run that has not returned from an already requested stop. Refs #1774

--- a/kernel/crates/astrid-native-kernel/src/domains/harness.rs
+++ b/kernel/crates/astrid-native-kernel/src/domains/harness.rs
@@ -6,7 +6,7 @@ use astrid_system_generation::ContentId;
 use astrid_system_generation::emulator_fixture::EMULATOR_COMPONENT_LEN;
 
 use super::admission;
-use super::manager::{self, CancelError, DomainIdentity, PrepareError};
+use super::manager::{self, CancelError, DomainIdentity, DomainState, PrepareError};
 use super::stage;
 use super::stop;
 use super::types::{BindError, ComponentImage, DomainGeneration, DomainHandle, DomainId};
@@ -31,7 +31,7 @@ const RESTORE_GATE: &str = "exact_kernel_cr3_restore";
 const IPC_EXCHANGE_GATE: &str = "authenticated_domains_exchange_bounded_capability_message";
 const IPC_FAULT_GATE: &str = "peer_fault_wakes_blocked_recv_with_typed_status";
 const IPC_CANCEL_GATE: &str = "cancel_reclaims_blocked_ipc_exactly_once";
-const RUNNING_STOP_GATE: &str = "running_timer_stop_cancels_and_reclaims_exactly_once";
+const RUNNING_STOP_GATE: &str = "returned_control_stop_reclaims_exactly_once";
 
 const PHASE_ENTRY: u64 = 0;
 const PHASE_INVALID_PREPARE: u64 = 1;
@@ -560,12 +560,37 @@ fn completed_stop_is_current_guarded(stop: DomainHandle) -> bool {
 
 fn running_stop_done() -> ! {
     let stop = handle(&IPC_SERVER_HANDLE);
-    let passed = manager::is_stale(stop)
-        && manager::outstanding_frames() == 0
+    let expected = authenticated_component_id();
+    serial::ev_control_returned(stop.id().0 + 1, stop.generation().0);
+    let returned_ok = manager::outstanding_frames() > 0
+        && !manager::is_stale(stop)
+        && manager::staged_state(stop) == Ok(Some((DomainState::Running, Scenario::RunningStop)))
+        && !manager::CURRENT.active.load(Ordering::SeqCst)
+        && manager::CURRENT.root.load(Ordering::SeqCst) == 0
+        && manager::CURRENT.root_flags.load(Ordering::SeqCst) == 0
         && manager::kernel_cr3_restored();
+    if !returned_ok {
+        fail("running_control_return_was_not_quiescent");
+    }
+    let substituted_component = ContentId::from_payload(b"returned-control-substitution");
     let stale = DomainHandle::new(stop.id(), DomainGeneration(stop.generation().0 + 1));
     let foreign_slot = DomainHandle::new(DomainId((stop.id().0 + 1) % 2), stop.generation());
-    let substituted_component = ContentId::from_payload(b"running-stop-substitution");
+    let substitutions_rejected =
+        manager::request_returned_stop(stop, substituted_component, Scenario::RunningStop).is_err()
+            && manager::request_returned_stop(stop, expected, Scenario::Exit).is_err()
+            && manager::request_returned_stop(stale, expected, Scenario::RunningStop).is_err()
+            && manager::request_returned_stop(foreign_slot, expected, Scenario::RunningStop)
+                .is_err()
+            && manager::outstanding_frames() > 0
+            && !manager::is_stale(stop);
+    if !substitutions_rejected {
+        fail("returned_control_substitution_accepted");
+    }
+    let accepted = manager::request_returned_stop(stop, expected, Scenario::RunningStop).is_ok();
+    let passed = accepted
+        && manager::is_stale(stop)
+        && manager::outstanding_frames() == 0
+        && manager::kernel_cr3_restored();
     let suppression_ok = completed_stop_is_current_guarded(stop);
     let exact =
         stop::observe_completed_stop(stop, authenticated_component_id(), Scenario::RunningStop);

--- a/kernel/crates/astrid-native-kernel/src/domains/manager/control.rs
+++ b/kernel/crates/astrid-native-kernel/src/domains/manager/control.rs
@@ -1,0 +1,559 @@
+//! Private execution-control lease for a running native domain.
+
+use astrid_system_generation::ContentId;
+
+#[cfg(not(test))]
+use core::sync::atomic::Ordering;
+#[cfg(not(test))]
+use x86_64::registers::control::Cr3;
+
+use super::super::types::Outcome;
+use super::super::types::{DomainHandle, Scenario};
+use super::TrapContext;
+use super::{CURRENT, MANAGER};
+use crate::platform::TrapFrame;
+#[cfg(not(test))]
+use crate::serial;
+use spin::Mutex;
+
+pub(in crate::domains) type HostManifestIdentity = astrid_system_generation::ManifestIdentity;
+
+pub(in crate::domains) type DomainControl = Control<HostManifestIdentity, ContentId>;
+
+#[cfg(not(test))]
+static RETURNED_CONTROL: Mutex<Option<ReturnedRun>> = Mutex::new(None);
+
+#[cfg(test)]
+mod tests;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ControlError {
+    NotAdmitted,
+    AlreadyReturned,
+    HandleMismatch,
+    ManifestMismatch,
+    ComponentMismatch,
+    ScenarioMismatch,
+    ContextMismatch,
+    NotReturned,
+    AlreadyRequested,
+    StateMismatch,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ReturnedControlError {
+    Control(ControlError),
+    ActiveDomain,
+    WrongCr3,
+    ReleaseFailed,
+}
+
+impl ReturnedControlError {
+    pub(crate) const fn as_reason(self) -> &'static str {
+        match self {
+            Self::Control(error) => error.as_reason(),
+            Self::ActiveDomain => "active_domain",
+            Self::WrongCr3 => "wrong_cr3",
+            Self::ReleaseFailed => "release_failed",
+        }
+    }
+}
+
+impl ControlError {
+    pub(crate) const fn as_reason(self) -> &'static str {
+        match self {
+            Self::NotAdmitted => "control_not_admitted",
+            Self::AlreadyReturned => "control_already_returned",
+            Self::HandleMismatch => "control_handle_mismatch",
+            Self::ManifestMismatch => "control_manifest_mismatch",
+            Self::ComponentMismatch => "control_component_mismatch",
+            Self::ScenarioMismatch => "control_scenario_mismatch",
+            Self::ContextMismatch => "control_context_mismatch",
+            Self::NotReturned => "control_not_returned",
+            Self::AlreadyRequested => "control_already_requested",
+            Self::StateMismatch => "control_state_mismatch",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(in crate::domains) struct RunTicket<G, C> {
+    handle: DomainHandle,
+    manifest_identity: G,
+    component_id: C,
+    scenario: Scenario,
+}
+
+impl<G, C> RunTicket<G, C>
+where
+    G: Copy + PartialEq,
+    C: Copy + PartialEq,
+{
+    fn verify(
+        &self,
+        handle: DomainHandle,
+        manifest_identity: G,
+        component_id: C,
+        scenario: Scenario,
+    ) -> Result<(), ControlError> {
+        if self.handle != handle {
+            return Err(ControlError::HandleMismatch);
+        }
+        if self.manifest_identity != manifest_identity {
+            return Err(ControlError::ManifestMismatch);
+        }
+        if self.component_id != component_id {
+            return Err(ControlError::ComponentMismatch);
+        }
+        if self.scenario != scenario {
+            return Err(ControlError::ScenarioMismatch);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(in crate::domains) struct LeaseContext {
+    root: u64,
+    root_flags: u64,
+    source: u64,
+    source_flags: u64,
+    stack_end: u64,
+}
+
+impl LeaseContext {
+    pub(in crate::domains) const fn new(
+        root: u64,
+        root_flags: u64,
+        source: u64,
+        source_flags: u64,
+        stack_end: u64,
+    ) -> Self {
+        Self {
+            root,
+            root_flags,
+            source,
+            source_flags,
+            stack_end,
+        }
+    }
+
+    const fn matches_current(self, root: u64, root_flags: u64) -> bool {
+        self.root == root && self.root_flags == root_flags
+    }
+
+    const fn matches_kernel(self, source: u64, source_flags: u64) -> bool {
+        self.source == source && self.source_flags == source_flags
+    }
+}
+
+pub(in crate::domains) struct ReturnedRun {
+    root: u64,
+    root_flags: u64,
+    frame: TrapFrame,
+}
+
+impl Clone for ReturnedRun {
+    fn clone(&self) -> Self {
+        Self {
+            root: self.root,
+            root_flags: self.root_flags,
+            frame: copy_frame(&self.frame),
+        }
+    }
+}
+
+impl core::fmt::Debug for ReturnedRun {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        formatter
+            .debug_struct("ReturnedRun")
+            .field("root", &self.root)
+            .field("root_flags", &self.root_flags)
+            .field("vector", &self.frame.vector)
+            .field("rip", &self.frame.rip)
+            .field("cs", &self.frame.cs)
+            .finish_non_exhaustive()
+    }
+}
+
+impl PartialEq for ReturnedRun {
+    fn eq(&self, other: &Self) -> bool {
+        self.root == other.root
+            && self.root_flags == other.root_flags
+            && self.frame.vector == other.frame.vector
+            && self.frame.rip == other.frame.rip
+            && self.frame.cs == other.frame.cs
+    }
+}
+
+impl Eq for ReturnedRun {}
+
+impl ReturnedRun {
+    pub(in crate::domains) const fn vector(&self) -> u8 {
+        self.frame.vector as u8
+    }
+
+    pub(in crate::domains) const fn error_code(&self) -> u64 {
+        self.frame.error_code
+    }
+
+    pub(in crate::domains) const fn rip(&self) -> u64 {
+        self.frame.rip
+    }
+
+    pub(in crate::domains) const fn cs(&self) -> u64 {
+        self.frame.cs
+    }
+
+    #[cfg(test)]
+    pub(in crate::domains) const fn fault_address(&self) -> u64 {
+        0
+    }
+}
+
+#[cfg(test)]
+impl ReturnedRun {
+    pub(in crate::domains) const fn trap_context(&self) -> TrapContext {
+        TrapContext {
+            slot: 0,
+            generation: 0,
+            vector: self.frame.vector as u8,
+            error_code: self.frame.error_code,
+            rip: self.frame.rip,
+            cs: self.frame.cs,
+            fault_address: 0,
+            outcome: Outcome::Cancelled,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum Control<G, C> {
+    Inactive,
+    Admitted(RunTicket<G, C>, LeaseContext),
+    Returned(ReturnedRun, RunTicket<G, C>, LeaseContext),
+    StopRequested(ReturnedRun, RunTicket<G, C>, LeaseContext),
+}
+
+impl<G, C> Control<G, C>
+where
+    G: Copy + PartialEq,
+    C: Copy + PartialEq,
+{
+    pub(crate) fn return_at_trap(
+        self,
+        handle: DomainHandle,
+        manifest_identity: G,
+        component_id: C,
+        scenario: Scenario,
+        trap: TrapSnapshot<'_>,
+    ) -> Result<(Self, ReturnedRun), ControlError> {
+        let Self::Admitted(ticket, context) = self else {
+            return Err(ControlError::AlreadyReturned);
+        };
+        ticket.verify(handle, manifest_identity, component_id, scenario)?;
+        if scenario != Scenario::RunningStop
+            || !context.matches_current(trap.root, trap.root_flags)
+            || trap.frame.cs & 3 != 3
+        {
+            return Err(ControlError::ContextMismatch);
+        }
+        let returned = ReturnedRun {
+            root: trap.root,
+            root_flags: trap.root_flags,
+            frame: copy_frame(trap.frame),
+        };
+        Ok((Self::Returned(returned.clone(), ticket, context), returned))
+    }
+
+    pub(crate) fn request_stop(
+        self,
+        handle: DomainHandle,
+        manifest_identity: G,
+        component_id: C,
+        scenario: Scenario,
+        context_guard: ContextGuard,
+    ) -> Result<(Self, ReturnedRun), ControlError> {
+        let Self::Returned(returned, ticket, context) = self else {
+            return Err(ControlError::AlreadyRequested);
+        };
+        ticket.verify(handle, manifest_identity, component_id, scenario)?;
+        if scenario != Scenario::RunningStop
+            || !context_guard.is_quiescent()
+            || !context.matches_current(returned.root, returned.root_flags)
+            || !context.matches_kernel(context_guard.source, context_guard.source_flags)
+        {
+            return Err(ControlError::ContextMismatch);
+        }
+        Ok((
+            Self::StopRequested(returned.clone(), ticket, context),
+            returned,
+        ))
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(in crate::domains) struct TrapSnapshot<'a> {
+    pub(in crate::domains) root: u64,
+    pub(in crate::domains) root_flags: u64,
+    pub(in crate::domains) frame: &'a TrapFrame,
+}
+
+#[derive(Clone, Copy)]
+pub(in crate::domains) struct ContextGuard {
+    current_root: u64,
+    current_flags: u64,
+    source: u64,
+    source_flags: u64,
+}
+
+impl ContextGuard {
+    pub(in crate::domains) const fn new(
+        current_root: u64,
+        current_flags: u64,
+        source: u64,
+        source_flags: u64,
+    ) -> Self {
+        Self {
+            current_root,
+            current_flags,
+            source,
+            source_flags,
+        }
+    }
+
+    const fn is_quiescent(self) -> bool {
+        self.current_root == 0 && self.current_flags == 0
+    }
+}
+
+impl<G, C> Control<G, C>
+where
+    G: Copy + PartialEq,
+    C: Copy + PartialEq,
+{
+    pub(crate) const fn inactive() -> Self {
+        Self::Inactive
+    }
+
+    pub(crate) fn admit(
+        handle: DomainHandle,
+        manifest_identity: G,
+        component_id: C,
+        scenario: Scenario,
+        context: LeaseContext,
+    ) -> Result<Self, ControlError> {
+        if handle.generation().value() == 0 {
+            return Err(ControlError::HandleMismatch);
+        }
+        Ok(Self::Admitted(
+            RunTicket {
+                handle,
+                manifest_identity,
+                component_id,
+                scenario,
+            },
+            context,
+        ))
+    }
+}
+
+#[cfg(not(test))]
+pub(in crate::domains) fn request_returned_stop(
+    handle: DomainHandle,
+    component_id: ContentId,
+    scenario: Scenario,
+) -> Result<ReturnedRun, ReturnedControlError> {
+    if scenario != Scenario::RunningStop {
+        return Err(ReturnedControlError::Control(
+            ControlError::ScenarioMismatch,
+        ));
+    }
+    let manifest_identity = super::super::admission::confirm_start(handle, component_id)
+        .map_err(|_| ReturnedControlError::Control(ControlError::ManifestMismatch))?;
+    super::MANAGER
+        .lock()
+        .accept_returned_stop(handle, manifest_identity, component_id, scenario)
+}
+
+#[cfg(not(test))]
+fn returned_context_error() -> Option<ReturnedControlError> {
+    if CURRENT.active.load(Ordering::SeqCst)
+        || CURRENT.root.load(Ordering::SeqCst) != 0
+        || CURRENT.root_flags.load(Ordering::SeqCst) != 0
+    {
+        return Some(ReturnedControlError::ActiveDomain);
+    }
+    let Some(expected) = super::KERNEL_CR3.get().copied() else {
+        return Some(ReturnedControlError::WrongCr3);
+    };
+    (Cr3::read() != expected).then_some(ReturnedControlError::WrongCr3)
+}
+
+#[cfg(not(test))]
+pub(in crate::domains) fn stage_returning_trap(
+    frame: &TrapFrame,
+) -> Result<(), ReturnedControlError> {
+    let handle = super::super::wait::current_handle();
+    let scenario = Scenario::try_from(CURRENT.scenario.load(Ordering::SeqCst))
+        .map_err(|_| ReturnedControlError::Control(ControlError::ScenarioMismatch))?;
+    let trap = TrapSnapshot {
+        root: CURRENT.root.load(Ordering::SeqCst),
+        root_flags: CURRENT.root_flags.load(Ordering::SeqCst),
+        frame,
+    };
+    let component_id = {
+        let manager = MANAGER.lock();
+        manager
+            .valid_domain(handle)
+            .and_then(|domain| domain.stop.exact_component(handle, scenario))
+            .ok_or(ReturnedControlError::Control(ControlError::NotAdmitted))?
+    };
+    let manifest_identity = super::super::admission::confirm_start(handle, component_id)
+        .map_err(|_| ReturnedControlError::Control(ControlError::ManifestMismatch))?;
+    let returned = {
+        let mut manager = MANAGER.lock();
+        let Some(domain) = manager.valid_domain_mut(handle) else {
+            return Err(ReturnedControlError::Control(ControlError::NotAdmitted));
+        };
+        let (control, returned) = domain
+            .control
+            .clone()
+            .return_at_trap(handle, manifest_identity, component_id, scenario, trap)
+            .map_err(ReturnedControlError::Control)?;
+        domain.control = control;
+        returned
+    };
+    *RETURNED_CONTROL.lock() = Some(returned);
+    Ok(())
+}
+
+#[cfg(not(test))]
+#[unsafe(naked)]
+pub(in crate::domains) extern "C" fn switch_to_return(stack_end: usize) -> ! {
+    core::arch::naked_asm!(
+        "mov rsp, rdi",
+        "xor ebp, ebp",
+        "call {returned}",
+        "ud2",
+        returned = sym finish_return,
+    );
+}
+
+#[cfg(not(test))]
+extern "C" fn finish_return() -> ! {
+    let Some(_returned) = RETURNED_CONTROL.lock().take() else {
+        serial::ev_domain_harness(false);
+        serial::ev_halt(false);
+        serial::exit_qemu(false);
+    };
+    let Some(expected) = super::KERNEL_CR3.get().copied() else {
+        super::fail_terminal("kernel_cr3_missing");
+    };
+    // SAFETY: execution is now on the kernel resume stack; the exact kernel
+    // root can safely replace the domain's guarded transition root.
+    unsafe {
+        Cr3::write(expected.0, expected.1);
+    }
+    CURRENT.active.store(false, Ordering::SeqCst);
+    CURRENT.root.store(0, Ordering::SeqCst);
+    CURRENT.root_flags.store(0, Ordering::SeqCst);
+    super::scheduler_resume()
+}
+
+#[cfg(not(test))]
+impl super::Manager {
+    pub(in crate::domains) fn accept_returned_stop(
+        &mut self,
+        handle: DomainHandle,
+        manifest_identity: HostManifestIdentity,
+        component_id: ContentId,
+        scenario: Scenario,
+    ) -> Result<ReturnedRun, ReturnedControlError> {
+        if let Some(error) = returned_context_error() {
+            return Err(error);
+        }
+        let Some((kernel_root, kernel_flags)) = super::KERNEL_CR3.get().copied() else {
+            return Err(ReturnedControlError::WrongCr3);
+        };
+        let returned = {
+            let Some(domain) = self.valid_domain_mut(handle) else {
+                return Err(ReturnedControlError::Control(ControlError::NotReturned));
+            };
+            let (control, returned) = domain
+                .control
+                .clone()
+                .request_stop(
+                    handle,
+                    manifest_identity,
+                    component_id,
+                    scenario,
+                    ContextGuard::new(
+                        CURRENT.root.load(Ordering::SeqCst),
+                        CURRENT.root_flags.load(Ordering::SeqCst),
+                        kernel_root.start_address().as_u64(),
+                        kernel_flags.bits(),
+                    ),
+                )
+                .map_err(ReturnedControlError::Control)?;
+            domain
+                .stop
+                .take_timer(handle, scenario)
+                .map_err(|_| ReturnedControlError::Control(ControlError::StateMismatch))?;
+            serial::ev_stop_requested(handle.id().0 + 1, handle.generation().0);
+            domain.control = control;
+            returned
+        };
+        let event = TrapContext {
+            slot: handle.id().0,
+            generation: handle.generation().0,
+            vector: returned.vector(),
+            error_code: returned.error_code(),
+            rip: returned.rip(),
+            cs: returned.cs(),
+            fault_address: 0,
+            outcome: Outcome::Cancelled,
+        };
+        serial::ev_stop_taken(
+            handle.id().0 + 1,
+            handle.generation().0,
+            u64::from(event.vector),
+        );
+        let stats = self.release_slot_with_stop(handle, Some(&event));
+        if stats.exactly_once() {
+            serial::ev_stop_current_inactive(handle.id().0 + 1, handle.generation().0);
+            serial::ev_stop_completed(handle.id().0 + 1, handle.generation().0, true);
+            Ok(returned)
+        } else {
+            serial::ev_stop_completed(handle.id().0 + 1, handle.generation().0, false);
+            Err(ReturnedControlError::ReleaseFailed)
+        }
+    }
+}
+
+fn copy_frame(frame: &TrapFrame) -> TrapFrame {
+    TrapFrame {
+        rax: frame.rax,
+        rbx: frame.rbx,
+        rcx: frame.rcx,
+        rdx: frame.rdx,
+        rsi: frame.rsi,
+        rdi: frame.rdi,
+        rbp: frame.rbp,
+        r8: frame.r8,
+        r9: frame.r9,
+        r10: frame.r10,
+        r11: frame.r11,
+        r12: frame.r12,
+        r13: frame.r13,
+        r14: frame.r14,
+        r15: frame.r15,
+        vector: frame.vector,
+        error_code: frame.error_code,
+        rip: frame.rip,
+        cs: frame.cs,
+        rflags: frame.rflags,
+        rsp: frame.rsp,
+        ss: frame.ss,
+    }
+}

--- a/kernel/crates/astrid-native-kernel/src/domains/manager/control.rs
+++ b/kernel/crates/astrid-native-kernel/src/domains/manager/control.rs
@@ -10,10 +10,12 @@ use x86_64::registers::control::Cr3;
 use super::super::types::Outcome;
 use super::super::types::{DomainHandle, Scenario};
 use super::TrapContext;
+#[cfg(not(test))]
 use super::{CURRENT, MANAGER};
 use crate::platform::TrapFrame;
 #[cfg(not(test))]
 use crate::serial;
+#[cfg(not(test))]
 use spin::Mutex;
 
 pub(in crate::domains) type HostManifestIdentity = astrid_system_generation::ManifestIdentity;
@@ -142,6 +144,10 @@ impl LeaseContext {
         self.root == root && self.root_flags == root_flags
     }
 
+    const fn matches_stack(self, stack_end: u64) -> bool {
+        self.stack_end == stack_end
+    }
+
     const fn matches_kernel(self, source: u64, source_flags: u64) -> bool {
         self.source == source && self.source_flags == source_flags
     }
@@ -183,6 +189,7 @@ impl PartialEq for ReturnedRun {
             && self.frame.vector == other.frame.vector
             && self.frame.rip == other.frame.rip
             && self.frame.cs == other.frame.cs
+            && self.frame.rsp == other.frame.rsp
     }
 }
 
@@ -254,6 +261,7 @@ where
         ticket.verify(handle, manifest_identity, component_id, scenario)?;
         if scenario != Scenario::RunningStop
             || !context.matches_current(trap.root, trap.root_flags)
+            || !context.matches_stack(trap.frame.rsp)
             || trap.frame.cs & 3 != 3
         {
             return Err(ControlError::ContextMismatch);
@@ -274,8 +282,14 @@ where
         scenario: Scenario,
         context_guard: ContextGuard,
     ) -> Result<(Self, ReturnedRun), ControlError> {
-        let Self::Returned(returned, ticket, context) = self else {
-            return Err(ControlError::AlreadyRequested);
+        let (returned, ticket, context) = match self {
+            Self::Returned(returned, ticket, context) => (returned, ticket, context),
+            Self::Admitted(_, _) | Self::Inactive => {
+                return Err(ControlError::NotReturned);
+            },
+            Self::StopRequested(_, _, _) => {
+                return Err(ControlError::AlreadyRequested);
+            },
         };
         ticket.verify(handle, manifest_identity, component_id, scenario)?;
         if scenario != Scenario::RunningStop

--- a/kernel/crates/astrid-native-kernel/src/domains/manager/control/tests.rs
+++ b/kernel/crates/astrid-native-kernel/src/domains/manager/control/tests.rs
@@ -1,0 +1,344 @@
+//! Host falsifiers for the private returned-control lease state machine.
+
+use super::super::super::types::{DomainGeneration, DomainHandle, DomainId, Scenario};
+use super::{ContextGuard, Control, ControlError, LeaseContext, TrapSnapshot};
+use crate::platform::TrapFrame;
+use astrid_system_generation::ContentId;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct TestManifest(u8);
+
+const MANIFEST: TestManifest = TestManifest(7);
+
+fn handle(slot: u64, generation: u64) -> DomainHandle {
+    DomainHandle::new(DomainId(slot), DomainGeneration(generation))
+}
+
+fn component() -> ContentId {
+    ContentId::from_payload(b"returned-control-falsifier")
+}
+
+fn substituted() -> ContentId {
+    ContentId::from_payload(b"returned-control-substitution")
+}
+
+fn context() -> LeaseContext {
+    LeaseContext::new(0xfeed_1000, 0, 0x101_000, 0, 0xfeed_f000)
+}
+
+const fn frame(vector: u64) -> TrapFrame {
+    TrapFrame {
+        rax: 1,
+        rbx: 2,
+        rcx: 3,
+        rdx: 4,
+        rsi: 5,
+        rdi: Scenario::RunningStop.value(),
+        rbp: 6,
+        r8: 8,
+        r9: 9,
+        r10: 10,
+        r11: 11,
+        r12: 12,
+        r13: 13,
+        r14: 14,
+        r15: 15,
+        vector,
+        error_code: 0,
+        rip: 0x2000,
+        cs: 3,
+        rflags: 0x202,
+        rsp: 0x4000,
+        ss: 0x1b,
+    }
+}
+
+static TIMER_FRAME: TrapFrame = frame(32);
+
+fn snapshot(root: u64) -> TrapSnapshot<'static> {
+    TrapSnapshot {
+        root,
+        root_flags: 0,
+        frame: &TIMER_FRAME,
+    }
+}
+
+fn guard(current_root: u64, current_flags: u64, source: u64) -> ContextGuard {
+    ContextGuard::new(current_root, current_flags, source, 0)
+}
+
+fn admitted(slot: u64, generation: u64) -> Control<TestManifest, ContentId> {
+    Control::admit(
+        handle(slot, generation),
+        MANIFEST,
+        component(),
+        Scenario::RunningStop,
+        context(),
+    )
+    .unwrap()
+}
+
+fn returned(slot: u64, generation: u64) -> Control<TestManifest, ContentId> {
+    let (control, run) = admitted(slot, generation)
+        .return_at_trap(
+            handle(slot, generation),
+            MANIFEST,
+            component(),
+            Scenario::RunningStop,
+            snapshot(0xfeed_1000),
+        )
+        .unwrap();
+    assert_eq!(run.vector(), 32);
+    assert_eq!(run.cs(), 3);
+    control
+}
+
+fn request(
+    control: Control<TestManifest, ContentId>,
+    slot: u64,
+    generation: u64,
+    manifest: TestManifest,
+    component_id: ContentId,
+    scenario: Scenario,
+    current_root: u64,
+    current_flags: u64,
+    source: u64,
+) -> Result<Control<TestManifest, ContentId>, ControlError> {
+    control
+        .request_stop(
+            handle(slot, generation),
+            manifest,
+            component_id,
+            scenario,
+            guard(current_root, current_flags, source),
+        )
+        .map(|(control, _)| control)
+}
+
+#[test]
+fn admitted_lease_binds_exact_dispatch_identity() {
+    let wrong_handle = admitted(0, 4)
+        .return_at_trap(
+            handle(1, 4),
+            MANIFEST,
+            component(),
+            Scenario::RunningStop,
+            snapshot(0xfeed_1000),
+        )
+        .err();
+    let wrong_manifest = admitted(0, 4)
+        .return_at_trap(
+            handle(0, 4),
+            TestManifest(8),
+            component(),
+            Scenario::RunningStop,
+            snapshot(0xfeed_1000),
+        )
+        .err();
+    let wrong_component = admitted(0, 4)
+        .return_at_trap(
+            handle(0, 4),
+            MANIFEST,
+            substituted(),
+            Scenario::RunningStop,
+            snapshot(0xfeed_1000),
+        )
+        .err();
+    let wrong_scenario = admitted(0, 4)
+        .return_at_trap(
+            handle(0, 4),
+            MANIFEST,
+            component(),
+            Scenario::Exit,
+            snapshot(0xfeed_1000),
+        )
+        .err();
+    let wrong_root = admitted(0, 4)
+        .return_at_trap(
+            handle(0, 4),
+            MANIFEST,
+            component(),
+            Scenario::RunningStop,
+            snapshot(0xfeed_2000),
+        )
+        .err();
+    assert_eq!(wrong_handle, Some(ControlError::HandleMismatch));
+    assert_eq!(wrong_manifest, Some(ControlError::ManifestMismatch));
+    assert_eq!(wrong_component, Some(ControlError::ComponentMismatch));
+    assert_eq!(wrong_scenario, Some(ControlError::ScenarioMismatch));
+    assert_eq!(wrong_root, Some(ControlError::ContextMismatch));
+    assert_eq!(returned(0, 4), returned(0, 4));
+}
+
+#[test]
+fn ring3_timer_returns_once_without_terminal_request() {
+    let control = returned(0, 4);
+    let repeat = control
+        .clone()
+        .return_at_trap(
+            handle(0, 4),
+            MANIFEST,
+            component(),
+            Scenario::RunningStop,
+            snapshot(0xfeed_1000),
+        )
+        .err();
+    assert_eq!(repeat, Some(ControlError::AlreadyReturned));
+    assert_eq!(control, returned(0, 4));
+}
+
+#[test]
+fn returned_request_rejects_identity_and_context_before_transition() {
+    let control = returned(0, 4);
+    let cases = [
+        request(
+            control.clone(),
+            0,
+            5,
+            MANIFEST,
+            component(),
+            Scenario::RunningStop,
+            0,
+            0,
+            0x101_000,
+        ),
+        request(
+            control.clone(),
+            0,
+            4,
+            TestManifest(8),
+            component(),
+            Scenario::RunningStop,
+            0,
+            0,
+            0x101_000,
+        ),
+        request(
+            control.clone(),
+            0,
+            4,
+            MANIFEST,
+            substituted(),
+            Scenario::RunningStop,
+            0,
+            0,
+            0x101_000,
+        ),
+        request(
+            control.clone(),
+            0,
+            4,
+            MANIFEST,
+            component(),
+            Scenario::Exit,
+            0,
+            0,
+            0x101_000,
+        ),
+        request(
+            control.clone(),
+            0,
+            4,
+            MANIFEST,
+            component(),
+            Scenario::RunningStop,
+            0xfeed_1000,
+            0,
+            0x101_000,
+        ),
+        request(
+            control.clone(),
+            0,
+            4,
+            MANIFEST,
+            component(),
+            Scenario::RunningStop,
+            0,
+            1,
+            0x101_000,
+        ),
+        request(
+            control,
+            0,
+            4,
+            MANIFEST,
+            component(),
+            Scenario::RunningStop,
+            0,
+            0,
+            0x102_000,
+        ),
+    ];
+    assert_eq!(cases[0], Err(ControlError::HandleMismatch));
+    assert_eq!(cases[1], Err(ControlError::ManifestMismatch));
+    assert_eq!(cases[2], Err(ControlError::ComponentMismatch));
+    assert_eq!(cases[3], Err(ControlError::ScenarioMismatch));
+    for result in &cases[4..] {
+        assert_eq!(*result, Err(ControlError::ContextMismatch));
+    }
+    assert_eq!(returned(0, 4), returned(0, 4));
+}
+
+#[test]
+fn exact_quiescent_request_is_one_shot() {
+    let requested = request(
+        returned(1, 6),
+        1,
+        6,
+        MANIFEST,
+        component(),
+        Scenario::RunningStop,
+        0,
+        0,
+        0x101_000,
+    )
+    .unwrap();
+    assert!(matches!(requested, Control::StopRequested(_, _, _)));
+    let repeated = request(
+        requested.clone(),
+        1,
+        6,
+        MANIFEST,
+        component(),
+        Scenario::RunningStop,
+        0,
+        0,
+        0x101_000,
+    );
+    assert_eq!(repeated, Err(ControlError::AlreadyRequested));
+    assert_eq!(requested, requested);
+}
+
+#[test]
+fn admitted_lifecycle_states_are_not_returned() {
+    for control in [admitted(0, 2), admitted(0, 2)] {
+        assert_eq!(
+            request(
+                control,
+                0,
+                2,
+                MANIFEST,
+                component(),
+                Scenario::RunningStop,
+                0,
+                0,
+                0x101_000
+            ),
+            Err(ControlError::NotReturned)
+        );
+    }
+}
+
+#[test]
+fn zero_generation_is_not_admitted() {
+    assert_eq!(
+        Control::<TestManifest, ContentId>::admit(
+            handle(0, 0),
+            MANIFEST,
+            component(),
+            Scenario::RunningStop,
+            context()
+        ),
+        Err(ControlError::HandleMismatch)
+    );
+}

--- a/kernel/crates/astrid-native-kernel/src/domains/manager/control/tests.rs
+++ b/kernel/crates/astrid-native-kernel/src/domains/manager/control/tests.rs
@@ -48,18 +48,28 @@ const fn frame(vector: u64) -> TrapFrame {
         rip: 0x2000,
         cs: 3,
         rflags: 0x202,
-        rsp: 0x4000,
+        rsp: 0xfeed_f000,
         ss: 0x1b,
     }
 }
 
 static TIMER_FRAME: TrapFrame = frame(32);
+const fn frame_with_stack(vector: u64, rsp: u64) -> TrapFrame {
+    let mut frame = frame(vector);
+    frame.rsp = rsp;
+    frame
+}
+static WRONG_STACK_FRAME: TrapFrame = frame_with_stack(32, 0xfeed_e000);
 
 fn snapshot(root: u64) -> TrapSnapshot<'static> {
+    snapshot_with_frame(root, &TIMER_FRAME)
+}
+
+fn snapshot_with_frame(root: u64, frame: &TrapFrame) -> TrapSnapshot<'_> {
     TrapSnapshot {
         root,
         root_flags: 0,
-        frame: &TIMER_FRAME,
+        frame,
     }
 }
 
@@ -162,11 +172,21 @@ fn admitted_lease_binds_exact_dispatch_identity() {
             snapshot(0xfeed_2000),
         )
         .err();
+    let wrong_stack = admitted(0, 4)
+        .return_at_trap(
+            handle(0, 4),
+            MANIFEST,
+            component(),
+            Scenario::RunningStop,
+            snapshot_with_frame(0xfeed_1000, &WRONG_STACK_FRAME),
+        )
+        .err();
     assert_eq!(wrong_handle, Some(ControlError::HandleMismatch));
     assert_eq!(wrong_manifest, Some(ControlError::ManifestMismatch));
     assert_eq!(wrong_component, Some(ControlError::ComponentMismatch));
     assert_eq!(wrong_scenario, Some(ControlError::ScenarioMismatch));
     assert_eq!(wrong_root, Some(ControlError::ContextMismatch));
+    assert_eq!(wrong_stack, Some(ControlError::ContextMismatch));
     assert_eq!(returned(0, 4), returned(0, 4));
 }
 

--- a/kernel/crates/astrid-native-kernel/src/domains/manager/mod.rs
+++ b/kernel/crates/astrid-native-kernel/src/domains/manager/mod.rs
@@ -13,6 +13,7 @@ use x86_64::registers::control::{Cr3, Cr3Flags};
 #[cfg(not(test))]
 use x86_64::structures::paging::{PhysFrame, Size4KiB};
 
+pub(in crate::domains) use self::control::DomainControl;
 #[cfg(not(test))]
 use super::paging::AddressSpace;
 use super::stop::{DomainStop, HostManifestIdentity};
@@ -144,6 +145,7 @@ pub struct Domain {
     pub(super) space: Option<()>,
     pub(super) ipc_enabled: bool,
     pub(super) stop: DomainStop,
+    pub(super) control: DomainControl,
 }
 
 #[derive(Default)]
@@ -411,6 +413,7 @@ pub fn prepare(
                 | Scenario::IpcCancelGuest
         ),
         stop: DomainStop::inactive(),
+        control: DomainControl::inactive(),
     });
     let handle = DomainHandle::new(
         super::types::DomainId(slot as u64),
@@ -480,6 +483,7 @@ pub fn peer_is_prepared(handle: DomainHandle) -> bool {
         })
 }
 
+mod control;
 mod start;
 #[cfg(test)]
 mod stop_tests;
@@ -489,6 +493,10 @@ mod trap;
 #[cfg(not(test))]
 pub use trap::handle_domain_trap;
 
+#[cfg(not(test))]
+pub(in crate::domains) use control::{
+    request_returned_stop, stage_returning_trap, switch_to_return,
+};
 pub(super) use start::StartContext;
 #[cfg(not(test))]
 pub(super) use start::{enter_running, stage_context, staged_state, start_running};
@@ -566,6 +574,7 @@ pub fn generation_overflow_rejects_prepare(raw: &[u8], expected: ContentId) -> b
             space: None,
             ipc_enabled: false,
             stop: DomainStop::inactive(),
+            control: DomainControl::inactive(),
         });
     }
     let rejected = matches!(
@@ -600,6 +609,7 @@ impl Manager {
             .then_some(domain)
     }
 
+    #[cfg(test)]
     pub(in crate::domains) fn take_running_stop(
         &mut self,
         handle: DomainHandle,

--- a/kernel/crates/astrid-native-kernel/src/domains/manager/start.rs
+++ b/kernel/crates/astrid-native-kernel/src/domains/manager/start.rs
@@ -11,6 +11,8 @@ use x86_64::registers::control::Cr3;
 #[cfg(not(test))]
 use super::super::stop::DomainStop;
 #[cfg(not(test))]
+use super::control::LeaseContext;
+#[cfg(not(test))]
 use super::{CURRENT, DomainState, MANAGER, PrepareError};
 #[cfg(not(test))]
 use crate::apic;
@@ -49,6 +51,25 @@ impl StartContext {
             quota_ticks,
             source,
         }
+    }
+}
+
+#[cfg(not(test))]
+impl StartContext {
+    const fn scenario(&self) -> Scenario {
+        self.scenario
+    }
+
+    const fn root(&self) -> u64 {
+        self.root
+    }
+
+    const fn user_stack(&self) -> u64 {
+        self.user_stack
+    }
+
+    const fn source(&self) -> u64 {
+        self.source
     }
 }
 
@@ -140,11 +161,27 @@ pub(in crate::domains) fn start_running(
         if let Some(error) = super::lifecycle_error() {
             return Err(error);
         }
+        let (_, current_flags) = Cr3::read();
+        let control = super::control::Control::admit(
+            handle,
+            manifest_identity,
+            component_id,
+            context.scenario(),
+            LeaseContext::new(
+                context.root(),
+                current_flags.bits(),
+                context.source(),
+                current_flags.bits(),
+                context.user_stack(),
+            ),
+        )
+        .map_err(|_| PrepareError::Bind(BindError::Malformed))?;
         let armed_stop = stop
             .into_armed(handle, manifest_identity, component_id, context.scenario)
             .map_err(|_| PrepareError::Bind(BindError::Malformed))?;
         domain.state = DomainState::Running;
         domain.stop = armed_stop;
+        domain.control = control;
         if context.scenario == crate::domains::types::Scenario::RunningStop {
             serial::ev_stop_armed(handle.id().0 + 1, handle.generation().0);
         }

--- a/kernel/crates/astrid-native-kernel/src/domains/manager/stop_tests.rs
+++ b/kernel/crates/astrid-native-kernel/src/domains/manager/stop_tests.rs
@@ -1,5 +1,5 @@
 use super::{ADMISSION_RELEASES, RELATION_RELEASE_FAILURE, ReclaimStats, SPACE_RELEASE_FAILURE};
-use super::{Domain, DomainState, DomainStop, Manager, Scenario};
+use super::{Domain, DomainControl, DomainState, DomainStop, Manager, Scenario};
 use crate::domains::types::{DomainGeneration, DomainHandle, DomainId};
 use crate::ipc::{DomainToken, prepare_domain};
 use astrid_system_generation::ContentId;
@@ -44,6 +44,7 @@ fn install_taken_domain(space: Option<()>) -> spin::MutexGuard<'static, Manager>
         space,
         ipc_enabled: false,
         stop,
+        control: DomainControl::inactive(),
     });
     manager.used_frames = 3;
     manager
@@ -276,6 +277,7 @@ fn same_slot_fresh_generation_hides_old_completed_observation() {
         space: None,
         ipc_enabled: false,
         stop: completed_stop(handle(), old_component),
+        control: DomainControl::inactive(),
     });
 
     assert!(
@@ -293,6 +295,7 @@ fn same_slot_fresh_generation_hides_old_completed_observation() {
         space: None,
         ipc_enabled: false,
         stop: completed_stop(fresh, fresh_component),
+        control: DomainControl::inactive(),
     });
     assert!(
         manager

--- a/kernel/crates/astrid-native-kernel/src/domains/manager/trap.rs
+++ b/kernel/crates/astrid-native-kernel/src/domains/manager/trap.rs
@@ -98,15 +98,6 @@ fn handle_ipc_syscall(frame: &mut TrapFrame) -> Option<bool> {
     }
 }
 
-fn take_running_stop_trap(frame: &TrapFrame, vector: u8, fault_address: u64) -> ! {
-    let handle = super::super::wait::current_handle();
-    super::super::stop::take_timer_trap(handle);
-    apic::mask_timer();
-    apic::eoi();
-    serial::ev_stop_taken(handle.id().0 + 1, handle.generation().0, u64::from(vector));
-    stage_terminal(frame, fault_address, Outcome::Cancelled);
-}
-
 fn ipc_cancel_guest_resume(frame: &mut TrapFrame) -> Option<()> {
     let scenario = CURRENT.scenario.load(Ordering::SeqCst);
     if frame.vector == 6
@@ -211,7 +202,11 @@ pub fn handle_domain_trap(frame: &mut TrapFrame, fault_address: u64) -> bool {
         return true;
     }
     if vector == apic::TIMER_VECTOR && scenario == Scenario::RunningStop.value() {
-        take_running_stop_trap(frame, vector, fault_address);
+        super::stage_returning_trap(frame).unwrap_or_else(|error| fail_terminal(error.as_reason()));
+        apic::mask_timer();
+        apic::eoi();
+        let _ = (vector, fault_address);
+        super::switch_to_return(super::resume_stack_end());
     }
     if vector == apic::TIMER_VECTOR && scenario >= Scenario::IpcServer.value() {
         // The landed #1704 dispatch is byte-frozen and has no path for the

--- a/kernel/crates/astrid-native-kernel/src/domains/stop/mod.rs
+++ b/kernel/crates/astrid-native-kernel/src/domains/stop/mod.rs
@@ -6,7 +6,7 @@ use astrid_system_generation::ContentId;
 use astrid_system_generation::ManifestIdentity;
 
 #[cfg(not(test))]
-use super::manager::{CURRENT, MANAGER, fail_terminal};
+use super::manager::{CURRENT, MANAGER};
 #[cfg(not(test))]
 use crate::serial;
 
@@ -179,6 +179,17 @@ where
     G: Copy + PartialEq,
     C: Copy + PartialEq,
 {
+    pub(in crate::domains) fn exact_component(
+        &self,
+        handle: DomainHandle,
+        scenario: Scenario,
+    ) -> Option<C> {
+        let Self::Armed(ticket) = self else {
+            return None;
+        };
+        (ticket.handle == handle && ticket.scenario == scenario).then_some(ticket.component_id)
+    }
+
     pub(crate) const fn inactive() -> Self {
         Self::Inactive
     }
@@ -283,30 +294,6 @@ where
             Self::Aborted(ticket)
         };
         Ok(())
-    }
-}
-
-#[cfg(not(test))]
-pub(crate) fn take_timer_trap(handle: DomainHandle) {
-    let scenario = Scenario::try_from(CURRENT.scenario.load(core::sync::atomic::Ordering::SeqCst))
-        .unwrap_or_else(|_| fail_terminal("stop_scenario_invalid"));
-    let root = CURRENT.root.load(core::sync::atomic::Ordering::SeqCst);
-    let flags = CURRENT
-        .root_flags
-        .load(core::sync::atomic::Ordering::SeqCst);
-    let (current_root, current_flags) = x86_64::registers::control::Cr3::read();
-    if handle != super::wait::current_handle()
-        || scenario != Scenario::RunningStop
-        || current_root.start_address().as_u64() != root
-        || current_flags.bits() != flags
-    {
-        fail_terminal("stop_trap_context_mismatch");
-    }
-    {
-        let mut manager = MANAGER.lock();
-        if manager.take_running_stop(handle, scenario).is_err() {
-            fail_terminal("stop_take_rejected");
-        }
     }
 }
 

--- a/kernel/crates/astrid-native-kernel/src/domains/stop/tests.rs
+++ b/kernel/crates/astrid-native-kernel/src/domains/stop/tests.rs
@@ -1,6 +1,6 @@
 //! Host falsifiers for the private stop lifecycle state machine.
 
-use super::super::manager::{Domain, DomainState, MANAGER};
+use super::super::manager::{Domain, DomainControl, DomainState, MANAGER};
 use super::super::types::{DomainGeneration, DomainHandle, DomainId, Scenario};
 use super::{StopError, StopLifecycle};
 use astrid_system_generation::ContentId;
@@ -70,6 +70,7 @@ fn installed_armed_with_state(
         space: None,
         ipc_enabled: false,
         stop,
+        control: DomainControl::inactive(),
     });
     manager
 }

--- a/kernel/crates/astrid-native-kernel/src/domains/test_support.rs
+++ b/kernel/crates/astrid-native-kernel/src/domains/test_support.rs
@@ -1,6 +1,6 @@
 //! Host-test fixtures for the production domain authority state.
 
-use super::manager::{Domain, DomainState, MANAGER};
+use super::manager::{Domain, DomainControl, DomainState, MANAGER};
 use super::types::{DomainHandle, Scenario};
 
 pub(crate) fn reset() {
@@ -21,6 +21,7 @@ pub(crate) fn install_blocked(handle: DomainHandle) -> bool {
         space: None,
         ipc_enabled: true,
         stop: super::stop::DomainStop::inactive(),
+        control: DomainControl::inactive(),
     });
     true
 }

--- a/kernel/crates/astrid-native-kernel/src/serial.rs
+++ b/kernel/crates/astrid-native-kernel/src/serial.rs
@@ -245,9 +245,21 @@ pub fn ev_stop_armed(id: u64, generation: u64) {
     ));
 }
 
+pub fn ev_control_returned(id: u64, generation: u64) {
+    emit(format_args!(
+        "\"ev\":\"domain.control.returned\",\"id\":{id},\"generation\":{generation},\"cpl\":3,\"terminal\":false"
+    ));
+}
+
+pub fn ev_stop_requested(id: u64, generation: u64) {
+    emit(format_args!(
+        "\"ev\":\"domain.stop.request\",\"id\":{id},\"generation\":{generation}"
+    ));
+}
+
 pub fn ev_stop_taken(id: u64, generation: u64, vector: u64) {
     emit(format_args!(
-        "\"ev\":\"domain.stop.taken\",\"id\":{id},\"generation\":{generation},\"source\":\"timer\",\"vector\":{vector},\"cpl\":3"
+        "\"ev\":\"domain.stop.taken\",\"id\":{id},\"generation\":{generation},\"source\":\"returned\",\"vector\":{vector},\"cpl\":0"
     ));
 }
 

--- a/kernel/tools/ktest/src/events/lifecycle.rs
+++ b/kernel/tools/ktest/src/events/lifecycle.rs
@@ -52,7 +52,6 @@ const DOMAIN_REGISTERS: &[(u64, u64, u64)] = &[
     (2, 3, 0),
     (2, 4, 0),
     (1, 9, 0),
-    (1, 10, 11),
 ];
 const STOP_DOMAIN: (u64, u64) = (1, 10);
 const DOMAIN_RECLAIMS: &[(u64, u64)] = &[
@@ -91,7 +90,7 @@ const DOMAIN_OUTCOMES: &[(u64, u64, &str, u64, u64, &str, u64)] = &[
     (1, 9, "clean_exit", 3, 0, "0x0", 3),
     (1, 10, "cancelled", 32, 0, "0x0", 3),
 ];
-const STOP_TAKEN: &[(u64, u64, u64, u64)] = &[(1, 10, 32, 3)];
+const STOP_TAKEN: &[(u64, u64, u64, u64)] = &[(1, 10, 32, 0)];
 pub(crate) const HOSTILE_IPC_FAULT_ADDRESS: &str = "0x328000002000";
 const IPC_RECLAIMS: &[(u64, u64, u64, u64, u64)] = &[
     (2, 3, 1, 0, 0),
@@ -248,6 +247,24 @@ pub(super) fn domain_lifecycle_holds(events: &[Value]) -> bool {
             )
         })
         .eq(STOP_TAKEN.iter().copied());
+    let control_returned_ok = exact_pairs(
+        events,
+        "domain.control.returned",
+        "id",
+        "generation",
+        &[STOP_DOMAIN],
+    ) && named_events(events, "domain.control.returned")
+        .into_iter()
+        .all(|event| {
+            u64_field(event, "cpl") == Some(3) && bool_field(event, "terminal") == Some(false)
+        });
+    let control_requested_ok = exact_pairs(
+        events,
+        "domain.stop.request",
+        "id",
+        "generation",
+        &[STOP_DOMAIN],
+    );
     let stop_tail_ok = all_bools(events, "domain.stop.relation-retired", "ok", true)
         && all_bools(events, "domain.stop.admission-released", "ok", true)
         && all_bools(events, "domain.stop.completed", "ok", true)
@@ -396,7 +413,11 @@ pub(super) fn domain_lifecycle_holds(events: &[Value]) -> bool {
         "exact running-stop staging and arming",
         stop_staged_ok && stop_armed_ok,
     );
-    ok &= check("exact qualifying timer-stop consumption", stop_taken_ok);
+    ok &= check(
+        "exact returned-control quiescence and request",
+        control_returned_ok && control_requested_ok,
+    );
+    ok &= check("exact returned-stop consumption", stop_taken_ok);
     ok &= check("running-stop terminal completion order", stop_tail_ok);
     ok &= check("exact reclaim generations and accounting", reclaims_ok);
     ok &= check("restores accompany every reclaim", restores_ok);

--- a/kernel/tools/ktest/src/events/mod.rs
+++ b/kernel/tools/ktest/src/events/mod.rs
@@ -55,7 +55,7 @@ const DOMAIN_REQUIRED_PASSES: &[&str] = &[
     "authenticated_domains_exchange_bounded_capability_message",
     "peer_fault_wakes_blocked_recv_with_typed_status",
     "cancel_reclaims_blocked_ipc_exactly_once",
-    "running_timer_stop_cancels_and_reclaims_exactly_once",
+    "returned_control_stop_reclaims_exactly_once",
 ];
 
 const EXTRA_REQUIRED_PASSES: &[&str] = &[

--- a/kernel/tools/ktest/src/events/sequence.rs
+++ b/kernel/tools/ktest/src/events/sequence.rs
@@ -125,8 +125,9 @@ const IPC_CANCEL_GUEST_TAIL_EVENTS: &[&str] = &[
     "domain.reclaim",
 ];
 const RUNNING_STOP_TAIL_EVENTS: &[&str] = &[
+    "domain.control.returned",
+    "domain.stop.request",
     "domain.stop.taken",
-    "domain.registers",
     "domain.outcome",
     "domain.stop.relation-retired",
     "domain.restore",

--- a/kernel/tools/ktest/src/events/tests.rs
+++ b/kernel/tools/ktest/src/events/tests.rs
@@ -404,8 +404,9 @@ fn passing_serial_with(kernel: &str, sysgen: &str, kfloor: u64, sfloor: u64) -> 
     ev("\"ev\":\"domain.stop.armed\",\"id\":1,\"generation\":10".into());
     emit_start(&mut ev, 1, 10, 11);
     emit_context(&mut ev, 1, 10, 0);
-    ev("\"ev\":\"domain.stop.taken\",\"id\":1,\"generation\":10,\"source\":\"timer\",\"vector\":32,\"cpl\":3".into());
-    ev("\"ev\":\"domain.registers\",\"id\":1,\"generation\":10,\"cpl\":3,\"rax\":0,\"rbx\":0,\"rcx\":0,\"rdx\":0,\"rsi\":0,\"rdi\":11,\"rbp\":0,\"r8\":0,\"r9\":0,\"r10\":0,\"r11\":0,\"r12\":0,\"r13\":0,\"r14\":0,\"r15\":0,\"rsp\":\"0x1000\"".into());
+    ev("\"ev\":\"domain.control.returned\",\"id\":1,\"generation\":10,\"cpl\":3,\"terminal\":false".into());
+    ev("\"ev\":\"domain.stop.request\",\"id\":1,\"generation\":10".into());
+    ev("\"ev\":\"domain.stop.taken\",\"id\":1,\"generation\":10,\"source\":\"returned\",\"vector\":32,\"cpl\":0".into());
     ev("\"ev\":\"domain.outcome\",\"id\":1,\"generation\":10,\"kind\":\"cancelled\",\"vector\":32,\"error_code\":0,\"fault_address\":\"0x0\",\"rip\":\"0x100000\",\"cpl\":3".into());
     ev("\"ev\":\"domain.stop.relation-retired\",\"id\":1,\"generation\":10,\"ok\":true".into());
     ev("\"ev\":\"domain.restore\",\"id\":1,\"generation\":10,\"ok\":true,\"root\":\"0x101000\",\"flags\":0".into());


### PR DESCRIPTION
## Linked Issue

Tracking #1774

## Summary

Running native domains return to the scheduler through a private, identity-bound execution-control lease. A nonterminal returned run preserves lifecycle ownership and live frames until the exact lease accepts one post-start stop request. Universal terminal release then performs relation retirement, exact reclamation, admission release, and completion evidence. Returned control is never Ready and never terminal before that request succeeds.

## Changes

- Bind the admitted user-stack end into nonterminal return validation and compare the returned stack context.
- Distinguish `NotReturned` for a run that has not returned from `AlreadyRequested` after the one accepted request.
- Gate runtime-only control imports and initialize inactive control state in native host-test fixtures.
- Add host falsifiers for wrong-stack return, state distinctions, identity substitution, stale or foreign handles, context mismatch, and repeated requests.
- Restore the existing issue fragment and add a new fixed fragment.
- Preserve q35 serial ordering from CPL3 entry through return, exact request, universal retirement, restore, reclaim, admission release, current inactivity, and stop completion.

## Verification

- `env -u CARGO_TARGET_DIR cargo test -p astrid-native-kernel --lib --locked` — 109 passed.
- `env -u CARGO_TARGET_DIR cargo test -p ktest --locked` — 33 passed.
- `env -u CARGO_TARGET_DIR cargo clippy -p astrid-native-kernel --target x86_64-unknown-none --locked -- -D warnings` — pass.
- `env -u CARGO_TARGET_DIR cargo clippy -p ktest --all-targets --locked -- -D warnings` — pass.
- `env -u CARGO_TARGET_DIR cargo fmt -p astrid-native-kernel -p ktest -- --check` — pass. No formatting claim is made for the vendored bootloader.
- `python3 scripts/changelog.py check --base ce59c2147f1372c6836abfc6ca766bbf312cbffa --head HEAD` — pass.
- Fresh q35, UEFI, one-CPU, explicit-TCG proof passed with deterministic image BLAKE3 `915f97846dbd8591a511d8d4d0abebc30cb33876bc5491b655d3a09d27156930`, 238 contiguous events, QEMU exit `33`, and all assertions passing. The bounded tamper run failed before entry, and plan mismatch rejected with QEMU exit `35`.
- The nested UEFI/q35 workflow used `/Users/joshuaj.bouw/.cache/cargo-target-lanes/os-1774-returning` exclusively. Ordinary Cargo used the shared default with `CARGO_TARGET_DIR` unset.

## Test Plan

- Run the native library and ktest host suites listed above.
- Inspect the returned-control tests for wrong-stack rejection, non-returned versus repeated-request distinctions, identity substitutions, stale handles, and context failures.
- Run the q35 harness to verify the exact nonterminal return and one-shot stop completion ordering.

## AI / Tool Assistance

Assisted-by: Codex

Codex assisted with the state-machine edits, host falsifiers, changelog correction, and validation commands. The submission was reviewed for scope, state ownership, fail-closed behavior, ancestry, signature, DCO, changelog compliance, and proof evidence.