### PR TITLE
ci(windows): certify storage tests with Job Object ownership

### DIFF
--- a/.github/workflows/windows-filesystem-native.yml
+++ b/.github/workflows/windows-filesystem-native.yml
@@ -293,6 +293,32 @@ jobs:
           cargo test --locked --target ${{ matrix.target }} -p astrid-core
           local_transport -- --nocapture --test-threads=1
 
+      - name: Build the Windows storage job runner
+        if: matrix.target == 'x86_64-pc-windows-msvc'
+        shell: pwsh
+        run: |
+          dotnet publish `
+            scripts/ci/windows-storage-job-runner/Astrid.WindowsStorageJobRunner.csproj `
+            -c Release -r win-x64 --self-contained false `
+            /p:UseSharedCompilation=false
+          $runner = Join-Path `
+            scripts/ci/windows-storage-job-runner/bin/Release/net8.0/win-x64/publish `
+            "astrid-windows-storage-job-runner.exe"
+          if (-not (Test-Path -LiteralPath $runner -PathType Leaf)) {
+            throw "the Windows storage job runner was not published: $runner"
+          }
+          Add-Content -LiteralPath $env:GITHUB_ENV `
+            -Value "ASTRID_WINDOWS_STORAGE_JOB_RUNNER=$runner"
+
+      - name: Run Windows storage job runner self-tests
+        if: matrix.target == 'x86_64-pc-windows-msvc'
+        shell: pwsh
+        run: |
+          & $env:ASTRID_WINDOWS_STORAGE_JOB_RUNNER selftest
+          if ($LASTEXITCODE -ne 0) {
+            throw "the Windows storage job runner self-tests failed with exit code $LASTEXITCODE"
+          }
+
       - name: Run storage callback transport tests in trusted staging
         if: matrix.target == 'x86_64-pc-windows-msvc'
         shell: pwsh
@@ -342,6 +368,7 @@ jobs:
           if (-not (Test-Path -LiteralPath $provider -PathType Leaf)) {
             throw "the exact Windows process storage provider was not built"
           }
+          $builtProviderHash = (Get-FileHash -LiteralPath $provider -Algorithm SHA256).Hash.ToLowerInvariant()
           $stage = Join-Path $env:RUNNER_TEMP ([System.IO.Path]::GetRandomFileName())
           New-Item -ItemType Directory -Path $stage | Out-Null
           $userSid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value
@@ -394,12 +421,32 @@ jobs:
           $stagedTestExecutable = Join-Path $stage (Split-Path -Leaf $testExecutable)
           Copy-Item -LiteralPath $provider -Destination $stagedProvider
           Copy-Item -LiteralPath $testExecutable -Destination $stagedTestExecutable
+          $stagedProviderHash = (Get-FileHash -LiteralPath $stagedProvider -Algorithm SHA256).Hash.ToLowerInvariant()
+          if ($stagedProviderHash -ne $builtProviderHash) {
+            throw "the staged Windows process storage provider changed: $builtProviderHash -> $stagedProviderHash"
+          }
+          $stagedProviderCanonical = (Get-Item -LiteralPath $stagedProvider).FullName
+          $stagedTestExecutableCanonical = (Get-Item -LiteralPath $stagedTestExecutable).FullName
           Get-Item -LiteralPath $stagedProvider, $stagedTestExecutable |
             Select-Object FullName, Length
           $env:ASTRID_PROCESS_PROVIDER_TESTS = "1"
-          & $stagedTestExecutable storage_mount -- --nocapture --test-threads=1
+          $jobLogs = Join-Path $env:RUNNER_TEMP `
+            "astrid-storage-job-logs-$([System.IO.Path]::GetRandomFileName())"
+          New-Item -ItemType Directory -Path $jobLogs | Out-Null
+          & $env:ASTRID_WINDOWS_STORAGE_JOB_RUNNER certify `
+            --test-executable $stagedTestExecutableCanonical `
+            --provider-canonical $stagedProviderCanonical `
+            --provider $stagedProviderCanonical `
+            --provider-sha256 $stagedProviderHash `
+            --working-directory $env:GITHUB_WORKSPACE `
+            --log-directory $jobLogs `
+            --list-timeout-seconds 180 `
+            --aggregate-timeout-seconds 1200 `
+            --diagnostic-timeout-seconds 180 `
+            --cleanup-timeout-seconds 30 `
+            --heartbeat-seconds 15
           if ($LASTEXITCODE -ne 0) {
-            throw "the trusted process storage provider tests failed with exit code $LASTEXITCODE"
+            throw "the job-owned trusted process storage certification failed with exit code $LASTEXITCODE"
           }
 
       - name: Run the native WinFsp filesystem round trip

--- a/scripts/ci/windows-storage-job-runner/Astrid.WindowsStorageJobRunner.csproj
+++ b/scripts/ci/windows-storage-job-runner/Astrid.WindowsStorageJobRunner.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Astrid.Ci.Windows</RootNamespace>
+    <AssemblyName>astrid-windows-storage-job-runner</AssemblyName>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisLevel>latest-recommended</AnalysisLevel>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+  </PropertyGroup>
+
+</Project>

--- a/scripts/ci/windows-storage-job-runner/Models.cs
+++ b/scripts/ci/windows-storage-job-runner/Models.cs
@@ -46,3 +46,15 @@ internal sealed class ControllerException : Exception
     {
     }
 }
+
+internal static class JobProcessList
+{
+    internal static void ValidateCounts(int assignedProcesses, int processIdCount)
+    {
+        if (assignedProcesses < 0 || processIdCount < 0 || processIdCount > assignedProcesses)
+        {
+            throw new ControllerException(
+                $"Job Object returned invalid process counts: assigned={assignedProcesses}, listed={processIdCount}");
+        }
+    }
+}

--- a/scripts/ci/windows-storage-job-runner/Models.cs
+++ b/scripts/ci/windows-storage-job-runner/Models.cs
@@ -4,6 +4,13 @@ using Microsoft.Win32.SafeHandles;
 
 namespace Astrid.Ci.Windows;
 
+internal delegate bool QueryJobProcessList(
+    SafeJobHandle job,
+    IntPtr information,
+    uint length,
+    out uint returnLength,
+    out int win32Error);
+
 internal enum JobOutcome
 {
     Succeeded,
@@ -54,6 +61,120 @@ internal sealed class ControllerException : Exception
 
 internal static class JobProcessList
 {
+    internal const int ProcessIdListOffset = 16;
+    internal const int MinimumStructureLength = 24;
+    internal const int MaximumBufferLength = 16 * 1024 * 1024;
+
+    internal static uint[] ReadIds(SafeJobHandle job, QueryJobProcessList query)
+    {
+        const int maximumAttempts = 12;
+        var bufferLength = (uint)MinimumStructureLength;
+
+        for (var attempt = 0; attempt < maximumAttempts; attempt++)
+        {
+            if (bufferLength < MinimumStructureLength || bufferLength > MaximumBufferLength)
+            {
+                throw new ControllerException(
+                    $"Job Object process ID list capacity is invalid: {bufferLength}");
+            }
+
+            var buffer = Marshal.AllocHGlobal((int)bufferLength);
+            try
+            {
+                if (query(
+                        job,
+                        buffer,
+                        bufferLength,
+                        out var returnLength,
+                        out var win32Error))
+                {
+                    return ParseVerifiedList(buffer, bufferLength, returnLength);
+                }
+
+                if (win32Error != 234)
+                {
+                    throw new ControllerException(
+                        $"QueryInformationJobObject failed: Win32 error {win32Error}");
+                }
+
+                bufferLength = GetGrownCapacity(buffer, bufferLength, returnLength);
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(buffer);
+            }
+        }
+
+        throw new ControllerException("the Job Object process ID list did not stabilize");
+    }
+
+    private static uint GetGrownCapacity(IntPtr buffer, uint currentCapacity, uint returnedLength)
+    {
+        if (currentCapacity < ProcessIdListOffset)
+        {
+            throw new ControllerException("the Job Object process ID list header is too small");
+        }
+
+        var assignedProcesses = Marshal.ReadInt32(buffer, 0);
+        var processIdCount = Marshal.ReadInt32(buffer, sizeof(int));
+        ValidateCounts(assignedProcesses, processIdCount);
+        var requiredByCounts = RequiredLength(processIdCount);
+        var doubled = (long)currentCapacity * 2;
+        var desired = Math.Max(Math.Max(doubled, returnedLength), requiredByCounts);
+        if (desired > MaximumBufferLength)
+        {
+            throw new ControllerException(
+                $"Job Object process ID list exceeds bounded capacity: required {desired}, maximum {MaximumBufferLength}");
+        }
+
+        var nextCapacity = (uint)desired;
+        if (nextCapacity <= currentCapacity)
+        {
+            throw new ControllerException("the Job Object process ID list capacity did not grow after ERROR_MORE_DATA");
+        }
+
+        return nextCapacity;
+    }
+
+    private static uint[] ParseVerifiedList(IntPtr buffer, uint bufferCapacity, uint returnLength)
+    {
+        if (returnLength < MinimumStructureLength || returnLength > bufferCapacity)
+        {
+            throw new ControllerException(
+                $"Job Object process ID list return length is unverified: return={returnLength}, capacity={bufferCapacity}");
+        }
+
+        var assignedProcesses = Marshal.ReadInt32(buffer, 0);
+        var processIdCount = Marshal.ReadInt32(buffer, sizeof(int));
+        ValidateCounts(assignedProcesses, processIdCount);
+        var requiredLength = RequiredLength(processIdCount);
+        if (returnLength < requiredLength)
+        {
+            throw new ControllerException(
+                $"Job Object process ID list return length is insufficient: return={returnLength}, required={requiredLength}");
+        }
+
+        var processIds = new uint[processIdCount];
+        for (var index = 0; index < processIdCount; index++)
+        {
+            processIds[index] = (uint)Marshal.ReadIntPtr(buffer, ProcessIdListOffset + index * IntPtr.Size);
+        }
+
+        return processIds;
+    }
+
+    private static long RequiredLength(int processIdCount)
+    {
+        try
+        {
+            return checked(ProcessIdListOffset + (long)processIdCount * IntPtr.Size);
+        }
+        catch (OverflowException exception)
+        {
+            throw new ControllerException("the Job Object process ID list length overflows", exception);
+        }
+    }
+
     internal static void ValidateCounts(int assignedProcesses, int processIdCount)
     {
         if (assignedProcesses < 0 || processIdCount < 0 || processIdCount > assignedProcesses)

--- a/scripts/ci/windows-storage-job-runner/Models.cs
+++ b/scripts/ci/windows-storage-job-runner/Models.cs
@@ -174,6 +174,12 @@ internal static class JobProcessList
                 $"Job Object process ID list return length is insufficient: return={returnLength}, required={requiredLength}");
         }
 
+        if (processIdCount > 0 && returnLength != requiredLength)
+        {
+            throw new ControllerException(
+                $"Job Object process ID list return length is overlong: return={returnLength}, exact={requiredLength}");
+        }
+
         var processIds = new uint[processIdCount];
         for (var index = 0; index < processIdCount; index++)
         {
@@ -228,6 +234,48 @@ internal static class MarkerChild
         Console.Error.WriteLine("marker-child-ready");
         Console.Error.Flush();
         return requestedExitCode;
+    }
+}
+
+internal static class ParityChild
+{
+    internal static int Run(string receivedPathText, IReadOnlyList<string> arguments)
+    {
+        var receivedPath = Path.GetFullPath(receivedPathText);
+        if (!string.Equals(receivedPath, receivedPathText, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ControllerException($"parity received path is not canonical: expected {receivedPath}, got {receivedPathText}");
+        }
+
+        if (arguments is ["--list", "--format=terse", "storage_mount"])
+        {
+            Console.Out.WriteLine("alpha: test");
+            Console.Out.WriteLine("beta: test");
+            Console.Out.Flush();
+            return 0;
+        }
+
+        if (arguments is ["storage_mount", "--", "--nocapture", "--test-threads=1"])
+        {
+            Record(receivedPath, "aggregate");
+            return 0;
+        }
+
+        if (arguments is [var testName, "--", "--exact", "--nocapture", "--test-threads=1"] &&
+            testName is "alpha" or "beta")
+        {
+            Record(receivedPath, testName);
+            return 0;
+        }
+
+        return 10;
+    }
+
+    private static void Record(string receivedPath, string phase)
+    {
+        File.AppendAllText(receivedPath, $"{phase}{Environment.NewLine}");
+        Console.Out.WriteLine($"parity-recorded {phase}");
+        Console.Out.Flush();
     }
 }
 

--- a/scripts/ci/windows-storage-job-runner/Models.cs
+++ b/scripts/ci/windows-storage-job-runner/Models.cs
@@ -1,0 +1,48 @@
+namespace Astrid.Ci.Windows;
+
+internal enum JobOutcome
+{
+    Succeeded,
+    ChildFailed,
+    TimedOut,
+    ControllerFailed,
+}
+
+internal sealed record JobRunResult(
+    JobOutcome Outcome,
+    uint ExitCode,
+    string OriginalCause,
+    bool CleanupComplete,
+    uint[] ActiveProcessIds,
+    string StdoutPath,
+    string StderrPath,
+    int ProcessId,
+    TimeSpan Elapsed);
+
+internal sealed class CertificationOptions
+{
+    public string TestExecutable { get; set; } = string.Empty;
+    public string ProviderCanonical { get; set; } = string.Empty;
+    public string Provider { get; set; } = string.Empty;
+    public string ProviderSha256 { get; set; } = string.Empty;
+    public string WorkingDirectory { get; set; } = string.Empty;
+    public string LogDirectory { get; set; } = string.Empty;
+    public TimeSpan ListTimeout { get; set; }
+    public TimeSpan AggregateTimeout { get; set; }
+    public TimeSpan DiagnosticTimeout { get; set; }
+    public TimeSpan CleanupTimeout { get; set; }
+    public TimeSpan HeartbeatInterval { get; set; }
+}
+
+internal sealed class ControllerException : Exception
+{
+    public ControllerException(string message)
+        : base(message)
+    {
+    }
+
+    public ControllerException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/scripts/ci/windows-storage-job-runner/Models.cs
+++ b/scripts/ci/windows-storage-job-runner/Models.cs
@@ -103,6 +103,7 @@ internal static class JobProcessList
                     }
 
                     bufferLength = GetGrownCapacity(buffer, bufferLength, returnLength);
+                    continue;
                 }
 
                 if (win32Error != 234)

--- a/scripts/ci/windows-storage-job-runner/Models.cs
+++ b/scripts/ci/windows-storage-job-runner/Models.cs
@@ -48,21 +48,29 @@ internal sealed class CertificationOptions
 
 internal sealed class ControllerException : Exception
 {
+    public Exception? CleanupFailure { get; }
+
     public ControllerException(string message)
         : base(message)
     {
     }
 
     public ControllerException(string message, Exception innerException)
+        : this(message, innerException, null)
+    {
+    }
+
+    public ControllerException(string message, Exception innerException, Exception? cleanupFailure)
         : base(message, innerException)
     {
+        CleanupFailure = cleanupFailure;
     }
 }
 
 internal static class JobProcessList
 {
-    internal const int ProcessIdListOffset = 16;
-    internal const int MinimumStructureLength = 24;
+    internal const int ProcessIdListOffset = 8;
+    internal const int MinimumStructureLength = 16;
     internal const int MaximumBufferLength = 16 * 1024 * 1024;
 
     internal static uint[] ReadIds(SafeJobHandle job, QueryJobProcessList query)
@@ -88,7 +96,13 @@ internal static class JobProcessList
                         out var returnLength,
                         out var win32Error))
                 {
-                    return ParseVerifiedList(buffer, bufferLength, returnLength);
+                    var processIds = ParseVerifiedList(buffer, bufferLength, returnLength, out var truncated);
+                    if (!truncated)
+                    {
+                        return processIds;
+                    }
+
+                    bufferLength = GetGrownCapacity(buffer, bufferLength, returnLength);
                 }
 
                 if (win32Error != 234)
@@ -110,7 +124,7 @@ internal static class JobProcessList
 
     private static uint GetGrownCapacity(IntPtr buffer, uint currentCapacity, uint returnedLength)
     {
-        if (currentCapacity < ProcessIdListOffset)
+        if (currentCapacity < MinimumStructureLength)
         {
             throw new ControllerException("the Job Object process ID list header is too small");
         }
@@ -118,9 +132,9 @@ internal static class JobProcessList
         var assignedProcesses = Marshal.ReadInt32(buffer, 0);
         var processIdCount = Marshal.ReadInt32(buffer, sizeof(int));
         ValidateCounts(assignedProcesses, processIdCount);
-        var requiredByCounts = RequiredLength(processIdCount);
+        var requiredByCounts = RequiredLength(assignedProcesses);
         var doubled = (long)currentCapacity * 2;
-        var desired = Math.Max(Math.Max(doubled, returnedLength), requiredByCounts);
+        var desired = Math.Max(Math.Max(doubled, (long)returnedLength), requiredByCounts);
         if (desired > MaximumBufferLength)
         {
             throw new ControllerException(
@@ -136,7 +150,11 @@ internal static class JobProcessList
         return nextCapacity;
     }
 
-    private static uint[] ParseVerifiedList(IntPtr buffer, uint bufferCapacity, uint returnLength)
+    private static uint[] ParseVerifiedList(
+        IntPtr buffer,
+        uint bufferCapacity,
+        uint returnLength,
+        out bool truncated)
     {
         if (returnLength < MinimumStructureLength || returnLength > bufferCapacity)
         {
@@ -160,6 +178,7 @@ internal static class JobProcessList
             processIds[index] = (uint)Marshal.ReadIntPtr(buffer, ProcessIdListOffset + index * IntPtr.Size);
         }
 
+        truncated = processIdCount < assignedProcesses;
         return processIds;
     }
 
@@ -244,5 +263,22 @@ internal static class RootProcessCleanup
         while (stopwatch.Elapsed < cleanupTimeout);
 
         return false;
+    }
+}
+
+internal static class ControllerErrors
+{
+    internal static ControllerException PreservePrimaryCleanupFailure(
+        ControllerException primary,
+        Exception? cleanupFailure,
+        string stdoutPath,
+        string stderrPath)
+    {
+        var cleanupDetail = cleanupFailure?.Message ?? "cleanup did not reach ACTIVE_PROCESS_ZERO";
+        return new ControllerException(
+            $"primary cause preserved: {primary.Message}; separate cleanup failure: {cleanupDetail}; "
+            + $"stdout={stdoutPath}; stderr={stderrPath}",
+            primary,
+            cleanupFailure);
     }
 }

--- a/scripts/ci/windows-storage-job-runner/Models.cs
+++ b/scripts/ci/windows-storage-job-runner/Models.cs
@@ -69,6 +69,7 @@ internal sealed class ControllerException : Exception
 
 internal static class JobProcessList
 {
+    internal const int MinimumReturnedHeaderLength = 8;
     internal const int ProcessIdListOffset = 8;
     internal const int MinimumStructureLength = 16;
     internal const int MaximumBufferLength = 16 * 1024 * 1024;
@@ -157,7 +158,7 @@ internal static class JobProcessList
         uint returnLength,
         out bool truncated)
     {
-        if (returnLength < MinimumStructureLength || returnLength > bufferCapacity)
+        if (returnLength < MinimumReturnedHeaderLength || returnLength > bufferCapacity)
         {
             throw new ControllerException(
                 $"Job Object process ID list return length is unverified: return={returnLength}, capacity={bufferCapacity}");

--- a/scripts/ci/windows-storage-job-runner/Models.cs
+++ b/scripts/ci/windows-storage-job-runner/Models.cs
@@ -1,3 +1,7 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
 namespace Astrid.Ci.Windows;
 
 internal enum JobOutcome
@@ -17,6 +21,7 @@ internal sealed record JobRunResult(
     string StdoutPath,
     string StderrPath,
     int ProcessId,
+    bool RootHandlesReleased,
     TimeSpan Elapsed);
 
 internal sealed class CertificationOptions
@@ -56,5 +61,67 @@ internal static class JobProcessList
             throw new ControllerException(
                 $"Job Object returned invalid process counts: assigned={assignedProcesses}, listed={processIdCount}");
         }
+    }
+}
+
+internal static class MarkerChild
+{
+    internal static int Run(string markerPathText, string exitCodeText)
+    {
+        var markerPath = Path.GetFullPath(markerPathText);
+        if (!string.Equals(markerPath, markerPathText, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ControllerException($"marker path is not canonical: expected {markerPath}, got {markerPathText}");
+        }
+
+        if (!int.TryParse(exitCodeText, out var requestedExitCode) ||
+            requestedExitCode is < 0 or > 255)
+        {
+            throw new ControllerException("marker-child exit code must be between 0 and 255");
+        }
+
+        File.WriteAllText(markerPath, "ready");
+        Console.Out.WriteLine($"marker-created {markerPath}");
+        Console.Out.Flush();
+        Console.Error.WriteLine("marker-child-ready");
+        Console.Error.Flush();
+        return requestedExitCode;
+    }
+}
+
+internal static class RootProcessCleanup
+{
+    internal static bool ReleaseHandles(SafeWindowsHandle thread, SafeProcessHandle process)
+    {
+        if (thread.IsInvalid || thread.IsClosed || process.IsInvalid || process.IsClosed)
+        {
+            return false;
+        }
+
+        thread.Dispose();
+        process.Dispose();
+        return thread.IsClosed && process.IsClosed;
+    }
+
+    internal static bool WaitForProcessExit(SafeProcessHandle process, TimeSpan cleanupTimeout)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        do
+        {
+            var wait = NativeMethods.WaitForSingleObject(process, 50);
+            if (wait == NativeMethods.WaitObject0)
+            {
+                return true;
+            }
+
+            if (wait != NativeMethods.WaitTimeout)
+            {
+                throw new ControllerException(
+                    $"waiting for the unassigned process failed: Win32 error {Marshal.GetLastWin32Error()}");
+            }
+        }
+        while (stopwatch.Elapsed < cleanupTimeout);
+
+        return false;
     }
 }

--- a/scripts/ci/windows-storage-job-runner/Models.cs
+++ b/scripts/ci/windows-storage-job-runner/Models.cs
@@ -279,6 +279,157 @@ internal static class ParityChild
     }
 }
 
+internal static class LibTestChild
+{
+    internal static readonly string[] TestNames =
+    [
+        "storage_mount::process_broker::lease_atomicity_tests::cache_invalidation_tests::alpha",
+        "storage_mount::process_broker::lease_atomicity_tests::cache_invalidation_tests::beta",
+    ];
+
+    internal static int Run(string journalPathText, IReadOnlyList<string> arguments)
+    {
+        var journalPath = Path.GetFullPath(journalPathText);
+        if (!string.Equals(journalPath, journalPathText, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ControllerException($"libtest journal path is not canonical: expected {journalPath}, got {journalPathText}");
+        }
+
+        var parsed = ParseArguments(arguments);
+        var stateDirectory = Path.GetDirectoryName(journalPath);
+        if (string.IsNullOrEmpty(stateDirectory))
+        {
+            throw new ControllerException("the libtest journal path has no directory");
+        }
+
+        Directory.CreateDirectory(stateDirectory);
+        var lockPath = Path.Combine(stateDirectory, "libtest-child.lock");
+        var activePath = Path.Combine(stateDirectory, "libtest-child.active");
+        var lockStream = new FileStream(
+            lockPath,
+            FileMode.OpenOrCreate,
+            FileAccess.ReadWrite,
+            FileShare.None);
+
+        try
+        {
+            if (File.Exists(activePath))
+            {
+                Console.Error.WriteLine("cache-invalidation tests overlap: another test is active");
+                return 10;
+            }
+
+            File.WriteAllText(activePath, $"{Environment.ProcessId};{parsed.Filter}");
+            foreach (var testName in parsed.SelectedTests)
+            {
+                var begin = $"{Environment.ProcessId};begin;{testName};{Stopwatch.GetTimestamp()}";
+                File.AppendAllText(journalPath, $"{begin}{Environment.NewLine}");
+                if (parsed.NoCapture)
+                {
+                    Console.Out.WriteLine($"running {testName}");
+                }
+
+                Thread.Sleep(25);
+                File.AppendAllText(journalPath, $"{begin.Replace(";begin;", ";end;")}{Environment.NewLine}");
+                if (parsed.NoCapture)
+                {
+                    Console.Out.WriteLine($"test {testName} ok");
+                }
+            }
+
+            File.Delete(activePath);
+            return 0;
+        }
+        catch (IOException)
+        {
+            Console.Error.WriteLine("cache-invalidation tests overlap: execution lock was already held");
+            return 10;
+        }
+        finally
+        {
+            lockStream.Dispose();
+        }
+    }
+
+    private static (bool NoCapture, string Filter, IReadOnlyList<string> SelectedTests) ParseArguments(
+        IReadOnlyList<string> arguments)
+    {
+        var noCapture = false;
+        var exact = false;
+        int? testThreads = null;
+        var filters = new List<string>();
+        var filtersStarted = false;
+
+        foreach (var argument in arguments)
+        {
+            if (argument == "--")
+            {
+                throw new ControllerException("cargo-style separator is not accepted by direct libtest execution");
+            }
+
+            if (argument.StartsWith('-'))
+            {
+                if (filtersStarted)
+                {
+                    throw new ControllerException($"libtest option follows positional filter: {argument}");
+                }
+
+                switch (argument)
+                {
+                    case "--nocapture" when noCapture:
+                    case "--exact" when exact:
+                        throw new ControllerException($"duplicate libtest option: {argument}");
+                    case "--nocapture":
+                        noCapture = true;
+                        break;
+                    case "--exact":
+                        exact = true;
+                        break;
+                    case "--test-threads=1" when testThreads.HasValue:
+                    case var _ when argument.StartsWith("--test-threads=", StringComparison.Ordinal):
+                        if (testThreads.HasValue)
+                        {
+                            throw new ControllerException("duplicate libtest option: --test-threads");
+                        }
+
+                        if (argument != "--test-threads=1")
+                        {
+                            throw new ControllerException(
+                                $"libtest maximum concurrency must be 1: {argument}");
+                        }
+
+                        testThreads = 1;
+                        break;
+                    default:
+                        throw new ControllerException($"unknown libtest option: {argument}");
+                }
+
+                continue;
+            }
+
+            filtersStarted = true;
+            filters.Add(argument);
+        }
+
+        if (!noCapture || testThreads != 1 || filters.Count != 1)
+        {
+            throw new ControllerException(
+                $"libtest arguments must require nocapture, one thread, and one filter: nocapture={noCapture}, threads={testThreads}, filters={filters.Count}");
+        }
+
+        var filter = filters[0];
+        var selectedTests = exact
+            ? TestNames.Where(name => string.Equals(name, filter, StringComparison.Ordinal)).ToArray()
+            : TestNames.Where(name => name.Contains(filter, StringComparison.OrdinalIgnoreCase)).ToArray();
+        if (selectedTests.Length == 0)
+        {
+            throw new ControllerException($"libtest filter selected no cache-invalidation tests: {filter}");
+        }
+
+        return (noCapture, filter, selectedTests);
+    }
+}
+
 internal static class RootProcessCleanup
 {
     internal static bool ReleaseHandles(SafeWindowsHandle thread, SafeProcessHandle process)

--- a/scripts/ci/windows-storage-job-runner/NativeMethods.cs
+++ b/scripts/ci/windows-storage-job-runner/NativeMethods.cs
@@ -140,6 +140,15 @@ internal static partial class NativeMethods
     [return: MarshalAs(UnmanagedType.Bool)]
     internal static partial bool TerminateProcess(SafeProcessHandle process, uint exitCode);
 
+    [LibraryImport("kernel32.dll", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+    internal static partial uint SearchPathW(
+        IntPtr searchPath,
+        string fileName,
+        IntPtr extension,
+        uint bufferLength,
+        IntPtr buffer,
+        IntPtr filePart);
+
     [LibraryImport("kernel32.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
     internal static partial bool QueryInformationJobObject(

--- a/scripts/ci/windows-storage-job-runner/NativeMethods.cs
+++ b/scripts/ci/windows-storage-job-runner/NativeMethods.cs
@@ -1,0 +1,193 @@
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+namespace Astrid.Ci.Windows;
+
+internal static partial class NativeMethods
+{
+    public const uint GenericWrite = 0x40000000;
+    public const uint FileShareRead = 1;
+    public const uint CreateAlways = 2;
+    public const uint FileAttributeNormal = 0x80;
+    public const uint CreateSuspended = 4;
+    public const uint StartupUseStandardHandles = 0x100;
+    public const uint WaitObject0 = 0;
+    public const uint WaitTimeout = 0x102;
+    public const int JobObjectExtendedLimitInformation = 9;
+    public const int JobObjectBasicProcessIdList = 3;
+    public const uint JobObjectLimitKillOnJobClose = 0x2000;
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct SecurityAttributes
+    {
+        public uint Length;
+        public IntPtr SecurityDescriptor;
+        public uint InheritHandle;
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    public struct StartupInfoW
+    {
+        public uint Size;
+        public IntPtr Desktop;
+        public IntPtr Title;
+        public uint X;
+        public uint Y;
+        public uint Width;
+        public uint Height;
+        public uint CountChars;
+        public uint FillAttribute;
+        public uint Flags;
+        public ushort ShowWindow;
+        public ushort Reserved;
+        public IntPtr Reserved2;
+        public IntPtr StandardInput;
+        public IntPtr StandardOutput;
+        public IntPtr StandardError;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct ProcessInformation
+    {
+        public IntPtr Process;
+        public IntPtr Thread;
+        public int ProcessId;
+        public int ThreadId;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct IoCounters
+    {
+        public ulong ReadOperationCount;
+        public ulong WriteOperationCount;
+        public ulong OtherOperationCount;
+        public ulong ReadTransferCount;
+        public ulong WriteTransferCount;
+        public ulong OtherTransferCount;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct BasicLimitInformation
+    {
+        public long PerProcessUserTimeLimit;
+        public long PerJobUserTimeLimit;
+        public uint LimitFlags;
+        public UIntPtr MinimumWorkingSetSize;
+        public UIntPtr MaximumWorkingSetSize;
+        public uint ActiveProcessLimit;
+        public UIntPtr Affinity;
+        public uint PriorityClass;
+        public uint SchedulingClass;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct ExtendedLimitInformation
+    {
+        public BasicLimitInformation BasicLimitInformation;
+        public IoCounters IoInfo;
+        public UIntPtr ProcessMemoryLimit;
+        public UIntPtr JobMemoryLimit;
+        public UIntPtr PeakProcessMemoryUsed;
+        public UIntPtr PeakJobMemoryUsed;
+    }
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    internal static partial bool CreateProcessW(
+        [MarshalAs(UnmanagedType.LPWStr)] string? applicationName,
+        [MarshalAs(UnmanagedType.LPWStr)] string commandLine,
+        IntPtr processAttributes,
+        IntPtr threadAttributes,
+        [MarshalAs(UnmanagedType.Bool)] bool inheritHandles,
+        uint creationFlags,
+        IntPtr environment,
+        [MarshalAs(UnmanagedType.LPWStr)] string? currentDirectory,
+        ref StartupInfoW startupInfo,
+        out ProcessInformation processInformation);
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    internal static partial SafeJobHandle CreateJobObjectW(IntPtr attributes, [MarshalAs(UnmanagedType.LPWStr)] string? name);
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    internal static partial bool SetInformationJobObject(
+        SafeJobHandle job,
+        int informationClass,
+        ref ExtendedLimitInformation information,
+        int length);
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    internal static partial bool AssignProcessToJobObject(SafeJobHandle job, SafeProcessHandle process);
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    internal static partial uint ResumeThread(SafeWindowsHandle thread);
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    internal static partial uint WaitForSingleObject(SafeProcessHandle handle, uint milliseconds);
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    internal static partial bool GetExitCodeProcess(SafeProcessHandle process, out uint exitCode);
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    internal static partial bool TerminateJobObject(SafeJobHandle job, uint exitCode);
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    internal static partial bool QueryInformationJobObject(
+        SafeJobHandle job,
+        int informationClass,
+        IntPtr information,
+        uint length,
+        out uint returnLength);
+
+    [LibraryImport("kernel32.dll", SetLastError = true, EntryPoint = "CreateFileW", StringMarshalling = StringMarshalling.Utf16)]
+    internal static partial SafeFileHandle CreateFileW(
+        string fileName,
+        uint desiredAccess,
+        uint shareMode,
+        ref SecurityAttributes securityAttributes,
+        uint creationDisposition,
+        uint flagsAndAttributes,
+        IntPtr templateFile);
+}
+
+internal sealed partial class SafeJobHandle : SafeHandleMinusOneIsInvalid
+{
+    public SafeJobHandle()
+        : base(true)
+    {
+    }
+
+    public override bool IsInvalid => IsClosed || handle == IntPtr.Zero;
+
+    protected override bool ReleaseHandle() => CloseHandle(handle);
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool CloseHandle(IntPtr handle);
+}
+
+internal sealed partial class SafeWindowsHandle : SafeHandleMinusOneIsInvalid
+{
+    public SafeWindowsHandle()
+        : base(true)
+    {
+    }
+
+    public SafeWindowsHandle(IntPtr existingHandle, bool ownsHandle)
+        : base(ownsHandle)
+    {
+        SetHandle(existingHandle);
+    }
+
+    public override bool IsInvalid => IsClosed || handle == IntPtr.Zero;
+
+    protected override bool ReleaseHandle() => CloseHandle(handle);
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool CloseHandle(IntPtr handle);
+}

--- a/scripts/ci/windows-storage-job-runner/NativeMethods.cs
+++ b/scripts/ci/windows-storage-job-runner/NativeMethods.cs
@@ -166,6 +166,23 @@ internal static partial class NativeMethods
         uint length,
         out uint returnLength);
 
+    internal static bool QueryJobProcessIdsNative(
+        SafeJobHandle job,
+        IntPtr information,
+        uint length,
+        out uint returnLength,
+        out int win32Error)
+    {
+        var succeeded = QueryInformationJobObject(
+            job,
+            JobObjectBasicProcessIdList,
+            information,
+            length,
+            out returnLength);
+        win32Error = Marshal.GetLastWin32Error();
+        return succeeded;
+    }
+
     [LibraryImport("kernel32.dll", SetLastError = true, EntryPoint = "CreateFileW", StringMarshalling = StringMarshalling.Utf16)]
     internal static partial SafeFileHandle CreateFileW(
         string fileName,

--- a/scripts/ci/windows-storage-job-runner/NativeMethods.cs
+++ b/scripts/ci/windows-storage-job-runner/NativeMethods.cs
@@ -58,6 +58,14 @@ internal static partial class NativeMethods
     }
 
     [StructLayout(LayoutKind.Sequential)]
+    public struct BasicProcessIdList
+    {
+        public uint NumberOfAssignedProcesses;
+        public uint NumberOfProcessIdsInList;
+        public IntPtr ProcessIdList;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
     public struct IoCounters
     {
         public ulong ReadOperationCount;

--- a/scripts/ci/windows-storage-job-runner/NativeMethods.cs
+++ b/scripts/ci/windows-storage-job-runner/NativeMethods.cs
@@ -25,25 +25,27 @@ internal static partial class NativeMethods
         public uint InheritHandle;
     }
 
-    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    [StructLayout(LayoutKind.Sequential)]
     public struct StartupInfoW
     {
-        public uint Size;
-        public IntPtr Desktop;
-        public IntPtr Title;
-        public uint X;
-        public uint Y;
-        public uint Width;
-        public uint Height;
-        public uint CountChars;
-        public uint FillAttribute;
-        public uint Flags;
-        public ushort ShowWindow;
-        public ushort Reserved;
-        public IntPtr Reserved2;
-        public IntPtr StandardInput;
-        public IntPtr StandardOutput;
-        public IntPtr StandardError;
+        public uint cb;
+        public IntPtr lpReserved;
+        public IntPtr lpDesktop;
+        public IntPtr lpTitle;
+        public uint dwX;
+        public uint dwY;
+        public uint dwXSize;
+        public uint dwYSize;
+        public uint dwXCountChars;
+        public uint dwYCountChars;
+        public uint dwFillAttribute;
+        public uint dwFlags;
+        public ushort wShowWindow;
+        public ushort cbReserved2;
+        public IntPtr lpReserved2;
+        public IntPtr hStdInput;
+        public IntPtr hStdOutput;
+        public IntPtr hStdError;
     }
 
     [StructLayout(LayoutKind.Sequential)]
@@ -133,6 +135,10 @@ internal static partial class NativeMethods
     [LibraryImport("kernel32.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
     internal static partial bool TerminateJobObject(SafeJobHandle job, uint exitCode);
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    internal static partial bool TerminateProcess(SafeProcessHandle process, uint exitCode);
 
     [LibraryImport("kernel32.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]

--- a/scripts/ci/windows-storage-job-runner/OutputTail.cs
+++ b/scripts/ci/windows-storage-job-runner/OutputTail.cs
@@ -1,0 +1,119 @@
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace Astrid.Ci.Windows;
+
+internal static class OutputTail
+{
+    internal static async Task TailOutput(
+        string path,
+        TextWriter writer,
+        StrongBox<long> bytes,
+        CancellationToken cancellationToken)
+    {
+        await using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        var buffer = new byte[4096];
+        var pending = new List<byte>();
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                var read = await stream.ReadAsync(buffer.AsMemory(), cancellationToken);
+                if (read == 0)
+                {
+                    await WaitForMoreOutputAsync(cancellationToken);
+                    continue;
+                }
+
+                Interlocked.Add(ref bytes.Value, read);
+                await ProcessTailBytes(writer, bytes, pending, buffer, read);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+        }
+
+        int drained;
+        do
+        {
+            drained = await stream.ReadAsync(buffer.AsMemory(), CancellationToken.None);
+            if (drained != 0)
+            {
+                Interlocked.Add(ref bytes.Value, drained);
+                await ProcessTailBytes(writer, bytes, pending, buffer, drained);
+            }
+        }
+        while (drained != 0);
+
+        if (pending.Count != 0)
+        {
+            await WriteFinalTailBytes(writer, bytes, pending);
+        }
+    }
+
+    private static async Task ProcessTailBytes(
+        TextWriter writer,
+        StrongBox<long> bytes,
+        List<byte> pending,
+        byte[] input,
+        int count)
+    {
+        for (var index = 0; index < count; index++)
+        {
+            var value = input[index];
+            pending.Add(value);
+            if (value == '\n')
+            {
+                await WriteCompleteTailLine(writer, bytes, pending);
+            }
+        }
+    }
+
+    private static async Task<bool> WaitForMoreOutputAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await Task.Delay(100, cancellationToken);
+            return !cancellationToken.IsCancellationRequested;
+        }
+        catch (OperationCanceledException)
+        {
+            return false;
+        }
+    }
+
+    private static async Task WriteCompleteTailLine(
+        TextWriter writer,
+        StrongBox<long> bytes,
+        List<byte> pending)
+    {
+        var textLength = pending.Count;
+        if (textLength > 0 && pending[textLength - 1] == '\r')
+        {
+            --textLength;
+        }
+
+        var line = Encoding.UTF8.GetString(pending.Take(textLength).ToArray());
+        await writer.WriteLineAsync(line);
+        await writer.FlushAsync();
+        pending.Clear();
+    }
+
+    private static async Task WriteFinalTailBytes(
+        TextWriter writer,
+        StrongBox<long> bytes,
+        List<byte> pending)
+    {
+        var textLength = pending.Count;
+        if (textLength > 0 && pending[textLength - 1] == '\r')
+        {
+            --textLength;
+        }
+
+        var line = Encoding.UTF8.GetString(pending.Take(textLength).ToArray());
+        await writer.WriteLineAsync(line);
+        await writer.FlushAsync();
+        pending.Clear();
+    }
+
+}

--- a/scripts/ci/windows-storage-job-runner/Program.cs
+++ b/scripts/ci/windows-storage-job-runner/Program.cs
@@ -334,14 +334,16 @@ internal static class Program
         SafeProcessHandle? process = null;
         SafeWindowsHandle? thread = null;
         JobRunResult result;
+        var processAssignedToJob = false;
+        var directProcessCleanupComplete = false;
         try
         {
             var startup = default(NativeMethods.StartupInfoW);
-            startup.Size = (uint)sizeof(NativeMethods.StartupInfoW);
-            startup.Flags = NativeMethods.StartupUseStandardHandles;
-            startup.StandardOutput = stdoutHandle.DangerousGetHandle();
-            startup.StandardError = stderrHandle.DangerousGetHandle();
-            startup.StandardInput = IntPtr.Zero;
+            startup.cb = (uint)sizeof(NativeMethods.StartupInfoW);
+            startup.dwFlags = NativeMethods.StartupUseStandardHandles;
+            startup.hStdOutput = stdoutHandle.DangerousGetHandle();
+            startup.hStdError = stderrHandle.DangerousGetHandle();
+            startup.hStdInput = IntPtr.Zero;
 
             var commandLine = BuildCommandLine(executable, arguments);
             if (!NativeMethods.CreateProcessW(
@@ -365,10 +367,16 @@ internal static class Program
             var processId = rawProcessInformation.ProcessId;
             if (!NativeMethods.AssignProcessToJobObject(job, process))
             {
+                var assignmentError = Marshal.GetLastWin32Error();
+                var directCleanup = TerminateUnassignedProcessAndAwait(process, cleanupTimeout);
+                directProcessCleanupComplete = directCleanup;
                 throw new ControllerException(
-                    $"AssignProcessToJobObject failed for process {processId}: Win32 error {Marshal.GetLastWin32Error()}");
+                    $"AssignProcessToJobObject failed for process {processId}: Win32 error {assignmentError}; "
+                    + $"cleanup={(directCleanup ? "PROCESS_EXITED" : "INCOMPLETE")}; "
+                    + $"stdout={stdoutPath}; stderr={stderrPath}");
             }
 
+            processAssignedToJob = true;
             afterAssignment?.Invoke();
             var previousSuspendCount = NativeMethods.ResumeThread(thread);
             if (previousSuspendCount != 1)
@@ -399,6 +407,11 @@ internal static class Program
         }
         catch (ControllerException)
         {
+            if (!processAssignedToJob)
+            {
+                throw;
+            }
+
             if (!TryTerminateAndAwait(job, process, cleanupTimeout))
             {
                 throw new ControllerException(
@@ -471,8 +484,8 @@ internal static class Program
             }
         }, heartbeatToken);
 
-        var stdoutTail = TailOutput(stdoutPath, Console.Out, stdoutCounter);
-        var stderrTail = TailOutput(stderrPath, Console.Error, stderrCounter);
+        var stdoutTail = OutputTail.TailOutput(stdoutPath, Console.Out, stdoutCounter, heartbeatToken);
+        var stderrTail = OutputTail.TailOutput(stderrPath, Console.Error, stderrCounter, heartbeatToken);
         var stopwatch = Stopwatch.StartNew();
         var outcome = JobOutcome.ControllerFailed;
         var exitCode = 0u;
@@ -587,16 +600,46 @@ internal static class Program
         }
     }
 
-    private static async Task TailOutput(string path, TextWriter writer, StrongBox<long> bytes)
+    private static bool TerminateUnassignedProcessAndAwait(
+        SafeProcessHandle? process,
+        TimeSpan cleanupTimeout)
     {
-        await using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-        using var reader = new StreamReader(stream, Encoding.UTF8, false, 4096, leaveOpen: false);
-        while (await reader.ReadLineAsync() is { } line)
+        if (process is null || process.IsInvalid)
         {
-            await writer.WriteLineAsync(line);
-            await writer.FlushAsync();
-            Interlocked.Add(ref bytes.Value, Encoding.UTF8.GetByteCount(line) + Environment.NewLine.Length);
+            return false;
         }
+
+        try
+        {
+            _ = NativeMethods.TerminateProcess(process, ControllerFailureExitCode);
+            return WaitForProcessExit(process, cleanupTimeout);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static bool WaitForProcessExit(SafeProcessHandle process, TimeSpan cleanupTimeout)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        do
+        {
+            var wait = NativeMethods.WaitForSingleObject(process, 50);
+            if (wait == NativeMethods.WaitObject0)
+            {
+                return true;
+            }
+
+            if (wait != NativeMethods.WaitTimeout)
+            {
+                throw new ControllerException(
+                    $"waiting for the unassigned process failed: Win32 error {Marshal.GetLastWin32Error()}");
+            }
+        }
+        while (stopwatch.Elapsed < cleanupTimeout);
+
+        return false;
     }
 
     private static bool WaitForActiveProcessZero(
@@ -702,6 +745,8 @@ internal static class Program
 
     internal static IReadOnlyList<string> ParseTestListForSelfTest(IEnumerable<string> lines) =>
         ParseTestList(lines);
+
+    internal static string[] BuildCanonicalListArgumentsForSelfTest() => BuildCanonicalListArguments();
 
     internal static void AssertProviderForSelfTest(string expectedPath, string actualPath, string expectedHash) =>
         AssertProvider(expectedPath, actualPath, expectedHash);
@@ -865,51 +910,4 @@ internal static class Program
     }
 
     private const string StorageTestFilter = "storage_mount";
-}
-
-internal enum JobOutcome
-{
-    Succeeded,
-    ChildFailed,
-    TimedOut,
-    ControllerFailed,
-}
-
-internal sealed record JobRunResult(
-    JobOutcome Outcome,
-    uint ExitCode,
-    string OriginalCause,
-    bool CleanupComplete,
-    uint[] ActiveProcessIds,
-    string StdoutPath,
-    string StderrPath,
-    int ProcessId,
-    TimeSpan Elapsed);
-
-internal sealed class CertificationOptions
-{
-    public string TestExecutable { get; set; } = string.Empty;
-    public string ProviderCanonical { get; set; } = string.Empty;
-    public string Provider { get; set; } = string.Empty;
-    public string ProviderSha256 { get; set; } = string.Empty;
-    public string WorkingDirectory { get; set; } = string.Empty;
-    public string LogDirectory { get; set; } = string.Empty;
-    public TimeSpan ListTimeout { get; set; }
-    public TimeSpan AggregateTimeout { get; set; }
-    public TimeSpan DiagnosticTimeout { get; set; }
-    public TimeSpan CleanupTimeout { get; set; }
-    public TimeSpan HeartbeatInterval { get; set; }
-}
-
-internal sealed class ControllerException : Exception
-{
-    public ControllerException(string message)
-        : base(message)
-    {
-    }
-
-    public ControllerException(string message, Exception innerException)
-        : base(message, innerException)
-    {
-    }
 }

--- a/scripts/ci/windows-storage-job-runner/Program.cs
+++ b/scripts/ci/windows-storage-job-runner/Program.cs
@@ -505,10 +505,14 @@ internal static class Program
                 throw;
             }
 
-            if (!TryTerminateAndAwait(job, process, cleanupTimeout))
+            var cleanupSucceeded = TryTerminateAndAwait(job, process, cleanupTimeout);
+            if (!cleanupSucceeded)
             {
-                throw new ControllerException(
-                    $"launch cleanup did not reach ACTIVE_PROCESS_ZERO; stdout={stdoutPath}; stderr={stderrPath}");
+                throw PreservePrimaryCleanupFailure(
+                    new ControllerException(
+                        "job cleanup did not reach ACTIVE_PROCESS_ZERO after the primary controller failure"),
+                    stdoutPath,
+                    stderrPath);
             }
 
             throw;
@@ -712,6 +716,17 @@ internal static class Program
         }
     }
 
+    internal static ControllerException PreservePrimaryCleanupFailure(
+        ControllerException primary,
+        string stdoutPath,
+        string stderrPath)
+    {
+        return new ControllerException(
+            $"primary cause preserved: {primary.Message}; separate cleanup failure: "
+            + $"cleanup did not reach ACTIVE_PROCESS_ZERO; stdout={stdoutPath}; stderr={stderrPath}",
+            primary);
+    }
+
     private static bool TerminateUnassignedProcessAndAwait(
         SafeProcessHandle? process,
         TimeSpan cleanupTimeout)
@@ -756,73 +771,24 @@ internal static class Program
 
     private static uint[] GetJobProcessIds(SafeJobHandle job)
     {
-        const int errorMoreData = 234;
-        const int headerLength = 2 * sizeof(int);
-        const int maximumAttempts = 8;
-        var bufferLength = (uint)headerLength;
+        return JobProcessList.ReadIds(job, QueryJobProcessIdsNative);
+    }
 
-        for (var attempt = 0; attempt < maximumAttempts; attempt++)
-        {
-            if (bufferLength < headerLength || bufferLength > int.MaxValue)
-            {
-                throw new ControllerException("the Job Object process ID list length is invalid");
-            }
-
-            var buffer = Marshal.AllocHGlobal((int)bufferLength);
-            try
-            {
-                if (NativeMethods.QueryInformationJobObject(
-                        job,
-                        NativeMethods.JobObjectBasicProcessIdList,
-                        buffer,
-                        bufferLength,
-                        out var returnLength))
-                {
-                    if (returnLength < headerLength)
-                    {
-                        throw new ControllerException("the Job Object process ID list return length is too short");
-                    }
-
-                    var assignedProcesses = Marshal.ReadInt32(buffer, 0);
-                    var processIdCount = Marshal.ReadInt32(buffer, sizeof(int));
-                    JobProcessList.ValidateCounts(assignedProcesses, processIdCount);
-                    var expectedLength = (long)headerLength + processIdCount * IntPtr.Size;
-                    if (returnLength < expectedLength)
-                    {
-                        throw new ControllerException(
-                            $"Job Object process ID list was truncated: return {returnLength}, expected {expectedLength}");
-                    }
-
-                    var processIds = new uint[processIdCount];
-                    for (var index = 0; index < processIdCount; index++)
-                    {
-                        processIds[index] = (uint)Marshal.ReadIntPtr(buffer, headerLength + index * IntPtr.Size);
-                    }
-
-                    return processIds;
-                }
-
-                var error = Marshal.GetLastWin32Error();
-                if (error != errorMoreData)
-                {
-                    throw new ControllerException($"QueryInformationJobObject failed: Win32 error {error}");
-                }
-
-                if (returnLength < headerLength || returnLength > int.MaxValue)
-                {
-                    throw new ControllerException(
-                        $"Job Object process ID list requires an invalid length: {returnLength}");
-                }
-
-                bufferLength = returnLength;
-            }
-            finally
-            {
-                Marshal.FreeHGlobal(buffer);
-            }
-        }
-
-        throw new ControllerException("the Job Object process ID list did not stabilize");
+    private static bool QueryJobProcessIdsNative(
+        SafeJobHandle job,
+        IntPtr information,
+        uint length,
+        out uint returnLength,
+        out int win32Error)
+    {
+        var succeeded = NativeMethods.QueryInformationJobObject(
+            job,
+            NativeMethods.JobObjectBasicProcessIdList,
+            information,
+            length,
+            out returnLength);
+        win32Error = Marshal.GetLastWin32Error();
+        return succeeded;
     }
 
     internal static IReadOnlyList<string> ParseTestListForSelfTest(IEnumerable<string> lines) =>
@@ -834,6 +800,17 @@ internal static class Program
         AssertProvider(expectedPath, actualPath, expectedHash);
 
     internal static uint[] GetJobProcessIdsForSelfTest(SafeJobHandle job) => GetJobProcessIds(job);
+
+    internal static uint[] ReadJobProcessIdsForSelfTest(
+        SafeJobHandle job,
+        QueryJobProcessList query) =>
+        JobProcessList.ReadIds(job, query);
+
+    internal static bool TryTerminateAndAwaitForSelfTest(
+        SafeJobHandle job,
+        SafeProcessHandle? process,
+        TimeSpan cleanupTimeout) =>
+        TryTerminateAndAwait(job, process, cleanupTimeout);
 
     internal static JobRunResult RunCommandForSelfTest(
         string workingDirectory,

--- a/scripts/ci/windows-storage-job-runner/Program.cs
+++ b/scripts/ci/windows-storage-job-runner/Program.cs
@@ -29,6 +29,7 @@ internal static class Program
                 ["selftest"] => SelfTest.Run(),
                 ["marker-child", var markerPath, var exitCodeText] => MarkerChild.Run(markerPath, exitCodeText),
                 ["parity-child", var receivedPath, .. var parityArguments] => ParityChild.Run(receivedPath, parityArguments),
+                ["libtest-child", var journalPath, .. var libtestArguments] => LibTestChild.Run(journalPath, libtestArguments),
                 ["certify", .. var certificationArgs] => Certify(ParseOptions(certificationArgs)),
                 _ => throw new ControllerException("expected 'selftest' or 'certify' with named options"),
             };
@@ -165,10 +166,10 @@ internal static class Program
         ["--list", "--format=terse", StorageTestFilter];
 
     private static string[] BuildCanonicalAggregateArguments() =>
-        [StorageTestFilter, "--", "--nocapture", "--test-threads=1"];
+        ["--nocapture", "--test-threads=1", StorageTestFilter];
 
     private static string[] BuildCanonicalDiagnosticArguments(string testName) =>
-        [testName, "--", "--exact", "--nocapture", "--test-threads=1"];
+        ["--exact", "--nocapture", "--test-threads=1", testName];
 
     private static List<string> ParseTestList(IEnumerable<string> lines)
     {
@@ -806,6 +807,11 @@ internal static class Program
         ParseTestList(lines);
 
     internal static string[] BuildCanonicalListArgumentsForSelfTest() => BuildCanonicalListArguments();
+
+    internal static string[] BuildCanonicalAggregateArgumentsForSelfTest() => BuildCanonicalAggregateArguments();
+
+    internal static string[] BuildCanonicalDiagnosticArgumentsForSelfTest(string testName) =>
+        BuildCanonicalDiagnosticArguments(testName);
 
     internal static void AssertProviderForSelfTest(string expectedPath, string actualPath, string expectedHash) =>
         AssertProvider(expectedPath, actualPath, expectedHash);

--- a/scripts/ci/windows-storage-job-runner/Program.cs
+++ b/scripts/ci/windows-storage-job-runner/Program.cs
@@ -27,6 +27,7 @@ internal static class Program
             return args switch
             {
                 ["selftest"] => SelfTest.Run(),
+                ["marker-child", var markerPath, var exitCodeText] => MarkerChild.Run(markerPath, exitCodeText),
                 ["certify", .. var certificationArgs] => Certify(ParseOptions(certificationArgs)),
                 _ => throw new ControllerException("expected 'selftest' or 'certify' with named options"),
             };
@@ -479,6 +480,7 @@ internal static class Program
             afterResume?.Invoke(job);
             result = WaitAndCleanUpAsync(
                 job,
+                thread,
                 process,
                 processId,
                 stdoutPath,
@@ -546,6 +548,7 @@ internal static class Program
 
     private static async Task<JobRunResult> WaitAndCleanUpAsync(
         SafeJobHandle job,
+        SafeWindowsHandle thread,
         SafeProcessHandle process,
         int processId,
         string stdoutPath,
@@ -581,6 +584,7 @@ internal static class Program
         var outcome = JobOutcome.ControllerFailed;
         var exitCode = 0u;
         bool cleanupComplete;
+        var rootHandlesReleased = false;
         var activeProcessIds = Array.Empty<uint>();
         var originalCause = string.Empty;
 
@@ -617,31 +621,47 @@ internal static class Program
                     throw new ControllerException(
                         $"TerminateJobObject failed after timeout: Win32 error {Marshal.GetLastWin32Error()}");
                 }
-            }
-            else
-            {
-                var descendantWait = Stopwatch.StartNew();
-                while (descendantWait.Elapsed < cleanupTimeout)
-                {
-                    activeProcessIds = GetJobProcessIds(job);
-                    if (activeProcessIds.Length == 0)
-                    {
-                        break;
-                    }
 
-                    Thread.Sleep(50);
+                if (!RootProcessCleanup.WaitForProcessExit(process, cleanupTimeout))
+                {
+                    throw new ControllerException(
+                        $"timed-out root process {processId} did not exit within the cleanup budget");
                 }
 
-                activeProcessIds = GetJobProcessIds(job);
-                if (activeProcessIds.Length != 0)
+                if (!NativeMethods.GetExitCodeProcess(process, out exitCode))
                 {
-                    originalCause = $"process {processId} exited while descendants remained active";
-                    outcome = JobOutcome.ControllerFailed;
-                    if (!NativeMethods.TerminateJobObject(job, ControllerFailureExitCode))
-                    {
-                        throw new ControllerException(
-                            $"TerminateJobObject failed for surviving descendants: Win32 error {Marshal.GetLastWin32Error()}");
-                    }
+                    throw new ControllerException(
+                        $"GetExitCodeProcess failed for timed-out process {processId}: Win32 error {Marshal.GetLastWin32Error()}");
+                }
+            }
+
+            rootHandlesReleased = RootProcessCleanup.ReleaseHandles(thread, process);
+            if (!rootHandlesReleased)
+            {
+                throw new ControllerException($"root thread/process handles were not released for process {processId}");
+            }
+
+            var descendantWait = Stopwatch.StartNew();
+            while (descendantWait.Elapsed < cleanupTimeout)
+            {
+                activeProcessIds = GetJobProcessIds(job);
+                if (activeProcessIds.Length == 0)
+                {
+                    break;
+                }
+
+                Thread.Sleep(50);
+            }
+
+            activeProcessIds = GetJobProcessIds(job);
+            if (activeProcessIds.Length != 0)
+            {
+                originalCause = $"process {processId} exited while descendants remained active";
+                outcome = JobOutcome.ControllerFailed;
+                if (!NativeMethods.TerminateJobObject(job, ControllerFailureExitCode))
+                {
+                    throw new ControllerException(
+                        $"TerminateJobObject failed for surviving descendants: Win32 error {Marshal.GetLastWin32Error()}");
                 }
             }
 
@@ -668,6 +688,7 @@ internal static class Program
             stdoutPath,
             stderrPath,
             processId,
+            rootHandlesReleased,
             stopwatch.Elapsed);
     }
 
@@ -703,34 +724,12 @@ internal static class Program
         try
         {
             _ = NativeMethods.TerminateProcess(process, ControllerFailureExitCode);
-            return WaitForProcessExit(process, cleanupTimeout);
+            return RootProcessCleanup.WaitForProcessExit(process, cleanupTimeout);
         }
         catch
         {
             return false;
         }
-    }
-
-    private static bool WaitForProcessExit(SafeProcessHandle process, TimeSpan cleanupTimeout)
-    {
-        var stopwatch = Stopwatch.StartNew();
-        do
-        {
-            var wait = NativeMethods.WaitForSingleObject(process, 50);
-            if (wait == NativeMethods.WaitObject0)
-            {
-                return true;
-            }
-
-            if (wait != NativeMethods.WaitTimeout)
-            {
-                throw new ControllerException(
-                    $"waiting for the unassigned process failed: Win32 error {Marshal.GetLastWin32Error()}");
-            }
-        }
-        while (stopwatch.Elapsed < cleanupTimeout);
-
-        return false;
     }
 
     private static bool WaitForActiveProcessZero(

--- a/scripts/ci/windows-storage-job-runner/Program.cs
+++ b/scripts/ci/windows-storage-job-runner/Program.cs
@@ -28,6 +28,7 @@ internal static class Program
             {
                 ["selftest"] => SelfTest.Run(),
                 ["marker-child", var markerPath, var exitCodeText] => MarkerChild.Run(markerPath, exitCodeText),
+                ["parity-child", var receivedPath, .. var parityArguments] => ParityChild.Run(receivedPath, parityArguments),
                 ["certify", .. var certificationArgs] => Certify(ParseOptions(certificationArgs)),
                 _ => throw new ControllerException("expected 'selftest' or 'certify' with named options"),
             };

--- a/scripts/ci/windows-storage-job-runner/Program.cs
+++ b/scripts/ci/windows-storage-job-runner/Program.cs
@@ -1,0 +1,915 @@
+using System.Diagnostics;
+using System.Security.Cryptography;
+using System.Text;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+[assembly: DisableRuntimeMarshalling]
+
+namespace Astrid.Ci.Windows;
+
+internal static class Program
+{
+    internal const int TimeoutExitCode = 124;
+    internal const int ControllerFailureExitCode = 125;
+
+    public static int Main(string[] args)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            Console.Error.WriteLine("the Windows storage certification runner requires Windows");
+            return ControllerFailureExitCode;
+        }
+
+        try
+        {
+            return args switch
+            {
+                ["selftest"] => SelfTest.Run(),
+                ["certify", .. var certificationArgs] => Certify(ParseOptions(certificationArgs)),
+                _ => throw new ControllerException("expected 'selftest' or 'certify' with named options"),
+            };
+        }
+        catch (ControllerException exception)
+        {
+            Console.Error.WriteLine($"controller failure: {exception.Message}");
+            return ControllerFailureExitCode;
+        }
+        catch (Exception exception)
+        {
+            Console.Error.WriteLine($"controller failure: unexpected {exception.GetType().Name}: {exception.Message}");
+            return ControllerFailureExitCode;
+        }
+    }
+
+    private static int Certify(CertificationOptions options)
+    {
+        ValidateCommonOptions(options);
+        AssertProvider(options.ProviderCanonical, options.Provider, options.ProviderSha256);
+
+        var listArguments = BuildCanonicalListArguments();
+        var listResult = RunJobProcess(
+            options.TestExecutable,
+            listArguments,
+            options.WorkingDirectory,
+            Path.Combine(options.LogDirectory, "list.stdout.log"),
+            Path.Combine(options.LogDirectory, "list.stderr.log"),
+            options.ListTimeout,
+            options.CleanupTimeout,
+            options.HeartbeatInterval);
+        ReportJob("list", listResult);
+        if (listResult.Outcome is JobOutcome.ControllerFailed)
+        {
+            return ControllerFailureExitCode;
+        }
+
+        if (listResult.Outcome is not JobOutcome.Succeeded)
+        {
+            throw new ControllerException(
+                $"libtest discovery failed with exit code {listResult.ExitCode}; stdout={listResult.StdoutPath}; stderr={listResult.StderrPath}");
+        }
+
+        var testNames = ParseTestList(File.ReadAllLines(listResult.StdoutPath));
+        if (testNames.Count == 0)
+        {
+            throw new ControllerException("the storage_mount libtest list was empty");
+        }
+
+        Console.WriteLine($"[storage-job] discovered {testNames.Count} storage_mount tests");
+        foreach (var testName in testNames)
+        {
+            Console.WriteLine($"[storage-job] listed {testName}");
+        }
+
+        AssertProvider(options.ProviderCanonical, options.Provider, options.ProviderSha256);
+        var aggregateResult = RunJobProcess(
+            options.TestExecutable,
+            BuildCanonicalAggregateArguments(),
+            options.WorkingDirectory,
+            Path.Combine(options.LogDirectory, "aggregate.stdout.log"),
+            Path.Combine(options.LogDirectory, "aggregate.stderr.log"),
+            options.AggregateTimeout,
+            options.CleanupTimeout,
+            options.HeartbeatInterval);
+        ReportJob("aggregate", aggregateResult);
+
+        if (aggregateResult.Outcome is JobOutcome.TimedOut)
+        {
+            IdentifyTimeoutWithFreshJobs(options, testNames);
+            Console.Error.WriteLine(
+                $"aggregate storage_mount certification timed out; diagnostics are advisory only; stdout={aggregateResult.StdoutPath}; stderr={aggregateResult.StderrPath}");
+            return TimeoutExitCode;
+        }
+
+        if (aggregateResult.Outcome is JobOutcome.ControllerFailed)
+        {
+            return ControllerFailureExitCode;
+        }
+
+        if (aggregateResult.Outcome is not JobOutcome.Succeeded)
+        {
+            Console.Error.WriteLine(
+                $"aggregate storage_mount certification failed with exit code {aggregateResult.ExitCode}; stdout={aggregateResult.StdoutPath}; stderr={aggregateResult.StderrPath}");
+            return unchecked((int)aggregateResult.ExitCode);
+        }
+
+        Console.WriteLine("[storage-job] aggregate storage_mount certification passed");
+        return 0;
+    }
+
+    private static void IdentifyTimeoutWithFreshJobs(CertificationOptions options, IReadOnlyList<string> testNames)
+    {
+        Console.WriteLine("[diagnostic] aggregate timeout detected; identifying tests with fresh job objects");
+        var identified = new List<string>();
+
+        foreach (var testName in testNames)
+        {
+            AssertProvider(options.ProviderCanonical, options.Provider, options.ProviderSha256);
+            var result = RunJobProcess(
+                options.TestExecutable,
+                BuildCanonicalDiagnosticArguments(testName),
+                options.WorkingDirectory,
+                Path.Combine(options.LogDirectory, $"diagnostic.{SafeFileName(testName)}.stdout.log"),
+                Path.Combine(options.LogDirectory, $"diagnostic.{SafeFileName(testName)}.stderr.log"),
+                options.DiagnosticTimeout,
+                options.CleanupTimeout,
+                options.HeartbeatInterval);
+            ReportJob($"diagnostic {testName}", result);
+
+            if (result.Outcome is JobOutcome.ControllerFailed)
+            {
+                throw new ControllerException(
+                    $"diagnostic controller failure for {testName}; stdout={result.StdoutPath}; stderr={result.StderrPath}");
+            }
+
+            if (result.Outcome is JobOutcome.TimedOut)
+            {
+                identified.Add(testName);
+            }
+        }
+
+        if (identified.Count == 0)
+        {
+            Console.WriteLine("[diagnostic] no individual test timed out; the aggregate run exceeded its cumulative budget");
+        }
+        else
+        {
+            Console.Error.WriteLine($"[diagnostic] timed-out tests: {string.Join(", ", identified)}");
+        }
+    }
+
+    private static string[] BuildCanonicalListArguments() =>
+        ["--list", "--format=terse", StorageTestFilter];
+
+    private static string[] BuildCanonicalAggregateArguments() =>
+        [StorageTestFilter, "--", "--nocapture", "--test-threads=1"];
+
+    private static string[] BuildCanonicalDiagnosticArguments(string testName) =>
+        [testName, "--", "--exact", "--nocapture", "--test-threads=1"];
+
+    private static List<string> ParseTestList(IEnumerable<string> lines)
+    {
+        var names = new List<string>();
+        foreach (var line in lines)
+        {
+            const string marker = ": test";
+            if (!line.EndsWith(marker, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var testName = line[..^marker.Length].Trim();
+            if (testName.Length != 0)
+            {
+                names.Add(testName);
+            }
+        }
+
+        return names;
+    }
+
+    private static void ReportJob(string phase, JobRunResult result)
+    {
+        var outcome = result.Outcome switch
+        {
+            JobOutcome.Succeeded => "succeeded",
+            JobOutcome.ChildFailed => $"failed with exit code {result.ExitCode}",
+            JobOutcome.TimedOut => "timed out",
+            JobOutcome.ControllerFailed => "hit a controller failure",
+            _ => "ended in an unknown state",
+        };
+        Console.WriteLine(
+            $"[storage-job] {phase} {outcome} in {result.Elapsed.TotalSeconds:F1}s; cleanup={FormatCleanup(result)}; stdout={result.StdoutPath}; stderr={result.StderrPath}");
+    }
+
+    private static string FormatCleanup(JobRunResult result) =>
+        result.CleanupComplete ? "ACTIVE_PROCESS_ZERO" : $"incomplete (active: {string.Join(',', result.ActiveProcessIds)})";
+
+    private static void ValidateCommonOptions(CertificationOptions options)
+    {
+        if (!File.Exists(options.TestExecutable))
+        {
+            throw new ControllerException($"the libtest executable is not a file: {options.TestExecutable}");
+        }
+
+        if (!Directory.Exists(options.WorkingDirectory))
+        {
+            throw new ControllerException($"the working directory does not exist: {options.WorkingDirectory}");
+        }
+
+        Directory.CreateDirectory(options.LogDirectory);
+    }
+
+    private static void AssertProvider(string expectedPath, string actualPath, string expectedHash)
+    {
+        var expectedCanonical = Path.GetFullPath(expectedPath);
+        var actualCanonical = Path.GetFullPath(actualPath);
+        if (!string.Equals(expectedCanonical, actualCanonical, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ControllerException(
+                $"provider path substitution rejected: expected {expectedCanonical}, got {actualCanonical}");
+        }
+
+        if (!File.Exists(actualCanonical))
+        {
+            throw new ControllerException($"the exact staged provider is not a file: {actualCanonical}");
+        }
+
+        var actualHash = Convert.ToHexString(SHA256.HashData(File.ReadAllBytes(actualCanonical))).ToLowerInvariant();
+        if (!string.Equals(expectedHash, actualHash, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ControllerException($"staged provider SHA-256 mismatch: expected {expectedHash}, got {actualHash}");
+        }
+    }
+
+    private static string SafeFileName(string testName)
+    {
+        var invalid = Path.GetInvalidFileNameChars();
+        var builder = new StringBuilder(testName.Length);
+        foreach (var character in testName)
+        {
+            builder.Append(Array.IndexOf(invalid, character) >= 0 ? '_' : character);
+        }
+
+        return builder.ToString();
+    }
+
+    private static JobRunResult RunJobProcess(
+        string executable,
+        IReadOnlyList<string> arguments,
+        string workingDirectory,
+        string stdoutPath,
+        string stderrPath,
+        TimeSpan timeout,
+        TimeSpan cleanupTimeout,
+        TimeSpan heartbeatInterval)
+    {
+        if (timeout <= TimeSpan.Zero || cleanupTimeout <= TimeSpan.Zero)
+        {
+            throw new ControllerException("controller and cleanup timeouts must be greater than zero");
+        }
+
+        var stdoutHandle = OpenInheritableWriteFile(stdoutPath);
+        var stderrHandle = OpenInheritableWriteFile(stderrPath);
+        try
+        {
+            return ExecuteInJob(
+                executable,
+                arguments,
+                workingDirectory,
+                stdoutPath,
+                stderrPath,
+                stdoutHandle,
+                stderrHandle,
+                timeout,
+                cleanupTimeout,
+                heartbeatInterval,
+                afterAssignment: null,
+                afterResume: null);
+        }
+        finally
+        {
+            stdoutHandle.Dispose();
+            stderrHandle.Dispose();
+        }
+    }
+
+    private static unsafe SafeFileHandle OpenInheritableWriteFile(string path)
+    {
+        var security = default(NativeMethods.SecurityAttributes);
+        security.Length = (uint)sizeof(NativeMethods.SecurityAttributes);
+        security.InheritHandle = 1;
+        var handle = NativeMethods.CreateFileW(
+            path,
+            NativeMethods.GenericWrite,
+            NativeMethods.FileShareRead,
+            ref security,
+            NativeMethods.CreateAlways,
+            NativeMethods.FileAttributeNormal,
+            IntPtr.Zero);
+        if (handle.IsInvalid)
+        {
+            throw new ControllerException($"could not create durable output file {path}: Win32 error {Marshal.GetLastWin32Error()}");
+        }
+
+        return handle;
+    }
+
+    private static unsafe JobRunResult ExecuteInJob(
+        string executable,
+        IReadOnlyList<string> arguments,
+        string workingDirectory,
+        string stdoutPath,
+        string stderrPath,
+        SafeFileHandle stdoutHandle,
+        SafeFileHandle stderrHandle,
+        TimeSpan timeout,
+        TimeSpan cleanupTimeout,
+        TimeSpan heartbeatInterval,
+        Action? afterAssignment,
+        Action<SafeJobHandle>? afterResume)
+    {
+        using var job = CreateKillOnCloseJob();
+        SafeProcessHandle? process = null;
+        SafeWindowsHandle? thread = null;
+        JobRunResult result;
+        try
+        {
+            var startup = default(NativeMethods.StartupInfoW);
+            startup.Size = (uint)sizeof(NativeMethods.StartupInfoW);
+            startup.Flags = NativeMethods.StartupUseStandardHandles;
+            startup.StandardOutput = stdoutHandle.DangerousGetHandle();
+            startup.StandardError = stderrHandle.DangerousGetHandle();
+            startup.StandardInput = IntPtr.Zero;
+
+            var commandLine = BuildCommandLine(executable, arguments);
+            if (!NativeMethods.CreateProcessW(
+                    executable,
+                    commandLine,
+                    IntPtr.Zero,
+                    IntPtr.Zero,
+                    true,
+                    NativeMethods.CreateSuspended,
+                    IntPtr.Zero,
+                    workingDirectory,
+                    ref startup,
+                    out var rawProcessInformation))
+            {
+                throw new ControllerException(
+                    $"CreateProcessW failed for {executable}: Win32 error {Marshal.GetLastWin32Error()}");
+            }
+
+            process = new SafeProcessHandle(rawProcessInformation.Process, ownsHandle: true);
+            thread = new SafeWindowsHandle(rawProcessInformation.Thread, ownsHandle: true);
+            var processId = rawProcessInformation.ProcessId;
+            if (!NativeMethods.AssignProcessToJobObject(job, process))
+            {
+                throw new ControllerException(
+                    $"AssignProcessToJobObject failed for process {processId}: Win32 error {Marshal.GetLastWin32Error()}");
+            }
+
+            afterAssignment?.Invoke();
+            var previousSuspendCount = NativeMethods.ResumeThread(thread);
+            if (previousSuspendCount != 1)
+            {
+                throw new ControllerException(
+                    $"ResumeThread did not prove CREATE_SUSPENDED for process {processId}: previous count {previousSuspendCount}");
+            }
+
+            afterResume?.Invoke(job);
+            result = WaitAndCleanUpAsync(
+                job,
+                process,
+                processId,
+                stdoutPath,
+                stderrPath,
+                timeout,
+                cleanupTimeout,
+                heartbeatInterval).GetAwaiter().GetResult();
+            thread.Dispose();
+            process.Dispose();
+        }
+        catch (Exception exception) when (exception is not ControllerException)
+        {
+            var cleanup = TryTerminateAndAwait(job, process, cleanupTimeout);
+            throw new ControllerException(
+                $"{exception.Message}; cleanup={(cleanup ? "ACTIVE_PROCESS_ZERO" : "incomplete")}; stdout={stdoutPath}; stderr={stderrPath}",
+                exception);
+        }
+        catch (ControllerException)
+        {
+            if (!TryTerminateAndAwait(job, process, cleanupTimeout))
+            {
+                throw new ControllerException(
+                    $"launch cleanup did not reach ACTIVE_PROCESS_ZERO; stdout={stdoutPath}; stderr={stderrPath}");
+            }
+
+            throw;
+        }
+        finally
+        {
+            thread?.Dispose();
+            process?.Dispose();
+        }
+
+        return result;
+    }
+
+    private static unsafe SafeJobHandle CreateKillOnCloseJob()
+    {
+        var job = NativeMethods.CreateJobObjectW(IntPtr.Zero, null);
+        if (job.IsInvalid)
+        {
+            throw new ControllerException($"CreateJobObjectW failed: Win32 error {Marshal.GetLastWin32Error()}");
+        }
+
+        var limits = default(NativeMethods.ExtendedLimitInformation);
+        limits.BasicLimitInformation.LimitFlags = NativeMethods.JobObjectLimitKillOnJobClose;
+        if (!NativeMethods.SetInformationJobObject(
+                job,
+                NativeMethods.JobObjectExtendedLimitInformation,
+                ref limits,
+                sizeof(NativeMethods.ExtendedLimitInformation)))
+        {
+            job.Dispose();
+            throw new ControllerException(
+                $"setting JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE failed: Win32 error {Marshal.GetLastWin32Error()}");
+        }
+
+        return job;
+    }
+
+    private static async Task<JobRunResult> WaitAndCleanUpAsync(
+        SafeJobHandle job,
+        SafeProcessHandle process,
+        int processId,
+        string stdoutPath,
+        string stderrPath,
+        TimeSpan timeout,
+        TimeSpan cleanupTimeout,
+        TimeSpan heartbeatInterval)
+    {
+        var stdoutCounter = new StrongBox<long>();
+        var stderrCounter = new StrongBox<long>();
+        using var heartbeatSource = new CancellationTokenSource();
+        var heartbeatToken = heartbeatSource.Token;
+        var heartbeat = Task.Run(async () =>
+        {
+            var elapsed = Stopwatch.StartNew();
+            while (!heartbeatToken.IsCancellationRequested)
+            {
+                try
+                {
+                    await Task.Delay(heartbeatInterval, heartbeatToken);
+                    Console.WriteLine(
+                        $"[heartbeat] process {processId} elapsed={elapsed.Elapsed.TotalSeconds:F0}s stdout={Interlocked.Read(ref stdoutCounter.Value)}B stderr={Interlocked.Read(ref stderrCounter.Value)}B");
+                }
+                catch (OperationCanceledException)
+                {
+                }
+            }
+        }, heartbeatToken);
+
+        var stdoutTail = TailOutput(stdoutPath, Console.Out, stdoutCounter);
+        var stderrTail = TailOutput(stderrPath, Console.Error, stderrCounter);
+        var stopwatch = Stopwatch.StartNew();
+        var outcome = JobOutcome.ControllerFailed;
+        var exitCode = 0u;
+        bool cleanupComplete;
+        var activeProcessIds = Array.Empty<uint>();
+        var originalCause = string.Empty;
+
+        try
+        {
+            while (stopwatch.Elapsed < timeout)
+            {
+                var wait = NativeMethods.WaitForSingleObject(process, 100);
+                if (wait == NativeMethods.WaitObject0)
+                {
+                    if (!NativeMethods.GetExitCodeProcess(process, out exitCode))
+                    {
+                        throw new ControllerException(
+                            $"GetExitCodeProcess failed for process {processId}: Win32 error {Marshal.GetLastWin32Error()}");
+                    }
+
+                    outcome = exitCode == 0 ? JobOutcome.Succeeded : JobOutcome.ChildFailed;
+                    break;
+                }
+
+                if (wait != NativeMethods.WaitTimeout)
+                {
+                    throw new ControllerException(
+                        $"waiting for process {processId} failed: Win32 error {Marshal.GetLastWin32Error()}");
+                }
+            }
+
+            if (outcome is JobOutcome.ControllerFailed && stopwatch.Elapsed >= timeout)
+            {
+                outcome = JobOutcome.TimedOut;
+                originalCause = $"controller timeout after {timeout.TotalSeconds:F0}s";
+                if (!NativeMethods.TerminateJobObject(job, TimeoutExitCode))
+                {
+                    throw new ControllerException(
+                        $"TerminateJobObject failed after timeout: Win32 error {Marshal.GetLastWin32Error()}");
+                }
+            }
+            else
+            {
+                var descendantWait = Stopwatch.StartNew();
+                while (descendantWait.Elapsed < cleanupTimeout)
+                {
+                    activeProcessIds = GetJobProcessIds(job);
+                    if (activeProcessIds.Length == 0)
+                    {
+                        break;
+                    }
+
+                    Thread.Sleep(50);
+                }
+
+                activeProcessIds = GetJobProcessIds(job);
+                if (activeProcessIds.Length != 0)
+                {
+                    originalCause = $"process {processId} exited while descendants remained active";
+                    outcome = JobOutcome.ControllerFailed;
+                    if (!NativeMethods.TerminateJobObject(job, ControllerFailureExitCode))
+                    {
+                        throw new ControllerException(
+                            $"TerminateJobObject failed for surviving descendants: Win32 error {Marshal.GetLastWin32Error()}");
+                    }
+                }
+            }
+
+            if (!WaitForActiveProcessZero(job, cleanupTimeout, out activeProcessIds))
+            {
+                throw new ControllerException(
+                    $"job cleanup did not reach ACTIVE_PROCESS_ZERO; active {string.Join(',', activeProcessIds)}");
+            }
+
+            cleanupComplete = true;
+        }
+        finally
+        {
+            heartbeatSource.Cancel();
+            await Task.WhenAll(heartbeat, stdoutTail, stderrTail);
+        }
+
+        return new JobRunResult(
+            outcome,
+            exitCode,
+            originalCause,
+            cleanupComplete,
+            activeProcessIds,
+            stdoutPath,
+            stderrPath,
+            processId,
+            stopwatch.Elapsed);
+    }
+
+    private static bool TryTerminateAndAwait(
+        SafeJobHandle job,
+        SafeProcessHandle? process,
+        TimeSpan cleanupTimeout)
+    {
+        try
+        {
+            if (process is not null && !process.IsInvalid && !NativeMethods.TerminateJobObject(job, ControllerFailureExitCode))
+            {
+                return false;
+            }
+
+            return WaitForActiveProcessZero(job, cleanupTimeout, out _);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static async Task TailOutput(string path, TextWriter writer, StrongBox<long> bytes)
+    {
+        await using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        using var reader = new StreamReader(stream, Encoding.UTF8, false, 4096, leaveOpen: false);
+        while (await reader.ReadLineAsync() is { } line)
+        {
+            await writer.WriteLineAsync(line);
+            await writer.FlushAsync();
+            Interlocked.Add(ref bytes.Value, Encoding.UTF8.GetByteCount(line) + Environment.NewLine.Length);
+        }
+    }
+
+    private static bool WaitForActiveProcessZero(
+        SafeJobHandle job,
+        TimeSpan cleanupTimeout,
+        out uint[] activeProcessIds)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        do
+        {
+            activeProcessIds = GetJobProcessIds(job);
+            if (activeProcessIds.Length == 0)
+            {
+                return true;
+            }
+
+            Thread.Sleep(50);
+        }
+        while (stopwatch.Elapsed < cleanupTimeout);
+
+        activeProcessIds = GetJobProcessIds(job);
+        return activeProcessIds.Length == 0;
+    }
+
+    private static uint[] GetJobProcessIds(SafeJobHandle job)
+    {
+        const int errorMoreData = 234;
+        if (NativeMethods.QueryInformationJobObject(
+                job,
+                NativeMethods.JobObjectBasicProcessIdList,
+                IntPtr.Zero,
+                0,
+                out _))
+        {
+            return [];
+        }
+
+        var error = Marshal.GetLastWin32Error();
+        if (error != errorMoreData)
+        {
+            throw new ControllerException($"QueryInformationJobObject failed: Win32 error {error}");
+        }
+
+        var probe = Marshal.AllocHGlobal(2 * sizeof(int));
+        try
+        {
+            if (!NativeMethods.QueryInformationJobObject(
+                    job,
+                    NativeMethods.JobObjectBasicProcessIdList,
+                    probe,
+                    (uint)(2 * sizeof(int)),
+                    out _))
+            {
+                throw new ControllerException(
+                    $"querying assigned job processes failed: Win32 error {Marshal.GetLastWin32Error()}");
+            }
+
+            var processIdCapacity = Marshal.ReadInt32(probe, sizeof(int));
+            if (processIdCapacity <= 0)
+            {
+                return [];
+            }
+
+            var bufferSize = 2 * sizeof(int) + processIdCapacity * IntPtr.Size;
+            var buffer = Marshal.AllocHGlobal(bufferSize);
+            try
+            {
+                if (!NativeMethods.QueryInformationJobObject(
+                        job,
+                        NativeMethods.JobObjectBasicProcessIdList,
+                        buffer,
+                        (uint)bufferSize,
+                        out _))
+                {
+                    throw new ControllerException(
+                        $"querying active job process IDs failed: Win32 error {Marshal.GetLastWin32Error()}");
+                }
+
+                var count = Marshal.ReadInt32(buffer, sizeof(int));
+                if (count < 0 || count > processIdCapacity)
+                {
+                    throw new ControllerException("the Job Object returned an invalid process ID count");
+                }
+
+                var processIds = new uint[count];
+                for (var index = 0; index < count; index++)
+                {
+                    processIds[index] = (uint)Marshal.ReadIntPtr(buffer, 2 * sizeof(int) + index * IntPtr.Size);
+                }
+
+                return processIds;
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(buffer);
+            }
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(probe);
+        }
+    }
+
+    internal static IReadOnlyList<string> ParseTestListForSelfTest(IEnumerable<string> lines) =>
+        ParseTestList(lines);
+
+    internal static void AssertProviderForSelfTest(string expectedPath, string actualPath, string expectedHash) =>
+        AssertProvider(expectedPath, actualPath, expectedHash);
+
+    internal static uint[] GetJobProcessIdsForSelfTest(SafeJobHandle job) => GetJobProcessIds(job);
+
+    internal static JobRunResult RunCommandForSelfTest(
+        string workingDirectory,
+        IReadOnlyList<string> command,
+        string stdoutPath,
+        string stderrPath,
+        TimeSpan timeout,
+        TimeSpan cleanupTimeout,
+        TimeSpan heartbeatInterval,
+        Action? afterAssignment,
+        Action<SafeJobHandle>? afterResume)
+    {
+        var stdoutHandle = OpenInheritableWriteFile(stdoutPath);
+        var stderrHandle = OpenInheritableWriteFile(stderrPath);
+        try
+        {
+            return ExecuteInJob(
+                command[0],
+                command.Skip(1).ToArray(),
+                workingDirectory,
+                stdoutPath,
+                stderrPath,
+                stdoutHandle,
+                stderrHandle,
+                timeout,
+                cleanupTimeout,
+                heartbeatInterval,
+                afterAssignment,
+                afterResume);
+        }
+        finally
+        {
+            stdoutHandle.Dispose();
+            stderrHandle.Dispose();
+        }
+    }
+
+    private static string BuildCommandLine(string executable, IReadOnlyList<string> arguments)
+    {
+        var builder = new StringBuilder();
+        AppendCommandLineArgument(builder, executable);
+        foreach (var argument in arguments)
+        {
+            builder.Append(' ');
+            AppendCommandLineArgument(builder, argument);
+        }
+
+        return builder.ToString();
+    }
+
+    private static void AppendCommandLineArgument(StringBuilder builder, string argument)
+    {
+        if (argument.Length != 0 && !argument.Any(char.IsWhiteSpace) && !argument.Contains('"'))
+        {
+            builder.Append(argument);
+            return;
+        }
+
+        builder.Append('"');
+        var backslashes = 0;
+        foreach (var character in argument)
+        {
+            if (character == '\\')
+            {
+                ++backslashes;
+            }
+            else
+            {
+                if (backslashes > 0)
+                {
+                    builder.Append('\\', backslashes * 2);
+                    backslashes = 0;
+                }
+
+                if (character == '"')
+                {
+                    builder.Append("\\\"");
+                }
+                else
+                {
+                    builder.Append(character);
+                }
+            }
+        }
+
+        if (backslashes > 0)
+        {
+            builder.Append('\\', backslashes * 2);
+        }
+
+        builder.Append('"');
+    }
+
+    private static CertificationOptions ParseOptions(string[] args)
+    {
+        var options = new CertificationOptions();
+        for (var index = 0; index < args.Length; index += 2)
+        {
+            if (index + 1 >= args.Length)
+            {
+                throw new ControllerException($"missing value for {args[index]}");
+            }
+
+            var value = args[index + 1];
+            switch (args[index])
+            {
+                case "--test-executable":
+                    options.TestExecutable = value;
+                    break;
+                case "--provider-canonical":
+                    options.ProviderCanonical = value;
+                    break;
+                case "--provider":
+                    options.Provider = value;
+                    break;
+                case "--provider-sha256":
+                    options.ProviderSha256 = value;
+                    break;
+                case "--working-directory":
+                    options.WorkingDirectory = value;
+                    break;
+                case "--log-directory":
+                    options.LogDirectory = value;
+                    break;
+                case "--list-timeout-seconds":
+                    options.ListTimeout = ParsePositiveTimeSpan(args[index], value);
+                    break;
+                case "--aggregate-timeout-seconds":
+                    options.AggregateTimeout = ParsePositiveTimeSpan(args[index], value);
+                    break;
+                case "--diagnostic-timeout-seconds":
+                    options.DiagnosticTimeout = ParsePositiveTimeSpan(args[index], value);
+                    break;
+                case "--cleanup-timeout-seconds":
+                    options.CleanupTimeout = ParsePositiveTimeSpan(args[index], value);
+                    break;
+                case "--heartbeat-seconds":
+                    options.HeartbeatInterval = ParsePositiveTimeSpan(args[index], value);
+                    break;
+                default:
+                    throw new ControllerException($"unknown certification option: {args[index]}");
+            }
+        }
+
+        return options;
+    }
+
+    private static TimeSpan ParsePositiveTimeSpan(string option, string value)
+    {
+        if (!int.TryParse(value, out var seconds) || seconds <= 0)
+        {
+            throw new ControllerException($"{option} must be a positive integer");
+        }
+
+        return TimeSpan.FromSeconds(seconds);
+    }
+
+    private const string StorageTestFilter = "storage_mount";
+}
+
+internal enum JobOutcome
+{
+    Succeeded,
+    ChildFailed,
+    TimedOut,
+    ControllerFailed,
+}
+
+internal sealed record JobRunResult(
+    JobOutcome Outcome,
+    uint ExitCode,
+    string OriginalCause,
+    bool CleanupComplete,
+    uint[] ActiveProcessIds,
+    string StdoutPath,
+    string StderrPath,
+    int ProcessId,
+    TimeSpan Elapsed);
+
+internal sealed class CertificationOptions
+{
+    public string TestExecutable { get; set; } = string.Empty;
+    public string ProviderCanonical { get; set; } = string.Empty;
+    public string Provider { get; set; } = string.Empty;
+    public string ProviderSha256 { get; set; } = string.Empty;
+    public string WorkingDirectory { get; set; } = string.Empty;
+    public string LogDirectory { get; set; } = string.Empty;
+    public TimeSpan ListTimeout { get; set; }
+    public TimeSpan AggregateTimeout { get; set; }
+    public TimeSpan DiagnosticTimeout { get; set; }
+    public TimeSpan CleanupTimeout { get; set; }
+    public TimeSpan HeartbeatInterval { get; set; }
+}
+
+internal sealed class ControllerException : Exception
+{
+    public ControllerException(string message)
+        : base(message)
+    {
+    }
+
+    public ControllerException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/scripts/ci/windows-storage-job-runner/Program.cs
+++ b/scripts/ci/windows-storage-job-runner/Program.cs
@@ -416,7 +416,8 @@ internal static class Program
         TimeSpan heartbeatInterval,
         Action? afterAssignment,
         Action<SafeJobHandle>? afterResume,
-        bool forceAssignmentFailure = false)
+        bool forceAssignmentFailure = false,
+        Func<SafeJobHandle, SafeProcessHandle?, TimeSpan, Exception?>? cleanupFailureOverride = null)
     {
         executable = ResolveExecutable(executable);
         using var job = CreateKillOnCloseJob();
@@ -493,24 +494,35 @@ internal static class Program
         }
         catch (Exception exception) when (exception is not ControllerException)
         {
-            var cleanup = TryTerminateAndAwait(job, process, cleanupTimeout);
+            var cleanup = CleanupAfterFailure(
+                job,
+                process,
+                cleanupTimeout,
+                cleanupFailureOverride,
+                out var genericCleanupFailure);
             throw new ControllerException(
                 $"{exception.Message}; cleanup={(cleanup ? "ACTIVE_PROCESS_ZERO" : "incomplete")}; stdout={stdoutPath}; stderr={stderrPath}",
-                exception);
+                exception,
+                genericCleanupFailure);
         }
-        catch (ControllerException)
+        catch (ControllerException primary)
         {
             if (!processAssignedToJob)
             {
                 throw;
             }
 
-            var cleanupSucceeded = TryTerminateAndAwait(job, process, cleanupTimeout);
+            var cleanupSucceeded = CleanupAfterFailure(
+                job,
+                process,
+                cleanupTimeout,
+                cleanupFailureOverride,
+                out var cleanupFailure);
             if (!cleanupSucceeded)
             {
-                throw PreservePrimaryCleanupFailure(
-                    new ControllerException(
-                        "job cleanup did not reach ACTIVE_PROCESS_ZERO after the primary controller failure"),
+                throw ControllerErrors.PreservePrimaryCleanupFailure(
+                    primary,
+                    cleanupFailure,
                     stdoutPath,
                     stderrPath);
             }
@@ -699,8 +711,10 @@ internal static class Program
     private static bool TryTerminateAndAwait(
         SafeJobHandle job,
         SafeProcessHandle? process,
-        TimeSpan cleanupTimeout)
+        TimeSpan cleanupTimeout,
+        out Exception? cleanupFailure)
     {
+        cleanupFailure = null;
         try
         {
             if (process is not null && !process.IsInvalid)
@@ -708,23 +722,36 @@ internal static class Program
                 _ = NativeMethods.TerminateJobObject(job, ControllerFailureExitCode);
             }
 
-            return WaitForActiveProcessZero(job, cleanupTimeout, out _);
+            if (WaitForActiveProcessZero(job, cleanupTimeout, out var activeProcessIds))
+            {
+                return true;
+            }
+
+            cleanupFailure = new ControllerException(
+                $"cleanup timed out with {activeProcessIds.Length} active process IDs: {string.Join(',', activeProcessIds)}");
+            return false;
         }
-        catch
+        catch (Exception exception)
         {
+            cleanupFailure = exception;
             return false;
         }
     }
 
-    internal static ControllerException PreservePrimaryCleanupFailure(
-        ControllerException primary,
-        string stdoutPath,
-        string stderrPath)
+    private static bool CleanupAfterFailure(
+        SafeJobHandle job,
+        SafeProcessHandle? process,
+        TimeSpan cleanupTimeout,
+        Func<SafeJobHandle, SafeProcessHandle?, TimeSpan, Exception?>? cleanupFailureOverride,
+        out Exception? cleanupFailure)
     {
-        return new ControllerException(
-            $"primary cause preserved: {primary.Message}; separate cleanup failure: "
-            + $"cleanup did not reach ACTIVE_PROCESS_ZERO; stdout={stdoutPath}; stderr={stderrPath}",
-            primary);
+        if (cleanupFailureOverride is not null)
+        {
+            cleanupFailure = cleanupFailureOverride(job, process, cleanupTimeout);
+            return cleanupFailure is null;
+        }
+
+        return TryTerminateAndAwait(job, process, cleanupTimeout, out cleanupFailure);
     }
 
     private static bool TerminateUnassignedProcessAndAwait(
@@ -771,24 +798,7 @@ internal static class Program
 
     private static uint[] GetJobProcessIds(SafeJobHandle job)
     {
-        return JobProcessList.ReadIds(job, QueryJobProcessIdsNative);
-    }
-
-    private static bool QueryJobProcessIdsNative(
-        SafeJobHandle job,
-        IntPtr information,
-        uint length,
-        out uint returnLength,
-        out int win32Error)
-    {
-        var succeeded = NativeMethods.QueryInformationJobObject(
-            job,
-            NativeMethods.JobObjectBasicProcessIdList,
-            information,
-            length,
-            out returnLength);
-        win32Error = Marshal.GetLastWin32Error();
-        return succeeded;
+        return JobProcessList.ReadIds(job, NativeMethods.QueryJobProcessIdsNative);
     }
 
     internal static IReadOnlyList<string> ParseTestListForSelfTest(IEnumerable<string> lines) =>
@@ -806,12 +816,6 @@ internal static class Program
         QueryJobProcessList query) =>
         JobProcessList.ReadIds(job, query);
 
-    internal static bool TryTerminateAndAwaitForSelfTest(
-        SafeJobHandle job,
-        SafeProcessHandle? process,
-        TimeSpan cleanupTimeout) =>
-        TryTerminateAndAwait(job, process, cleanupTimeout);
-
     internal static JobRunResult RunCommandForSelfTest(
         string workingDirectory,
         IReadOnlyList<string> command,
@@ -822,7 +826,8 @@ internal static class Program
         TimeSpan heartbeatInterval,
         Action? afterAssignment,
         Action<SafeJobHandle>? afterResume,
-        bool forceAssignmentFailure = false)
+        bool forceAssignmentFailure = false,
+        Func<SafeJobHandle, SafeProcessHandle?, TimeSpan, Exception?>? cleanupFailureOverride = null)
     {
         var stdoutHandle = OpenInheritableWriteFile(stdoutPath);
         var stderrHandle = OpenInheritableWriteFile(stderrPath);
@@ -841,7 +846,8 @@ internal static class Program
                 heartbeatInterval,
                 afterAssignment,
                 afterResume,
-                forceAssignmentFailure);
+                forceAssignmentFailure,
+                cleanupFailureOverride);
         }
         finally
         {

--- a/scripts/ci/windows-storage-job-runner/Program.cs
+++ b/scripts/ci/windows-storage-job-runner/Program.cs
@@ -208,9 +208,16 @@ internal static class Program
 
     private static void ValidateCommonOptions(CertificationOptions options)
     {
-        if (!File.Exists(options.TestExecutable))
+        var testExecutable = Path.GetFullPath(options.TestExecutable);
+        if (!string.Equals(testExecutable, options.TestExecutable, StringComparison.OrdinalIgnoreCase))
         {
-            throw new ControllerException($"the libtest executable is not a file: {options.TestExecutable}");
+            throw new ControllerException(
+                $"the libtest executable is not canonical: expected {testExecutable}, got {options.TestExecutable}");
+        }
+
+        if (!File.Exists(testExecutable))
+        {
+            throw new ControllerException($"the libtest executable is not a file: {testExecutable}");
         }
 
         if (!Directory.Exists(options.WorkingDirectory))
@@ -255,6 +262,84 @@ internal static class Program
         return builder.ToString();
     }
 
+    internal static string ResolveExecutableForSelfTest(string executable) => ResolveExecutable(executable);
+
+    private static string ResolveExecutable(string executable)
+    {
+        if (string.IsNullOrWhiteSpace(executable))
+        {
+            throw new ControllerException("the executable path is empty");
+        }
+
+        if (Path.IsPathRooted(executable))
+        {
+            var canonical = Path.GetFullPath(executable);
+            if (!string.Equals(canonical, executable, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new ControllerException(
+                    $"executable path is not canonical: expected {canonical}, got {executable}");
+            }
+
+            if (!File.Exists(canonical))
+            {
+                throw new ControllerException($"canonical executable is not a file: {canonical}");
+            }
+
+            return canonical;
+        }
+
+        const int maxSearchLength = 32768;
+        var requiredLength = NativeMethods.SearchPathW(
+            IntPtr.Zero,
+            executable,
+            IntPtr.Zero,
+            0,
+            IntPtr.Zero,
+            IntPtr.Zero);
+        if (requiredLength == 0)
+        {
+            throw new ControllerException(
+                $"could not resolve executable {executable}: Win32 error {Marshal.GetLastWin32Error()}");
+        }
+
+        var bufferLength = requiredLength + 1;
+        if (bufferLength > maxSearchLength)
+        {
+            throw new ControllerException($"resolved executable path is too long: {requiredLength}");
+        }
+
+        var buffer = Marshal.AllocHGlobal((int)bufferLength * sizeof(char));
+        try
+        {
+            var returnedLength = NativeMethods.SearchPathW(
+                IntPtr.Zero,
+                executable,
+                IntPtr.Zero,
+                bufferLength,
+                buffer,
+                IntPtr.Zero);
+            if (returnedLength == 0 || returnedLength >= bufferLength)
+            {
+                throw new ControllerException(
+                    $"searching for executable {executable} failed: Win32 error {Marshal.GetLastWin32Error()}");
+            }
+
+            var searched = Marshal.PtrToStringUni(buffer, (int)returnedLength)
+                ?? throw new ControllerException($"SearchPathW returned an invalid executable path for {executable}");
+            var canonical = Path.GetFullPath(searched);
+            if (!string.Equals(canonical, searched, StringComparison.OrdinalIgnoreCase) || !File.Exists(canonical))
+            {
+                throw new ControllerException($"SearchPathW did not return an existing canonical executable: {searched}");
+            }
+
+            return canonical;
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(buffer);
+        }
+    }
+
     private static JobRunResult RunJobProcess(
         string executable,
         IReadOnlyList<string> arguments,
@@ -286,7 +371,8 @@ internal static class Program
                 cleanupTimeout,
                 heartbeatInterval,
                 afterAssignment: null,
-                afterResume: null);
+                afterResume: null,
+                forceAssignmentFailure: false);
         }
         finally
         {
@@ -328,8 +414,10 @@ internal static class Program
         TimeSpan cleanupTimeout,
         TimeSpan heartbeatInterval,
         Action? afterAssignment,
-        Action<SafeJobHandle>? afterResume)
+        Action<SafeJobHandle>? afterResume,
+        bool forceAssignmentFailure = false)
     {
+        executable = ResolveExecutable(executable);
         using var job = CreateKillOnCloseJob();
         SafeProcessHandle? process = null;
         SafeWindowsHandle? thread = null;
@@ -365,13 +453,16 @@ internal static class Program
             process = new SafeProcessHandle(rawProcessInformation.Process, ownsHandle: true);
             thread = new SafeWindowsHandle(rawProcessInformation.Thread, ownsHandle: true);
             var processId = rawProcessInformation.ProcessId;
-            if (!NativeMethods.AssignProcessToJobObject(job, process))
+            var assignmentSucceeded = !forceAssignmentFailure && NativeMethods.AssignProcessToJobObject(job, process);
+            if (!assignmentSucceeded)
             {
-                var assignmentError = Marshal.GetLastWin32Error();
+                var assignmentFailure = forceAssignmentFailure
+                    ? "forced-self-test"
+                    : $"Win32 error {Marshal.GetLastWin32Error()}";
                 var directCleanup = TerminateUnassignedProcessAndAwait(process, cleanupTimeout);
                 directProcessCleanupComplete = directCleanup;
                 throw new ControllerException(
-                    $"AssignProcessToJobObject failed for process {processId}: Win32 error {assignmentError}; "
+                    $"AssignProcessToJobObject failed for process {processId}: {assignmentFailure}; "
                     + $"cleanup={(directCleanup ? "PROCESS_EXITED" : "INCOMPLETE")}; "
                     + $"stdout={stdoutPath}; stderr={stderrPath}");
             }
@@ -587,9 +678,9 @@ internal static class Program
     {
         try
         {
-            if (process is not null && !process.IsInvalid && !NativeMethods.TerminateJobObject(job, ControllerFailureExitCode))
+            if (process is not null && !process.IsInvalid)
             {
-                return false;
+                _ = NativeMethods.TerminateJobObject(job, ControllerFailureExitCode);
             }
 
             return WaitForActiveProcessZero(job, cleanupTimeout, out _);
@@ -667,80 +758,72 @@ internal static class Program
     private static uint[] GetJobProcessIds(SafeJobHandle job)
     {
         const int errorMoreData = 234;
-        if (NativeMethods.QueryInformationJobObject(
-                job,
-                NativeMethods.JobObjectBasicProcessIdList,
-                IntPtr.Zero,
-                0,
-                out _))
-        {
-            return [];
-        }
+        const int headerLength = 2 * sizeof(int);
+        const int maximumAttempts = 8;
+        var bufferLength = (uint)headerLength;
 
-        var error = Marshal.GetLastWin32Error();
-        if (error != errorMoreData)
+        for (var attempt = 0; attempt < maximumAttempts; attempt++)
         {
-            throw new ControllerException($"QueryInformationJobObject failed: Win32 error {error}");
-        }
-
-        var probe = Marshal.AllocHGlobal(2 * sizeof(int));
-        try
-        {
-            if (!NativeMethods.QueryInformationJobObject(
-                    job,
-                    NativeMethods.JobObjectBasicProcessIdList,
-                    probe,
-                    (uint)(2 * sizeof(int)),
-                    out _))
+            if (bufferLength < headerLength || bufferLength > int.MaxValue)
             {
-                throw new ControllerException(
-                    $"querying assigned job processes failed: Win32 error {Marshal.GetLastWin32Error()}");
+                throw new ControllerException("the Job Object process ID list length is invalid");
             }
 
-            var processIdCapacity = Marshal.ReadInt32(probe, sizeof(int));
-            if (processIdCapacity <= 0)
-            {
-                return [];
-            }
-
-            var bufferSize = 2 * sizeof(int) + processIdCapacity * IntPtr.Size;
-            var buffer = Marshal.AllocHGlobal(bufferSize);
+            var buffer = Marshal.AllocHGlobal((int)bufferLength);
             try
             {
-                if (!NativeMethods.QueryInformationJobObject(
+                if (NativeMethods.QueryInformationJobObject(
                         job,
                         NativeMethods.JobObjectBasicProcessIdList,
                         buffer,
-                        (uint)bufferSize,
-                        out _))
+                        bufferLength,
+                        out var returnLength))
+                {
+                    if (returnLength < headerLength)
+                    {
+                        throw new ControllerException("the Job Object process ID list return length is too short");
+                    }
+
+                    var assignedProcesses = Marshal.ReadInt32(buffer, 0);
+                    var processIdCount = Marshal.ReadInt32(buffer, sizeof(int));
+                    JobProcessList.ValidateCounts(assignedProcesses, processIdCount);
+                    var expectedLength = (long)headerLength + processIdCount * IntPtr.Size;
+                    if (returnLength < expectedLength)
+                    {
+                        throw new ControllerException(
+                            $"Job Object process ID list was truncated: return {returnLength}, expected {expectedLength}");
+                    }
+
+                    var processIds = new uint[processIdCount];
+                    for (var index = 0; index < processIdCount; index++)
+                    {
+                        processIds[index] = (uint)Marshal.ReadIntPtr(buffer, headerLength + index * IntPtr.Size);
+                    }
+
+                    return processIds;
+                }
+
+                var error = Marshal.GetLastWin32Error();
+                if (error != errorMoreData)
+                {
+                    throw new ControllerException($"QueryInformationJobObject failed: Win32 error {error}");
+                }
+
+                if (returnLength < headerLength || returnLength > int.MaxValue)
                 {
                     throw new ControllerException(
-                        $"querying active job process IDs failed: Win32 error {Marshal.GetLastWin32Error()}");
+                        $"Job Object process ID list requires an invalid length: {returnLength}");
                 }
 
-                var count = Marshal.ReadInt32(buffer, sizeof(int));
-                if (count < 0 || count > processIdCapacity)
-                {
-                    throw new ControllerException("the Job Object returned an invalid process ID count");
-                }
-
-                var processIds = new uint[count];
-                for (var index = 0; index < count; index++)
-                {
-                    processIds[index] = (uint)Marshal.ReadIntPtr(buffer, 2 * sizeof(int) + index * IntPtr.Size);
-                }
-
-                return processIds;
+                bufferLength = returnLength;
             }
             finally
             {
                 Marshal.FreeHGlobal(buffer);
             }
         }
-        finally
-        {
-            Marshal.FreeHGlobal(probe);
-        }
+
+        throw new ControllerException("the Job Object process ID list did not stabilize");
     }
 
     internal static IReadOnlyList<string> ParseTestListForSelfTest(IEnumerable<string> lines) =>
@@ -762,7 +845,8 @@ internal static class Program
         TimeSpan cleanupTimeout,
         TimeSpan heartbeatInterval,
         Action? afterAssignment,
-        Action<SafeJobHandle>? afterResume)
+        Action<SafeJobHandle>? afterResume,
+        bool forceAssignmentFailure = false)
     {
         var stdoutHandle = OpenInheritableWriteFile(stdoutPath);
         var stderrHandle = OpenInheritableWriteFile(stderrPath);
@@ -780,7 +864,8 @@ internal static class Program
                 cleanupTimeout,
                 heartbeatInterval,
                 afterAssignment,
-                afterResume);
+                afterResume,
+                forceAssignmentFailure);
         }
         finally
         {

--- a/scripts/ci/windows-storage-job-runner/SelfTest.cs
+++ b/scripts/ci/windows-storage-job-runner/SelfTest.cs
@@ -571,7 +571,7 @@ internal sealed class SelfTest
             Marshal.WriteInt32(buffer, 0, 1);
             Marshal.WriteInt32(buffer, sizeof(int), 1);
             Marshal.WriteIntPtr(buffer, 8, new IntPtr(0x123));
-            returnLength = 24;
+            returnLength = 16;
             win32Error = 0;
             finalIds = [0x123];
             return true;

--- a/scripts/ci/windows-storage-job-runner/SelfTest.cs
+++ b/scripts/ci/windows-storage-job-runner/SelfTest.cs
@@ -21,6 +21,9 @@ internal sealed class SelfTest
         try
         {
             StartupInfoLayout();
+            JobProcessIdListLayout();
+            BoundedProcessIdListQueries();
+            PrimaryCleanupFailurePreservation();
             ExecutableResolution(root);
             AssignmentBeforeExecution(root);
             ThreeGenerationDescendantTermination(root);
@@ -405,6 +408,132 @@ internal sealed class SelfTest
         }
 
         Console.WriteLine("[selftest] STARTUPINFOW x64 layout matched the official size and critical offsets");
+    }
+
+    private static void JobProcessIdListLayout()
+    {
+        if (!Environment.Is64BitProcess)
+        {
+            throw new ControllerException("the x64 Job Object process ID list layout requires a 64-bit process");
+        }
+
+#pragma warning disable CA1421
+        var actualSize = Marshal.SizeOf<NativeMethods.BasicProcessIdList>();
+        var assignedOffset = (int)Marshal.OffsetOf<NativeMethods.BasicProcessIdList>(
+            nameof(NativeMethods.BasicProcessIdList.NumberOfAssignedProcesses));
+        var listedOffset = (int)Marshal.OffsetOf<NativeMethods.BasicProcessIdList>(
+            nameof(NativeMethods.BasicProcessIdList.NumberOfProcessIdsInList));
+        var processIdListOffset = (int)Marshal.OffsetOf<NativeMethods.BasicProcessIdList>(
+            nameof(NativeMethods.BasicProcessIdList.ProcessIdList));
+#pragma warning restore CA1421
+
+        if (actualSize != JobProcessList.MinimumStructureLength ||
+            assignedOffset != 0 ||
+            listedOffset != sizeof(int) ||
+            processIdListOffset != JobProcessList.ProcessIdListOffset ||
+            IntPtr.Size != 8)
+        {
+            throw new ControllerException(
+                $"x64 Job Object process ID list layout changed: size={actualSize}, assigned={assignedOffset}, "
+                + $"listed={listedOffset}, list={processIdListOffset}, pointer={IntPtr.Size}");
+        }
+
+        Console.WriteLine("[selftest] x64 Job Object process ID list layout matched DWORD/header/padding ABI");
+    }
+
+    private static void BoundedProcessIdListQueries()
+    {
+        using var job = new SafeJobHandle();
+        var observedCapacities = new List<uint>();
+        var firstQuery = true;
+        uint[]? grownIds = null;
+
+        bool GrowQuery(SafeJobHandle queriedJob, IntPtr buffer, uint capacity, out uint returnLength, out int win32Error)
+        {
+            observedCapacities.Add(capacity);
+            if (firstQuery)
+            {
+                firstQuery = false;
+                Marshal.WriteInt32(buffer, 0, 3);
+                Marshal.WriteInt32(buffer, sizeof(int), 3);
+                returnLength = 0;
+                win32Error = 234;
+                return false;
+            }
+
+            Marshal.WriteInt32(buffer, 0, 3);
+            Marshal.WriteInt32(buffer, sizeof(int), 3);
+            Marshal.WriteIntPtr(buffer, JobProcessList.ProcessIdListOffset, new IntPtr(0x111));
+            Marshal.WriteIntPtr(buffer, JobProcessList.ProcessIdListOffset + IntPtr.Size, new IntPtr(0x222));
+            Marshal.WriteIntPtr(buffer, JobProcessList.ProcessIdListOffset + 2 * IntPtr.Size, new IntPtr(0x333));
+            returnLength = (uint)(JobProcessList.ProcessIdListOffset + 3 * IntPtr.Size);
+            win32Error = 0;
+            grownIds = [0x111, 0x222, 0x333];
+            return true;
+        }
+
+        var grown = Program.ReadJobProcessIdsForSelfTest(job, GrowQuery);
+        if (grownIds is null || !grown.SequenceEqual(grownIds) ||
+            observedCapacities is not [JobProcessList.MinimumStructureLength, 48])
+        {
+            throw new ControllerException(
+                $"bounded Job Object process ID growth failed: ids={string.Join(',', grown)}, capacities={string.Join(',', observedCapacities)}");
+        }
+
+        uint[]? rejectedIds = null;
+        bool MisleadingSuccess(SafeJobHandle queriedJob, IntPtr buffer, uint capacity, out uint returnLength, out int win32Error)
+        {
+            observedCapacities.Add(capacity);
+            Marshal.WriteInt32(buffer, 0, 3);
+            Marshal.WriteInt32(buffer, sizeof(int), 3);
+            returnLength = sizeof(int);
+            win32Error = 0;
+            return true;
+        }
+
+        try
+        {
+            rejectedIds = Program.ReadJobProcessIdsForSelfTest(job, MisleadingSuccess);
+        }
+        catch (ControllerException)
+        {
+        }
+
+        if (rejectedIds is not null)
+        {
+            throw new ControllerException("the insufficient return-length falsifier parsed unverified IDs");
+        }
+
+        Console.WriteLine("[selftest] x64 Job Object PID list grew monotonically and rejected misleading lengths");
+    }
+
+    private static void PrimaryCleanupFailurePreservation()
+    {
+        const string stdoutPath = "primary://stdout";
+        const string stderrPath = "primary://stderr";
+        using var failedCleanupJob = new SafeJobHandle();
+        var cleanupSucceeded = Program.TryTerminateAndAwaitForSelfTest(
+            failedCleanupJob,
+            null,
+            TimeSpan.FromMilliseconds(100));
+        if (cleanupSucceeded)
+        {
+            throw new ControllerException("the cleanup-failure falsifier did not exercise failed cleanup");
+        }
+
+        var primary = new ControllerException("primary enumeration sentinel");
+        var preserved = Program.PreservePrimaryCleanupFailure(primary, stdoutPath, stderrPath);
+        if (!ReferenceEquals(preserved.InnerException, primary) ||
+            !preserved.Message.Contains("primary cause preserved: primary enumeration sentinel", StringComparison.Ordinal) ||
+            !preserved.Message.Contains("separate cleanup failure", StringComparison.Ordinal) ||
+            !preserved.Message.Contains("ACTIVE_PROCESS_ZERO", StringComparison.Ordinal) ||
+            !preserved.Message.Contains(stdoutPath, StringComparison.Ordinal) ||
+            !preserved.Message.Contains(stderrPath, StringComparison.Ordinal))
+        {
+            throw new ControllerException("primary cleanup failure reporting lost the original cause or cleanup context");
+        }
+
+        Console.WriteLine("[selftest] primary enumeration errors retained cleanup failure as separate context");
     }
 
     private static void OutputTailCancellationAndFinalDrain(string root)

--- a/scripts/ci/windows-storage-job-runner/SelfTest.cs
+++ b/scripts/ci/windows-storage-job-runner/SelfTest.cs
@@ -23,7 +23,8 @@ internal sealed class SelfTest
             StartupInfoLayout();
             JobProcessIdListLayout();
             BoundedProcessIdListQueries();
-            PrimaryCleanupFailurePreservation();
+            PartialEnumerationNeverSatisfiesZero();
+            PrimaryCleanupFailurePreservation(root);
             ExecutableResolution(root);
             AssignmentBeforeExecution(root);
             ThreeGenerationDescendantTermination(root);
@@ -412,6 +413,8 @@ internal sealed class SelfTest
 
     private static void JobProcessIdListLayout()
     {
+        const int expectedSize = 16;
+        const int expectedProcessIdListOffset = 8;
         if (!Environment.Is64BitProcess)
         {
             throw new ControllerException("the x64 Job Object process ID list layout requires a 64-bit process");
@@ -427,14 +430,15 @@ internal sealed class SelfTest
             nameof(NativeMethods.BasicProcessIdList.ProcessIdList));
 #pragma warning restore CA1421
 
-        if (actualSize != JobProcessList.MinimumStructureLength ||
+        if (actualSize != expectedSize ||
             assignedOffset != 0 ||
             listedOffset != sizeof(int) ||
-            processIdListOffset != JobProcessList.ProcessIdListOffset ||
+            processIdListOffset != expectedProcessIdListOffset ||
             IntPtr.Size != 8)
         {
             throw new ControllerException(
-                $"x64 Job Object process ID list layout changed: size={actualSize}, assigned={assignedOffset}, "
+                $"x64 Job Object process ID list layout changed: expected size={expectedSize}, list={expectedProcessIdListOffset}; "
+                + $"actual size={actualSize}, assigned={assignedOffset}, "
                 + $"listed={listedOffset}, list={processIdListOffset}, pointer={IntPtr.Size}");
         }
 
@@ -445,36 +449,48 @@ internal sealed class SelfTest
     {
         using var job = new SafeJobHandle();
         var observedCapacities = new List<uint>();
-        var firstQuery = true;
+        var callIndex = 0;
         uint[]? grownIds = null;
 
         bool GrowQuery(SafeJobHandle queriedJob, IntPtr buffer, uint capacity, out uint returnLength, out int win32Error)
         {
             observedCapacities.Add(capacity);
-            if (firstQuery)
+            if (callIndex == 0)
             {
-                firstQuery = false;
                 Marshal.WriteInt32(buffer, 0, 3);
                 Marshal.WriteInt32(buffer, sizeof(int), 3);
                 returnLength = 0;
                 win32Error = 234;
+                ++callIndex;
                 return false;
             }
 
-            Marshal.WriteInt32(buffer, 0, 3);
-            Marshal.WriteInt32(buffer, sizeof(int), 3);
-            Marshal.WriteIntPtr(buffer, JobProcessList.ProcessIdListOffset, new IntPtr(0x111));
-            Marshal.WriteIntPtr(buffer, JobProcessList.ProcessIdListOffset + IntPtr.Size, new IntPtr(0x222));
-            Marshal.WriteIntPtr(buffer, JobProcessList.ProcessIdListOffset + 2 * IntPtr.Size, new IntPtr(0x333));
-            returnLength = (uint)(JobProcessList.ProcessIdListOffset + 3 * IntPtr.Size);
+            if (callIndex == 1)
+            {
+                Marshal.WriteInt32(buffer, 0, 4);
+                Marshal.WriteInt32(buffer, sizeof(int), 4);
+                returnLength = 8;
+                win32Error = 234;
+                ++callIndex;
+                return false;
+            }
+
+            Marshal.WriteInt32(buffer, 0, 4);
+            Marshal.WriteInt32(buffer, sizeof(int), 4);
+            Marshal.WriteIntPtr(buffer, 8, new IntPtr(0x111));
+            Marshal.WriteIntPtr(buffer, 8 + IntPtr.Size, new IntPtr(0x222));
+            Marshal.WriteIntPtr(buffer, 8 + 2 * IntPtr.Size, new IntPtr(0x333));
+            Marshal.WriteIntPtr(buffer, 8 + 3 * IntPtr.Size, new IntPtr(0x444));
+            returnLength = (uint)(8 + 4 * IntPtr.Size);
             win32Error = 0;
-            grownIds = [0x111, 0x222, 0x333];
+            grownIds = [0x111, 0x222, 0x333, 0x444];
+            ++callIndex;
             return true;
         }
 
         var grown = Program.ReadJobProcessIdsForSelfTest(job, GrowQuery);
         if (grownIds is null || !grown.SequenceEqual(grownIds) ||
-            observedCapacities is not [JobProcessList.MinimumStructureLength, 48])
+            observedCapacities is not [16, 32, 64])
         {
             throw new ControllerException(
                 $"bounded Job Object process ID growth failed: ids={string.Join(',', grown)}, capacities={string.Join(',', observedCapacities)}");
@@ -486,7 +502,7 @@ internal sealed class SelfTest
             observedCapacities.Add(capacity);
             Marshal.WriteInt32(buffer, 0, 3);
             Marshal.WriteInt32(buffer, sizeof(int), 3);
-            returnLength = sizeof(int);
+            returnLength = 4;
             win32Error = 0;
             return true;
         }
@@ -507,33 +523,95 @@ internal sealed class SelfTest
         Console.WriteLine("[selftest] x64 Job Object PID list grew monotonically and rejected misleading lengths");
     }
 
-    private static void PrimaryCleanupFailurePreservation()
+    private static void PartialEnumerationNeverSatisfiesZero()
     {
-        const string stdoutPath = "primary://stdout";
-        const string stderrPath = "primary://stderr";
-        using var failedCleanupJob = new SafeJobHandle();
-        var cleanupSucceeded = Program.TryTerminateAndAwaitForSelfTest(
-            failedCleanupJob,
-            null,
-            TimeSpan.FromMilliseconds(100));
-        if (cleanupSucceeded)
+        using var job = new SafeJobHandle();
+        var observedCapacities = new List<uint>();
+        var firstQuery = true;
+        uint[]? finalIds = null;
+
+        bool PartialQuery(SafeJobHandle queriedJob, IntPtr buffer, uint capacity, out uint returnLength, out int win32Error)
         {
-            throw new ControllerException("the cleanup-failure falsifier did not exercise failed cleanup");
+            observedCapacities.Add(capacity);
+            if (firstQuery)
+            {
+                firstQuery = false;
+                Marshal.WriteInt32(buffer, 0, 1);
+                Marshal.WriteInt32(buffer, sizeof(int), 0);
+                returnLength = 16;
+                win32Error = 0;
+                return true;
+            }
+
+            Marshal.WriteInt32(buffer, 0, 1);
+            Marshal.WriteInt32(buffer, sizeof(int), 1);
+            Marshal.WriteIntPtr(buffer, 8, new IntPtr(0x123));
+            returnLength = 24;
+            win32Error = 0;
+            finalIds = [0x123];
+            return true;
         }
 
+        var processIds = Program.ReadJobProcessIdsForSelfTest(job, PartialQuery);
+        if (finalIds is null || !processIds.SequenceEqual(finalIds) ||
+            processIds.Length == 0 ||
+            observedCapacities is not [16, 32])
+        {
+            throw new ControllerException(
+                $"partial enumeration retried incorrectly: ids={string.Join(',', processIds)}, capacities={string.Join(',', observedCapacities)}");
+        }
+
+        Console.WriteLine("[selftest] assigned=1/listed=0 was treated as truncation and retried without a false zero");
+    }
+
+    private static void PrimaryCleanupFailurePreservation(string root)
+    {
+        var stdoutPath = Path.Combine(root, "primary.stdout.log");
+        var stderrPath = Path.Combine(root, "primary.stderr.log");
+        var marker = Path.Combine(root, "real-catch.marker");
         var primary = new ControllerException("primary enumeration sentinel");
-        var preserved = Program.PreservePrimaryCleanupFailure(primary, stdoutPath, stderrPath);
-        if (!ReferenceEquals(preserved.InnerException, primary) ||
-            !preserved.Message.Contains("primary cause preserved: primary enumeration sentinel", StringComparison.Ordinal) ||
-            !preserved.Message.Contains("separate cleanup failure", StringComparison.Ordinal) ||
-            !preserved.Message.Contains("ACTIVE_PROCESS_ZERO", StringComparison.Ordinal) ||
-            !preserved.Message.Contains(stdoutPath, StringComparison.Ordinal) ||
-            !preserved.Message.Contains(stderrPath, StringComparison.Ordinal))
+        var cleanupFailure = new ControllerException("distinct cleanup sentinel");
+        ControllerException? reported = null;
+        try
         {
-            throw new ControllerException("primary cleanup failure reporting lost the original cause or cleanup context");
+            _ = Program.RunCommandForSelfTest(
+                root,
+                [RunnerExecutable, "marker-child", marker, "0"],
+                stdoutPath,
+                stderrPath,
+                TimeSpan.FromSeconds(15),
+                TimeSpan.FromSeconds(10),
+                TimeSpan.FromSeconds(1),
+                afterAssignment: null,
+                afterResume: _ => throw primary,
+                forceAssignmentFailure: false,
+                cleanupFailureOverride: (_, _, _) => cleanupFailure);
+        }
+        catch (ControllerException exception)
+        {
+            reported = exception;
         }
 
-        Console.WriteLine("[selftest] primary enumeration errors retained cleanup failure as separate context");
+        if (reported is null ||
+            ReferenceEquals(reported, primary) ||
+            !ReferenceEquals(reported.InnerException, primary) ||
+            !ReferenceEquals(reported.CleanupFailure, cleanupFailure) ||
+            !reported.Message.Contains("primary cause preserved: primary enumeration sentinel", StringComparison.Ordinal) ||
+            !reported.Message.Contains("separate cleanup failure: distinct cleanup sentinel", StringComparison.Ordinal) ||
+            !reported.Message.Contains(stdoutPath, StringComparison.Ordinal) ||
+            !reported.Message.Contains(stderrPath, StringComparison.Ordinal))
+        {
+            throw new ControllerException(
+                $"real catch path lost primary or cleanup roles: inner={reported?.InnerException?.GetType().Name}, "
+                + $"cleanup={reported?.CleanupFailure?.Message}, message={reported?.Message}");
+        }
+
+        if (File.Exists(marker))
+        {
+            throw new ControllerException("the real catch-path child executed despite suspension and cleanup");
+        }
+
+        Console.WriteLine("[selftest] real catch path retained distinct primary and cleanup errors in correct roles");
     }
 
     private static void OutputTailCancellationAndFinalDrain(string root)

--- a/scripts/ci/windows-storage-job-runner/SelfTest.cs
+++ b/scripts/ci/windows-storage-job-runner/SelfTest.cs
@@ -18,6 +18,7 @@ internal sealed class SelfTest
     public static int Run()
     {
         var root = Directory.CreateTempSubdirectory("astrid-storage-job-selftest-").FullName;
+        var preserveEvidence = false;
         try
         {
             StartupInfoLayout();
@@ -25,6 +26,7 @@ internal sealed class SelfTest
             BoundedProcessIdListQueries();
             PartialEnumerationNeverSatisfiesZero();
             EmptyHeaderAndReturnLengthBoundaries();
+            OverlongSuccessfulReturnRejected();
             PrimaryCleanupFailurePreservation(root);
             ExecutableResolution(root);
             AssignmentBeforeExecution(root);
@@ -41,14 +43,22 @@ internal sealed class SelfTest
             Console.WriteLine("[selftest] all Windows storage job controls passed");
             return 0;
         }
+        catch
+        {
+            preserveEvidence = true;
+            throw;
+        }
         finally
         {
-            try
+            if (!preserveEvidence)
             {
-                Directory.Delete(root, recursive: true);
-            }
-            catch (IOException)
-            {
+                try
+                {
+                    Directory.Delete(root, recursive: true);
+                }
+                catch (IOException)
+                {
+                }
             }
         }
     }
@@ -291,63 +301,77 @@ internal sealed class SelfTest
 
     private static void ArgumentAndListSetParity(string root)
     {
-        var stub = Path.Combine(root, "libtest-parity.cmd");
-        File.WriteAllLines(
-            stub,
-            [
-                "@echo off",
-                "if /I \"%~1\" == \"--list\" (",
-                "  if /I \"%~2\" == \"--format=terse\" if \"%~3\" == \"storage_mount\" (",
-                "    echo alpha: test",
-                "    echo beta: test",
-                "    exit /b 0",
-                "  )",
-                "  exit /b 10",
-                ")",
-                "if \"%~1\" == \"storage_mount\" (",
-                "  if \"%~2\" == \"--\" if \"%~3\" == \"--nocapture\" if \"%~4\" == \"--test-threads=1\" (",
-                "    echo aggregate>> received.txt",
-                "    exit /b 0",
-                "  )",
-                "  exit /b 11",
-                ")",
-                "if \"%~1\" == \"alpha\" if \"%~2\" == \"--\" if \"%~3\" == \"--exact\" if \"%~4\" == \"--nocapture\" if \"%~5\" == \"--test-threads=1\" (",
-                "  echo alpha>> received.txt",
-                "  exit /b 0",
-                ")",
-                "if \"%~1\" == \"beta\" if \"%~2\" == \"--\" if \"%~3\" == \"--exact\" if \"%~4\" == \"--nocapture\" if \"%~5\" == \"--test-threads=1\" (",
-                "  echo beta>> received.txt",
-                "  exit /b 0",
-                ")",
-                "exit /b 12",
-            ]);
         var received = Path.Combine(root, "received.txt");
-        var listResult = RunCommand(root, ["cmd.exe", "/d", "/c", stub, .. ListArguments], 15);
-        AssertOutcome(listResult, JobOutcome.Succeeded);
+        var listResult = RunParityPhase(root, received, "--list", ListArguments);
         var names = Program.ParseTestListForSelfTest(File.ReadAllLines(listResult.StdoutPath));
         if (names is not ["alpha", "beta"] || File.Exists(received))
         {
-            throw new ControllerException("the list did not return the stable nonempty set without running tests");
+            throw DescribeParityFailure("--list", listResult, "the list did not return the stable nonempty set without running tests");
         }
 
-        var aggregate = RunCommand(root, ["cmd.exe", "/d", "/c", stub, .. AggregateArguments], 15);
-        AssertOutcome(aggregate, JobOutcome.Succeeded);
+        var aggregate = RunParityPhase(root, received, "aggregate", AggregateArguments);
         foreach (var name in names)
         {
-            var diagnostic = RunCommand(
-                root,
-                ["cmd.exe", "/d", "/c", stub, name, "--", "--exact", "--nocapture", "--test-threads=1"],
-                15);
-            AssertOutcome(diagnostic, JobOutcome.Succeeded);
+            RunParityPhase(root, received, $"diagnostic:{name}", [name, "--", "--exact", "--nocapture", "--test-threads=1"]);
         }
 
         var receivedSets = File.ReadAllLines(received);
         if (receivedSets is not ["aggregate", "alpha", "beta"])
         {
-            throw new ControllerException("canonical list, aggregate, and diagnostic argument sets diverged");
+            throw DescribeParityFailure("diagnostic", aggregate, $"canonical receipt diverged: {string.Join(", ", receivedSets)}");
         }
 
         Console.WriteLine("[selftest] list, aggregate, and exact diagnostic argument sets had the same test set");
+    }
+
+    private static JobRunResult RunParityPhase(
+        string root,
+        string receivedPath,
+        string phase,
+        IReadOnlyList<string> arguments)
+    {
+        var result = RunCommand(root, [RunnerExecutable, "parity-child", receivedPath, .. arguments], 15);
+        if (result.Outcome is not JobOutcome.Succeeded)
+        {
+            throw DescribeParityFailure(phase, result, $"expected child success, got {result.Outcome}");
+        }
+
+        if (!result.RootHandlesReleased)
+        {
+            throw DescribeParityFailure(phase, result, "root handles were not released");
+        }
+
+        return result;
+    }
+
+    private static ControllerException DescribeParityFailure(
+        string phase,
+        JobRunResult? result,
+        string reason)
+    {
+        if (result is null)
+        {
+            return new ControllerException($"parity phase {phase} failed before launch: {reason}");
+        }
+
+        var stdout = SafeEvidence(result.StdoutPath);
+        var stderr = SafeEvidence(result.StderrPath);
+        return new ControllerException(
+            $"parity phase {phase} failed: {reason}; child exit code={result.ExitCode}; "
+            + $"stdout path={result.StdoutPath}; stdout content=<<<{stdout}>>>; "
+            + $"stderr path={result.StderrPath}; stderr content=<<<{stderr}>>>");
+    }
+
+    private static string SafeEvidence(string path)
+    {
+        try
+        {
+            return File.ReadAllText(path);
+        }
+        catch (Exception exception)
+        {
+            return $"<unreadable: {exception.Message}>";
+        }
     }
 
     private static void ExecutableResolution(string root)
@@ -631,6 +655,37 @@ internal sealed class SelfTest
         }
 
         Console.WriteLine("[selftest] empty returned headers were valid and short/over-capacity returns were rejected");
+    }
+
+    private static void OverlongSuccessfulReturnRejected()
+    {
+        using var job = new SafeJobHandle();
+        uint[]? parsedIds = null;
+
+        bool OverlongSuccess(SafeJobHandle queriedJob, IntPtr buffer, uint capacity, out uint returnLength, out int win32Error)
+        {
+            Marshal.WriteInt32(buffer, 0, 1);
+            Marshal.WriteInt32(buffer, sizeof(int), 1);
+            Marshal.WriteIntPtr(buffer, 8, new IntPtr(0x123));
+            returnLength = 32;
+            win32Error = 0;
+            return true;
+        }
+
+        try
+        {
+            parsedIds = Program.ReadJobProcessIdsForSelfTest(job, OverlongSuccess);
+        }
+        catch (ControllerException)
+        {
+        }
+
+        if (parsedIds is not null)
+        {
+            throw new ControllerException("a successful nonempty overlong return was parsed");
+        }
+
+        Console.WriteLine("[selftest] successful nonempty list required exact count-derived return length");
     }
 
     private static void PrimaryCleanupFailurePreservation(string root)

--- a/scripts/ci/windows-storage-job-runner/SelfTest.cs
+++ b/scripts/ci/windows-storage-job-runner/SelfTest.cs
@@ -24,6 +24,7 @@ internal sealed class SelfTest
             JobProcessIdListLayout();
             BoundedProcessIdListQueries();
             PartialEnumerationNeverSatisfiesZero();
+            EmptyHeaderAndReturnLengthBoundaries();
             PrimaryCleanupFailurePreservation(root);
             ExecutableResolution(root);
             AssignmentBeforeExecution(root);
@@ -562,6 +563,74 @@ internal sealed class SelfTest
         }
 
         Console.WriteLine("[selftest] assigned=1/listed=0 was treated as truncation and retried without a false zero");
+    }
+
+    private static void EmptyHeaderAndReturnLengthBoundaries()
+    {
+        using var job = new SafeJobHandle();
+
+        bool EmptySuccess(SafeJobHandle queriedJob, IntPtr buffer, uint capacity, out uint returnLength, out int win32Error)
+        {
+            Marshal.WriteInt32(buffer, 0, 0);
+            Marshal.WriteInt32(buffer, sizeof(int), 0);
+            returnLength = 8;
+            win32Error = 0;
+            return true;
+        }
+
+        var empty = Program.ReadJobProcessIdsForSelfTest(job, EmptySuccess);
+        if (empty.Length != 0)
+        {
+            throw new ControllerException($"a complete empty header returned {empty.Length} IDs");
+        }
+
+        uint[]? shortIds = null;
+        bool ShortHeader(SafeJobHandle queriedJob, IntPtr buffer, uint capacity, out uint returnLength, out int win32Error)
+        {
+            Marshal.WriteInt32(buffer, 0, 0);
+            Marshal.WriteInt32(buffer, sizeof(int), 0);
+            returnLength = 7;
+            win32Error = 0;
+            return true;
+        }
+
+        try
+        {
+            shortIds = Program.ReadJobProcessIdsForSelfTest(job, ShortHeader);
+        }
+        catch (ControllerException)
+        {
+        }
+
+        if (shortIds is not null)
+        {
+            throw new ControllerException("a return shorter than the two-DWORD header was accepted");
+        }
+
+        uint[]? overCapacityIds = null;
+        bool OverCapacityHeader(SafeJobHandle queriedJob, IntPtr buffer, uint capacity, out uint returnLength, out int win32Error)
+        {
+            Marshal.WriteInt32(buffer, 0, 0);
+            Marshal.WriteInt32(buffer, sizeof(int), 0);
+            returnLength = capacity + 1;
+            win32Error = 0;
+            return true;
+        }
+
+        try
+        {
+            overCapacityIds = Program.ReadJobProcessIdsForSelfTest(job, OverCapacityHeader);
+        }
+        catch (ControllerException)
+        {
+        }
+
+        if (overCapacityIds is not null)
+        {
+            throw new ControllerException("a return length greater than buffer capacity was accepted");
+        }
+
+        Console.WriteLine("[selftest] empty returned headers were valid and short/over-capacity returns were rejected");
     }
 
     private static void PrimaryCleanupFailurePreservation(string root)

--- a/scripts/ci/windows-storage-job-runner/SelfTest.cs
+++ b/scripts/ci/windows-storage-job-runner/SelfTest.cs
@@ -9,7 +9,7 @@ namespace Astrid.Ci.Windows;
 internal sealed class SelfTest
 {
     private static readonly string[] ListArguments = Program.BuildCanonicalListArgumentsForSelfTest();
-    private static readonly string[] AggregateArguments = ["storage_mount", "--", "--nocapture", "--test-threads=1"];
+    private static readonly string[] AggregateArguments = Program.BuildCanonicalAggregateArgumentsForSelfTest();
 
     private static string RunnerExecutable =>
         Program.ResolveExecutableForSelfTest(Environment.ProcessPath
@@ -309,19 +309,54 @@ internal sealed class SelfTest
             throw DescribeParityFailure("--list", listResult, "the list did not return the stable nonempty set without running tests");
         }
 
-        var aggregate = RunParityPhase(root, received, "aggregate", AggregateArguments);
-        foreach (var name in names)
+        var journal = Path.Combine(root, "libtest-execution_journal.log");
+        var aggregate = RunLibTestPhase(root, journal, "aggregate", AggregateArguments);
+        ValidateSerialExecution(journal, LibTestChild.TestNames);
+        var aggregateOutput = SafeEvidence(aggregate.StdoutPath);
+        if (!aggregateOutput.Contains("running storage_mount::", StringComparison.Ordinal))
         {
-            RunParityPhase(root, received, $"diagnostic:{name}", [name, "--", "--exact", "--nocapture", "--test-threads=1"]);
+            throw DescribeParityFailure("aggregate", aggregate, "nocapture execution output was missing");
         }
 
-        var receivedSets = File.ReadAllLines(received);
-        if (receivedSets is not ["aggregate", "alpha", "beta"])
+        var oldShape = RunLibTestChild(
+            root,
+            journal,
+            ["storage_mount", "--", "--nocapture", "--test-threads=1"]);
+        if (oldShape.Outcome is not JobOutcome.ChildFailed ||
+            !SafeEvidence(oldShape.StderrPath).Contains("cargo-style separator", StringComparison.Ordinal))
         {
-            throw DescribeParityFailure("diagnostic", aggregate, $"canonical receipt diverged: {string.Join(", ", receivedSets)}");
+            throw DescribeParityFailure("aggregate", oldShape, "the current cargo-style separator shape was not rejected");
         }
 
-        Console.WriteLine("[selftest] list, aggregate, and exact diagnostic argument sets had the same test set");
+        foreach (var testName in LibTestChild.TestNames)
+        {
+            var diagnostic = RunLibTestPhase(
+                root,
+                journal,
+                $"diagnostic:{testName}",
+                Program.BuildCanonicalDiagnosticArgumentsForSelfTest(testName));
+            var diagnosticOutput = SafeEvidence(diagnostic.StdoutPath);
+            if (!diagnosticOutput.Contains($"running {testName}", StringComparison.Ordinal))
+            {
+                throw DescribeParityFailure($"diagnostic:{testName}", diagnostic, "exact selection output was missing");
+            }
+        }
+
+        var overlapState = Path.Combine(root, "overlap-state");
+        Directory.CreateDirectory(overlapState);
+        var activePath = Path.Combine(overlapState, "libtest-child.active");
+        File.WriteAllText(activePath, "0;simulated-overlap");
+        var overlap = RunLibTestChild(
+            overlapState,
+            Path.Combine(overlapState, "journal.log"),
+            AggregateArguments);
+        if (overlap.Outcome is not JobOutcome.ChildFailed ||
+            !SafeEvidence(overlap.StderrPath).Contains("cache-invalidation tests overlap", StringComparison.Ordinal))
+        {
+            throw DescribeParityFailure("aggregate", overlap, "an overlapping cache-invalidation execution was not rejected");
+        }
+
+        Console.WriteLine("[selftest] list parity and semantic libtest execution selected exact serial test sets");
     }
 
     private static JobRunResult RunParityPhase(
@@ -371,6 +406,76 @@ internal sealed class SelfTest
         catch (Exception exception)
         {
             return $"<unreadable: {exception.Message}>";
+        }
+    }
+
+    private static JobRunResult RunLibTestPhase(
+        string root,
+        string journalPath,
+        string phase,
+        IReadOnlyList<string> arguments)
+    {
+        var result = RunLibTestChild(root, journalPath, arguments);
+        if (result.Outcome is not JobOutcome.Succeeded)
+        {
+            throw DescribeParityFailure(phase, result, $"expected semantic child success, got {result.Outcome}");
+        }
+
+        if (!result.RootHandlesReleased)
+        {
+            throw DescribeParityFailure(phase, result, "semantic child root handles were not released");
+        }
+
+        return result;
+    }
+
+    private static JobRunResult RunLibTestChild(
+        string root,
+        string journalPath,
+        IReadOnlyList<string> arguments)
+    {
+        return RunCommand(root, [RunnerExecutable, "libtest-child", journalPath, .. arguments], 15);
+    }
+
+    private static void ValidateSerialExecution(string journalPath, IReadOnlyList<string> expectedTestNames)
+    {
+        var active = new HashSet<string>(StringComparer.Ordinal);
+        var began = new List<string>();
+        foreach (var line in File.ReadAllLines(journalPath))
+        {
+            var fields = line.Split(';', 4);
+            if (fields.Length != 4)
+            {
+                throw new ControllerException($"invalid semantic libtest event: {line}");
+            }
+
+            var testName = fields[2];
+            if (fields[1] == "begin")
+            {
+                if (!active.Add(testName))
+                {
+                    throw new ControllerException($"overlapping cache-invalidation test execution: {testName}");
+                }
+
+                began.Add(testName);
+            }
+            else if (fields[1] == "end")
+            {
+                if (!active.Remove(testName))
+                {
+                    throw new ControllerException($"semantic libtest end event without begin: {testName}");
+                }
+            }
+            else
+            {
+                throw new ControllerException($"unknown semantic libtest event: {line}");
+            }
+        }
+
+        if (active.Count != 0 || !began.SequenceEqual(expectedTestNames))
+        {
+            throw new ControllerException(
+                $"semantic serial execution diverged: active={string.Join(',', active)}, began={string.Join(',', began)}");
         }
     }
 

--- a/scripts/ci/windows-storage-job-runner/SelfTest.cs
+++ b/scripts/ci/windows-storage-job-runner/SelfTest.cs
@@ -1,6 +1,8 @@
 using System.Diagnostics;
 using System.Security.Cryptography;
 using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
 
 namespace Astrid.Ci.Windows;
 
@@ -15,13 +17,16 @@ internal sealed class SelfTest
         try
         {
             StartupInfoLayout();
+            ExecutableResolution(root);
             AssignmentBeforeExecution(root);
-            DescendantTermination(root);
+            ThreeGenerationDescendantTermination(root);
             UnrelatedProcessSurvival(root);
             OutputAndExitCodePreservation(root);
+            ForcedAssignmentFailure(root);
             BoundedTimeoutAndCleanup(root);
             FreshJobIsolation(root);
             ArgumentAndListSetParity(root);
+            OutputTailCancellationAndFinalDrain(root);
             ProviderSubstitutionRejection(root);
             Console.WriteLine("[selftest] all Windows storage job controls passed");
             return 0;
@@ -62,28 +67,36 @@ internal sealed class SelfTest
         Console.WriteLine("[selftest] assignment occurred before child execution");
     }
 
-    private static void DescendantTermination(string root)
+    private static void ThreeGenerationDescendantTermination(string root)
     {
+        uint[] observedProcessIds = [];
         var result = RunCommand(
             root,
-            ["cmd.exe", "/d", "/c", "ping.exe -n 30 127.0.0.1 > NUL"],
+            ["cmd.exe", "/d", "/c", "cmd.exe /d /c ping.exe -n 30 127.0.0.1 > NUL"],
             1,
             afterResume: job =>
             {
-                Thread.Sleep(500);
-                if (Program.GetJobProcessIdsForSelfTest(job).Length < 2)
+                Thread.Sleep(750);
+                observedProcessIds = Program.GetJobProcessIdsForSelfTest(job);
+                if (observedProcessIds.Distinct().Count() < 3)
                 {
-                    throw new ControllerException("the descendant control did not observe two active processes");
+                    throw new ControllerException(
+                        $"the descendant control observed only {observedProcessIds.Length} live processes");
                 }
             });
         AssertOutcome(result, JobOutcome.TimedOut);
         AssertCleanup(result);
+        if (!observedProcessIds.Contains((uint)result.ProcessId))
+        {
+            throw new ControllerException("the descendant control did not contain the assigned root process");
+        }
+
         if (result.OriginalCause.Length == 0)
         {
             throw new ControllerException("the descendant termination test did not record its original timeout cause");
         }
 
-        Console.WriteLine("[selftest] job termination killed the child tree and observed ACTIVE_PROCESS_ZERO");
+        Console.WriteLine("[selftest] teardown killed three generations and observed ACTIVE_PROCESS_ZERO");
     }
 
     private static void UnrelatedProcessSurvival(string root)
@@ -139,6 +152,56 @@ internal sealed class SelfTest
         }
 
         Console.WriteLine("[selftest] durable stdout/stderr and injected exit code 7 were preserved");
+    }
+
+    private static void ForcedAssignmentFailure(string root)
+    {
+        var marker = Path.Combine(root, "forced-assignment.marker");
+        var stopwatch = Stopwatch.StartNew();
+        ControllerException? failure = null;
+        try
+        {
+            _ = Program.RunCommandForSelfTest(
+                root,
+                ["cmd.exe", "/d", "/c", $"echo ready> \"{marker}\""],
+                Path.Combine(root, $"{Guid.NewGuid():N}.stdout.log"),
+                Path.Combine(root, $"{Guid.NewGuid():N}.stderr.log"),
+                TimeSpan.FromSeconds(15),
+                TimeSpan.FromSeconds(10),
+                TimeSpan.FromSeconds(1),
+                afterAssignment: null,
+                afterResume: null,
+                forceAssignmentFailure: true);
+        }
+        catch (ControllerException exception)
+        {
+            failure = exception;
+        }
+
+        stopwatch.Stop();
+        if (failure is null)
+        {
+            throw new ControllerException("the forced assignment failure was accepted");
+        }
+
+        if (!failure.Message.Contains("AssignProcessToJobObject failed", StringComparison.Ordinal) ||
+            !failure.Message.Contains("forced-self-test", StringComparison.Ordinal) ||
+            !failure.Message.Contains("cleanup=PROCESS_EXITED", StringComparison.Ordinal))
+        {
+            throw new ControllerException($"forced assignment cleanup evidence was incomplete: {failure.Message}");
+        }
+
+        if (File.Exists(marker))
+        {
+            throw new ControllerException("the forced-assignment child executed before direct termination");
+        }
+
+        if (stopwatch.Elapsed > TimeSpan.FromSeconds(12))
+        {
+            throw new ControllerException($"forced assignment cleanup was unbounded: {stopwatch.Elapsed}");
+        }
+
+        Console.WriteLine("[selftest] forced assignment failure directly terminated the suspended root");
     }
 
     private static void BoundedTimeoutAndCleanup(string root)
@@ -231,6 +294,26 @@ internal sealed class SelfTest
         Console.WriteLine("[selftest] list, aggregate, and exact diagnostic argument sets had the same test set");
     }
 
+    private static void ExecutableResolution(string root)
+    {
+        var cmd = Program.ResolveExecutableForSelfTest("cmd.exe");
+        var canonicalCmd = Path.GetFullPath(cmd);
+        if (!Path.IsPathRooted(cmd) ||
+            !string.Equals(cmd, canonicalCmd, StringComparison.OrdinalIgnoreCase) ||
+            !File.Exists(cmd) ||
+            !string.Equals(Path.GetFileName(cmd), "cmd.exe", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ControllerException($"cmd.exe did not resolve to an existing canonical executable: {cmd}");
+        }
+
+        AssertControllerFailure(() => Program.ResolveExecutableForSelfTest(Path.Combine(root, "missing.exe")));
+        var tool = Path.Combine(root, "tool.cmd");
+        File.WriteAllText(tool, "@echo off\r\n");
+        var nonCanonical = Path.Combine(root, "subdir", "..", "tool.cmd");
+        AssertControllerFailure(() => Program.ResolveExecutableForSelfTest(nonCanonical));
+        Console.WriteLine($"[selftest] executable resolution accepted {cmd} and rejected missing/noncanonical paths");
+    }
+
     private static void StartupInfoLayout()
     {
         const int expectedSize = 104;
@@ -271,6 +354,68 @@ internal sealed class SelfTest
         }
 
         Console.WriteLine("[selftest] STARTUPINFOW x64 layout matched the official size and critical offsets");
+    }
+
+    private static void OutputTailCancellationAndFinalDrain(string root)
+    {
+        OutputTailCancellationAndFinalDrainAsync(root).GetAwaiter().GetResult();
+    }
+
+    private static async Task OutputTailCancellationAndFinalDrainAsync(string root)
+    {
+        var path = Path.Combine(root, "tail-drain.log");
+        File.WriteAllBytes(path, []);
+        using var cancellation = new CancellationTokenSource();
+        var bytes = new StrongBox<long>();
+        using var captured = new StringWriter();
+        var tail = OutputTail.TailOutput(path, captured, bytes, cancellation.Token);
+        var stopwatch = Stopwatch.StartNew();
+
+        using (var stream = new FileStream(path, FileMode.Append, FileAccess.Write, FileShare.ReadWrite))
+        {
+            await WriteTailProbeAsync(stream, "before-cancel\n");
+            var deadline = DateTime.UtcNow.AddSeconds(2);
+            while (Interlocked.Read(ref bytes.Value) == 0 && DateTime.UtcNow < deadline)
+            {
+                await Task.Delay(20);
+            }
+
+            if (Interlocked.Read(ref bytes.Value) == 0)
+            {
+                throw new ControllerException("the output tail did not observe bytes before cancellation");
+            }
+
+            await WriteTailProbeAsync(stream, "around-cancel");
+            cancellation.Cancel();
+            await Task.Delay(20);
+            await WriteTailProbeAsync(stream, "-final\n");
+        }
+
+        await tail;
+        stopwatch.Stop();
+        var durable = File.ReadAllText(path);
+        var rendered = captured.ToString();
+        if (!durable.Contains("before-cancel", StringComparison.Ordinal) ||
+            !durable.Contains("around-cancel", StringComparison.Ordinal) ||
+            !rendered.Contains("before-cancel", StringComparison.Ordinal) ||
+            !rendered.Contains("around-cancel", StringComparison.Ordinal))
+        {
+            throw new ControllerException($"output cancellation/drain lost bytes: durable={durable}; rendered={rendered}");
+        }
+
+        if (stopwatch.Elapsed > TimeSpan.FromSeconds(5))
+        {
+            throw new ControllerException($"output tail did not terminate boundedly: {stopwatch.Elapsed}");
+        }
+
+        Console.WriteLine("[selftest] output cancellation preserved buffered bytes and drained terminally");
+    }
+
+    private static async Task WriteTailProbeAsync(FileStream stream, string value)
+    {
+        var bytes = Encoding.UTF8.GetBytes(value);
+        await stream.WriteAsync(bytes);
+        await stream.FlushAsync();
     }
 
     private static void ProviderSubstitutionRejection(string root)

--- a/scripts/ci/windows-storage-job-runner/SelfTest.cs
+++ b/scripts/ci/windows-storage-job-runner/SelfTest.cs
@@ -1,0 +1,307 @@
+using System.Diagnostics;
+using System.Security.Cryptography;
+
+namespace Astrid.Ci.Windows;
+
+internal sealed class SelfTest
+{
+    private static readonly string[] ListArguments = ["--list", "--format=terse", "storage_mount"];
+    private static readonly string[] AggregateArguments = ["storage_mount", "--", "--nocapture", "--test-threads=1"];
+
+    public static int Run()
+    {
+        var root = Directory.CreateTempSubdirectory("astrid-storage-job-selftest-").FullName;
+        try
+        {
+            AssignmentBeforeExecution(root);
+            DescendantTermination(root);
+            UnrelatedProcessSurvival(root);
+            OutputAndExitCodePreservation(root);
+            BoundedTimeoutAndCleanup(root);
+            FreshJobIsolation(root);
+            ArgumentAndListSetParity(root);
+            ProviderSubstitutionRejection(root);
+            Console.WriteLine("[selftest] all Windows storage job controls passed");
+            return 0;
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(root, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+        }
+    }
+
+    private static void AssignmentBeforeExecution(string root)
+    {
+        var marker = Path.Combine(root, "assignment.marker");
+        var result = RunCommand(
+            root,
+            ["cmd.exe", "/d", "/c", $"echo ready> \"{marker}\""],
+            15,
+            afterAssignment: () =>
+            {
+                if (File.Exists(marker))
+                {
+                    throw new ControllerException("the suspended child executed before job assignment");
+                }
+            });
+        AssertOutcome(result, JobOutcome.Succeeded);
+        AssertCleanup(result);
+        if (!File.Exists(marker))
+        {
+            throw new ControllerException("the assignment-before-execution marker was lost");
+        }
+
+        Console.WriteLine("[selftest] assignment occurred before child execution");
+    }
+
+    private static void DescendantTermination(string root)
+    {
+        var result = RunCommand(
+            root,
+            ["cmd.exe", "/d", "/c", "ping.exe -n 30 127.0.0.1 > NUL"],
+            1,
+            afterResume: job =>
+            {
+                Thread.Sleep(500);
+                if (Program.GetJobProcessIdsForSelfTest(job).Length < 2)
+                {
+                    throw new ControllerException("the descendant control did not observe two active processes");
+                }
+            });
+        AssertOutcome(result, JobOutcome.TimedOut);
+        AssertCleanup(result);
+        if (result.OriginalCause.Length == 0)
+        {
+            throw new ControllerException("the descendant termination test did not record its original timeout cause");
+        }
+
+        Console.WriteLine("[selftest] job termination killed the child tree and observed ACTIVE_PROCESS_ZERO");
+    }
+
+    private static void UnrelatedProcessSurvival(string root)
+    {
+        using var unrelated = Process.Start(new ProcessStartInfo
+        {
+            FileName = "cmd.exe",
+            Arguments = "/d /c ping.exe -n 10 127.0.0.1 > NUL",
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        }) ?? throw new ControllerException("could not launch the unrelated same-executable control");
+        try
+        {
+            var result = RunCommand(root, ["cmd.exe", "/d", "/c", "ping.exe -n 20 127.0.0.1 > NUL"], 1);
+            AssertOutcome(result, JobOutcome.TimedOut);
+            AssertCleanup(result);
+            if (unrelated.HasExited)
+            {
+                throw new ControllerException("job cleanup terminated the unrelated cmd.exe process");
+            }
+        }
+        finally
+        {
+            if (!unrelated.HasExited)
+            {
+                unrelated.Kill(entireProcessTree: true);
+                unrelated.WaitForExit(5000);
+            }
+        }
+
+        Console.WriteLine("[selftest] the unrelated same-executable process remained alive");
+    }
+
+    private static void OutputAndExitCodePreservation(string root)
+    {
+        var result = RunCommand(
+            root,
+            ["cmd.exe", "/d", "/c", "echo stdout-marker & echo stderr-marker 1>&2 & exit /b 7"],
+            15);
+        AssertOutcome(result, JobOutcome.ChildFailed);
+        AssertCleanup(result);
+        if (result.ExitCode != 7)
+        {
+            throw new ControllerException($"injected child exit code changed: expected 7, got {result.ExitCode}");
+        }
+
+        var stdout = File.ReadAllText(result.StdoutPath);
+        var stderr = File.ReadAllText(result.StderrPath);
+        if (!stdout.Contains("stdout-marker", StringComparison.Ordinal) ||
+            !stderr.Contains("stderr-marker", StringComparison.Ordinal))
+        {
+            throw new ControllerException("the durable child output files were incomplete");
+        }
+
+        Console.WriteLine("[selftest] durable stdout/stderr and injected exit code 7 were preserved");
+    }
+
+    private static void BoundedTimeoutAndCleanup(string root)
+    {
+        var result = RunCommand(root, ["cmd.exe", "/d", "/c", "ping.exe -n 20 127.0.0.1 > NUL"], 1);
+        AssertOutcome(result, JobOutcome.TimedOut);
+        AssertCleanup(result);
+        if (result.Elapsed > TimeSpan.FromSeconds(10))
+        {
+            throw new ControllerException($"timeout plus cleanup was not bounded: {result.Elapsed}");
+        }
+
+        Console.WriteLine($"[selftest] timeout and cleanup stayed bounded at {result.Elapsed.TotalSeconds:F1}s");
+    }
+
+    private static void FreshJobIsolation(string root)
+    {
+        var first = RunCommand(root, ["cmd.exe", "/d", "/c", "exit /b 0"], 15);
+        AssertOutcome(first, JobOutcome.Succeeded);
+        AssertCleanup(first);
+        var second = RunCommand(root, ["cmd.exe", "/d", "/c", "exit /b 0"], 15);
+        AssertOutcome(second, JobOutcome.Succeeded);
+        AssertCleanup(second);
+        if (first.ProcessId == second.ProcessId || IsProcessAlive(first.ProcessId))
+        {
+            throw new ControllerException("diagnostic job state was shared with a prior process");
+        }
+
+        Console.WriteLine("[selftest] fresh diagnostic jobs did not share process state");
+    }
+
+    private static void ArgumentAndListSetParity(string root)
+    {
+        var stub = Path.Combine(root, "libtest-parity.cmd");
+        File.WriteAllLines(
+            stub,
+            [
+                "@echo off",
+                "if /I \"%~1\" == \"--list\" (",
+                "  if /I \"%~2\" == \"--format\" if /I \"%~3\" == \"terse\" if \"%~4\" == \"storage_mount\" (",
+                "    echo alpha: test",
+                "    echo beta: test",
+                "    exit /b 0",
+                "  )",
+                "  exit /b 10",
+                ")",
+                "if \"%~1\" == \"storage_mount\" (",
+                "  if \"%~2\" == \"--\" if \"%~3\" == \"--nocapture\" if \"%~4\" == \"--test-threads=1\" (",
+                "    echo aggregate>> received.txt",
+                "    exit /b 0",
+                "  )",
+                "  exit /b 11",
+                ")",
+                "if \"%~1\" == \"alpha\" if \"%~2\" == \"--\" if \"%~3\" == \"--exact\" if \"%~4\" == \"--nocapture\" if \"%~5\" == \"--test-threads=1\" (",
+                "  echo alpha>> received.txt",
+                "  exit /b 0",
+                ")",
+                "if \"%~1\" == \"beta\" if \"%~2\" == \"--\" if \"%~3\" == \"--exact\" if \"%~4\" == \"--nocapture\" if \"%~5\" == \"--test-threads=1\" (",
+                "  echo beta>> received.txt",
+                "  exit /b 0",
+                ")",
+                "exit /b 12",
+            ]);
+        var received = Path.Combine(root, "received.txt");
+        var listResult = RunCommand(root, ["cmd.exe", "/d", "/c", stub, .. ListArguments], 15);
+        AssertOutcome(listResult, JobOutcome.Succeeded);
+        var names = Program.ParseTestListForSelfTest(File.ReadAllLines(listResult.StdoutPath));
+        if (names is not ["alpha", "beta"] || File.Exists(received))
+        {
+            throw new ControllerException("the list did not return the stable nonempty set without running tests");
+        }
+
+        var aggregate = RunCommand(root, ["cmd.exe", "/d", "/c", stub, .. AggregateArguments], 15);
+        AssertOutcome(aggregate, JobOutcome.Succeeded);
+        foreach (var name in names)
+        {
+            var diagnostic = RunCommand(
+                root,
+                ["cmd.exe", "/d", "/c", stub, name, "--", "--exact", "--nocapture", "--test-threads=1"],
+                15);
+            AssertOutcome(diagnostic, JobOutcome.Succeeded);
+        }
+
+        var receivedSets = File.ReadAllLines(received);
+        if (receivedSets is not ["aggregate", "alpha", "beta"])
+        {
+            throw new ControllerException("canonical list, aggregate, and diagnostic argument sets diverged");
+        }
+
+        Console.WriteLine("[selftest] list, aggregate, and exact diagnostic argument sets had the same test set");
+    }
+
+    private static void ProviderSubstitutionRejection(string root)
+    {
+        var expected = Path.Combine(root, "provider-original.exe");
+        var substituted = Path.Combine(root, "provider-substitute.exe");
+        var bytes = new byte[] { 1, 2, 3, 4 };
+        File.WriteAllBytes(expected, bytes);
+        File.WriteAllBytes(substituted, bytes);
+        var hash = Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant();
+        Program.AssertProviderForSelfTest(expected, expected, hash);
+        AssertControllerFailure(() => Program.AssertProviderForSelfTest(expected, substituted, hash));
+        AssertControllerFailure(() =>
+            Program.AssertProviderForSelfTest(expected, expected, Convert.ToHexString(SHA256.HashData([5])).ToLowerInvariant()));
+        Console.WriteLine("[selftest] provider path and SHA-256 substitution were rejected");
+    }
+
+    private static JobRunResult RunCommand(
+        string root,
+        string[] command,
+        int timeoutSeconds,
+        Action? afterAssignment = null,
+        Action<SafeJobHandle>? afterResume = null) =>
+        Program.RunCommandForSelfTest(
+            root,
+            command,
+            Path.Combine(root, $"{Guid.NewGuid():N}.stdout.log"),
+            Path.Combine(root, $"{Guid.NewGuid():N}.stderr.log"),
+            TimeSpan.FromSeconds(timeoutSeconds),
+            TimeSpan.FromSeconds(10),
+            TimeSpan.FromSeconds(1),
+            afterAssignment,
+            afterResume);
+
+    private static void AssertOutcome(JobRunResult result, JobOutcome expected)
+    {
+        if (result.Outcome != expected)
+        {
+            throw new ControllerException(
+                $"selftest expected {expected}, got {result.Outcome} ({result.OriginalCause}); stdout={result.StdoutPath}; stderr={result.StderrPath}");
+        }
+    }
+
+    private static void AssertCleanup(JobRunResult result)
+    {
+        if (!result.CleanupComplete || result.ActiveProcessIds.Length != 0)
+        {
+            throw new ControllerException("the job did not reach ACTIVE_PROCESS_ZERO");
+        }
+    }
+
+    private static void AssertControllerFailure(Action action)
+    {
+        try
+        {
+            action();
+        }
+        catch (ControllerException)
+        {
+            return;
+        }
+
+        throw new ControllerException("the invalid provider binding was accepted");
+    }
+
+    private static bool IsProcessAlive(int processId)
+    {
+        try
+        {
+            using var process = Process.GetProcessById(processId);
+            return !process.HasExited;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+    }
+}

--- a/scripts/ci/windows-storage-job-runner/SelfTest.cs
+++ b/scripts/ci/windows-storage-job-runner/SelfTest.cs
@@ -11,6 +11,10 @@ internal sealed class SelfTest
     private static readonly string[] ListArguments = Program.BuildCanonicalListArgumentsForSelfTest();
     private static readonly string[] AggregateArguments = ["storage_mount", "--", "--nocapture", "--test-threads=1"];
 
+    private static string RunnerExecutable =>
+        Program.ResolveExecutableForSelfTest(Environment.ProcessPath
+            ?? throw new ControllerException("the selftest executable path is unavailable"));
+
     public static int Run()
     {
         var root = Directory.CreateTempSubdirectory("astrid-storage-job-selftest-").FullName;
@@ -22,6 +26,7 @@ internal sealed class SelfTest
             ThreeGenerationDescendantTermination(root);
             UnrelatedProcessSurvival(root);
             OutputAndExitCodePreservation(root);
+            HandleReleaseAndNonzeroExit(root);
             ForcedAssignmentFailure(root);
             BoundedTimeoutAndCleanup(root);
             FreshJobIsolation(root);
@@ -46,9 +51,10 @@ internal sealed class SelfTest
     private static void AssignmentBeforeExecution(string root)
     {
         var marker = Path.Combine(root, "assignment.marker");
+        var observedAfterResume = false;
         var result = RunCommand(
             root,
-            ["cmd.exe", "/d", "/c", $"echo ready> \"{marker}\""],
+            [RunnerExecutable, "marker-child", marker, "0"],
             15,
             afterAssignment: () =>
             {
@@ -56,9 +62,29 @@ internal sealed class SelfTest
                 {
                     throw new ControllerException("the suspended child executed before job assignment");
                 }
+            },
+            afterResume: _ =>
+            {
+                var deadline = DateTime.UtcNow.AddSeconds(2);
+                while (!File.Exists(marker) && DateTime.UtcNow < deadline)
+                {
+                    Thread.Sleep(20);
+                }
+
+                observedAfterResume = File.Exists(marker);
             });
         AssertOutcome(result, JobOutcome.Succeeded);
         AssertCleanup(result);
+        if (!observedAfterResume)
+        {
+            throw new ControllerException("the marker did not appear after resume");
+        }
+
+        if (!result.RootHandlesReleased)
+        {
+            throw new ControllerException("root handles were not released before job cleanup");
+        }
+
         if (!File.Exists(marker))
         {
             throw new ControllerException("the assignment-before-execution marker was lost");
@@ -132,12 +158,18 @@ internal sealed class SelfTest
 
     private static void OutputAndExitCodePreservation(string root)
     {
+        var marker = Path.Combine(root, "output.marker");
         var result = RunCommand(
             root,
-            ["cmd.exe", "/d", "/c", "echo stdout-marker & echo stderr-marker 1>&2 & exit /b 7"],
+            [RunnerExecutable, "marker-child", marker, "7"],
             15);
         AssertOutcome(result, JobOutcome.ChildFailed);
         AssertCleanup(result);
+        if (!result.RootHandlesReleased)
+        {
+            throw new ControllerException("root handles were released in the wrong order");
+        }
+
         if (result.ExitCode != 7)
         {
             throw new ControllerException($"injected child exit code changed: expected 7, got {result.ExitCode}");
@@ -145,13 +177,32 @@ internal sealed class SelfTest
 
         var stdout = File.ReadAllText(result.StdoutPath);
         var stderr = File.ReadAllText(result.StderrPath);
-        if (!stdout.Contains("stdout-marker", StringComparison.Ordinal) ||
-            !stderr.Contains("stderr-marker", StringComparison.Ordinal))
+        if (!stdout.Contains($"marker-created {marker}", StringComparison.Ordinal) ||
+            !stderr.Contains("marker-child-ready", StringComparison.Ordinal) ||
+            !File.Exists(marker))
         {
             throw new ControllerException("the durable child output files were incomplete");
         }
 
-        Console.WriteLine("[selftest] durable stdout/stderr and injected exit code 7 were preserved");
+        Console.WriteLine("[selftest] durable stdout/stderr and injected exit code 7 were preserved after handle release");
+    }
+
+    private static void HandleReleaseAndNonzeroExit(string root)
+    {
+        var marker = Path.Combine(root, "handle-release.marker");
+        var result = RunCommand(
+            root,
+            [RunnerExecutable, "marker-child", marker, "7"],
+            15);
+        AssertOutcome(result, JobOutcome.ChildFailed);
+        AssertCleanup(result);
+        if (result.ExitCode != 7 || !result.RootHandlesReleased || !File.Exists(marker))
+        {
+            throw new ControllerException(
+                $"exit/handle-release cleanup evidence was incomplete: exit={result.ExitCode}, handles={result.RootHandlesReleased}, marker={File.Exists(marker)}");
+        }
+
+        Console.WriteLine("[selftest] numeric exit 7 survived root handle release before ACTIVE_PROCESS_ZERO");
     }
 
     private static void ForcedAssignmentFailure(string root)
@@ -163,7 +214,7 @@ internal sealed class SelfTest
         {
             _ = Program.RunCommandForSelfTest(
                 root,
-                ["cmd.exe", "/d", "/c", $"echo ready> \"{marker}\""],
+                [RunnerExecutable, "marker-child", marker, "0"],
                 Path.Combine(root, $"{Guid.NewGuid():N}.stdout.log"),
                 Path.Combine(root, $"{Guid.NewGuid():N}.stderr.log"),
                 TimeSpan.FromSeconds(15),

--- a/scripts/ci/windows-storage-job-runner/SelfTest.cs
+++ b/scripts/ci/windows-storage-job-runner/SelfTest.cs
@@ -1,11 +1,12 @@
 using System.Diagnostics;
 using System.Security.Cryptography;
+using System.Runtime.InteropServices;
 
 namespace Astrid.Ci.Windows;
 
 internal sealed class SelfTest
 {
-    private static readonly string[] ListArguments = ["--list", "--format=terse", "storage_mount"];
+    private static readonly string[] ListArguments = Program.BuildCanonicalListArgumentsForSelfTest();
     private static readonly string[] AggregateArguments = ["storage_mount", "--", "--nocapture", "--test-threads=1"];
 
     public static int Run()
@@ -13,6 +14,7 @@ internal sealed class SelfTest
         var root = Directory.CreateTempSubdirectory("astrid-storage-job-selftest-").FullName;
         try
         {
+            StartupInfoLayout();
             AssignmentBeforeExecution(root);
             DescendantTermination(root);
             UnrelatedProcessSurvival(root);
@@ -176,7 +178,7 @@ internal sealed class SelfTest
             [
                 "@echo off",
                 "if /I \"%~1\" == \"--list\" (",
-                "  if /I \"%~2\" == \"--format\" if /I \"%~3\" == \"terse\" if \"%~4\" == \"storage_mount\" (",
+                "  if /I \"%~2\" == \"--format=terse\" if \"%~3\" == \"storage_mount\" (",
                 "    echo alpha: test",
                 "    echo beta: test",
                 "    exit /b 0",
@@ -227,6 +229,48 @@ internal sealed class SelfTest
         }
 
         Console.WriteLine("[selftest] list, aggregate, and exact diagnostic argument sets had the same test set");
+    }
+
+    private static void StartupInfoLayout()
+    {
+        const int expectedSize = 104;
+#pragma warning disable CA1421
+        var actualSize = Marshal.SizeOf<NativeMethods.StartupInfoW>();
+        var actualOffsets = new Dictionary<string, int>
+        {
+            [nameof(NativeMethods.StartupInfoW.dwFlags)] = (int)Marshal.OffsetOf<NativeMethods.StartupInfoW>(
+                nameof(NativeMethods.StartupInfoW.dwFlags)),
+            [nameof(NativeMethods.StartupInfoW.hStdInput)] = (int)Marshal.OffsetOf<NativeMethods.StartupInfoW>(
+                nameof(NativeMethods.StartupInfoW.hStdInput)),
+            [nameof(NativeMethods.StartupInfoW.hStdOutput)] = (int)Marshal.OffsetOf<NativeMethods.StartupInfoW>(
+                nameof(NativeMethods.StartupInfoW.hStdOutput)),
+            [nameof(NativeMethods.StartupInfoW.hStdError)] = (int)Marshal.OffsetOf<NativeMethods.StartupInfoW>(
+                nameof(NativeMethods.StartupInfoW.hStdError)),
+        };
+#pragma warning restore CA1421
+        var expectedOffsets = new Dictionary<string, int>
+        {
+            [nameof(NativeMethods.StartupInfoW.dwFlags)] = 60,
+            [nameof(NativeMethods.StartupInfoW.hStdInput)] = 80,
+            [nameof(NativeMethods.StartupInfoW.hStdOutput)] = 88,
+            [nameof(NativeMethods.StartupInfoW.hStdError)] = 96,
+        };
+
+        if (actualSize != expectedSize)
+        {
+            throw new ControllerException($"STARTUPINFOW size changed: expected {expectedSize}, got {actualSize}");
+        }
+
+        foreach (var field in expectedOffsets)
+        {
+            if (actualOffsets[field.Key] != field.Value)
+            {
+                throw new ControllerException(
+                    $"STARTUPINFOW {field.Key} offset changed: expected {field.Value}, got {actualOffsets[field.Key]}");
+            }
+        }
+
+        Console.WriteLine("[selftest] STARTUPINFOW x64 layout matched the official size and critical offsets");
     }
 
     private static void ProviderSubstitutionRejection(string root)


### PR DESCRIPTION
## Linked Issue

Tracking #1790. Related: #1710, #1792, #1818.

## Summary

Historical Windows Job Object certification vehicle for storage tests.

Windows release publication is out of the 2026.9.0 cut and parked under #1818. This stacked PR remains available as evidence and must not be merged, rebased, or presented as certification.

## Changes

- Adds Job Object ownership around Windows storage-test execution.
- Adds trusted staging and process-lifecycle checks.
- Does not establish native WinFsp certification.

## Verification

- Source and harness checks are supporting evidence only.
- The later exact-head Windows oracle failed before the required certification gates completed.

## AI / Tool Assistance

Assisted-by: Codex:GLM-5.3 Flash

AI assistance was used for implementation. The maintainer owns the parked disposition and claim limits.

## Checklist

- [x] Later-release owner identified
- [x] Certification claim excluded
- [ ] Ready to merge

