### PR TITLE
fix(cli): fence runtime shutdown generations

### DIFF
--- a/changes/1804.fixed.md
+++ b/changes/1804.fixed.md
@@ -1,0 +1,7 @@
+Make `astrid stop` authoritative across the daemon and persistent MCP
+gateway. Shutdown now authenticates the gateway control request, drains active
+attach sessions and daemon uplinks, confirms both processes and listeners are
+gone, acquires the singleton lock, and removes all runtime markers before
+reporting success. Unverified process identity, incomplete acknowledgement,
+timeouts, and cleanup failures return a staged nonzero error. JSON status now
+reports an explicit `stopped` state. Closes #1804

--- a/changes/1804.fixed.md
+++ b/changes/1804.fixed.md
@@ -2,6 +2,9 @@ Make `astrid stop` authoritative across the daemon and persistent MCP
 gateway. Shutdown now authenticates the gateway control request, drains active
 attach sessions and daemon uplinks, confirms both processes and listeners are
 gone, acquires the singleton lock, and removes all runtime markers before
-reporting success. Unverified process identity, incomplete acknowledgement,
-timeouts, and cleanup failures return a staged nonzero error. JSON status now
-reports an explicit `stopped` state. Closes #1804
+reporting success. Gateway generations are fenced by a lifecycle lock and a
+booting gateway is discoverable through an identity-bound startup lease. Daemon
+recovery uses a boot nonce and a start fence so stale healing cannot race a new
+generation. Unverified process identity, incomplete acknowledgement, timeouts,
+and cleanup failures return a staged nonzero error. JSON status now reports an
+explicit `stopped` state. Closes #1804

--- a/crates/astrid-cli/src/commands/daemon.rs
+++ b/crates/astrid-cli/src/commands/daemon.rs
@@ -432,7 +432,7 @@ fn start_clears_sentinels(action: StartAction) -> bool {
 /// that the same pathname is dead and race their children onto the singleton.
 pub(crate) async fn acquire_daemon_start_fence() -> Result<Arc<std::fs::File>> {
     let home = astrid_core::dirs::AstridHome::resolve().context("failed to resolve Astrid home")?;
-    let path = home.run_dir().join("system.start.lock");
+    let path = daemon_start_fence_path(&home);
     let file = tokio::task::spawn_blocking(move || -> std::io::Result<std::fs::File> {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
@@ -457,6 +457,14 @@ pub(crate) async fn acquire_daemon_start_fence() -> Result<Arc<std::fs::File>> {
     .context("daemon start fence task failed")?
     .map_err(|error| anyhow::anyhow!("failed to acquire daemon start fence: {error}"))?;
     Ok(Arc::new(file))
+}
+
+/// Keep the start fence outside the home until the kernel admits its layout.
+fn daemon_start_fence_path(home: &astrid_core::dirs::AstridHome) -> std::path::PathBuf {
+    let digest = blake3::hash(home.root().to_string_lossy().as_bytes());
+    std::env::temp_dir()
+        .join("astrid-start-fences")
+        .join(format!("{digest}.lock"))
 }
 
 /// Handle `astrid start`.
@@ -643,16 +651,36 @@ fn status_response(response: KernelResponse) -> Result<DaemonStatus> {
 /// `astrid start`/`restart` still see the recorded PID and give an actionable
 /// message instead of failing on the held lock with a raw DB error.
 pub(crate) async fn handle_stop() -> Result<()> {
+    // A pre-lease gateway may legitimately hold the start fence while it boots
+    // its daemon. Stop the gateway first so stop can reap it; then the fence
+    // linearizes the daemon phase against any other start/restart.
     let gateway = crate::commands::mcp::stop_gateway().await;
+    let start_fence = acquire_daemon_start_fence().await?;
     let daemon = stop_daemon().await;
+    drop(start_fence);
     let disposition = combine_stop_results(gateway, daemon)?;
+    print_stop_disposition(disposition);
+    Ok(())
+}
+
+pub(crate) async fn handle_gateway_stop() -> Result<()> {
+    crate::commands::mcp::stop_gateway().await
+}
+
+/// Stop only the daemon while the caller already owns the start fence.
+pub(crate) async fn handle_daemon_stop_locked() -> Result<()> {
+    let result = stop_daemon().await;
+    print_stop_disposition(result?);
+    Ok(())
+}
+
+fn print_stop_disposition(disposition: DaemonStopDisposition) {
     let message = match disposition {
         DaemonStopDisposition::AlreadyStopped => "Astrid runtime is stopped.",
         DaemonStopDisposition::Graceful => "Astrid runtime stopped.",
         DaemonStopDisposition::Forced => "Stopped the unresponsive Astrid runtime.",
     };
     println!("{}", theme::Theme::success(message));
-    Ok(())
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/astrid-cli/src/commands/daemon.rs
+++ b/crates/astrid-cli/src/commands/daemon.rs
@@ -8,6 +8,7 @@ use astrid_core::kernel_api::{DaemonStatus, KernelRequest, KernelResponse};
 
 use crate::bootstrap::find_companion_binary;
 use crate::commands::daemon_control;
+use crate::formatter::OutputFormat;
 use crate::{socket_client, theme};
 
 mod ready;
@@ -490,13 +491,13 @@ pub(crate) async fn handle_start() -> Result<()> {
 }
 
 /// Handle `astrid status`.
-pub(crate) async fn handle_status() -> Result<()> {
+pub(crate) async fn handle_status(output_format: OutputFormat) -> Result<()> {
     let socket_path = socket_client::proxy_socket_path();
     let endpoint_present = astrid_core::local_transport::endpoint_is_present(&socket_path)
         .context("failed to inspect daemon endpoint")?;
     match decide_status_action(endpoint_present, recorded_daemon_pid_is_alive()) {
         StatusAction::NotRunning => {
-            println!("{}", theme::Theme::info("No Astrid daemon is running."));
+            print_status(output_format, None)?;
             return Ok(());
         },
         StatusAction::RunningButUnreachable => {
@@ -516,6 +517,21 @@ pub(crate) async fn handle_status() -> Result<()> {
             .await
             .context("Failed to query daemon status")?,
     )?;
+    print_status(output_format, Some(&status))?;
+    Ok(())
+}
+
+fn print_status(output_format: OutputFormat, status: Option<&DaemonStatus>) -> Result<()> {
+    if output_format == OutputFormat::Json {
+        let document = status_document(status);
+        println!("{}", serde_json::to_string(&document)?);
+        return Ok(());
+    }
+    let Some(status) = status else {
+        println!("{}", theme::Theme::info("No Astrid daemon is running."));
+        return Ok(());
+    };
+
     let uptime_display = format_uptime(status.uptime_secs);
     println!(
         "{}",
@@ -531,6 +547,13 @@ pub(crate) async fn handle_status() -> Result<()> {
         println!("    - {capsule}");
     }
     Ok(())
+}
+
+fn status_document(status: Option<&DaemonStatus>) -> serde_json::Value {
+    status.map_or_else(
+        || serde_json::json!({ "state": "stopped" }),
+        |status| serde_json::json!({ "state": "running", "daemon": status }),
+    )
 }
 
 fn status_response(response: KernelResponse) -> Result<DaemonStatus> {
@@ -554,6 +577,39 @@ fn status_response(response: KernelResponse) -> Result<DaemonStatus> {
 /// `astrid start`/`restart` still see the recorded PID and give an actionable
 /// message instead of failing on the held lock with a raw DB error.
 pub(crate) async fn handle_stop() -> Result<()> {
+    let gateway = crate::commands::mcp::stop_gateway().await;
+    let daemon = stop_daemon().await;
+    let disposition = combine_stop_results(gateway, daemon)?;
+    let message = match disposition {
+        DaemonStopDisposition::AlreadyStopped => "Astrid runtime is stopped.",
+        DaemonStopDisposition::Graceful => "Astrid runtime stopped.",
+        DaemonStopDisposition::Forced => "Stopped the unresponsive Astrid runtime.",
+    };
+    println!("{}", theme::Theme::success(message));
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DaemonStopDisposition {
+    AlreadyStopped,
+    Graceful,
+    Forced,
+}
+
+fn combine_stop_results(
+    gateway: Result<()>,
+    daemon: Result<DaemonStopDisposition>,
+) -> Result<DaemonStopDisposition> {
+    match (gateway, daemon) {
+        (Ok(()), Ok(disposition)) => Ok(disposition),
+        (Err(primary), Ok(_)) | (Ok(()), Err(primary)) => Err(primary),
+        (Err(primary), Err(secondary)) => {
+            anyhow::bail!("{primary:#}; additional shutdown failure: {secondary:#}")
+        },
+    }
+}
+
+async fn stop_daemon() -> Result<DaemonStopDisposition> {
     let socket_path = socket_client::proxy_socket_path();
     let pid_path = socket_client::pid_path();
 
@@ -569,9 +625,8 @@ pub(crate) async fn handle_stop() -> Result<()> {
         .as_ref()
         .is_some_and(|(pid, _)| daemon_control::is_process_alive(*pid));
     if !socket_present && !recorded_alive {
-        println!("{}", theme::Theme::info("No Astrid daemon is running."));
-        let _ = std::fs::remove_file(&pid_path); // tidy a stale dead-PID file
-        return Ok(());
+        cleanup_daemon_runtime(&socket_path, &pid_path).await?;
+        return Ok(DaemonStopDisposition::AlreadyStopped);
     }
 
     // Graceful path: the socket is present and serviceable.
@@ -579,21 +634,27 @@ pub(crate) async fn handle_stop() -> Result<()> {
     // the recovery path when that daemon belongs to another project/layout.
     if socket_present && let Ok(client) = socket_client::connect_kernel_for_recovery().await {
         let mut client = client.with_timeout(Duration::from_secs(10));
-        match client
+        let response = client
             .request(KernelRequest::Shutdown {
                 reason: Some("astrid stop".to_string()),
             })
-            .await?
-        {
+            .await
+            .context("shutdown stage daemon.shutdown_ack")?;
+        let disposition = match response {
             KernelResponse::Success(_) => {
                 // ACK only — confirm the process actually exits before
                 // declaring success, and escalate if it wedged.
-                confirm_graceful_stop(recorded, &pid_path, &socket_path).await;
+                confirm_graceful_stop(recorded, &socket_path).await?
             },
-            KernelResponse::Error(reason) => anyhow::bail!("daemon rejected shutdown: {reason}"),
-            other => anyhow::bail!("unexpected response from daemon shutdown: {other:?}"),
-        }
-        return Ok(());
+            KernelResponse::Error(reason) => {
+                anyhow::bail!("shutdown stage daemon.shutdown_ack: rejected: {reason}")
+            },
+            other => {
+                anyhow::bail!("shutdown stage daemon.shutdown_ack: unexpected response: {other:?}")
+            },
+        };
+        cleanup_daemon_runtime(&socket_path, &pid_path).await?;
+        return Ok(disposition);
     }
 
     // Orphan path: the socket is present but unreachable (hung/half-dead
@@ -606,8 +667,9 @@ pub(crate) async fn handle_stop() -> Result<()> {
         Some((pid, exe)) => daemon_control::terminate_known(*pid, exe.as_deref()).await,
         None => daemon_control::KillOutcome::NotRunning,
     };
-    report_orphan_stop(outcome, socket_present, &pid_path, &socket_path);
-    Ok(())
+    let disposition = confirm_kill_outcome(outcome)?;
+    cleanup_daemon_runtime(&socket_path, &pid_path).await?;
+    Ok(disposition)
 }
 
 /// After a graceful shutdown ACK, confirm the daemon process actually exited —
@@ -617,26 +679,17 @@ pub(crate) async fn handle_stop() -> Result<()> {
 /// unreachable orphan. Runtime files are cleaned only once the process is gone.
 async fn confirm_graceful_stop(
     recorded: Option<(u32, Option<PathBuf>)>,
-    pid_path: &Path,
     socket_path: &Path,
-) {
+) -> Result<DaemonStopDisposition> {
     let Some((pid, exe)) = recorded else {
-        // Legacy pidless daemon (or an unresolved PID): we can't confirm exit,
-        // so trust the ACK. The daemon cleans up its own socket on a clean exit;
-        // remove the PID file best-effort in case one was left behind.
-        println!("{}", theme::Theme::success("Astrid daemon stopped."));
-        let _ = std::fs::remove_file(pid_path);
-        return;
+        anyhow::bail!(
+            "shutdown stage daemon.process_reap: shutdown was acknowledged but no recorded PID exists, so process exit cannot be verified (listener: {})",
+            socket_path.display()
+        );
     };
 
     if daemon_control::wait_for_exit(pid, daemon_control::GRACE).await {
-        // Confirmed gone — clear ALL runtime files. A clean daemon removes its
-        // own socket/readiness, but one that wedged briefly before finally
-        // exiting may not have, so remove them here too rather than leave a
-        // stale socket for the next `status`/`start` to trip on.
-        println!("{}", theme::Theme::success("Astrid daemon stopped."));
-        remove_runtime_files(pid_path, socket_path);
-        return;
+        return Ok(DaemonStopDisposition::Graceful);
     }
 
     // Acknowledged but still alive past the grace window → wedged mid-shutdown,
@@ -649,66 +702,116 @@ async fn confirm_graceful_stop(
         )
     );
     let outcome = daemon_control::terminate_known(pid, exe.as_deref()).await;
-    report_orphan_stop(outcome, true, pid_path, socket_path);
+    confirm_kill_outcome(outcome)
 }
 
-/// Report a signal-based stop outcome and clean up runtime files ONLY when the
-/// daemon is confirmed gone. When a kill can't confirm exit (`StillAlive` /
-/// `Unverified`), the socket/PID files are LEFT in place so `astrid start` /
-/// `astrid restart` still see the recorded PID and can print an actionable
-/// message rather than failing on the held lock with a raw DB error.
-fn report_orphan_stop(
-    outcome: daemon_control::KillOutcome,
-    socket_present: bool,
-    pid_path: &Path,
-    socket_path: &Path,
-) {
-    match &outcome {
-        daemon_control::KillOutcome::NotRunning => {
-            if socket_present {
-                println!("{}", theme::Theme::info("Cleaned up stale daemon socket."));
-            } else {
-                println!("{}", theme::Theme::info("No Astrid daemon is running."));
-            }
-        },
+fn confirm_kill_outcome(outcome: daemon_control::KillOutcome) -> Result<DaemonStopDisposition> {
+    match outcome {
+        daemon_control::KillOutcome::NotRunning => Ok(DaemonStopDisposition::AlreadyStopped),
         daemon_control::KillOutcome::TermExited | daemon_control::KillOutcome::KilledExited => {
-            println!(
-                "{}",
-                theme::Theme::success("Stopped an unresponsive Astrid daemon.")
-            );
+            Ok(DaemonStopDisposition::Forced)
         },
         daemon_control::KillOutcome::StillAlive => {
-            eprintln!(
-                "{}",
-                theme::Theme::error(
-                    "An unresponsive Astrid daemon did not exit even after SIGKILL; the \
-                     state-db lock may still be held. Inspect the process before retrying."
-                )
+            anyhow::bail!(
+                "shutdown stage daemon.process_reap: daemon did not exit after forced termination; the singleton lock may still be held"
             );
         },
         daemon_control::KillOutcome::Unverified(pid) => {
-            eprintln!(
-                "{}",
-                theme::Theme::warning(&format!(
-                    "A process (PID {pid}) holds the recorded daemon PID but I can't confirm \
-                     it's the Astrid daemon (possible PID reuse) — not killing it. If the daemon \
-                     is genuinely stuck, inspect PID {pid} and stop it manually."
-                ))
+            anyhow::bail!(
+                "shutdown stage daemon.process_identity: PID {pid} is live but cannot be verified as Astrid; no markers were removed"
             );
         },
     }
-    if stop_confirmed_gone(outcome) {
-        remove_runtime_files(pid_path, socket_path);
-    }
 }
 
-/// Remove the daemon's runtime files (socket, readiness, PID), best-effort.
-/// Called only once the daemon is confirmed gone — a dead daemon owns none of
-/// them, so clearing them leaves a clean slate for the next `start`.
-fn remove_runtime_files(pid_path: &Path, socket_path: &Path) {
-    let _ = astrid_core::local_transport::remove_endpoint(socket_path);
-    let _ = std::fs::remove_file(socket_client::readiness_path());
-    let _ = std::fs::remove_file(pid_path);
+/// Fence marker cleanup with the same singleton lock the daemon owns. Holding
+/// it through removal prevents a replacement daemon from publishing fresh
+/// markers between liveness proof and cleanup.
+async fn cleanup_daemon_runtime(socket_path: &Path, pid_path: &Path) -> Result<()> {
+    let home = astrid_core::dirs::AstridHome::resolve()
+        .context("shutdown stage daemon.home_resolution")?;
+    cleanup_daemon_runtime_for_home(&home, socket_path, pid_path).await
+}
+
+async fn cleanup_daemon_runtime_for_home(
+    home: &astrid_core::dirs::AstridHome,
+    socket_path: &Path,
+    pid_path: &Path,
+) -> Result<()> {
+    // An idempotent stop on a never-initialized home must not create the Astrid
+    // layout merely to prove that its absent runtime is absent.
+    if !home
+        .run_dir()
+        .try_exists()
+        .context("shutdown stage daemon.runtime_probe")?
+    {
+        return Ok(());
+    }
+    let lock_path = home.run_dir().join("system.lock");
+    let mut options = std::fs::OpenOptions::new();
+    options.read(true).write(true).create(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.mode(0o600);
+    }
+    let lock = options.open(&lock_path).with_context(|| {
+        format!(
+            "shutdown stage daemon.singleton_lock: open {}",
+            lock_path.display()
+        )
+    })?;
+    lock.try_lock().map_err(|error| match error {
+        std::fs::TryLockError::WouldBlock => anyhow::anyhow!(
+            "shutdown stage daemon.singleton_lock: lock remains held at {}",
+            lock_path.display()
+        ),
+        std::fs::TryLockError::Error(error) => anyhow::anyhow!(
+            "shutdown stage daemon.singleton_lock: failed to acquire {}: {error}",
+            lock_path.display()
+        ),
+    })?;
+
+    match astrid_core::local_transport::connect_outcome(socket_path)
+        .await
+        .context("shutdown stage daemon.listener_probe")?
+    {
+        astrid_core::local_transport::ConnectOutcome::Connected(_) => {
+            anyhow::bail!(
+                "shutdown stage daemon.listener_absence: endpoint remains live at {}",
+                socket_path.display()
+            );
+        },
+        astrid_core::local_transport::ConnectOutcome::Stale => {
+            astrid_core::local_transport::remove_stale_endpoint(socket_path).with_context(
+                || {
+                    format!(
+                        "shutdown stage daemon.listener_cleanup: {}",
+                        socket_path.display()
+                    )
+                },
+            )?;
+        },
+        astrid_core::local_transport::ConnectOutcome::Absent => {},
+    }
+    astrid_core::local_transport::remove_endpoint(socket_path).with_context(|| {
+        format!(
+            "shutdown stage daemon.listener_cleanup: {}",
+            socket_path.display()
+        )
+    })?;
+    for path in [home.ready_path(), pid_path.to_path_buf(), home.token_path()] {
+        match std::fs::remove_file(&path) {
+            Ok(()) => {},
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {},
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!("shutdown stage daemon.marker_cleanup: {}", path.display())
+                });
+            },
+        }
+    }
+    Ok(())
 }
 
 /// Whether a stop outcome CONFIRMS the daemon is gone — the only condition under
@@ -720,6 +823,7 @@ fn remove_runtime_files(pid_path: &Path, socket_path: &Path) {
 /// racing a fresh daemon onto a held lock (which surfaces as a raw "Database …
 /// is already locked" error). Pure over its input so the invariant is testable
 /// without a live daemon. Takes the `Copy` outcome by value (trivially small).
+#[cfg(test)]
 fn stop_confirmed_gone(outcome: daemon_control::KillOutcome) -> bool {
     matches!(
         outcome,
@@ -744,186 +848,5 @@ pub(crate) fn format_uptime(secs: u64) -> String {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn fresh_home_boot_log_does_not_preinitialize_layout() {
-        let temp = tempfile::tempdir().expect("temp dir");
-        let root = temp.path().join("astrid-home");
-        let home = astrid_core::dirs::AstridHome::from_path(&root);
-
-        assert!(boot_log_stderr_for_home(&home).is_none());
-        assert!(
-            !root.exists(),
-            "boot-log capture must not create content before kernel admission"
-        );
-    }
-
-    #[test]
-    fn daemon_workspace_metadata_rejects_unknown_or_different_selection() {
-        let expected = vec!["a".repeat(64)];
-        assert!(validate_daemon_workspace_metadata("", &expected).is_err());
-        assert!(
-            validate_daemon_workspace_metadata(&format!("v1:{}", "b".repeat(64)), &expected)
-                .is_err()
-        );
-        validate_daemon_workspace_metadata(&format!("v1:{}\n", expected[0]), &expected).unwrap();
-    }
-
-    #[test]
-    fn explicit_workspace_selection_wins_over_current_directory() {
-        let current = std::env::current_dir().expect("current directory");
-        let explicit = tempfile::tempdir().expect("explicit workspace");
-        assert_ne!(explicit.path(), current);
-
-        let explicit_fingerprint = astrid_core::dirs::checked_workspace_selection_fingerprint(
-            explicit.path(),
-            crate::workspace_layout::current(),
-        )
-        .unwrap();
-        assert!(
-            expected_workspace_fingerprints(Some(explicit.path()))
-                .unwrap()
-                .contains(&explicit_fingerprint)
-        );
-        let current_fingerprint = astrid_core::dirs::checked_workspace_selection_fingerprint(
-            &current,
-            crate::workspace_layout::current(),
-        )
-        .unwrap();
-        assert!(
-            expected_workspace_fingerprints(None)
-                .unwrap()
-                .contains(&current_fingerprint)
-        );
-    }
-
-    #[test]
-    fn ephemeral_boot_passes_the_selected_workspace_to_the_daemon() {
-        use std::ffi::OsStr;
-
-        let command = ephemeral_daemon_command(
-            Path::new("/installed/astrid-daemon"),
-            Path::new("/selected/project"),
-        );
-        let args = command.get_args().collect::<Vec<_>>();
-
-        assert_eq!(
-            args,
-            vec![
-                OsStr::new("--ephemeral"),
-                OsStr::new("--workspace"),
-                OsStr::new("/selected/project"),
-            ]
-        );
-        assert_eq!(
-            command
-                .get_envs()
-                .find(|(name, _)| *name == OsStr::new("ASTRID_WORKSPACE_STATE_DIR"))
-                .and_then(|(_, value)| value),
-            Some(OsStr::new(
-                crate::workspace_layout::current().state_dir_name()
-            ))
-        );
-    }
-
-    /// REGRESSION (#1120): `astrid stop` must remove the socket/PID files ONLY
-    /// when the daemon is confirmed gone. Before the fix, stop reported success
-    /// and deleted the PID file on the shutdown ACK alone; a daemon that then
-    /// wedged mid-shutdown leaked the lock with no PID handle left, and the next
-    /// `start` died on it. `StillAlive`/`Unverified` must NOT trigger cleanup.
-    #[test]
-    fn stop_cleans_up_only_when_confirmed_gone() {
-        use daemon_control::KillOutcome;
-        assert!(stop_confirmed_gone(KillOutcome::NotRunning));
-        assert!(stop_confirmed_gone(KillOutcome::TermExited));
-        assert!(stop_confirmed_gone(KillOutcome::KilledExited));
-        // A process that may still hold the lock → keep the files so restart/
-        // start can find the recorded PID and act on it.
-        assert!(!stop_confirmed_gone(KillOutcome::StillAlive));
-        assert!(!stop_confirmed_gone(KillOutcome::Unverified(4242)));
-    }
-
-    /// A reachable daemon is already running — regardless of whether a recorded
-    /// PID looks alive, `start` must take the fast path and leave the live run
-    /// files untouched (never clear sentinels).
-    #[test]
-    fn start_reachable_daemon_is_already_running() {
-        assert_eq!(
-            decide_start_action(true, false),
-            StartAction::AlreadyRunning
-        );
-        assert_eq!(decide_start_action(true, true), StartAction::AlreadyRunning);
-        assert!(!start_clears_sentinels(StartAction::AlreadyRunning));
-    }
-
-    /// REGRESSION (daemon-detach self-heal): a crashed daemon leaves stale run
-    /// files with a DEAD recorded PID. On the next `astrid start` the socket is
-    /// unreachable and the PID is dead → clear ALL stale sentinels and spawn,
-    /// so the stale run-dir recovers transparently (not only on `restart`).
-    #[test]
-    fn start_unreachable_with_dead_pid_heals_and_spawns() {
-        let action = decide_start_action(false, false);
-        assert_eq!(action, StartAction::HealAndSpawn);
-        assert!(start_clears_sentinels(action));
-    }
-
-    /// SAFETY INVARIANT: a recorded daemon PID that is still alive but whose
-    /// socket is unreachable (a daemon mid-boot still binding its socket, mid-
-    /// shutdown, wedged, or a recycled PID) must NEVER be killed or have its
-    /// sentinels cleared by `start` — that would clobber a booting daemon or an
-    /// innocent process. `start` defers to `restart`, leaving every sentinel
-    /// intact.
-    #[test]
-    fn start_unreachable_with_live_pid_defers_and_leaves_sentinels() {
-        let action = decide_start_action(false, true);
-        assert_eq!(action, StartAction::RunningButUnreachable);
-        assert!(!start_clears_sentinels(action));
-    }
-
-    #[test]
-    fn ensure_unlinked_or_stale_sock_with_live_pid_refuses_second_boot() {
-        use astrid_core::local_transport::ConnectOutcome;
-        assert_eq!(
-            decide_ensure_action(&ConnectOutcome::Absent, true),
-            EnsureAction::RefuseSecondBoot
-        );
-        assert_eq!(
-            decide_ensure_action(&ConnectOutcome::Stale, true),
-            EnsureAction::RefuseSecondBoot
-        );
-        assert_eq!(
-            decide_ensure_action(&ConnectOutcome::Absent, false),
-            EnsureAction::Spawn
-        );
-        assert_eq!(
-            decide_ensure_action(&ConnectOutcome::Stale, false),
-            EnsureAction::CleanStaleAndSpawn
-        );
-    }
-
-    #[test]
-    fn status_unlinked_sock_with_live_pid_is_unreachable() {
-        assert_eq!(
-            decide_status_action(false, true),
-            StatusAction::RunningButUnreachable
-        );
-        assert_eq!(decide_status_action(false, false), StatusAction::NotRunning);
-        assert_eq!(
-            decide_status_action(true, true),
-            StatusAction::QueryLiveSocket
-        );
-    }
-
-    #[test]
-    fn status_error_is_not_reported_as_a_successful_status() {
-        let error = status_response(KernelResponse::Error("denied".into()))
-            .expect_err("kernel status errors must fail the command");
-        assert!(
-            error
-                .to_string()
-                .contains("daemon rejected status request: denied")
-        );
-    }
-}
+#[path = "daemon/tests.rs"]
+mod tests;

--- a/crates/astrid-cli/src/commands/daemon.rs
+++ b/crates/astrid-cli/src/commands/daemon.rs
@@ -1,6 +1,7 @@
 //! Daemon lifecycle commands: start, stop, status, and spawn helpers.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
+use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
@@ -19,6 +20,8 @@ use ready::{
     readiness_attempts, wait_for_ready,
 };
 use workspace_fingerprint::{expected_workspace_fingerprints, validate_daemon_workspace_metadata};
+
+const STATUS_CONNECT_TIMEOUT: Duration = Duration::from_secs(1);
 
 /// Build a hint string pointing the user to the daemon log directory.
 fn log_hint() -> String {
@@ -175,6 +178,18 @@ enum DaemonSpawnMode {
 }
 
 async fn ensure_daemon_inner(
+    label: &str,
+    announce: bool,
+    spawn_mode: DaemonSpawnMode,
+    workspace_root: Option<&Path>,
+) -> Result<()> {
+    let start_fence = acquire_daemon_start_fence().await?;
+    let result = ensure_daemon_inner_locked(label, announce, spawn_mode, workspace_root).await;
+    drop(start_fence);
+    result
+}
+
+async fn ensure_daemon_inner_locked(
     label: &str,
     announce: bool,
     spawn_mode: DaemonSpawnMode,
@@ -413,6 +428,37 @@ fn start_clears_sentinels(action: StartAction) -> bool {
     matches!(action, StartAction::HealAndSpawn)
 }
 
+/// Serialize stale healing and boot decisions so two starts cannot both decide
+/// that the same pathname is dead and race their children onto the singleton.
+pub(crate) async fn acquire_daemon_start_fence() -> Result<Arc<std::fs::File>> {
+    let home = astrid_core::dirs::AstridHome::resolve().context("failed to resolve Astrid home")?;
+    let path = home.run_dir().join("system.start.lock");
+    let file = tokio::task::spawn_blocking(move || -> std::io::Result<std::fs::File> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700))?;
+            }
+        }
+        let mut options = std::fs::OpenOptions::new();
+        options.read(true).write(true).create(true).truncate(false);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let file = options.open(&path)?;
+        file.lock()?;
+        Ok(file)
+    })
+    .await
+    .context("daemon start fence task failed")?
+    .map_err(|error| anyhow::anyhow!("failed to acquire daemon start fence: {error}"))?;
+    Ok(Arc::new(file))
+}
+
 /// Handle `astrid start`.
 ///
 /// Fast path: a daemon answering on the socket is already running — do nothing.
@@ -435,6 +481,13 @@ fn start_clears_sentinels(action: StartAction) -> bool {
 /// This never removes a live daemon's socket or signals a live process — the
 /// only mutation happens when the recorded daemon is provably gone.
 pub(crate) async fn handle_start() -> Result<()> {
+    let start_fence = acquire_daemon_start_fence().await?;
+    let result = handle_start_locked().await;
+    drop(start_fence);
+    result
+}
+
+async fn handle_start_locked() -> Result<()> {
     let socket_path = socket_client::proxy_socket_path();
     let ready_path = socket_client::readiness_path();
     let pid_path = socket_client::pid_path();
@@ -494,8 +547,10 @@ pub(crate) async fn handle_start() -> Result<()> {
 pub(crate) async fn handle_status(output_format: OutputFormat) -> Result<()> {
     let socket_path = socket_client::proxy_socket_path();
     let endpoint_present = astrid_core::local_transport::endpoint_is_present(&socket_path)
-        .context("failed to inspect daemon endpoint")?;
-    match decide_status_action(endpoint_present, recorded_daemon_pid_is_alive()) {
+        .context("failed to inspect daemon endpoint")
+        .unwrap_or(false);
+    let recorded_alive = recorded_daemon_pid_is_alive();
+    match decide_status_action(endpoint_present, recorded_alive) {
         StatusAction::NotRunning => {
             print_status(output_format, None)?;
             return Ok(());
@@ -508,9 +563,20 @@ pub(crate) async fn handle_status(output_format: OutputFormat) -> Result<()> {
         StatusAction::QueryLiveSocket => {},
     }
 
-    let mut client = socket_client::connect_kernel_for_workspace(None)
-        .await
-        .context("Daemon socket exists but connection failed")?;
+    let connect = tokio::time::timeout(
+        STATUS_CONNECT_TIMEOUT,
+        socket_client::connect_kernel_for_workspace(None),
+    )
+    .await;
+    let Ok(Ok(mut client)) = connect else {
+        if recorded_alive {
+            anyhow::bail!(
+                "an Astrid daemon appears to be running but its uplink is unreachable; run `astrid restart`"
+            );
+        }
+        print_status(output_format, None)?;
+        return Ok(());
+    };
     let status = status_response(
         client
             .request(KernelRequest::GetStatus)
@@ -616,14 +682,14 @@ async fn stop_daemon() -> Result<DaemonStopDisposition> {
     // Capture the daemon's identity up front: it deletes its own PID file only
     // on a CLEAN exit, so reading it before shutdown is the only reliable way to
     // keep a handle for confirming exit / signalling a wedged shutdown.
-    let recorded = daemon_control::read_pid_file(&pid_path);
+    let recorded = daemon_control::read_daemon_identity(&pid_path);
     let socket_present = astrid_core::local_transport::endpoint_is_present(&socket_path)
         .context("failed to inspect daemon endpoint")?;
 
     // Genuinely nothing running: no socket AND no live recorded process.
     let recorded_alive = recorded
         .as_ref()
-        .is_some_and(|(pid, _)| daemon_control::is_process_alive(*pid));
+        .is_some_and(|identity| daemon_control::is_process_alive(identity.pid));
     if !socket_present && !recorded_alive {
         cleanup_daemon_runtime(&socket_path, &pid_path).await?;
         return Ok(DaemonStopDisposition::AlreadyStopped);
@@ -644,7 +710,7 @@ async fn stop_daemon() -> Result<DaemonStopDisposition> {
             KernelResponse::Success(_) => {
                 // ACK only — confirm the process actually exits before
                 // declaring success, and escalate if it wedged.
-                confirm_graceful_stop(recorded, &socket_path).await?
+                confirm_graceful_stop(recorded, &socket_path, &pid_path).await?
             },
             KernelResponse::Error(reason) => {
                 anyhow::bail!("shutdown stage daemon.shutdown_ack: rejected: {reason}")
@@ -663,8 +729,8 @@ async fn stop_daemon() -> Result<DaemonStopDisposition> {
     // signal the recorded PID (identity-gated) and clean up. Using the PID we
     // captured up front — not a re-read — closes the window where the daemon
     // deletes its own PID file mid-wedge.
-    let outcome = match &recorded {
-        Some((pid, exe)) => daemon_control::terminate_known(*pid, exe.as_deref()).await,
+    let outcome = match recorded.as_ref() {
+        Some(identity) => daemon_control::terminate_identity(identity, &pid_path).await,
         None => daemon_control::KillOutcome::NotRunning,
     };
     let disposition = confirm_kill_outcome(outcome)?;
@@ -678,17 +744,18 @@ async fn stop_daemon() -> Result<DaemonStopDisposition> {
 /// the lock, so escalate through the same identity-gated signal path as an
 /// unreachable orphan. Runtime files are cleaned only once the process is gone.
 async fn confirm_graceful_stop(
-    recorded: Option<(u32, Option<PathBuf>)>,
+    recorded: Option<daemon_control::DaemonIdentity>,
     socket_path: &Path,
+    pid_path: &Path,
 ) -> Result<DaemonStopDisposition> {
-    let Some((pid, exe)) = recorded else {
+    let Some(identity) = recorded else {
         anyhow::bail!(
             "shutdown stage daemon.process_reap: shutdown was acknowledged but no recorded PID exists, so process exit cannot be verified (listener: {})",
             socket_path.display()
         );
     };
 
-    if daemon_control::wait_for_exit(pid, daemon_control::GRACE).await {
+    if daemon_control::wait_for_exit(identity.pid, daemon_control::GRACE).await {
         return Ok(DaemonStopDisposition::Graceful);
     }
 
@@ -701,7 +768,7 @@ async fn confirm_graceful_stop(
              state-db lock is released."
         )
     );
-    let outcome = daemon_control::terminate_known(pid, exe.as_deref()).await;
+    let outcome = daemon_control::terminate_identity(&identity, pid_path).await;
     confirm_kill_outcome(outcome)
 }
 

--- a/crates/astrid-cli/src/commands/daemon/tests.rs
+++ b/crates/astrid-cli/src/commands/daemon/tests.rs
@@ -208,9 +208,13 @@ fn unconfirmed_termination_is_a_nonzero_outcome() {
 
 #[tokio::test]
 async fn acknowledged_shutdown_without_pid_is_unverified() {
-    let error = confirm_graceful_stop(None, Path::new("/tmp/absent-astrid.sock"))
-        .await
-        .expect_err("an ACK without a process identity cannot prove process exit");
+    let error = confirm_graceful_stop(
+        None,
+        Path::new("/tmp/absent-astrid.sock"),
+        Path::new("/tmp/absent-astrid.pid"),
+    )
+    .await
+    .expect_err("an ACK without a process identity cannot prove process exit");
     assert!(format!("{error:#}").contains("daemon.process_reap"));
 }
 

--- a/crates/astrid-cli/src/commands/daemon/tests.rs
+++ b/crates/astrid-cli/src/commands/daemon/tests.rs
@@ -1,0 +1,304 @@
+use super::*;
+
+#[test]
+fn fresh_home_boot_log_does_not_preinitialize_layout() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let root = temp.path().join("astrid-home");
+    let home = astrid_core::dirs::AstridHome::from_path(&root);
+
+    assert!(boot_log_stderr_for_home(&home).is_none());
+    assert!(
+        !root.exists(),
+        "boot-log capture must not create content before kernel admission"
+    );
+}
+
+#[tokio::test]
+async fn already_stopped_fresh_home_does_not_create_layout() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let root = temp.path().join("astrid-home");
+    let home = astrid_core::dirs::AstridHome::from_path(&root);
+
+    cleanup_daemon_runtime_for_home(&home, &home.socket_path(), &home.pid_path())
+        .await
+        .expect("an absent runtime is already stopped");
+    assert!(!root.exists(), "stop must not initialize a fresh home");
+}
+
+#[tokio::test]
+async fn marker_cleanup_failure_is_authoritative() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let home = astrid_core::dirs::AstridHome::from_path(temp.path().join("astrid-home"));
+    std::fs::create_dir_all(home.run_dir()).expect("runtime directory");
+    std::fs::create_dir(home.ready_path()).expect("directory-shaped ready marker");
+
+    let error = cleanup_daemon_runtime_for_home(&home, &home.socket_path(), &home.pid_path())
+        .await
+        .expect_err("an unremovable marker must fail stop");
+    assert!(
+        format!("{error:#}").contains("shutdown stage daemon.marker_cleanup"),
+        "unexpected error: {error:#}"
+    );
+    assert!(
+        home.ready_path().is_dir(),
+        "failed marker remains diagnosable"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn confirmed_stop_removes_every_runtime_marker() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let home = astrid_core::dirs::AstridHome::from_path(temp.path().join("astrid-home"));
+    std::fs::create_dir_all(home.run_dir()).expect("runtime directory");
+    for path in [home.ready_path(), home.pid_path(), home.token_path()] {
+        std::fs::write(&path, b"stale").expect("stale marker");
+    }
+    let listener = astrid_core::local_transport::bind(&home.socket_path()).expect("listener");
+    drop(listener);
+
+    cleanup_daemon_runtime_for_home(&home, &home.socket_path(), &home.pid_path())
+        .await
+        .expect("confirmed stale runtime cleanup");
+
+    for path in [
+        home.socket_path(),
+        home.ready_path(),
+        home.pid_path(),
+        home.token_path(),
+    ] {
+        assert!(
+            !path.exists(),
+            "marker survived cleanup: {}",
+            path.display()
+        );
+    }
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn live_listener_prevents_marker_removal() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let home = astrid_core::dirs::AstridHome::from_path(temp.path().join("astrid-home"));
+    std::fs::create_dir_all(home.run_dir()).expect("runtime directory");
+    std::fs::write(home.ready_path(), b"live").expect("ready marker");
+    let _listener = astrid_core::local_transport::bind(&home.socket_path()).expect("listener");
+
+    let error = cleanup_daemon_runtime_for_home(&home, &home.socket_path(), &home.pid_path())
+        .await
+        .expect_err("a live listener must fail cleanup");
+    assert!(format!("{error:#}").contains("daemon.listener_absence"));
+    assert!(home.ready_path().exists(), "live marker must remain");
+}
+
+#[tokio::test]
+async fn held_singleton_lock_prevents_marker_removal() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let home = astrid_core::dirs::AstridHome::from_path(temp.path().join("astrid-home"));
+    std::fs::create_dir_all(home.run_dir()).expect("runtime directory");
+    std::fs::write(home.ready_path(), b"live").expect("ready marker");
+    let lock_path = home.run_dir().join("system.lock");
+    let lock = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(lock_path)
+        .expect("singleton lock");
+    lock.try_lock().expect("hold singleton lock");
+
+    let error = cleanup_daemon_runtime_for_home(&home, &home.socket_path(), &home.pid_path())
+        .await
+        .expect_err("a held singleton lock must fail cleanup");
+    assert!(format!("{error:#}").contains("daemon.singleton_lock"));
+    assert!(home.ready_path().exists(), "locked marker must remain");
+}
+
+#[test]
+fn daemon_workspace_metadata_rejects_unknown_or_different_selection() {
+    let expected = vec!["a".repeat(64)];
+    assert!(validate_daemon_workspace_metadata("", &expected).is_err());
+    assert!(
+        validate_daemon_workspace_metadata(&format!("v1:{}", "b".repeat(64)), &expected).is_err()
+    );
+    validate_daemon_workspace_metadata(&format!("v1:{}\n", expected[0]), &expected).unwrap();
+}
+
+#[test]
+fn explicit_workspace_selection_wins_over_current_directory() {
+    let current = std::env::current_dir().expect("current directory");
+    let explicit = tempfile::tempdir().expect("explicit workspace");
+    assert_ne!(explicit.path(), current);
+
+    let explicit_fingerprint = astrid_core::dirs::checked_workspace_selection_fingerprint(
+        explicit.path(),
+        crate::workspace_layout::current(),
+    )
+    .unwrap();
+    assert!(
+        expected_workspace_fingerprints(Some(explicit.path()))
+            .unwrap()
+            .contains(&explicit_fingerprint)
+    );
+    let current_fingerprint = astrid_core::dirs::checked_workspace_selection_fingerprint(
+        &current,
+        crate::workspace_layout::current(),
+    )
+    .unwrap();
+    assert!(
+        expected_workspace_fingerprints(None)
+            .unwrap()
+            .contains(&current_fingerprint)
+    );
+}
+
+#[test]
+fn ephemeral_boot_passes_the_selected_workspace_to_the_daemon() {
+    use std::ffi::OsStr;
+
+    let command = ephemeral_daemon_command(
+        Path::new("/installed/astrid-daemon"),
+        Path::new("/selected/project"),
+    );
+    let args = command.get_args().collect::<Vec<_>>();
+
+    assert_eq!(
+        args,
+        vec![
+            OsStr::new("--ephemeral"),
+            OsStr::new("--workspace"),
+            OsStr::new("/selected/project"),
+        ]
+    );
+    assert_eq!(
+        command
+            .get_envs()
+            .find(|(name, _)| *name == OsStr::new("ASTRID_WORKSPACE_STATE_DIR"))
+            .and_then(|(_, value)| value),
+        Some(OsStr::new(
+            crate::workspace_layout::current().state_dir_name()
+        ))
+    );
+}
+
+/// REGRESSION (#1120): `astrid stop` must remove runtime markers only when the
+/// daemon is confirmed gone. `StillAlive`/`Unverified` retain diagnostic state.
+#[test]
+fn stop_cleans_up_only_when_confirmed_gone() {
+    use daemon_control::KillOutcome;
+    assert!(stop_confirmed_gone(KillOutcome::NotRunning));
+    assert!(stop_confirmed_gone(KillOutcome::TermExited));
+    assert!(stop_confirmed_gone(KillOutcome::KilledExited));
+    assert!(!stop_confirmed_gone(KillOutcome::StillAlive));
+    assert!(!stop_confirmed_gone(KillOutcome::Unverified(4242)));
+}
+
+#[test]
+fn unconfirmed_termination_is_a_nonzero_outcome() {
+    use daemon_control::KillOutcome;
+
+    let still_alive = confirm_kill_outcome(KillOutcome::StillAlive)
+        .expect_err("a live daemon cannot be successful");
+    assert!(format!("{still_alive:#}").contains("daemon.process_reap"));
+
+    let unverified = confirm_kill_outcome(KillOutcome::Unverified(4242))
+        .expect_err("PID reuse cannot be successful");
+    assert!(format!("{unverified:#}").contains("daemon.process_identity"));
+}
+
+#[tokio::test]
+async fn acknowledged_shutdown_without_pid_is_unverified() {
+    let error = confirm_graceful_stop(None, Path::new("/tmp/absent-astrid.sock"))
+        .await
+        .expect_err("an ACK without a process identity cannot prove process exit");
+    assert!(format!("{error:#}").contains("daemon.process_reap"));
+}
+
+#[test]
+fn first_shutdown_failure_remains_primary() {
+    let error = combine_stop_results(
+        Err(anyhow::anyhow!("gateway.final_ack")),
+        Err(anyhow::anyhow!("daemon.process_reap")),
+    )
+    .expect_err("both failures must be returned");
+    let message = format!("{error:#}");
+    assert!(message.starts_with("gateway.final_ack"));
+    assert!(message.contains("additional shutdown failure: daemon.process_reap"));
+}
+
+#[test]
+fn start_reachable_daemon_is_already_running() {
+    assert_eq!(
+        decide_start_action(true, false),
+        StartAction::AlreadyRunning
+    );
+    assert_eq!(decide_start_action(true, true), StartAction::AlreadyRunning);
+    assert!(!start_clears_sentinels(StartAction::AlreadyRunning));
+}
+
+#[test]
+fn start_unreachable_with_dead_pid_heals_and_spawns() {
+    let action = decide_start_action(false, false);
+    assert_eq!(action, StartAction::HealAndSpawn);
+    assert!(start_clears_sentinels(action));
+}
+
+#[test]
+fn start_unreachable_with_live_pid_defers_and_leaves_sentinels() {
+    let action = decide_start_action(false, true);
+    assert_eq!(action, StartAction::RunningButUnreachable);
+    assert!(!start_clears_sentinels(action));
+}
+
+#[test]
+fn ensure_unlinked_or_stale_sock_with_live_pid_refuses_second_boot() {
+    use astrid_core::local_transport::ConnectOutcome;
+    assert_eq!(
+        decide_ensure_action(&ConnectOutcome::Absent, true),
+        EnsureAction::RefuseSecondBoot
+    );
+    assert_eq!(
+        decide_ensure_action(&ConnectOutcome::Stale, true),
+        EnsureAction::RefuseSecondBoot
+    );
+    assert_eq!(
+        decide_ensure_action(&ConnectOutcome::Absent, false),
+        EnsureAction::Spawn
+    );
+    assert_eq!(
+        decide_ensure_action(&ConnectOutcome::Stale, false),
+        EnsureAction::CleanStaleAndSpawn
+    );
+}
+
+#[test]
+fn status_unlinked_sock_with_live_pid_is_unreachable() {
+    assert_eq!(
+        decide_status_action(false, true),
+        StatusAction::RunningButUnreachable
+    );
+    assert_eq!(decide_status_action(false, false), StatusAction::NotRunning);
+    assert_eq!(
+        decide_status_action(true, true),
+        StatusAction::QueryLiveSocket
+    );
+}
+
+#[test]
+fn status_error_is_not_reported_as_a_successful_status() {
+    let error = status_response(KernelResponse::Error("denied".into()))
+        .expect_err("kernel status errors must fail the command");
+    assert!(
+        error
+            .to_string()
+            .contains("daemon rejected status request: denied")
+    );
+}
+
+#[test]
+fn absent_daemon_has_typed_stopped_status() {
+    assert_eq!(
+        status_document(None),
+        serde_json::json!({ "state": "stopped" })
+    );
+}

--- a/crates/astrid-cli/src/commands/daemon/tests.rs
+++ b/crates/astrid-cli/src/commands/daemon/tests.rs
@@ -13,6 +13,18 @@ fn fresh_home_boot_log_does_not_preinitialize_layout() {
     );
 }
 
+#[test]
+fn fresh_home_start_fence_lives_outside_the_layout() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let root = temp.path().join("astrid-home");
+    let home = astrid_core::dirs::AstridHome::from_path(&root);
+    let fence = daemon_start_fence_path(&home);
+
+    assert!(fence.starts_with(std::env::temp_dir()));
+    assert!(!fence.starts_with(home.root()));
+    assert!(!root.exists());
+}
+
 #[tokio::test]
 async fn already_stopped_fresh_home_does_not_create_layout() {
     let temp = tempfile::tempdir().expect("temp dir");

--- a/crates/astrid-cli/src/commands/daemon_control.rs
+++ b/crates/astrid-cli/src/commands/daemon_control.rs
@@ -89,7 +89,7 @@ pub(crate) async fn terminate_identity(identity: &DaemonIdentity, pid_path: &Pat
         && read_daemon_identity_from_contents(
             &std::fs::read_to_string(pid_path).unwrap_or_default(),
         )
-        .is_some_and(|current| current.boot_nonce.as_deref() != Some(expected.as_str()))
+        .is_none_or(|current| current.boot_nonce.as_deref() != Some(expected.as_str()))
     {
         return KillOutcome::Unverified(identity.pid);
     }
@@ -590,6 +590,40 @@ mod tests {
         std::fs::write(&path, format!("{me}")).unwrap();
         assert_eq!(terminate_orphan(&path).await, KillOutcome::Unverified(me));
         assert!(is_process_alive(me));
+    }
+
+    #[tokio::test]
+    async fn captured_nonce_fails_closed_when_current_pid_file_is_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("system.pid");
+        let identity = DaemonIdentity {
+            pid: std::process::id(),
+            exe: std::env::current_exe().ok(),
+            boot_nonce: Some("captured-generation".into()),
+        };
+
+        assert_eq!(
+            terminate_identity(&identity, &path).await,
+            KillOutcome::Unverified(identity.pid)
+        );
+    }
+
+    #[tokio::test]
+    async fn captured_nonce_fails_closed_when_current_pid_file_is_malformed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("system.pid");
+        std::fs::write(&path, b"not-a-daemon-generation\n").unwrap();
+        let identity = DaemonIdentity {
+            pid: std::process::id(),
+            exe: std::env::current_exe().ok(),
+            boot_nonce: Some("captured-generation".into()),
+        };
+
+        assert_eq!(
+            terminate_identity(&identity, &path).await,
+            KillOutcome::Unverified(identity.pid)
+        );
+        assert!(is_process_alive(std::process::id()));
     }
 
     #[test]

--- a/crates/astrid-cli/src/commands/daemon_control.rs
+++ b/crates/astrid-cli/src/commands/daemon_control.rs
@@ -54,6 +54,68 @@ pub(crate) fn read_pid_file(pid_path: &Path) -> Option<(u32, Option<PathBuf>)> {
     parse_pid_file(&contents)
 }
 
+/// A captured daemon generation. The nonce is minted and published while the
+/// singleton lock is held; PID and executable path alone do not own it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DaemonIdentity {
+    pub pid: u32,
+    pub exe: Option<PathBuf>,
+    pub boot_nonce: Option<String>,
+}
+
+pub(crate) fn read_daemon_identity(pid_path: &Path) -> Option<DaemonIdentity> {
+    let contents = std::fs::read_to_string(pid_path).ok()?;
+    let mut lines = contents.lines();
+    let pid = parse_pid(lines.next()?)?;
+    let exe = lines
+        .next()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from);
+    let boot_nonce = lines
+        .next()
+        .map(str::trim)
+        .filter(|value| !value.is_empty() && value.len() <= 128)
+        .map(str::to_owned);
+    Some(DaemonIdentity {
+        pid,
+        exe,
+        boot_nonce,
+    })
+}
+
+pub(crate) async fn terminate_identity(identity: &DaemonIdentity, pid_path: &Path) -> KillOutcome {
+    if let Some(expected) = &identity.boot_nonce
+        && read_daemon_identity_from_contents(
+            &std::fs::read_to_string(pid_path).unwrap_or_default(),
+        )
+        .is_some_and(|current| current.boot_nonce.as_deref() != Some(expected.as_str()))
+    {
+        return KillOutcome::Unverified(identity.pid);
+    }
+    terminate_known(identity.pid, identity.exe.as_deref()).await
+}
+
+fn read_daemon_identity_from_contents(contents: &str) -> Option<DaemonIdentity> {
+    let mut lines = contents.lines();
+    let pid = parse_pid(lines.next()?)?;
+    let exe = lines
+        .next()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from);
+    let boot_nonce = lines
+        .next()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned);
+    Some(DaemonIdentity {
+        pid,
+        exe,
+        boot_nonce,
+    })
+}
+
 /// Parse the PID-file body: first line = PID (required), optional second line =
 /// the daemon's recorded executable path. Pure helper, split out for testing.
 pub(crate) fn parse_pid_file(contents: &str) -> Option<(u32, Option<PathBuf>)> {
@@ -255,10 +317,10 @@ pub(crate) enum KillOutcome {
 /// state db), so the function is self-contained and unit-testable against any
 /// PID.
 pub(crate) async fn terminate_orphan(pid_path: &Path) -> KillOutcome {
-    let Some((pid, recorded_exe)) = read_pid_file(pid_path) else {
+    let Some(identity) = read_daemon_identity(pid_path) else {
         return KillOutcome::NotRunning;
     };
-    terminate_known(pid, recorded_exe.as_deref()).await
+    terminate_identity(&identity, pid_path).await
 }
 
 /// Terminate a daemon whose PID and recorded exe are ALREADY in hand — the
@@ -376,6 +438,21 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("system.pid");
         assert_eq!(read_pid_file(&path), None);
+    }
+
+    #[test]
+    fn daemon_identity_binds_pid_exe_and_boot_nonce() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("system.pid");
+        std::fs::write(&path, "42\n/daemon\nnonce\n").unwrap();
+        assert_eq!(
+            read_daemon_identity(&path),
+            Some(DaemonIdentity {
+                pid: 42,
+                exe: Some(PathBuf::from("/daemon")),
+                boot_nonce: Some("nonce".into()),
+            })
+        );
     }
 
     #[test]

--- a/crates/astrid-cli/src/commands/mcp/gateway.rs
+++ b/crates/astrid-cli/src/commands/mcp/gateway.rs
@@ -9,15 +9,18 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
 use std::time::Duration;
 
 use anyhow::{Context, Result};
 use rmcp::ServiceExt;
 use rmcp::service::{Peer, RoleServer};
-use tokio::io::{AsyncRead, AsyncReadExt, BufReader};
+use serde::Deserialize;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
 use tokio::sync::{Mutex, Notify, OwnedMutexGuard, OwnedSemaphorePermit, Semaphore};
+use tokio::task::JoinHandle;
 use tokio::time::{Instant, timeout};
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
@@ -26,7 +29,8 @@ use uuid::Uuid;
 use super::idle::{ATTACH_IDLE_EOF, IdleEof, is_idle};
 
 use super::lifecycle::{
-    ATTACH_REGISTRATION_VERSION, AttachRegistration, GatewayReady, prepare_gateway_socket,
+    ATTACH_REGISTRATION_VERSION, AttachRegistration, GATEWAY_CONTROL_VERSION, GatewayControlAck,
+    GatewayControlOperation, GatewayControlRequest, GatewayReady, prepare_gateway_socket,
     remove_gateway_ready, write_gateway_ready,
 };
 use super::server::AstridMcpServer;
@@ -74,6 +78,13 @@ struct GatewayState {
     slots: Mutex<HashMap<String, AttachSlot>>,
     admission: Arc<Mutex<()>>,
     initialize: Mutex<()>,
+    shutdown: CancellationToken,
+    active_connections: AtomicUsize,
+    connections_drained: Notify,
+    watchers: Mutex<Vec<JoinHandle<()>>>,
+    shutdown_result: Mutex<Option<GatewayControlAck>>,
+    shutdown_finished: Notify,
+    shutdown_ack_sent: Notify,
 }
 
 impl GatewayState {
@@ -88,11 +99,21 @@ impl GatewayState {
             slots: Mutex::new(HashMap::new()),
             admission: Arc::new(Mutex::new(())),
             initialize: Mutex::new(()),
+            shutdown: CancellationToken::new(),
+            active_connections: AtomicUsize::new(0),
+            connections_drained: Notify::new(),
+            watchers: Mutex::new(Vec::new()),
+            shutdown_result: Mutex::new(None),
+            shutdown_finished: Notify::new(),
+            shutdown_ack_sent: Notify::new(),
         }
     }
 
     /// Get or establish the one daemon uplink for `principal`.
     async fn client_for(&self, principal: &astrid_core::PrincipalId) -> Result<Client> {
+        if self.shutdown.is_cancelled() {
+            anyhow::bail!("MCP gateway is shutting down");
+        }
         let key = principal.to_string();
         if let Some(client) = self.clients.lock().await.get(&key).cloned() {
             return Ok(client);
@@ -101,6 +122,9 @@ impl GatewayState {
         // Serialize first-use handshakes so two simultaneous attaches for a
         // new principal cannot create duplicate long-lived uplinks/watchers.
         let _initialize = self.initialize.lock().await;
+        if self.shutdown.is_cancelled() {
+            anyhow::bail!("MCP gateway is shutting down");
+        }
         if let Some(client) = self.clients.lock().await.get(&key).cloned() {
             return Ok(client);
         }
@@ -130,13 +154,35 @@ impl GatewayState {
             .lock()
             .await
             .insert(key.clone(), Arc::clone(&peers));
-        tokio::spawn(super::watch::run_many(
+        let watcher = tokio::spawn(super::watch::run_many(
             peers,
             key.clone(),
             self.daemon_root.clone(),
+            self.shutdown.clone(),
         ));
+        self.watchers.lock().await.push(watcher);
         info!(principal = %key, "MCP gateway opened persistent principal uplink");
         Ok(shared)
+    }
+
+    async fn verify_uplink(&self) -> Result<()> {
+        let client = self.client_for(&self.principal).await?;
+        let mut client = client.lock().await;
+        let principal = self.principal.clone();
+        crate::socket_client::reconnect_for_workspace(
+            &mut client,
+            principal.clone(),
+            Some(&self.daemon_root),
+            |connected| {
+                super::require_authenticated_unless_anonymous(
+                    &principal,
+                    connected.is_authenticated(),
+                )
+            },
+        )
+        .await
+        .context("failed to recover the persistent daemon uplink")?;
+        Ok(())
     }
 
     async fn peers_for(&self, principal: &str) -> Result<Peers> {
@@ -181,6 +227,9 @@ impl GatewayState {
         principal: &str,
     ) -> Result<AttachReservation> {
         let admission = Arc::clone(&self.admission).lock_owned().await;
+        if self.shutdown.is_cancelled() {
+            anyhow::bail!("MCP gateway is shutting down");
+        }
         self.replace_session(host_session_id).await?;
         let permit = self.acquire(principal).await?;
         Ok(AttachReservation { admission, permit })
@@ -257,6 +306,70 @@ impl GatewayState {
         tests::probe_finish_slot(&semaphore);
         done.notify_waiters();
     }
+
+    fn connection(self: &Arc<Self>) -> ConnectionGuard {
+        self.active_connections.fetch_add(1, Ordering::AcqRel);
+        ConnectionGuard {
+            state: Arc::clone(self),
+            active: true,
+        }
+    }
+
+    async fn wait_for_connections(&self) {
+        loop {
+            let drained = self.connections_drained.notified();
+            if self.active_connections.load(Ordering::Acquire) == 0 {
+                return;
+            }
+            drained.await;
+        }
+    }
+
+    async fn cancel_attach_slots(&self) {
+        for slot in self.slots.lock().await.values() {
+            slot.cancel.cancel();
+        }
+    }
+
+    async fn finish_shutdown(&self, result: GatewayControlAck) {
+        *self.shutdown_result.lock().await = Some(result);
+        self.shutdown_finished.notify_waiters();
+    }
+
+    async fn wait_for_shutdown(&self) -> GatewayControlAck {
+        loop {
+            let finished = self.shutdown_finished.notified();
+            if let Some(result) = self.shutdown_result.lock().await.clone() {
+                return result;
+            }
+            finished.await;
+        }
+    }
+}
+
+struct ConnectionGuard {
+    state: Arc<GatewayState>,
+    active: bool,
+}
+
+impl ConnectionGuard {
+    fn release(&mut self) {
+        if !self.active {
+            return;
+        }
+        self.active = false;
+        let previous = self.state.active_connections.fetch_sub(1, Ordering::AcqRel);
+        debug_assert!(previous > 0, "gateway connection count underflow");
+        if previous == 1 {
+            self.state.connections_drained.notify_waiters();
+        }
+    }
+}
+
+impl Drop for ConnectionGuard {
+    fn drop(&mut self) {
+        self.release();
+    }
 }
 
 impl AttachReservation {
@@ -313,31 +426,155 @@ pub(crate) async fn run(principal: Option<&str>) -> Result<ExitCode> {
         "MCP gateway ready"
     );
 
-    let result = accept_loop(listener, state).await;
-    remove_gateway_ready();
-    let _ = std::fs::remove_file(socket_path);
-    result
+    let accept_result = accept_loop(listener, Arc::clone(&state)).await;
+    let control_stop = state.shutdown.is_cancelled();
+    state.shutdown.cancel();
+    let cleanup_result =
+        shutdown_gateway(&state, (!control_stop).then_some(&ready), &socket_path).await;
+
+    if control_stop {
+        let ack_sent = state.shutdown_ack_sent.notified();
+        let ack = match (&accept_result, &cleanup_result) {
+            (Ok(_), Ok(())) => {
+                GatewayControlAck::success(GatewayControlOperation::Stop, std::process::id())
+            },
+            (Err(error), _) | (Ok(_), Err(error)) => GatewayControlAck::failure(
+                GatewayControlOperation::Stop,
+                std::process::id(),
+                format!("{error:#}"),
+            ),
+        };
+        state.finish_shutdown(ack).await;
+        timeout(crate::commands::daemon_control::GRACE, ack_sent)
+            .await
+            .context("shutdown stage gateway.final_ack_delivery")?;
+    }
+
+    combine_gateway_results(accept_result, cleanup_result)
+}
+
+fn combine_gateway_results(accept: Result<ExitCode>, cleanup: Result<()>) -> Result<ExitCode> {
+    match (accept, cleanup) {
+        (Ok(exit), Ok(())) => Ok(exit),
+        (Err(primary), Ok(())) | (Ok(_), Err(primary)) => Err(primary),
+        (Err(primary), Err(secondary)) => {
+            anyhow::bail!("{primary:#}; additional gateway cleanup failure: {secondary:#}")
+        },
+    }
 }
 
 async fn accept_loop(listener: UnixListener, state: Arc<GatewayState>) -> Result<ExitCode> {
     loop {
-        let (stream, _) = listener
-            .accept()
-            .await
-            .context("MCP gateway listener failed")?;
-        let state = Arc::clone(&state);
-        tokio::spawn(async move {
-            if let Err(error) = serve_attach(stream, state).await {
-                warn!(error = %error, "MCP gateway attach session ended with an error");
+        tokio::select! {
+            () = state.shutdown.cancelled() => return Ok(ExitCode::SUCCESS),
+            accepted = listener.accept() => {
+                let (stream, _) = accepted.context("MCP gateway listener failed")?;
+                let state = Arc::clone(&state);
+                // Count the connection before spawning its task. Otherwise a
+                // simultaneous stop can observe zero, finish cleanup, and let
+                // the not-yet-polled task start after teardown.
+                let connection = state.connection();
+                tokio::spawn(async move {
+                    if let Err(error) = serve_connection(stream, state, connection).await {
+                        warn!(error = %error, "MCP gateway connection ended with an error");
+                    }
+                });
             }
-        });
+        }
     }
 }
 
-async fn serve_attach(stream: UnixStream, state: Arc<GatewayState>) -> Result<()> {
+async fn shutdown_gateway(
+    state: &Arc<GatewayState>,
+    ready_to_remove: Option<&GatewayReady>,
+    socket_path: &Path,
+) -> Result<()> {
+    state.cancel_attach_slots().await;
+    timeout(
+        crate::commands::daemon_control::GRACE,
+        state.wait_for_connections(),
+    )
+    .await
+    .context("shutdown stage gateway.attach_drain: timed out")?;
+
+    let watchers = std::mem::take(&mut *state.watchers.lock().await);
+    let mut watcher_failure = None;
+    for mut watcher in watchers {
+        match timeout(crate::commands::daemon_control::GRACE, &mut watcher).await {
+            Ok(Ok(())) => {},
+            Ok(Err(error)) => {
+                watcher_failure.get_or_insert_with(|| {
+                    format!("shutdown stage gateway.uplink_teardown: {error}")
+                });
+            },
+            Err(_) => {
+                watcher.abort();
+                let _ = watcher.await;
+                watcher_failure.get_or_insert_with(|| {
+                    "shutdown stage gateway.uplink_teardown: timed out".to_string()
+                });
+            },
+        }
+    }
+
+    state.peers.lock().await.clear();
+    state.clients.lock().await.clear();
+    state.permits.lock().await.clear();
+    if !state.slots.lock().await.is_empty() {
+        anyhow::bail!("shutdown stage gateway.attach_slots: slots remained after teardown");
+    }
+    astrid_core::local_transport::remove_endpoint(socket_path).with_context(|| {
+        format!(
+            "shutdown stage gateway.listener_cleanup: {}",
+            socket_path.display()
+        )
+    })?;
+    if let Some(failure) = watcher_failure {
+        anyhow::bail!(failure);
+    }
+    // During an authenticated control stop, the caller removes the exact
+    // readiness record only after this process has exited. Natural/error
+    // shutdowns have no such caller, so the gateway cleans its own record.
+    if let Some(ready) = ready_to_remove {
+        remove_gateway_ready(ready).context("shutdown stage gateway.ready_cleanup")?;
+    }
+    Ok(())
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum GatewayRequest {
+    Control(GatewayControlRequest),
+    Attach(AttachRegistration),
+}
+
+async fn serve_connection(
+    stream: UnixStream,
+    state: Arc<GatewayState>,
+    connection: ConnectionGuard,
+) -> Result<()> {
     let (read_half, write_half) = tokio::io::split(stream);
     let mut reader = BufReader::new(read_half);
-    let registration = read_registration(&mut reader).await?;
+    let request = tokio::select! {
+        () = state.shutdown.cancelled() => return Ok(()),
+        request = read_gateway_request(&mut reader) => request?,
+    };
+    match request {
+        GatewayRequest::Control(request) => {
+            serve_control(request, write_half, state, Some(connection)).await
+        },
+        GatewayRequest::Attach(registration) => {
+            serve_attach(registration, reader, write_half, state).await
+        },
+    }
+}
+
+async fn serve_attach(
+    registration: AttachRegistration,
+    reader: BufReader<tokio::io::ReadHalf<UnixStream>>,
+    write_half: tokio::io::WriteHalf<UnixStream>,
+    state: Arc<GatewayState>,
+) -> Result<()> {
     let principal = authenticate_registration(&registration, &state)?;
     let workspace = validate_workspace(&registration.workspace_abs)?;
     let principal_key = principal.to_string();
@@ -348,7 +585,9 @@ async fn serve_attach(stream: UnixStream, state: Arc<GatewayState>) -> Result<()
         .reserve_session(&host_session_id, &principal_key)
         .await?;
     let last_activity = Arc::new(StdMutex::new(Instant::now()));
-    let cancel = CancellationToken::new();
+    // A child token preserves per-session replacement while guaranteeing a
+    // session admitted concurrently with stop inherits global cancellation.
+    let cancel = state.shutdown.child_token();
     let done = Arc::new(Notify::new());
     let slot_id = Uuid::new_v4();
     let permit = reservation
@@ -383,6 +622,76 @@ async fn serve_attach(stream: UnixStream, state: Arc<GatewayState>) -> Result<()
         .finish_slot(&host_session_id, slot_id, permit, done)
         .await;
     result
+}
+
+async fn serve_control<W>(
+    request: GatewayControlRequest,
+    mut writer: W,
+    state: Arc<GatewayState>,
+    mut connection: Option<ConnectionGuard>,
+) -> Result<()>
+where
+    W: AsyncWrite + Unpin,
+{
+    let pid = std::process::id();
+    let authenticated = request.version == GATEWAY_CONTROL_VERSION
+        && request.pid == pid
+        && request.hook_token == state.hook_token;
+    if !authenticated {
+        let ack = GatewayControlAck::failure(
+            request.operation,
+            pid,
+            "gateway control authority did not match this process",
+        );
+        write_control_ack(&mut writer, &ack).await?;
+        return Ok(());
+    }
+
+    match request.operation {
+        GatewayControlOperation::Health => {
+            let ack = match state.verify_uplink().await {
+                Ok(()) => GatewayControlAck::success(GatewayControlOperation::Health, pid),
+                Err(error) => GatewayControlAck::failure(
+                    GatewayControlOperation::Health,
+                    pid,
+                    format!("{error:#}"),
+                ),
+            };
+            write_control_ack(&mut writer, &ack).await
+        },
+        GatewayControlOperation::Stop => {
+            // Only an authenticated stop may release itself from the drain.
+            // A forged stop remains counted until its rejection is delivered.
+            drop(connection.take());
+            state.shutdown.cancel();
+            let ack = state.wait_for_shutdown().await;
+            let result = write_control_ack(&mut writer, &ack).await;
+            // `notify_one` retains a permit if the run loop has not polled its
+            // waiter yet, closing the fast-ACK lost-wakeup race.
+            state.shutdown_ack_sent.notify_one();
+            result
+        },
+    }
+}
+
+async fn write_control_ack<W>(writer: &mut W, ack: &GatewayControlAck) -> Result<()>
+where
+    W: AsyncWrite + Unpin,
+{
+    let bytes =
+        serde_json::to_vec(ack).context("failed to encode gateway control acknowledgement")?;
+    writer
+        .write_all(&bytes)
+        .await
+        .context("failed to write gateway control acknowledgement")?;
+    writer
+        .write_all(b"\n")
+        .await
+        .context("failed to terminate gateway control acknowledgement")?;
+    writer
+        .shutdown()
+        .await
+        .context("failed to finish gateway control acknowledgement")
 }
 
 async fn run_attached_session<S, R>(
@@ -429,6 +738,25 @@ async fn read_registration_inner<R>(reader: &mut BufReader<R>) -> Result<AttachR
 where
     R: AsyncRead + Unpin,
 {
+    match read_gateway_request_inner(reader).await? {
+        GatewayRequest::Attach(registration) => Ok(registration),
+        GatewayRequest::Control(_) => anyhow::bail!("expected MCP attach registration"),
+    }
+}
+
+async fn read_gateway_request<R>(reader: &mut BufReader<R>) -> Result<GatewayRequest>
+where
+    R: AsyncRead + Unpin,
+{
+    timeout(REGISTRATION_TIMEOUT, read_gateway_request_inner(reader))
+        .await
+        .context("timed out reading MCP gateway registration")?
+}
+
+async fn read_gateway_request_inner<R>(reader: &mut BufReader<R>) -> Result<GatewayRequest>
+where
+    R: AsyncRead + Unpin,
+{
     let mut line = Vec::new();
     let mut terminated = false;
     for _ in 0..=MAX_REGISTRATION_BYTES {
@@ -445,8 +773,26 @@ where
     if !terminated {
         anyhow::bail!("MCP attach registration is missing or too large");
     }
-    let registration: AttachRegistration =
-        serde_json::from_slice(&line).context("MCP attach registration is not valid JSON")?;
+    let request: GatewayRequest =
+        serde_json::from_slice(&line).context("MCP gateway registration is not valid JSON")?;
+    match &request {
+        GatewayRequest::Control(control) => {
+            if control.version != GATEWAY_CONTROL_VERSION {
+                anyhow::bail!(
+                    "unsupported MCP gateway control version {}",
+                    control.version
+                );
+            }
+            if control.pid == 0 || control.hook_token.trim().is_empty() {
+                anyhow::bail!("MCP gateway control authority is incomplete");
+            }
+        },
+        GatewayRequest::Attach(registration) => validate_registration(registration)?,
+    }
+    Ok(request)
+}
+
+fn validate_registration(registration: &AttachRegistration) -> Result<()> {
     if registration.version != ATTACH_REGISTRATION_VERSION {
         anyhow::bail!(
             "unsupported MCP attach registration version {}",
@@ -464,7 +810,7 @@ where
         anyhow::bail!("MCP attach registration is missing hook_token");
     }
     validate_workspace(&registration.workspace_abs)?;
-    Ok(registration)
+    Ok(())
 }
 
 fn authenticate_registration(

--- a/crates/astrid-cli/src/commands/mcp/gateway.rs
+++ b/crates/astrid-cli/src/commands/mcp/gateway.rs
@@ -86,6 +86,7 @@ struct GatewayState {
     shutdown_result: Mutex<Option<GatewayControlAck>>,
     shutdown_finished: Notify,
     shutdown_ack_sent: Notify,
+    stop_ack_waiters: AtomicUsize,
 }
 
 impl GatewayState {
@@ -107,6 +108,7 @@ impl GatewayState {
             shutdown_result: Mutex::new(None),
             shutdown_finished: Notify::new(),
             shutdown_ack_sent: Notify::new(),
+            stop_ack_waiters: AtomicUsize::new(0),
         }
     }
 
@@ -346,6 +348,52 @@ impl GatewayState {
             finished.await;
         }
     }
+
+    fn begin_stop_ack(&self) {
+        self.stop_ack_waiters.fetch_add(1, Ordering::AcqRel);
+    }
+
+    fn finish_stop_ack(&self) {
+        let remaining = self.stop_ack_waiters.fetch_sub(1, Ordering::AcqRel);
+        debug_assert!(remaining > 0, "shutdown ACK waiter count underflow");
+        if remaining == 1 {
+            // Unlike `notify_waiters`, `notify_one` retains a permit when the
+            // run loop has not yet registered. The waiter count, not the
+            // notification, is what prevents the first ACK from releasing run.
+            self.shutdown_ack_sent.notify_one();
+        }
+    }
+
+    async fn wait_for_stop_acks(&self) {
+        loop {
+            let delivered = self.shutdown_ack_sent.notified();
+            if self.stop_ack_waiters.load(Ordering::Acquire) == 0 {
+                return;
+            }
+            delivered.await;
+        }
+    }
+}
+
+struct StartupLeaseGuard {
+    boot_token: String,
+    armed: bool,
+}
+
+impl StartupLeaseGuard {
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for StartupLeaseGuard {
+    fn drop(&mut self) {
+        if self.armed
+            && let Err(error) = remove_gateway_startup_lease(Some(&self.boot_token))
+        {
+            warn!(error = %error, "failed to remove MCP gateway startup lease");
+        }
+    }
 }
 
 struct ConnectionGuard {
@@ -395,6 +443,24 @@ pub(crate) async fn run(principal: Option<&str>) -> Result<ExitCode> {
     })?;
     let daemon_root = std::env::current_dir().context("failed to read MCP gateway cwd")?;
 
+    let boot_token = mint_boot_token();
+    let gateway_exe = std::env::current_exe()
+        .and_then(std::fs::canonicalize)
+        .context("failed to resolve MCP gateway executable identity")?;
+    let startup_lease = GatewayStartupLease {
+        version: 1,
+        principal: caller.to_string(),
+        boot_token: boot_token.clone(),
+        supervisor_pid: std::process::id(),
+        gateway_pid: Some(std::process::id()),
+        gateway_exe: Some(gateway_exe),
+    };
+    write_gateway_startup_lease(&startup_lease)?;
+    let mut lease_guard = StartupLeaseGuard {
+        boot_token: boot_token.clone(),
+        armed: true,
+    };
+
     // Gateway startup is the one place that may create the persistent daemon.
     // `mcp serve` remains the explicitly requested per-session/ephemeral path.
     crate::commands::daemon::ensure_persistent_daemon("mcp-gateway")
@@ -408,18 +474,9 @@ pub(crate) async fn run(principal: Option<&str>) -> Result<ExitCode> {
         hook_token.clone(),
     ));
     // Warm the authenticated principal selected by `ready`/`gateway` before
-    // accepting any attach registration.
+    // accepting any attach registration. The lease was published first so this
+    // slow, pre-listener generation remains authenticated-stop capable.
     state.client_for(&caller).await?;
-
-    let boot_token = mint_hook_token();
-    let startup_lease = GatewayStartupLease {
-        version: 1,
-        principal: caller.to_string(),
-        boot_token: boot_token.clone(),
-        supervisor_pid: std::process::id(),
-        gateway_pid: Some(std::process::id()),
-    };
-    write_gateway_startup_lease(&startup_lease)?;
     let socket_path = prepare_gateway_socket(&lifecycle).await?;
     let listener = UnixListener::bind(&socket_path)
         .with_context(|| format!("failed to bind MCP gateway at {}", socket_path.display()))?;
@@ -433,6 +490,7 @@ pub(crate) async fn run(principal: Option<&str>) -> Result<ExitCode> {
         hook_token,
     };
     write_gateway_ready(&ready)?;
+    lease_guard.disarm();
     info!(
         principal = %caller,
         socket = %socket_path.display(),
@@ -451,7 +509,6 @@ pub(crate) async fn run(principal: Option<&str>) -> Result<ExitCode> {
     .await;
 
     if control_stop {
-        let ack_sent = state.shutdown_ack_sent.notified();
         let ack = match (&accept_result, &cleanup_result) {
             (Ok(_), Ok(())) => {
                 GatewayControlAck::success(GatewayControlOperation::Stop, std::process::id())
@@ -463,9 +520,12 @@ pub(crate) async fn run(principal: Option<&str>) -> Result<ExitCode> {
             ),
         };
         state.finish_shutdown(ack).await;
-        timeout(crate::commands::daemon_control::GRACE, ack_sent)
-            .await
-            .context("shutdown stage gateway.final_ack_delivery")?;
+        timeout(
+            crate::commands::daemon_control::GRACE,
+            state.wait_for_stop_acks(),
+        )
+        .await
+        .context("shutdown stage gateway.final_ack_delivery")?;
     }
 
     combine_gateway_results(accept_result, cleanup_result)
@@ -483,9 +543,6 @@ fn combine_gateway_results(accept: Result<ExitCode>, cleanup: Result<()>) -> Res
 
 async fn accept_loop(listener: UnixListener, state: Arc<GatewayState>) -> Result<ExitCode> {
     loop {
-        if state.shutdown.is_cancelled() && state.shutdown_result.lock().await.is_some() {
-            return Ok(ExitCode::SUCCESS);
-        }
         tokio::select! {
             accepted = listener.accept() => {
                 let (stream, _) = accepted.context("MCP gateway listener failed")?;
@@ -501,13 +558,10 @@ async fn accept_loop(listener: UnixListener, state: Arc<GatewayState>) -> Result
                 });
             }
             () = state.shutdown.cancelled() => {
-                // Keep accepting until final shutdown state is published so
-                // every accepted stopper receives the same idempotent ACK.
-            },
-            () = state.shutdown_finished.notified() => {
-                if state.shutdown_result.lock().await.is_some() {
-                    return Ok(ExitCode::SUCCESS);
-                }
+                // Stop handing out new transports. `run` can now drain the
+                // connections already admitted, finish teardown, and publish
+                // the one final ACK without waiting for this loop.
+                return Ok(ExitCode::SUCCESS);
             },
         }
     }
@@ -699,12 +753,11 @@ where
             // Only an authenticated stop may release itself from the drain.
             // A forged stop remains counted until its rejection is delivered.
             drop(connection.take());
+            state.begin_stop_ack();
             state.shutdown.cancel();
             let ack = state.wait_for_shutdown().await;
             let result = write_control_ack(&mut writer, &ack).await;
-            // `notify_one` retains a permit if the run loop has not polled its
-            // waiter yet, closing the fast-ACK lost-wakeup race.
-            state.shutdown_ack_sent.notify_one();
+            state.finish_stop_ack();
             result
         },
     }
@@ -873,6 +926,10 @@ fn mint_hook_token() -> String {
         Uuid::new_v4().as_simple(),
         Uuid::new_v4().as_simple()
     )
+}
+
+fn mint_boot_token() -> String {
+    Uuid::new_v4().as_simple().to_string()
 }
 
 fn validate_workspace(value: &str) -> Result<PathBuf> {

--- a/crates/astrid-cli/src/commands/mcp/gateway.rs
+++ b/crates/astrid-cli/src/commands/mcp/gateway.rs
@@ -30,8 +30,9 @@ use super::idle::{ATTACH_IDLE_EOF, IdleEof, is_idle};
 
 use super::lifecycle::{
     ATTACH_REGISTRATION_VERSION, AttachRegistration, GATEWAY_CONTROL_VERSION, GatewayControlAck,
-    GatewayControlOperation, GatewayControlRequest, GatewayReady, prepare_gateway_socket,
-    remove_gateway_ready, write_gateway_ready,
+    GatewayControlOperation, GatewayControlRequest, GatewayReady, GatewayStartupLease,
+    prepare_gateway_socket, remove_gateway_ready, remove_gateway_startup_lease,
+    try_acquire_gateway_lifecycle, write_gateway_ready, write_gateway_startup_lease,
 };
 use super::server::AstridMcpServer;
 
@@ -389,6 +390,9 @@ impl AttachReservation {
 /// Run the durable MCP gateway until it is terminated.
 pub(crate) async fn run(principal: Option<&str>) -> Result<ExitCode> {
     let caller = super::lifecycle::resolve_principal(principal)?;
+    let lifecycle = try_acquire_gateway_lifecycle()?.ok_or_else(|| {
+        anyhow::anyhow!("another MCP gateway startup or lifecycle is already active")
+    })?;
     let daemon_root = std::env::current_dir().context("failed to read MCP gateway cwd")?;
 
     // Gateway startup is the one place that may create the persistent daemon.
@@ -407,7 +411,16 @@ pub(crate) async fn run(principal: Option<&str>) -> Result<ExitCode> {
     // accepting any attach registration.
     state.client_for(&caller).await?;
 
-    let socket_path = prepare_gateway_socket().await?;
+    let boot_token = mint_hook_token();
+    let startup_lease = GatewayStartupLease {
+        version: 1,
+        principal: caller.to_string(),
+        boot_token: boot_token.clone(),
+        supervisor_pid: std::process::id(),
+        gateway_pid: Some(std::process::id()),
+    };
+    write_gateway_startup_lease(&startup_lease)?;
+    let socket_path = prepare_gateway_socket(&lifecycle).await?;
     let listener = UnixListener::bind(&socket_path)
         .with_context(|| format!("failed to bind MCP gateway at {}", socket_path.display()))?;
     set_socket_mode(&socket_path)?;
@@ -429,8 +442,13 @@ pub(crate) async fn run(principal: Option<&str>) -> Result<ExitCode> {
     let accept_result = accept_loop(listener, Arc::clone(&state)).await;
     let control_stop = state.shutdown.is_cancelled();
     state.shutdown.cancel();
-    let cleanup_result =
-        shutdown_gateway(&state, (!control_stop).then_some(&ready), &socket_path).await;
+    let cleanup_result = shutdown_gateway(
+        &state,
+        (!control_stop).then_some(&ready),
+        &socket_path,
+        &boot_token,
+    )
+    .await;
 
     if control_stop {
         let ack_sent = state.shutdown_ack_sent.notified();
@@ -465,8 +483,10 @@ fn combine_gateway_results(accept: Result<ExitCode>, cleanup: Result<()>) -> Res
 
 async fn accept_loop(listener: UnixListener, state: Arc<GatewayState>) -> Result<ExitCode> {
     loop {
+        if state.shutdown.is_cancelled() && state.shutdown_result.lock().await.is_some() {
+            return Ok(ExitCode::SUCCESS);
+        }
         tokio::select! {
-            () = state.shutdown.cancelled() => return Ok(ExitCode::SUCCESS),
             accepted = listener.accept() => {
                 let (stream, _) = accepted.context("MCP gateway listener failed")?;
                 let state = Arc::clone(&state);
@@ -480,6 +500,15 @@ async fn accept_loop(listener: UnixListener, state: Arc<GatewayState>) -> Result
                     }
                 });
             }
+            () = state.shutdown.cancelled() => {
+                // Keep accepting until final shutdown state is published so
+                // every accepted stopper receives the same idempotent ACK.
+            },
+            () = state.shutdown_finished.notified() => {
+                if state.shutdown_result.lock().await.is_some() {
+                    return Ok(ExitCode::SUCCESS);
+                }
+            },
         }
     }
 }
@@ -488,6 +517,7 @@ async fn shutdown_gateway(
     state: &Arc<GatewayState>,
     ready_to_remove: Option<&GatewayReady>,
     socket_path: &Path,
+    boot_token: &str,
 ) -> Result<()> {
     state.cancel_attach_slots().await;
     timeout(
@@ -538,6 +568,8 @@ async fn shutdown_gateway(
     if let Some(ready) = ready_to_remove {
         remove_gateway_ready(ready).context("shutdown stage gateway.ready_cleanup")?;
     }
+    remove_gateway_startup_lease(Some(boot_token))
+        .context("shutdown stage gateway.startup_cleanup")?;
     Ok(())
 }
 
@@ -555,9 +587,13 @@ async fn serve_connection(
 ) -> Result<()> {
     let (read_half, write_half) = tokio::io::split(stream);
     let mut reader = BufReader::new(read_half);
-    let request = tokio::select! {
-        () = state.shutdown.cancelled() => return Ok(()),
-        request = read_gateway_request(&mut reader) => request?,
+    let request = if state.shutdown.is_cancelled() {
+        read_gateway_request(&mut reader).await?
+    } else {
+        tokio::select! {
+            () = state.shutdown.cancelled() => read_gateway_request(&mut reader).await?,
+            request = read_gateway_request(&mut reader) => request?,
+        }
     };
     match request {
         GatewayRequest::Control(request) => {

--- a/crates/astrid-cli/src/commands/mcp/gateway_tests.rs
+++ b/crates/astrid-cli/src/commands/mcp/gateway_tests.rs
@@ -631,3 +631,150 @@ async fn acquire_does_not_evict_active_slots() {
         cancel.cancel();
     }
 }
+
+#[tokio::test]
+async fn forged_gateway_stop_cannot_cancel_the_process() {
+    use tokio::io::AsyncReadExt;
+
+    let principal = astrid_core::PrincipalId::new("codex-code").expect("principal");
+    let state = Arc::new(GatewayState::new(
+        PathBuf::from("/runtime-home"),
+        principal,
+        "gateway-token".into(),
+    ));
+    let request = GatewayControlRequest {
+        version: GATEWAY_CONTROL_VERSION,
+        operation: GatewayControlOperation::Stop,
+        pid: std::process::id(),
+        hook_token: "forged-token".into(),
+    };
+    let (server, mut client) = tokio::io::duplex(4096);
+    let connection = state.connection();
+
+    serve_control(request, server, Arc::clone(&state), Some(connection))
+        .await
+        .expect("forged control receives a bounded rejection");
+    let mut response = Vec::new();
+    client
+        .read_to_end(&mut response)
+        .await
+        .expect("control ACK");
+    let ack: GatewayControlAck =
+        serde_json::from_slice(&response).expect("rejection is valid JSON");
+    assert!(!ack.ok);
+    assert!(!state.shutdown.is_cancelled());
+    assert_eq!(state.active_connections.load(Ordering::Acquire), 0);
+}
+
+#[tokio::test]
+async fn authenticated_gateway_stop_waits_for_final_teardown_ack() {
+    use tokio::io::AsyncReadExt;
+    use tokio::time::{Duration, timeout};
+
+    let principal = astrid_core::PrincipalId::new("codex-code").expect("principal");
+    let state = Arc::new(GatewayState::new(
+        PathBuf::from("/runtime-home"),
+        principal,
+        "gateway-token".into(),
+    ));
+    let request = GatewayControlRequest {
+        version: GATEWAY_CONTROL_VERSION,
+        operation: GatewayControlOperation::Stop,
+        pid: std::process::id(),
+        hook_token: "gateway-token".into(),
+    };
+    let (server, mut client) = tokio::io::duplex(4096);
+    let serving_state = Arc::clone(&state);
+    let connection = state.connection();
+    let serving = tokio::spawn(async move {
+        serve_control(request, server, serving_state, Some(connection)).await
+    });
+
+    timeout(Duration::from_secs(1), state.shutdown.cancelled())
+        .await
+        .expect("authenticated stop must cancel the gateway");
+    assert_eq!(state.active_connections.load(Ordering::Acquire), 0);
+    assert!(
+        timeout(Duration::from_millis(20), client.read_u8())
+            .await
+            .is_err(),
+        "no success ACK may precede final teardown"
+    );
+
+    state
+        .finish_shutdown(GatewayControlAck::success(
+            GatewayControlOperation::Stop,
+            std::process::id(),
+        ))
+        .await;
+    let mut response = Vec::new();
+    client
+        .read_to_end(&mut response)
+        .await
+        .expect("control ACK");
+    serving
+        .await
+        .expect("control task")
+        .expect("authenticated control");
+    let ack: GatewayControlAck = serde_json::from_slice(&response).expect("valid ACK JSON");
+    assert!(ack.ok);
+    timeout(Duration::from_secs(1), state.shutdown_ack_sent.notified())
+        .await
+        .expect("ACK completion notification retains its permit");
+}
+
+#[tokio::test]
+async fn shutdown_waits_for_precounted_connections() {
+    use tokio::time::{Duration, timeout};
+
+    let principal = astrid_core::PrincipalId::new("codex-code").expect("principal");
+    let state = Arc::new(GatewayState::new(
+        PathBuf::from("/runtime-home"),
+        principal,
+        "gateway-token".into(),
+    ));
+    let connection = state.connection();
+    let waiting_state = Arc::clone(&state);
+    let mut waiting = tokio::spawn(async move { waiting_state.wait_for_connections().await });
+
+    assert!(
+        timeout(Duration::from_millis(20), &mut waiting)
+            .await
+            .is_err(),
+        "shutdown must not race past an accepted, not-yet-polled connection"
+    );
+    drop(connection);
+    timeout(Duration::from_secs(1), waiting)
+        .await
+        .expect("connection drain")
+        .expect("connection waiter");
+}
+
+#[tokio::test]
+async fn shutdown_rejects_late_attach_admission() {
+    let principal = astrid_core::PrincipalId::new("codex-code").expect("principal");
+    let state = GatewayState::new(
+        PathBuf::from("/runtime-home"),
+        principal,
+        "gateway-token".into(),
+    );
+    state.shutdown.cancel();
+
+    let Err(error) = state.reserve_session("thread-late", "codex-code").await else {
+        panic!("stop must close attach admission");
+    };
+    assert!(error.to_string().contains("shutting down"));
+}
+
+#[test]
+fn gateway_cleanup_failure_does_not_mask_accept_failure() {
+    let error = combine_gateway_results(
+        Err(anyhow::anyhow!("gateway.accept")),
+        Err(anyhow::anyhow!("gateway.listener_cleanup")),
+    )
+    .expect_err("both failures must be returned");
+    let message = format!("{error:#}");
+    assert!(message.starts_with("gateway.accept"));
+    assert!(message.contains("additional gateway cleanup failure"));
+    assert!(message.contains("gateway.listener_cleanup"));
+}

--- a/crates/astrid-cli/src/commands/mcp/gateway_tests.rs
+++ b/crates/astrid-cli/src/commands/mcp/gateway_tests.rs
@@ -751,6 +751,70 @@ async fn shutdown_waits_for_precounted_connections() {
 }
 
 #[tokio::test]
+async fn concurrent_accepted_stoppers_receive_the_same_final_ack() {
+    use tokio::io::AsyncWriteExt;
+    use tokio::net::UnixListener;
+    use tokio::time::{Duration, timeout};
+
+    let principal = astrid_core::PrincipalId::new("codex-code").expect("principal");
+    let state = Arc::new(GatewayState::new(
+        PathBuf::from("/runtime-home"),
+        principal,
+        "gateway-token".into(),
+    ));
+    let socket = std::env::temp_dir().join(format!("astrid-1809-stop-{}.sock", std::process::id()));
+    let _ = std::fs::remove_file(&socket);
+    let listener = UnixListener::bind(&socket).expect("short-path gateway listener");
+    let accepting_state = Arc::clone(&state);
+    let accepting = tokio::spawn(async move { accept_loop(listener, accepting_state).await });
+
+    let request = serde_json::to_vec(&GatewayControlRequest {
+        version: GATEWAY_CONTROL_VERSION,
+        operation: GatewayControlOperation::Stop,
+        pid: std::process::id(),
+        hook_token: "gateway-token".into(),
+    })
+    .expect("control request");
+    let mut clients = Vec::new();
+    for _ in 0..2 {
+        let mut client = tokio::net::UnixStream::connect(&socket)
+            .await
+            .expect("connect stopper");
+        client
+            .write_all(&request)
+            .await
+            .expect("queue stop request");
+        client.write_all(b"\n").await.expect("terminate request");
+        clients.push(client);
+    }
+    tokio::task::yield_now().await;
+    state.shutdown.cancel();
+
+    state
+        .finish_shutdown(GatewayControlAck::success(
+            GatewayControlOperation::Stop,
+            std::process::id(),
+        ))
+        .await;
+    timeout(Duration::from_secs(1), accepting)
+        .await
+        .expect("accept loop drains all stoppers")
+        .expect("accept loop task")
+        .expect("normal accept exit");
+
+    let mut acks = Vec::new();
+    for mut client in clients {
+        let mut response = Vec::new();
+        tokio::io::AsyncReadExt::read_to_end(&mut client, &mut response)
+            .await
+            .expect("control ACK");
+        acks.push(serde_json::from_slice::<GatewayControlAck>(&response).expect("valid ACK"));
+    }
+    assert!(acks.iter().all(|ack| ack.ok));
+    let _ = std::fs::remove_file(&socket);
+}
+
+#[tokio::test]
 async fn shutdown_rejects_late_attach_admission() {
     let principal = astrid_core::PrincipalId::new("codex-code").expect("principal");
     let state = GatewayState::new(

--- a/crates/astrid-cli/src/commands/mcp/gateway_tests.rs
+++ b/crates/astrid-cli/src/commands/mcp/gateway_tests.rs
@@ -56,6 +56,41 @@ fn attach_cap_is_bounded_per_principal_channel() {
     assert_eq!(MAX_ATTACHES, 16);
 }
 
+#[test]
+fn control_tokens_have_distinct_lifetimes_and_widths() {
+    let boot_token = mint_boot_token();
+    let hook_token = mint_hook_token();
+    assert_eq!(boot_token.len(), 32);
+    assert_eq!(hook_token.len(), 64);
+    assert_ne!(boot_token, hook_token);
+}
+
+#[tokio::test]
+async fn every_stopper_is_counted_until_its_ack_delivery_finishes() {
+    let principal = astrid_core::PrincipalId::new("codex-code").expect("principal");
+    let state = GatewayState::new(
+        PathBuf::from("/runtime-home"),
+        principal,
+        "gateway-token".into(),
+    );
+    state.begin_stop_ack();
+    state.begin_stop_ack();
+
+    let waiting = state.wait_for_stop_acks();
+    tokio::pin!(waiting);
+    tokio::task::yield_now().await;
+    state.finish_stop_ack();
+    tokio::time::timeout(std::time::Duration::from_millis(20), &mut waiting)
+        .await
+        .expect_err("the final stopper must not release the run loop early");
+
+    tokio::task::yield_now().await;
+    state.finish_stop_ack();
+    tokio::time::timeout(std::time::Duration::from_millis(1), &mut waiting)
+        .await
+        .expect("final ACK delivery must be bounded");
+}
+
 #[tokio::test]
 async fn attach_cap_rejects_the_seventeenth_live_session() {
     let principal = astrid_core::PrincipalId::new("codex-code").expect("principal");

--- a/crates/astrid-cli/src/commands/mcp/lifecycle.rs
+++ b/crates/astrid-cli/src/commands/mcp/lifecycle.rs
@@ -27,7 +27,7 @@ pub(crate) const READY_TIMEOUT: Duration = Duration::from_secs(15);
 /// Broker warm-up is a legitimate pre-listener startup stage. This budget only
 /// applies while `ready` is waiting for a generation it spawned; control ACKs
 /// continue to use the shorter [`READY_TIMEOUT`].
-const SPAWNED_READY_TIMEOUT: Duration = Duration::from_secs(60);
+const SPAWNED_READY_TIMEOUT: Duration = Duration::from_mins(1);
 const READY_POLL: Duration = Duration::from_millis(100);
 /// A control frame is a tiny owner-local message. This is a protocol/DoS
 /// ceiling, not an operator tuning knob.

--- a/crates/astrid-cli/src/commands/mcp/lifecycle.rs
+++ b/crates/astrid-cli/src/commands/mcp/lifecycle.rs
@@ -7,6 +7,7 @@ use std::time::{Duration, Instant};
 use anyhow::{Context, Result};
 use astrid_core::PrincipalId;
 use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::UnixStream;
 
 /// The gateway endpoint is deliberately separate from the daemon's
@@ -16,9 +17,14 @@ pub(crate) const GATEWAY_SOCKET_NAME: &str = "mcp-gateway.sock";
 /// Readiness metadata is written only after the gateway has authenticated its
 /// broker uplink and bound the listener.
 pub(crate) const GATEWAY_READY_NAME: &str = "mcp-gateway.ready";
+/// Version of the owner-authenticated gateway control exchange.
+pub(crate) const GATEWAY_CONTROL_VERSION: u8 = 1;
 /// `ready` is a bounded hook probe, never a doctor or full capsule scan.
 pub(crate) const READY_TIMEOUT: Duration = Duration::from_secs(15);
 const READY_POLL: Duration = Duration::from_millis(100);
+/// A control frame is a tiny owner-local message. This is a protocol/DoS
+/// ceiling, not an operator tuning knob.
+pub(crate) const MAX_CONTROL_BYTES: usize = 16 * 1024;
 
 /// Versioned preface sent by every short-lived `mcp attach` process before it
 /// starts speaking MCP. The gateway uses this host-owned context to preserve
@@ -45,6 +51,57 @@ pub(crate) struct GatewayReady {
     pub hook_token: String,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum GatewayControlOperation {
+    Health,
+    Stop,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct GatewayControlRequest {
+    pub version: u8,
+    pub operation: GatewayControlOperation,
+    pub pid: u32,
+    pub hook_token: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct GatewayControlAck {
+    pub version: u8,
+    pub operation: GatewayControlOperation,
+    pub pid: u32,
+    pub ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+impl GatewayControlAck {
+    pub(crate) const fn success(operation: GatewayControlOperation, pid: u32) -> Self {
+        Self {
+            version: GATEWAY_CONTROL_VERSION,
+            operation,
+            pid,
+            ok: true,
+            error: None,
+        }
+    }
+
+    pub(crate) fn failure(
+        operation: GatewayControlOperation,
+        pid: u32,
+        error: impl Into<String>,
+    ) -> Self {
+        Self {
+            version: GATEWAY_CONTROL_VERSION,
+            operation,
+            pid,
+            ok: false,
+            error: Some(error.into()),
+        }
+    }
+}
+
 /// Resolve a principal once at the command boundary.
 pub(crate) fn resolve_principal(requested: Option<&str>) -> Result<PrincipalId> {
     match requested {
@@ -63,7 +120,7 @@ pub(crate) fn gateway_socket_path() -> Result<PathBuf> {
 }
 
 /// Resolve the gateway readiness metadata path under the private Astrid home.
-fn gateway_ready_path() -> Result<PathBuf> {
+pub(crate) fn gateway_ready_path() -> Result<PathBuf> {
     Ok(astrid_core::dirs::AstridHome::resolve()?
         .run_dir()
         .join(GATEWAY_READY_NAME))
@@ -72,7 +129,11 @@ fn gateway_ready_path() -> Result<PathBuf> {
 /// Read and validate the gateway's atomically-written readiness record.
 pub(crate) fn read_gateway_ready() -> Result<Option<GatewayReady>> {
     let path = gateway_ready_path()?;
-    let body = match std::fs::read_to_string(&path) {
+    read_gateway_ready_at(&path)
+}
+
+fn read_gateway_ready_at(path: &Path) -> Result<Option<GatewayReady>> {
+    let body = match std::fs::read_to_string(path) {
         Ok(body) => body,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(error) => {
@@ -118,10 +179,21 @@ pub(crate) fn write_gateway_ready(record: &GatewayReady) -> Result<()> {
     Ok(())
 }
 
-/// Remove this gateway's readiness marker during a clean shutdown.
-pub(crate) fn remove_gateway_ready() {
-    if let Ok(path) = gateway_ready_path() {
-        let _ = std::fs::remove_file(path);
+/// Remove this gateway's readiness marker without deleting a successor's.
+pub(crate) fn remove_gateway_ready(record: &GatewayReady) -> Result<()> {
+    let path = gateway_ready_path()?;
+    remove_gateway_ready_at(&path, record)
+}
+
+fn remove_gateway_ready_at(path: &Path, record: &GatewayReady) -> Result<()> {
+    match read_gateway_ready_at(path)? {
+        Some(current) if current == *record => std::fs::remove_file(path)
+            .with_context(|| format!("failed to remove {}", path.display())),
+        Some(_) => anyhow::bail!(
+            "MCP gateway readiness changed before cleanup at {}",
+            path.display()
+        ),
+        None => Ok(()),
     }
 }
 
@@ -187,9 +259,30 @@ pub(crate) async fn wait_for_gateway(principal: &PrincipalId, format: &str) -> R
                     principal
                 );
             }
-            if UnixStream::connect(&socket).await.is_ok() {
-                emit_ready(format, &record)?;
-                return Ok(ExitCode::SUCCESS);
+            match astrid_core::local_transport::connect_outcome(&socket)
+                .await
+                .context("failed to inspect MCP gateway endpoint")?
+            {
+                astrid_core::local_transport::ConnectOutcome::Connected(stream) => {
+                    request_gateway_control(stream, &record, GatewayControlOperation::Health)
+                        .await
+                        .context("MCP gateway cannot prove a recoverable daemon uplink")?;
+                    emit_ready(format, &record)?;
+                    return Ok(ExitCode::SUCCESS);
+                },
+                astrid_core::local_transport::ConnectOutcome::Absent
+                | astrid_core::local_transport::ConnectOutcome::Stale
+                    if crate::commands::daemon_control::is_process_alive(record.pid) =>
+                {
+                    anyhow::bail!(
+                        "MCP gateway PID {} is alive but its listener is unavailable",
+                        record.pid
+                    );
+                },
+                astrid_core::local_transport::ConnectOutcome::Absent
+                | astrid_core::local_transport::ConnectOutcome::Stale => {
+                    remove_dead_gateway_markers(&record).await?;
+                },
             }
         }
         if !spawned {
@@ -204,6 +297,158 @@ pub(crate) async fn wait_for_gateway(principal: &PrincipalId, format: &str) -> R
         }
         tokio::time::sleep(READY_POLL).await;
     }
+}
+
+/// Stop the persistent gateway through its owner-authenticated control path.
+///
+/// Success means the gateway returned its final teardown ACK, its recorded
+/// process exited, the listener is absent, and the exact readiness record is
+/// gone. Inconsistent or unowned state is left intact and reported.
+pub(crate) async fn stop_gateway() -> Result<()> {
+    let socket = gateway_socket_path()?;
+    let Some(record) = read_gateway_ready()? else {
+        return match astrid_core::local_transport::connect_outcome(&socket)
+            .await
+            .context("shutdown stage gateway.listener_probe")?
+        {
+            astrid_core::local_transport::ConnectOutcome::Absent => Ok(()),
+            astrid_core::local_transport::ConnectOutcome::Stale => {
+                astrid_core::local_transport::remove_stale_endpoint(&socket)
+                    .context("shutdown stage gateway.stale_listener_cleanup")?;
+                Ok(())
+            },
+            astrid_core::local_transport::ConnectOutcome::Connected(_) => anyhow::bail!(
+                "shutdown stage gateway.authentication: live gateway has no readiness authority"
+            ),
+        };
+    };
+
+    let stream = match astrid_core::local_transport::connect_outcome(&socket)
+        .await
+        .context("shutdown stage gateway.listener_probe")?
+    {
+        astrid_core::local_transport::ConnectOutcome::Connected(stream) => stream,
+        astrid_core::local_transport::ConnectOutcome::Absent
+        | astrid_core::local_transport::ConnectOutcome::Stale
+            if crate::commands::daemon_control::is_process_alive(record.pid) =>
+        {
+            anyhow::bail!(
+                "shutdown stage gateway.listener_absence: PID {} is alive without its authenticated listener",
+                record.pid
+            );
+        },
+        astrid_core::local_transport::ConnectOutcome::Absent
+        | astrid_core::local_transport::ConnectOutcome::Stale => {
+            remove_dead_gateway_markers(&record).await?;
+            return Ok(());
+        },
+    };
+
+    request_gateway_control(stream, &record, GatewayControlOperation::Stop)
+        .await
+        .context("shutdown stage gateway.final_ack")?;
+    if !crate::commands::daemon_control::wait_for_exit(
+        record.pid,
+        crate::commands::daemon_control::GRACE,
+    )
+    .await
+    {
+        anyhow::bail!(
+            "shutdown stage gateway.process_reap: authenticated gateway PID {} did not exit",
+            record.pid
+        );
+    }
+    remove_dead_gateway_markers(&record).await
+}
+
+async fn request_gateway_control(
+    stream: UnixStream,
+    record: &GatewayReady,
+    operation: GatewayControlOperation,
+) -> Result<GatewayControlAck> {
+    let request = GatewayControlRequest {
+        version: GATEWAY_CONTROL_VERSION,
+        operation,
+        pid: record.pid,
+        hook_token: record.hook_token.clone(),
+    };
+    let (read_half, mut write_half) = stream.into_split();
+    let bytes = serde_json::to_vec(&request).context("failed to encode MCP gateway control")?;
+    write_half
+        .write_all(&bytes)
+        .await
+        .context("failed to write MCP gateway control")?;
+    write_half
+        .write_all(b"\n")
+        .await
+        .context("failed to terminate MCP gateway control")?;
+    write_half
+        .flush()
+        .await
+        .context("failed to flush MCP gateway control")?;
+
+    let mut reader = BufReader::new(read_half);
+    let response = tokio::time::timeout(READY_TIMEOUT, read_bounded_line(&mut reader))
+        .await
+        .context("timed out waiting for MCP gateway control acknowledgement")??;
+    let ack: GatewayControlAck =
+        serde_json::from_slice(&response).context("invalid MCP gateway control acknowledgement")?;
+    if ack.version != GATEWAY_CONTROL_VERSION || ack.operation != operation || ack.pid != record.pid
+    {
+        anyhow::bail!("MCP gateway returned an unbound control acknowledgement");
+    }
+    if !ack.ok {
+        anyhow::bail!(
+            "MCP gateway rejected {operation:?}: {}",
+            ack.error.as_deref().unwrap_or("unknown gateway failure")
+        );
+    }
+    Ok(ack)
+}
+
+pub(crate) async fn read_bounded_line<R>(reader: &mut R) -> Result<Vec<u8>>
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    let mut line = Vec::new();
+    for _ in 0..=MAX_CONTROL_BYTES {
+        let byte = reader
+            .read_u8()
+            .await
+            .context("failed to read control frame")?;
+        if byte == b'\n' {
+            return Ok(line);
+        }
+        line.push(byte);
+    }
+    anyhow::bail!("MCP gateway control frame is missing or too large")
+}
+
+async fn remove_dead_gateway_markers(record: &GatewayReady) -> Result<()> {
+    if crate::commands::daemon_control::is_process_alive(record.pid) {
+        anyhow::bail!(
+            "shutdown stage gateway.process_reap: PID {} is still alive",
+            record.pid
+        );
+    }
+    let socket = gateway_socket_path()?;
+    match astrid_core::local_transport::connect_outcome(&socket)
+        .await
+        .context("shutdown stage gateway.listener_probe")?
+    {
+        astrid_core::local_transport::ConnectOutcome::Connected(_) => {
+            anyhow::bail!(
+                "shutdown stage gateway.listener_absence: a gateway is still accepting connections"
+            );
+        },
+        astrid_core::local_transport::ConnectOutcome::Absent => {},
+        astrid_core::local_transport::ConnectOutcome::Stale => {
+            astrid_core::local_transport::remove_stale_endpoint(&socket)
+                .context("shutdown stage gateway.listener_cleanup")?;
+        },
+    }
+    remove_gateway_ready(record).context("shutdown stage gateway.ready_cleanup")?;
+    Ok(())
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -408,10 +653,10 @@ fn process_command(pid: u32) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        GatewayReady, ReadyFormat, is_long_mcp_serve, is_mcp_attach, is_python_frame,
-        parse_process_row,
-    };
+    use tokio::io::{AsyncWriteExt, BufReader};
+    use tokio::net::UnixStream;
+
+    use super::*;
 
     #[test]
     fn process_parser_preserves_command_after_pid_fields() {
@@ -464,5 +709,67 @@ mod tests {
         let body = serde_json::to_string(&record).expect("record json");
         assert_eq!(serde_json::from_str::<GatewayReady>(&body).unwrap(), record);
         assert_eq!(ReadyFormat::parse("hook").unwrap(), ReadyFormat::Hook);
+    }
+
+    #[test]
+    fn ready_cleanup_cannot_remove_a_successor_record() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let path = temp.path().join(GATEWAY_READY_NAME);
+        let old = GatewayReady {
+            version: 1,
+            principal: "codex-code".into(),
+            pid: 41,
+            hook_token: "old-token".into(),
+        };
+        let successor = GatewayReady {
+            version: 1,
+            principal: "codex-code".into(),
+            pid: 42,
+            hook_token: "successor-token".into(),
+        };
+        std::fs::write(&path, serde_json::to_vec(&successor).unwrap()).unwrap();
+
+        let error = remove_gateway_ready_at(&path, &old)
+            .expect_err("old cleanup must not remove a successor marker");
+        assert!(error.to_string().contains("readiness changed"));
+        assert_eq!(
+            read_gateway_ready_at(&path).unwrap(),
+            Some(successor.clone())
+        );
+
+        remove_gateway_ready_at(&path, &successor).expect("successor removes its own marker");
+        assert!(!path.exists());
+    }
+
+    #[tokio::test]
+    async fn control_ack_is_bound_to_operation_pid_and_success() {
+        for ack in [
+            GatewayControlAck::success(GatewayControlOperation::Stop, 42),
+            GatewayControlAck::success(GatewayControlOperation::Health, 43),
+            GatewayControlAck::failure(GatewayControlOperation::Health, 42, "uplink unavailable"),
+        ] {
+            let (client, server) = UnixStream::pair().expect("stream pair");
+            let serving = tokio::spawn(async move {
+                let (read_half, mut write_half) = server.into_split();
+                let mut reader = BufReader::new(read_half);
+                let request = read_bounded_line(&mut reader).await.expect("request");
+                serde_json::from_slice::<GatewayControlRequest>(&request).expect("valid request");
+                write_half
+                    .write_all(&serde_json::to_vec(&ack).unwrap())
+                    .await
+                    .unwrap();
+                write_half.write_all(b"\n").await.unwrap();
+            });
+            let record = GatewayReady {
+                version: 1,
+                principal: "codex-code".into(),
+                pid: 42,
+                hook_token: "gateway-token".into(),
+            };
+            request_gateway_control(client, &record, GatewayControlOperation::Health)
+                .await
+                .expect_err("an unbound or unsuccessful ACK must fail");
+            serving.await.expect("fake server");
+        }
     }
 }

--- a/crates/astrid-cli/src/commands/mcp/lifecycle.rs
+++ b/crates/astrid-cli/src/commands/mcp/lifecycle.rs
@@ -24,6 +24,10 @@ const GATEWAY_STARTUP_LEASE_NAME: &str = "mcp-gateway.starting";
 pub(crate) const GATEWAY_CONTROL_VERSION: u8 = 1;
 /// `ready` is a bounded hook probe, never a doctor or full capsule scan.
 pub(crate) const READY_TIMEOUT: Duration = Duration::from_secs(15);
+/// Broker warm-up is a legitimate pre-listener startup stage. This budget only
+/// applies while `ready` is waiting for a generation it spawned; control ACKs
+/// continue to use the shorter [`READY_TIMEOUT`].
+const SPAWNED_READY_TIMEOUT: Duration = Duration::from_secs(60);
 const READY_POLL: Duration = Duration::from_millis(100);
 /// A control frame is a tiny owner-local message. This is a protocol/DoS
 /// ceiling, not an operator tuning knob.
@@ -64,6 +68,8 @@ pub(crate) struct GatewayStartupLease {
     pub supervisor_pid: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gateway_pid: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gateway_exe: Option<PathBuf>,
 }
 
 /// An advisory lock held by one gateway for its entire lifetime.
@@ -155,6 +161,10 @@ pub(crate) fn read_gateway_startup_lease() -> Result<Option<GatewayStartupLease>
                 || lease.boot_token.len() != 32
                 || lease.supervisor_pid == 0
                 || lease.gateway_pid.is_some_and(|pid| pid == 0)
+                || lease
+                    .gateway_exe
+                    .as_ref()
+                    .is_none_or(|path| path.as_os_str().is_empty())
             {
                 anyhow::bail!("invalid MCP gateway startup lease at {}", path.display());
             }
@@ -390,7 +400,7 @@ pub(crate) async fn wait_for_gateway(principal: &PrincipalId, format: &str) -> R
     let format = ReadyFormat::parse(format)?;
     let socket = gateway_socket_path()?;
     let deadline = Instant::now()
-        .checked_add(READY_TIMEOUT)
+        .checked_add(SPAWNED_READY_TIMEOUT)
         .unwrap_or_else(Instant::now);
     let mut spawned = false;
     loop {
@@ -437,7 +447,7 @@ pub(crate) async fn wait_for_gateway(principal: &PrincipalId, format: &str) -> R
                 if Instant::now() >= deadline {
                     anyhow::bail!(
                         "MCP gateway startup supervisor remained active within {} seconds",
-                        READY_TIMEOUT.as_secs()
+                        SPAWNED_READY_TIMEOUT.as_secs()
                     );
                 }
                 tokio::time::sleep(READY_POLL).await;
@@ -454,34 +464,35 @@ pub(crate) async fn wait_for_gateway(principal: &PrincipalId, format: &str) -> R
                     anyhow::bail!(
                         "MCP gateway PID {} is still starting within {} seconds",
                         lease.supervisor_pid,
-                        READY_TIMEOUT.as_secs()
+                        SPAWNED_READY_TIMEOUT.as_secs()
                     );
                 }
                 tokio::time::sleep(READY_POLL).await;
                 continue;
             }
-            let lifecycle = try_acquire_gateway_lifecycle()?;
-            if lifecycle.is_some() {
+            let Some(lifecycle) = try_acquire_gateway_lifecycle()? else {
                 drop(supervisor);
                 if Instant::now() >= deadline {
                     anyhow::bail!(
                         "MCP gateway is starting but has not published readiness within {} seconds",
-                        READY_TIMEOUT.as_secs()
+                        SPAWNED_READY_TIMEOUT.as_secs()
                     );
                 }
                 tokio::time::sleep(READY_POLL).await;
                 continue;
-            }
-            clean_unowned_gateway_startup()
+            };
+            clean_unowned_gateway_startup(&lifecycle)
                 .await
                 .context("shutdown stage gateway.startup_cleanup")?;
             spawn_gateway(principal)?;
+            drop(lifecycle);
+            drop(supervisor);
             spawned = true;
         }
         if Instant::now() >= deadline {
             anyhow::bail!(
                 "MCP gateway did not become ready within {} seconds",
-                READY_TIMEOUT.as_secs()
+                SPAWNED_READY_TIMEOUT.as_secs()
             );
         }
         tokio::time::sleep(READY_POLL).await;
@@ -499,13 +510,17 @@ pub(crate) async fn stop_gateway() -> Result<()> {
         let deadline = Instant::now()
             .checked_add(READY_TIMEOUT)
             .unwrap_or_else(Instant::now);
-        while try_acquire_gateway_lifecycle()?.is_none()
-            || read_gateway_startup_lease()?.is_some_and(|lease| {
-                crate::commands::daemon_control::is_process_alive(lease.supervisor_pid)
-            })
-        {
+        while try_acquire_gateway_lifecycle()?.is_none() {
             if let Some(record) = read_gateway_ready()? {
                 return stop_ready_gateway(record, socket).await;
+            }
+            if let Some(lease) = read_gateway_startup_lease()?
+                && lease
+                    .gateway_pid
+                    .is_some_and(crate::commands::daemon_control::is_process_alive)
+            {
+                stop_startup_gateway(&lease).await?;
+                continue;
             }
             if Instant::now() >= deadline {
                 anyhow::bail!(
@@ -518,7 +533,7 @@ pub(crate) async fn stop_gateway() -> Result<()> {
         let lifecycle = try_acquire_gateway_lifecycle()?.ok_or_else(|| {
             anyhow::anyhow!("shutdown stage gateway.startup_stop: lifecycle changed")
         })?;
-        clean_unowned_gateway_startup()
+        clean_unowned_gateway_startup(&lifecycle)
             .await
             .context("shutdown stage gateway.stale_listener_cleanup")?;
         drop(lifecycle);
@@ -566,9 +581,35 @@ async fn stop_ready_gateway(record: GatewayReady, socket: PathBuf) -> Result<()>
     remove_dead_gateway_markers(&record).await
 }
 
-async fn clean_unowned_gateway_startup() -> Result<()> {
-    let lifecycle = try_acquire_gateway_lifecycle()?
-        .ok_or_else(|| anyhow::anyhow!("MCP gateway lifecycle remains held"))?;
+async fn stop_startup_gateway(lease: &GatewayStartupLease) -> Result<()> {
+    let Some(gateway_pid) = lease.gateway_pid else {
+        anyhow::bail!("shutdown stage gateway.startup_identity: lease has no gateway PID");
+    };
+    let Some(gateway_exe) = lease.gateway_exe.as_deref() else {
+        anyhow::bail!("shutdown stage gateway.startup_identity: lease has no executable");
+    };
+    let current = read_gateway_startup_lease()?.ok_or_else(|| {
+        anyhow::anyhow!("shutdown stage gateway.startup_identity: lease disappeared")
+    })?;
+    if current != *lease {
+        anyhow::bail!("shutdown stage gateway.startup_identity: startup generation changed");
+    }
+
+    let outcome =
+        crate::commands::daemon_control::terminate_known(gateway_pid, Some(gateway_exe)).await;
+    if !matches!(
+        outcome,
+        crate::commands::daemon_control::KillOutcome::TermExited
+            | crate::commands::daemon_control::KillOutcome::KilledExited
+    ) {
+        anyhow::bail!(
+            "shutdown stage gateway.startup_reap: starting gateway PID {gateway_pid} is {outcome:?}"
+        );
+    }
+    Ok(())
+}
+
+async fn clean_unowned_gateway_startup(lifecycle: &GatewayLifecycleLock) -> Result<()> {
     let socket = gateway_socket_path()?;
     match astrid_core::local_transport::connect_outcome(&socket)
         .await
@@ -584,7 +625,7 @@ async fn clean_unowned_gateway_startup() -> Result<()> {
         ),
     }
     remove_gateway_startup_lease(None).context("shutdown stage gateway.startup_cleanup")?;
-    drop(lifecycle);
+    let _ = lifecycle.file();
     Ok(())
 }
 
@@ -887,144 +928,5 @@ fn process_command(pid: u32) -> Option<String> {
 }
 
 #[cfg(test)]
-mod tests {
-    use tokio::io::{AsyncWriteExt, BufReader};
-    use tokio::net::UnixStream;
-
-    use super::*;
-
-    #[test]
-    fn gateway_lifecycle_admits_only_one_generation() {
-        let first = try_acquire_gateway_lifecycle()
-            .expect("lifecycle probe")
-            .expect("first generation owns the lifecycle");
-        assert!(
-            try_acquire_gateway_lifecycle()
-                .expect("lifecycle probe")
-                .is_none(),
-            "a successor must not bind while a generation lifecycle is held"
-        );
-        drop(first);
-        assert!(
-            try_acquire_gateway_lifecycle()
-                .expect("lifecycle probe")
-                .is_some(),
-            "releasing the lifecycle must permit the next generation"
-        );
-    }
-
-    #[test]
-    fn process_parser_preserves_command_after_pid_fields() {
-        let row = parse_process_row(" 123  1 /usr/local/bin/aos mcp serve --request-timeout 1d5m")
-            .expect("process row");
-        assert_eq!(row.pid, 123);
-        assert_eq!(row.ppid, 1);
-        assert!(is_long_mcp_serve(&row.command));
-    }
-
-    #[test]
-    fn gc_match_is_exact_about_timeout_and_verb() {
-        assert!(is_long_mcp_serve("aos mcp serve --request-timeout 1d5m"));
-        assert!(is_long_mcp_serve("aos mcp serve --request-timeout=1d5m"));
-        assert!(!is_long_mcp_serve("aos mcp serve --request-timeout 30s"));
-        assert!(!is_long_mcp_serve("aos mcp gateway --request-timeout 1d5m"));
-    }
-
-    #[test]
-    fn gc_reaps_orphaned_attach_but_never_python_frames() {
-        assert!(is_mcp_attach(
-            "/Users/me/.aos/runtime/bin/astrid --principal codex-code mcp attach --workspace /tmp/proj"
-        ));
-        assert!(is_mcp_attach("aos --principal codex-code mcp attach"));
-        assert!(!is_mcp_attach(
-            "/opt/homebrew/Cellar/python@3.14/3.14.6/Frameworks/Python.framework/Versions/3.14/Resources/Python.app/Contents/MacOS/Python -u /cache/unicity-aos/bin/aos-mcp-frame /runtime/bin/astrid --principal codex-code mcp attach --workspace /plugin"
-        ));
-        assert!(is_python_frame(
-            "Python -u /cache/bin/aos-mcp-frame astrid --principal codex-code mcp attach"
-        ));
-        assert!(!is_mcp_attach(
-            "node worker.js mcp attach --workspace /tmp/astrid"
-        ));
-        assert!(!is_mcp_attach("node /tmp/astrid worker.js mcp attach"));
-        assert!(is_mcp_attach(
-            "env ASTRID_SESSION_ID=thread-1 /opt/aos mcp attach --workspace /tmp/proj"
-        ));
-        assert!(!is_mcp_attach("astrid --principal codex-code mcp gateway"));
-        assert!(!is_mcp_attach("aos mcp serve --request-timeout 1d5m"));
-    }
-
-    #[test]
-    fn ready_record_is_stable_json_contract() {
-        let record = GatewayReady {
-            version: 1,
-            principal: "codex-code".into(),
-            pid: 42,
-            hook_token: "test-hook-token".into(),
-        };
-        let body = serde_json::to_string(&record).expect("record json");
-        assert_eq!(serde_json::from_str::<GatewayReady>(&body).unwrap(), record);
-        assert_eq!(ReadyFormat::parse("hook").unwrap(), ReadyFormat::Hook);
-    }
-
-    #[test]
-    fn ready_cleanup_cannot_remove_a_successor_record() {
-        let temp = tempfile::tempdir().expect("temp dir");
-        let path = temp.path().join(GATEWAY_READY_NAME);
-        let old = GatewayReady {
-            version: 1,
-            principal: "codex-code".into(),
-            pid: 41,
-            hook_token: "old-token".into(),
-        };
-        let successor = GatewayReady {
-            version: 1,
-            principal: "codex-code".into(),
-            pid: 42,
-            hook_token: "successor-token".into(),
-        };
-        std::fs::write(&path, serde_json::to_vec(&successor).unwrap()).unwrap();
-
-        let error = remove_gateway_ready_at(&path, &old)
-            .expect_err("old cleanup must not remove a successor marker");
-        assert!(error.to_string().contains("readiness changed"));
-        assert_eq!(
-            read_gateway_ready_at(&path).unwrap(),
-            Some(successor.clone())
-        );
-
-        remove_gateway_ready_at(&path, &successor).expect("successor removes its own marker");
-        assert!(!path.exists());
-    }
-
-    #[tokio::test]
-    async fn control_ack_is_bound_to_operation_pid_and_success() {
-        for ack in [
-            GatewayControlAck::success(GatewayControlOperation::Stop, 42),
-            GatewayControlAck::success(GatewayControlOperation::Health, 43),
-            GatewayControlAck::failure(GatewayControlOperation::Health, 42, "uplink unavailable"),
-        ] {
-            let (client, server) = UnixStream::pair().expect("stream pair");
-            let serving = tokio::spawn(async move {
-                let (read_half, mut write_half) = server.into_split();
-                let mut reader = BufReader::new(read_half);
-                let request = read_bounded_line(&mut reader).await.expect("request");
-                serde_json::from_slice::<GatewayControlRequest>(&request).expect("valid request");
-                write_half
-                    .write_all(&serde_json::to_vec(&ack).unwrap())
-                    .await
-                    .unwrap();
-                write_half.write_all(b"\n").await.unwrap();
-            });
-            let record = GatewayReady {
-                version: 1,
-                principal: "codex-code".into(),
-                pid: 42,
-                hook_token: "gateway-token".into(),
-            };
-            request_gateway_control(client, &record, GatewayControlOperation::Health)
-                .await
-                .expect_err("an unbound or unsuccessful ACK must fail");
-            serving.await.expect("fake server");
-        }
-    }
-}
+#[path = "lifecycle_tests.rs"]
+mod tests;

--- a/crates/astrid-cli/src/commands/mcp/lifecycle.rs
+++ b/crates/astrid-cli/src/commands/mcp/lifecycle.rs
@@ -17,6 +17,9 @@ pub(crate) const GATEWAY_SOCKET_NAME: &str = "mcp-gateway.sock";
 /// Readiness metadata is written only after the gateway has authenticated its
 /// broker uplink and bound the listener.
 pub(crate) const GATEWAY_READY_NAME: &str = "mcp-gateway.ready";
+const GATEWAY_LIFECYCLE_LOCK_NAME: &str = "mcp-gateway.lifecycle.lock";
+const GATEWAY_SUPERVISOR_LOCK_NAME: &str = "mcp-gateway.start.lock";
+const GATEWAY_STARTUP_LEASE_NAME: &str = "mcp-gateway.starting";
 /// Version of the owner-authenticated gateway control exchange.
 pub(crate) const GATEWAY_CONTROL_VERSION: u8 = 1;
 /// `ready` is a bounded hook probe, never a doctor or full capsule scan.
@@ -49,6 +52,150 @@ pub(crate) struct GatewayReady {
     pub principal: String,
     pub pid: u32,
     pub hook_token: String,
+}
+
+/// Identity for a gateway that has acquired its lifecycle lock but is not yet
+/// ready. The boot token binds cleanup to one attempted generation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct GatewayStartupLease {
+    pub version: u8,
+    pub principal: String,
+    pub boot_token: String,
+    pub supervisor_pid: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gateway_pid: Option<u32>,
+}
+
+/// An advisory lock held by one gateway for its entire lifetime.
+#[derive(Debug)]
+pub(crate) struct GatewayLifecycleLock(std::fs::File);
+
+/// Serializes `mcp ready` spawn attempts without being owned by the gateway.
+#[derive(Debug)]
+pub(crate) struct GatewaySupervisorLock(std::fs::File);
+
+impl GatewayLifecycleLock {
+    pub(crate) const fn file(&self) -> &std::fs::File {
+        &self.0
+    }
+}
+
+impl GatewaySupervisorLock {
+    pub(crate) const fn file(&self) -> &std::fs::File {
+        &self.0
+    }
+}
+
+fn open_lock_file(path: &Path) -> Result<std::fs::File> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("MCP gateway lock path has no parent"))?;
+    ensure_private_dir(parent)?;
+    let mut options = std::fs::OpenOptions::new();
+    options.read(true).write(true).create(true).truncate(false);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.mode(0o600);
+    }
+    options
+        .open(path)
+        .with_context(|| format!("failed to open {}", path.display()))
+}
+
+fn try_lock_file(file: std::fs::File, path: &Path) -> Result<Option<std::fs::File>> {
+    match file.try_lock() {
+        Ok(()) => Ok(Some(file)),
+        Err(std::fs::TryLockError::WouldBlock) => Ok(None),
+        Err(std::fs::TryLockError::Error(error)) => {
+            Err(error).with_context(|| format!("failed to lock {}", path.display()))
+        },
+    }
+}
+
+pub(crate) fn gateway_lifecycle_path() -> Result<PathBuf> {
+    Ok(astrid_core::dirs::AstridHome::resolve()?
+        .run_dir()
+        .join(GATEWAY_LIFECYCLE_LOCK_NAME))
+}
+
+pub(crate) fn gateway_supervisor_path() -> Result<PathBuf> {
+    Ok(astrid_core::dirs::AstridHome::resolve()?
+        .run_dir()
+        .join(GATEWAY_SUPERVISOR_LOCK_NAME))
+}
+
+pub(crate) fn gateway_startup_lease_path() -> Result<PathBuf> {
+    Ok(astrid_core::dirs::AstridHome::resolve()?
+        .run_dir()
+        .join(GATEWAY_STARTUP_LEASE_NAME))
+}
+
+pub(crate) fn try_acquire_gateway_lifecycle() -> Result<Option<GatewayLifecycleLock>> {
+    let path = gateway_lifecycle_path()?;
+    let file = open_lock_file(&path)?;
+    Ok(try_lock_file(file, &path)?.map(GatewayLifecycleLock))
+}
+
+pub(crate) fn try_acquire_gateway_supervisor() -> Result<Option<GatewaySupervisorLock>> {
+    let path = gateway_supervisor_path()?;
+    let file = open_lock_file(&path)?;
+    Ok(try_lock_file(file, &path)?.map(GatewaySupervisorLock))
+}
+
+pub(crate) fn read_gateway_startup_lease() -> Result<Option<GatewayStartupLease>> {
+    let path = gateway_startup_lease_path()?;
+    match std::fs::read(&path) {
+        Ok(bytes) => {
+            let lease: GatewayStartupLease = serde_json::from_slice(&bytes).with_context(|| {
+                format!("invalid MCP gateway startup lease at {}", path.display())
+            })?;
+            if lease.version != 1
+                || lease.principal.is_empty()
+                || lease.boot_token.len() != 32
+                || lease.supervisor_pid == 0
+                || lease.gateway_pid.is_some_and(|pid| pid == 0)
+            {
+                anyhow::bail!("invalid MCP gateway startup lease at {}", path.display());
+            }
+            Ok(Some(lease))
+        },
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error).with_context(|| format!("failed to read {}", path.display())),
+    }
+}
+
+pub(crate) fn write_gateway_startup_lease(lease: &GatewayStartupLease) -> Result<()> {
+    let path = gateway_startup_lease_path()?;
+    let parent = path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("MCP gateway startup lease path has no parent"))?;
+    ensure_private_dir(parent)?;
+    let temp = path.with_extension(format!("starting.tmp.{}", std::process::id()));
+    let bytes = serde_json::to_vec(lease).context("failed to encode MCP gateway startup lease")?;
+    std::fs::write(&temp, bytes).with_context(|| format!("failed to write {}", temp.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&temp, std::fs::Permissions::from_mode(0o600))?;
+    }
+    std::fs::rename(&temp, &path).with_context(|| format!("failed to publish {}", path.display()))
+}
+
+pub(crate) fn remove_gateway_startup_lease(boot_token: Option<&str>) -> Result<()> {
+    let path = gateway_startup_lease_path()?;
+    let lease = read_gateway_startup_lease()?;
+    if let Some(lease) = lease
+        && let Some(expected) = boot_token
+        && lease.boot_token != expected
+    {
+        anyhow::bail!("MCP gateway startup generation changed before cleanup");
+    }
+    match std::fs::remove_file(&path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error).with_context(|| format!("failed to remove {}", path.display())),
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -214,7 +361,7 @@ pub(crate) fn ensure_private_dir(path: &Path) -> Result<()> {
 }
 
 /// Bind-time cleanup and endpoint ownership check for a gateway listener.
-pub(crate) async fn prepare_gateway_socket() -> Result<PathBuf> {
+pub(crate) async fn prepare_gateway_socket(_lifecycle: &GatewayLifecycleLock) -> Result<PathBuf> {
     let path = gateway_socket_path()?;
     let parent = path
         .parent()
@@ -225,10 +372,9 @@ pub(crate) async fn prepare_gateway_socket() -> Result<PathBuf> {
         if UnixStream::connect(&path).await.is_ok() {
             anyhow::bail!("MCP gateway is already running at {}", path.display());
         }
-        // A failed connect means the pathname is stale or the old gateway is
-        // still between bind and accept. Removing it is safe because the
-        // listener itself is the ownership primitive; a concurrent bind below
-        // still wins with `AddrInUse` and is reported rather than clobbered.
+        // The lifecycle lock excludes every gateway generation. If the
+        // pathname survived a crash, this holder is now the only process that
+        // may remove and replace it.
         std::fs::remove_file(&path).with_context(|| {
             format!(
                 "failed to remove stale MCP gateway socket {}",
@@ -286,6 +432,49 @@ pub(crate) async fn wait_for_gateway(principal: &PrincipalId, format: &str) -> R
             }
         }
         if !spawned {
+            let supervisor = try_acquire_gateway_supervisor()?;
+            let Some(supervisor) = supervisor else {
+                if Instant::now() >= deadline {
+                    anyhow::bail!(
+                        "MCP gateway startup supervisor remained active within {} seconds",
+                        READY_TIMEOUT.as_secs()
+                    );
+                }
+                tokio::time::sleep(READY_POLL).await;
+                continue;
+            };
+            if read_gateway_ready()?.is_some() {
+                continue;
+            }
+            if let Some(lease) = read_gateway_startup_lease()?
+                && crate::commands::daemon_control::is_process_alive(lease.supervisor_pid)
+            {
+                drop(supervisor);
+                if Instant::now() >= deadline {
+                    anyhow::bail!(
+                        "MCP gateway PID {} is still starting within {} seconds",
+                        lease.supervisor_pid,
+                        READY_TIMEOUT.as_secs()
+                    );
+                }
+                tokio::time::sleep(READY_POLL).await;
+                continue;
+            }
+            let lifecycle = try_acquire_gateway_lifecycle()?;
+            if lifecycle.is_some() {
+                drop(supervisor);
+                if Instant::now() >= deadline {
+                    anyhow::bail!(
+                        "MCP gateway is starting but has not published readiness within {} seconds",
+                        READY_TIMEOUT.as_secs()
+                    );
+                }
+                tokio::time::sleep(READY_POLL).await;
+                continue;
+            }
+            clean_unowned_gateway_startup()
+                .await
+                .context("shutdown stage gateway.startup_cleanup")?;
             spawn_gateway(principal)?;
             spawned = true;
         }
@@ -307,22 +496,38 @@ pub(crate) async fn wait_for_gateway(principal: &PrincipalId, format: &str) -> R
 pub(crate) async fn stop_gateway() -> Result<()> {
     let socket = gateway_socket_path()?;
     let Some(record) = read_gateway_ready()? else {
-        return match astrid_core::local_transport::connect_outcome(&socket)
-            .await
-            .context("shutdown stage gateway.listener_probe")?
+        let deadline = Instant::now()
+            .checked_add(READY_TIMEOUT)
+            .unwrap_or_else(Instant::now);
+        while try_acquire_gateway_lifecycle()?.is_none()
+            || read_gateway_startup_lease()?.is_some_and(|lease| {
+                crate::commands::daemon_control::is_process_alive(lease.supervisor_pid)
+            })
         {
-            astrid_core::local_transport::ConnectOutcome::Absent => Ok(()),
-            astrid_core::local_transport::ConnectOutcome::Stale => {
-                astrid_core::local_transport::remove_stale_endpoint(&socket)
-                    .context("shutdown stage gateway.stale_listener_cleanup")?;
-                Ok(())
-            },
-            astrid_core::local_transport::ConnectOutcome::Connected(_) => anyhow::bail!(
-                "shutdown stage gateway.authentication: live gateway has no readiness authority"
-            ),
-        };
+            if let Some(record) = read_gateway_ready()? {
+                return stop_ready_gateway(record, socket).await;
+            }
+            if Instant::now() >= deadline {
+                anyhow::bail!(
+                    "shutdown stage gateway.startup_stop: a starting gateway did not become stoppable within {} seconds",
+                    READY_TIMEOUT.as_secs()
+                );
+            }
+            tokio::time::sleep(READY_POLL).await;
+        }
+        let lifecycle = try_acquire_gateway_lifecycle()?.ok_or_else(|| {
+            anyhow::anyhow!("shutdown stage gateway.startup_stop: lifecycle changed")
+        })?;
+        clean_unowned_gateway_startup()
+            .await
+            .context("shutdown stage gateway.stale_listener_cleanup")?;
+        drop(lifecycle);
+        return Ok(());
     };
+    stop_ready_gateway(record, socket).await
+}
 
+async fn stop_ready_gateway(record: GatewayReady, socket: PathBuf) -> Result<()> {
     let stream = match astrid_core::local_transport::connect_outcome(&socket)
         .await
         .context("shutdown stage gateway.listener_probe")?
@@ -359,6 +564,28 @@ pub(crate) async fn stop_gateway() -> Result<()> {
         );
     }
     remove_dead_gateway_markers(&record).await
+}
+
+async fn clean_unowned_gateway_startup() -> Result<()> {
+    let lifecycle = try_acquire_gateway_lifecycle()?
+        .ok_or_else(|| anyhow::anyhow!("MCP gateway lifecycle remains held"))?;
+    let socket = gateway_socket_path()?;
+    match astrid_core::local_transport::connect_outcome(&socket)
+        .await
+        .context("shutdown stage gateway.listener_probe")?
+    {
+        astrid_core::local_transport::ConnectOutcome::Absent => {},
+        astrid_core::local_transport::ConnectOutcome::Stale => {
+            astrid_core::local_transport::remove_stale_endpoint(&socket)
+                .context("shutdown stage gateway.stale_listener_cleanup")?;
+        },
+        astrid_core::local_transport::ConnectOutcome::Connected(_) => anyhow::bail!(
+            "shutdown stage gateway.authentication: live gateway has no readiness authority"
+        ),
+    }
+    remove_gateway_startup_lease(None).context("shutdown stage gateway.startup_cleanup")?;
+    drop(lifecycle);
+    Ok(())
 }
 
 async fn request_gateway_control(
@@ -431,6 +658,12 @@ async fn remove_dead_gateway_markers(record: &GatewayReady) -> Result<()> {
             record.pid
         );
     }
+    let lifecycle = try_acquire_gateway_lifecycle()?;
+    let Some(lifecycle) = lifecycle else {
+        anyhow::bail!(
+            "shutdown stage gateway.lifecycle_fence: a successor gateway lifecycle remains active"
+        );
+    };
     let socket = gateway_socket_path()?;
     match astrid_core::local_transport::connect_outcome(&socket)
         .await
@@ -448,6 +681,8 @@ async fn remove_dead_gateway_markers(record: &GatewayReady) -> Result<()> {
         },
     }
     remove_gateway_ready(record).context("shutdown stage gateway.ready_cleanup")?;
+    remove_gateway_startup_lease(None).context("shutdown stage gateway.startup_cleanup")?;
+    drop(lifecycle);
     Ok(())
 }
 
@@ -657,6 +892,26 @@ mod tests {
     use tokio::net::UnixStream;
 
     use super::*;
+
+    #[test]
+    fn gateway_lifecycle_admits_only_one_generation() {
+        let first = try_acquire_gateway_lifecycle()
+            .expect("lifecycle probe")
+            .expect("first generation owns the lifecycle");
+        assert!(
+            try_acquire_gateway_lifecycle()
+                .expect("lifecycle probe")
+                .is_none(),
+            "a successor must not bind while a generation lifecycle is held"
+        );
+        drop(first);
+        assert!(
+            try_acquire_gateway_lifecycle()
+                .expect("lifecycle probe")
+                .is_some(),
+            "releasing the lifecycle must permit the next generation"
+        );
+    }
 
     #[test]
     fn process_parser_preserves_command_after_pid_fields() {

--- a/crates/astrid-cli/src/commands/mcp/lifecycle_tests.rs
+++ b/crates/astrid-cli/src/commands/mcp/lifecycle_tests.rs
@@ -1,0 +1,139 @@
+use tokio::io::{AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+
+use super::*;
+
+#[test]
+fn gateway_lifecycle_admits_only_one_generation() {
+    let first = try_acquire_gateway_lifecycle()
+        .expect("lifecycle probe")
+        .expect("first generation owns the lifecycle");
+    assert!(
+        try_acquire_gateway_lifecycle()
+            .expect("lifecycle probe")
+            .is_none(),
+        "a successor must not bind while a generation lifecycle is held"
+    );
+    drop(first);
+    assert!(
+        try_acquire_gateway_lifecycle()
+            .expect("lifecycle probe")
+            .is_some(),
+        "releasing the lifecycle must permit the next generation"
+    );
+}
+
+#[test]
+fn process_parser_preserves_command_after_pid_fields() {
+    let row = parse_process_row(" 123  1 /usr/local/bin/aos mcp serve --request-timeout 1d5m")
+        .expect("process row");
+    assert_eq!(row.pid, 123);
+    assert_eq!(row.ppid, 1);
+    assert!(is_long_mcp_serve(&row.command));
+}
+
+#[test]
+fn gc_match_is_exact_about_timeout_and_verb() {
+    assert!(is_long_mcp_serve("aos mcp serve --request-timeout 1d5m"));
+    assert!(is_long_mcp_serve("aos mcp serve --request-timeout=1d5m"));
+    assert!(!is_long_mcp_serve("aos mcp serve --request-timeout 30s"));
+    assert!(!is_long_mcp_serve("aos mcp gateway --request-timeout 1d5m"));
+}
+
+#[test]
+fn gc_reaps_orphaned_attach_but_never_python_frames() {
+    assert!(is_mcp_attach(
+        "/Users/me/.aos/runtime/bin/astrid --principal codex-code mcp attach --workspace /tmp/proj"
+    ));
+    assert!(is_mcp_attach("aos --principal codex-code mcp attach"));
+    assert!(!is_mcp_attach(
+        "/opt/homebrew/Cellar/python@3.14/3.14.6/Frameworks/Python.framework/Versions/3.14/Resources/Python.app/Contents/MacOS/Python -u /cache/unicity-aos/bin/aos-mcp-frame /runtime/bin/astrid --principal codex-code mcp attach --workspace /plugin"
+    ));
+    assert!(is_python_frame(
+        "Python -u /cache/bin/aos-mcp-frame astrid --principal codex-code mcp attach --workspace /plugin"
+    ));
+    assert!(!is_mcp_attach(
+        "node worker.js mcp attach --workspace /tmp/astrid"
+    ));
+    assert!(!is_mcp_attach("node /tmp/astrid worker.js mcp attach"));
+    assert!(is_mcp_attach(
+        "env ASTRID_SESSION_ID=thread-1 /opt/aos mcp attach --workspace /tmp/proj"
+    ));
+    assert!(!is_mcp_attach("astrid --principal codex-code mcp gateway"));
+    assert!(!is_mcp_attach("aos mcp serve --request-timeout 1d5m"));
+}
+
+#[test]
+fn ready_record_is_stable_json_contract() {
+    let record = GatewayReady {
+        version: 1,
+        principal: "codex-code".into(),
+        pid: 42,
+        hook_token: "test-hook-token".into(),
+    };
+    let body = serde_json::to_string(&record).expect("record json");
+    assert_eq!(serde_json::from_str::<GatewayReady>(&body).unwrap(), record);
+    assert_eq!(ReadyFormat::parse("hook").unwrap(), ReadyFormat::Hook);
+}
+
+#[test]
+fn ready_cleanup_cannot_remove_a_successor_record() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let path = temp.path().join(GATEWAY_READY_NAME);
+    let old = GatewayReady {
+        version: 1,
+        principal: "codex-code".into(),
+        pid: 41,
+        hook_token: "old-token".into(),
+    };
+    let successor = GatewayReady {
+        version: 1,
+        principal: "codex-code".into(),
+        pid: 42,
+        hook_token: "successor-token".into(),
+    };
+    std::fs::write(&path, serde_json::to_vec(&successor).unwrap()).unwrap();
+
+    let error = remove_gateway_ready_at(&path, &old)
+        .expect_err("old cleanup must not remove a successor marker");
+    assert!(error.to_string().contains("readiness changed"));
+    assert_eq!(
+        read_gateway_ready_at(&path).unwrap(),
+        Some(successor.clone())
+    );
+
+    remove_gateway_ready_at(&path, &successor).expect("successor removes its own marker");
+    assert!(!path.exists());
+}
+
+#[tokio::test]
+async fn control_ack_is_bound_to_operation_pid_and_success() {
+    for ack in [
+        GatewayControlAck::success(GatewayControlOperation::Stop, 42),
+        GatewayControlAck::success(GatewayControlOperation::Health, 43),
+        GatewayControlAck::failure(GatewayControlOperation::Health, 42, "uplink unavailable"),
+    ] {
+        let (client, server) = UnixStream::pair().expect("stream pair");
+        let serving = tokio::spawn(async move {
+            let (read_half, mut write_half) = server.into_split();
+            let mut reader = BufReader::new(read_half);
+            let request = read_bounded_line(&mut reader).await.expect("request");
+            serde_json::from_slice::<GatewayControlRequest>(&request).expect("valid request");
+            write_half
+                .write_all(&serde_json::to_vec(&ack).unwrap())
+                .await
+                .unwrap();
+            write_half.write_all(b"\n").await.unwrap();
+        });
+        let record = GatewayReady {
+            version: 1,
+            principal: "codex-code".into(),
+            pid: 42,
+            hook_token: "gateway-token".into(),
+        };
+        request_gateway_control(client, &record, GatewayControlOperation::Health)
+            .await
+            .expect_err("an unbound or unsuccessful ACK must fail");
+        serving.await.expect("fake server");
+    }
+}

--- a/crates/astrid-cli/src/commands/mcp/mod.rs
+++ b/crates/astrid-cli/src/commands/mcp/mod.rs
@@ -82,6 +82,10 @@ mod lifecycle {
         anyhow::bail!("MCP gateway readiness is only supported on Unix hosts")
     }
 
+    pub(crate) async fn stop_gateway() -> Result<()> {
+        Ok(())
+    }
+
     pub(crate) fn gc() -> Result<ExitCode> {
         anyhow::bail!("MCP gateway cleanup is only supported on Unix hosts")
     }
@@ -101,7 +105,7 @@ pub(crate) use attach::run as attach;
 #[allow(unused_imports)]
 pub(crate) use gateway::run as gateway;
 #[allow(unused_imports)]
-pub(crate) use lifecycle::{gc, ready};
+pub(crate) use lifecycle::{gc, ready, stop_gateway};
 
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;

--- a/crates/astrid-cli/src/commands/mcp/watch.rs
+++ b/crates/astrid-cli/src/commands/mcp/watch.rs
@@ -49,6 +49,7 @@ use std::time::Duration;
 use rmcp::service::{Peer, RoleServer};
 use serde_json::{Value, json};
 use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 use uuid::Uuid;
 
@@ -194,6 +195,7 @@ pub(super) async fn run_many(
     peers: Arc<Mutex<HashMap<String, Peer<RoleServer>>>>,
     principal: String,
     daemon_root: PathBuf,
+    shutdown: CancellationToken,
 ) {
     let caller = match astrid_core::PrincipalId::new(&principal) {
         Ok(c) => c,
@@ -203,20 +205,24 @@ pub(super) async fn run_many(
         },
     };
     let session = astrid_core::SessionId::from_uuid(Uuid::new_v4());
-    let mut watch_client = match crate::socket_client::connect_for_workspace(
-        session,
-        caller,
-        Some(daemon_root.as_path()),
-    )
-    .await
-    {
+    let mut watch_client = match tokio::select! {
+        () = shutdown.cancelled() => return,
+        connected = crate::socket_client::connect_for_workspace(
+            session,
+            caller,
+            Some(daemon_root.as_path()),
+        ) => connected,
+    } {
         Ok(c) => c,
         Err(e) => {
             warn!(error = %e, "MCP gateway watcher: failed to open watch uplink");
             return;
         },
     };
-    let mut last_known = match enumerate_on(&mut watch_client, &principal).await {
+    let mut last_known = match tokio::select! {
+        () = shutdown.cancelled() => return,
+        enumerated = enumerate_on(&mut watch_client, &principal) => enumerated,
+    } {
         Ok(names) => names,
         Err(e) => {
             warn!(error = %e, "MCP gateway watcher: baseline seed failed");
@@ -225,7 +231,10 @@ pub(super) async fn run_many(
     };
 
     loop {
-        let frame = match watch_client.read_raw_frame().await {
+        let frame = match tokio::select! {
+            () = shutdown.cancelled() => return,
+            frame = watch_client.read_raw_frame() => frame,
+        } {
             Ok(Some(bytes)) => bytes,
             Ok(None) => return,
             Err(e) => {

--- a/crates/astrid-cli/src/commands/restart.rs
+++ b/crates/astrid-cli/src/commands/restart.rs
@@ -17,6 +17,9 @@ use crate::theme::Theme;
 
 /// Entry point for `astrid restart`.
 pub(crate) async fn run() -> Result<ExitCode> {
+    // Own the recovery/start boundary across stop, stale-marker recovery, and
+    // the replacement boot so a concurrent `start` cannot heal the same files.
+    let start_fence = daemon::acquire_daemon_start_fence().await?;
     daemon::handle_stop().await?;
 
     // Wait until the socket file is gone — `handle_stop` returns as
@@ -85,5 +88,6 @@ pub(crate) async fn run() -> Result<ExitCode> {
     }
 
     daemon::spawn_persistent_daemon().await?;
+    drop(start_fence);
     Ok(ExitCode::SUCCESS)
 }

--- a/crates/astrid-cli/src/commands/restart.rs
+++ b/crates/astrid-cli/src/commands/restart.rs
@@ -19,8 +19,9 @@ use crate::theme::Theme;
 pub(crate) async fn run() -> Result<ExitCode> {
     // Own the recovery/start boundary across stop, stale-marker recovery, and
     // the replacement boot so a concurrent `start` cannot heal the same files.
+    daemon::handle_gateway_stop().await?;
     let start_fence = daemon::acquire_daemon_start_fence().await?;
-    daemon::handle_stop().await?;
+    daemon::handle_daemon_stop_locked().await?;
 
     // Wait until the socket file is gone — `handle_stop` returns as
     // soon as the daemon acknowledges the request, but the actual

--- a/crates/astrid-cli/src/dispatch.rs
+++ b/crates/astrid-cli/src/dispatch.rs
@@ -211,7 +211,7 @@ async fn dispatch_subcommand(
             Ok(ExitCode::SUCCESS)
         },
         Some(Commands::Status) => {
-            commands::daemon::handle_status().await?;
+            commands::daemon::handle_status(output_format).await?;
             Ok(ExitCode::SUCCESS)
         },
         Some(Commands::Stop) => {

--- a/crates/astrid-kernel/src/socket.rs
+++ b/crates/astrid-kernel/src/socket.rs
@@ -337,12 +337,13 @@ pub fn write_pid_file() -> Result<(), std::io::Error> {
         .and_then(std::fs::canonicalize)
         .ok()
         .and_then(|p| p.to_str().map(str::to_owned));
+    let boot_nonce = uuid::Uuid::new_v4().as_simple().to_string();
 
     let write_result = (|| -> std::io::Result<()> {
         let mut file = opts.open(&tmp)?;
         match &exe_line {
-            Some(exe) => write!(file, "{}\n{}", std::process::id(), exe)?,
-            None => write!(file, "{}", std::process::id())?,
+            Some(exe) => write!(file, "{}\n{}\n{}", std::process::id(), exe, boot_nonce)?,
+            None => write!(file, "{}\n{}", std::process::id(), boot_nonce)?,
         }
         file.flush()?;
         file.sync_all()?;


### PR DESCRIPTION
## Linked Issue

Closes #1804.

## Summary

Fences daemon and MCP-gateway shutdown by runtime generation so a successful stop means the selected generation is no longer serving.

The current head also expresses the spawned-readiness timeout with `Duration::from_mins(1)` instead of `Duration::from_secs(60)`. This remains a reviewed candidate, not a release gate.

## Changes

- Coordinates concurrent stoppers and generation-scoped acknowledgements.
- Prevents stale gateway and daemon generations from satisfying a later stop.
- Publishes an identity-bound startup lease before slow gateway boot work and disarms it on readiness.
- Adds lifecycle regressions for start, ready, stop, restart, and gateway ownership.
- Expresses the spawned MCP readiness timeout in minutes.

## Verification

- Independent exact-head GLM and Luna executable reviews accepted commit `09560039eb2ad5b3324227ef85d5da80b78012bc`.
- Isolated daemon and MCP-gateway lifecycle falsifiers on this head, including ready-gateway double ACK, 32-hex startup lease captured before readiness, pre-lease stop, stale-lease cleanup, never-admitted-home start, malformed process-identity fail-closed, concurrent start/stop, and simultaneous stopper ACKs.
- `lifecycle.rs` remains under the 1000-line cap.
- A never-admitted `astrid stop` can still create `run/` lock files. That residual is outside this vehicle and is not a shutdown-fencing failure.
- No live installation or release claim is made.

## AI / Tool Assistance

Assisted-by: Codex:GLM-5.3 Flash

AI assistance was used for implementation and tests. Independent execution and the final landing decision remain maintainer-owned.

## Checklist

- [x] Linked issue
- [x] Writer-executed lifecycle falsifiers on this head
- [x] Independent exact-head executable review complete
- [x] Exact-head required checks complete
- [x] Ready to merge