### PR TITLE
Add Windows x86_64 release archive certification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -391,10 +391,18 @@ jobs:
           name: binary-${{ matrix.target }}
           path: ${{ env.ASSET }}
 
+  windows-release-archive-cert:
+    name: Windows x86_64 archive certification
+    needs: [classify, build]
+    uses: ./.github/workflows/windows-release-archive-cert.yml
+    with:
+      source_commit: ${{ needs.classify.outputs.source-commit }}
+      version: ${{ needs.classify.outputs.version }}
+
   # ── Create the GitHub release with all binaries ───────────────────
   github-release:
     name: GitHub Release
-    needs: [classify, build]
+    needs: [classify, build, windows-release-archive-cert]
     runs-on: ubuntu-latest
     environment: release
     permissions:

--- a/.github/workflows/windows-release-archive-cert.yml
+++ b/.github/workflows/windows-release-archive-cert.yml
@@ -1,0 +1,208 @@
+name: Windows release archive certification
+run-name: Windows x86_64 archive certification ${{ inputs.source_commit }}
+
+on:
+  workflow_call:
+    inputs:
+      source_commit:
+        description: Exact source commit whose release archive is being certified
+        required: true
+        type: string
+      version:
+        description: Release version bound into the archive name
+        required: true
+        type: string
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/windows-release-archive-cert.yml'
+      - 'scripts/test_windows_release_archive.ps1'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: windows-release-archive-cert-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: "1"
+
+jobs:
+  windows-archive-cert:
+    name: Install, mount, and uninstall the release archive
+    runs-on: windows-2025
+    timeout-minutes: 60
+    outputs:
+      archive: ${{ steps.archive.outputs.name }}
+      archive_sha256: ${{ steps.archive.outputs.sha256 }}
+      source_commit: ${{ steps.source.outputs.commit }}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - name: Establish the throwaway certification boundary
+        shell: pwsh
+        run: |
+          $certRoot = Join-Path $env:RUNNER_TEMP "windows-archive-cert-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT"
+          "CERT_ROOT=$certRoot" | Add-Content -Encoding ascii -Path $env:GITHUB_ENV
+          "ASTRID_HOME=$(Join-Path $certRoot 'astrid-home')" | Add-Content -Encoding ascii -Path $env:GITHUB_ENV
+          "DIAGNOSTICS=$(Join-Path $certRoot 'diagnostics')" | Add-Content -Encoding ascii -Path $env:GITHUB_ENV
+
+      - name: Checkout the exact certification source
+        id: source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.source_commit || github.sha }}
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Bind the workflow to one clean source commit
+        shell: bash
+        run: |
+          set -euo pipefail
+          ACTUAL=$(git rev-parse 'HEAD^{commit}')
+          EXPECTED="${{ inputs.source_commit || github.sha }}"
+          [[ "$ACTUAL" == "$EXPECTED" ]]
+          [[ "$ACTUAL" =~ ^[0-9a-f]{40}$ ]]
+          git diff --exit-code
+          git diff --cached --exit-code
+          echo "commit=$ACTUAL" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.12'
+
+      - name: Download the exact release-built archive
+        if: github.event_name == 'workflow_call'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: binary-x86_64-pc-windows-msvc
+          path: downloaded-windows-archive
+
+      - name: Install Rust toolchain
+        if: github.event_name != 'workflow_call'
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: '1.95.0'
+          targets: x86_64-pc-windows-msvc
+
+      - name: Cache Rust artifacts
+        if: github.event_name != 'workflow_call'
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: windows-release-archive-cert-x86_64-pc-windows-msvc
+          cache-on-failure: true
+
+      - name: Install the pinned WinFsp build prerequisite
+        if: github.event_name != 'workflow_call'
+        shell: pwsh
+        run: |
+          $msi = Join-Path $env:RUNNER_TEMP 'winfsp-2.1.25156.msi'
+          Invoke-WebRequest `
+            -Uri 'https://github.com/winfsp/winfsp/releases/download/v2.1/winfsp-2.1.25156.msi' `
+            -OutFile $msi
+          $hash = (Get-FileHash -LiteralPath $msi -Algorithm SHA256).Hash
+          if ($hash -ne '073A70E00F77423E34BED98B86E600DEF93393BA5822204FAC57A29324DB9F7A') {
+            throw "WinFsp MSI digest mismatch: $hash"
+          }
+          $exitCode = (Start-Process -FilePath 'msiexec.exe' `
+            -ArgumentList @('/i', "`"$msi`"", 'ADDLOCAL=F.Developer', '/qn', '/norestart') `
+            -Wait -PassThru).ExitCode
+          if ($exitCode -ne 0 -and $exitCode -ne 3010) {
+            throw "WinFsp installation failed with exit code $exitCode"
+          }
+          $registry = Get-ItemProperty -LiteralPath 'HKLM:\SOFTWARE\WOW6432Node\WinFsp' -ErrorAction Stop
+          if ([string]::IsNullOrWhiteSpace($registry.InstallDir)) {
+            throw 'WinFsp installation did not publish InstallDir'
+          }
+          "WINFSP_MSI=$msi" | Add-Content -Encoding ascii -Path $env:GITHUB_ENV
+          "WINFSP_ROOT=$($registry.InstallDir)" | Add-Content -Encoding ascii -Path $env:GITHUB_ENV
+
+      - name: Produce a candidate release archive
+        if: github.event_name != 'workflow_call'
+        shell: bash
+        run: |
+          set -euo pipefail
+          TARGET=x86_64-pc-windows-msvc
+          VERSION=$(python -c 'import tomllib; print(tomllib.load(open("Cargo.toml", "rb"))["workspace"]["package"]["version"])')
+          DIR="astrid-${VERSION}-${TARGET}"
+          BINARY_ROOT="target/${TARGET}/release"
+
+          cargo build --release --locked --target "$TARGET" -p astrid
+          cargo build --release --locked --target "$TARGET" -p astrid-storage-provider-winfsp
+
+          mkdir "$DIR"
+          cp "$BINARY_ROOT/astrid.exe" "$DIR/"
+          cp "$BINARY_ROOT/astrid-daemon.exe" "$DIR/"
+          cp "$BINARY_ROOT/astrid-build.exe" "$DIR/"
+          cp "$BINARY_ROOT/astrid-emit.exe" "$DIR/"
+          cp "$BINARY_ROOT/astrid-storage-provider-winfsp.exe" "$DIR/"
+          cp "$WINFSP_ROOT/bin/winfsp-x64.dll" "$DIR/"
+          cp "$WINFSP_MSI" "$DIR/winfsp-2.1.25156.msi"
+          cp scripts/install-windows.ps1 scripts/uninstall-windows.ps1 "$DIR/"
+          cp LICENSE* README.md "$DIR/" 2>/dev/null || true
+
+          SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)
+          python scripts/package_release_archive.py \
+            --root "$DIR" \
+            --output "${DIR}.tar.gz" \
+            --mtime "$SOURCE_DATE_EPOCH"
+          python scripts/validate_release_archive.py "${DIR}.tar.gz" --target "$TARGET"
+          echo "ASSET=${DIR}.tar.gz" >> "$GITHUB_ENV"
+
+      - name: Bind the exact archive bytes
+        id: archive
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $searchRoot = $env:GITHUB_WORKSPACE
+          if ($env:GITHUB_EVENT_NAME -eq 'workflow_call') {
+            $searchRoot = Join-Path $env:GITHUB_WORKSPACE 'downloaded-windows-archive'
+          }
+          $archives = @(Get-ChildItem -LiteralPath $searchRoot -File -Filter 'astrid-*-x86_64-pc-windows-msvc.tar.gz')
+          if ($archives.Count -ne 1) {
+            throw "expected exactly one Windows x86_64 archive, found $($archives.Count)"
+          }
+          $archive = $archives[0]
+          $sha256 = (Get-FileHash -LiteralPath $archive.FullName -Algorithm SHA256).Hash
+          "ARCHIVE_PATH=$($archive.FullName)" | Add-Content -Encoding ascii -Path $env:GITHUB_ENV
+          "name=$($archive.Name)" | Add-Content -Encoding ascii -Path $env:GITHUB_OUTPUT
+          "sha256=$sha256" | Add-Content -Encoding ascii -Path $env:GITHUB_OUTPUT
+          Write-Host "Certifying $($archive.Name)"
+          Write-Host "Archive SHA-256: $sha256"
+
+      - name: Validate and certify the extracted release bytes
+        shell: pwsh
+        run: |
+          python scripts/validate_release_archive.py "$env:ARCHIVE_PATH" --target x86_64-pc-windows-msvc
+          & scripts/test_windows_release_archive.ps1 `
+            -ArchivePath $env:ARCHIVE_PATH `
+            -ExpectedArchiveSha256 '${{ steps.archive.outputs.sha256 }}' `
+            -ExpectedSourceCommit '${{ steps.source.outputs.commit }}' `
+            -ExpectedVersion '${{ inputs.version }}'
+
+      - name: Upload certification diagnostics
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: windows-archive-cert-diagnostics-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ env.DIAGNOSTICS }}
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Remove the throwaway certification root
+        if: always()
+        shell: pwsh
+        run: |
+          $expectedPrefix = Join-Path $env:RUNNER_TEMP 'windows-archive-cert-'
+          if (-not $env:CERT_ROOT.StartsWith($expectedPrefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+            throw "refusing to remove unexpected certification root: $($env:CERT_ROOT)"
+          }
+          if (Test-Path -LiteralPath $env:CERT_ROOT) {
+            Remove-Item -LiteralPath $env:CERT_ROOT -Recurse -Force
+          }

--- a/scripts/test_windows_release_archive.ps1
+++ b/scripts/test_windows_release_archive.ps1
@@ -1,0 +1,470 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ArchivePath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ExpectedArchiveSha256,
+
+    [string]$ExpectedSourceCommit = '',
+
+    [string]$ExpectedVersion = ''
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 3.0
+
+function Assert-RegularFile {
+    param([string]$Path, [string]$Description)
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        throw "$Description is missing: $Path"
+    }
+    $item = Get-Item -LiteralPath $Path -Force
+    if ($item.PSIsContainer -or
+        ($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
+        throw "$Description must be a regular, non-redirected file: $Path"
+    }
+}
+
+function Get-Sha256 {
+    param([string]$Path)
+
+    Assert-RegularFile -Path $Path -Description 'Hashed file'
+    return (Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash
+}
+
+function Assert-SameFileBytes {
+    param([string]$Expected, [string]$Actual, [string]$Description)
+
+    $expectedHash = Get-Sha256 -Path $Expected
+    $actualHash = Get-Sha256 -Path $Actual
+    if ($expectedHash -ne $actualHash) {
+        throw "$Description bytes changed during installation ($expectedHash -> $actualHash)"
+    }
+    return $actualHash
+}
+
+function Get-SidValue {
+    param([object]$Identity)
+
+    try {
+        if ($Identity -is [System.Security.Principal.SecurityIdentifier]) {
+            return $Identity.Value
+        }
+        if ($Identity -is [System.Security.Principal.IdentityReference]) {
+            return $Identity.Translate([System.Security.Principal.SecurityIdentifier]).Value
+        }
+        return ([System.Security.Principal.SecurityIdentifier]::new([string]$Identity)).Value
+    } catch {
+        throw "cannot resolve certification ACL identity '$Identity'"
+    }
+}
+
+function Get-ExpectedVersion {
+    if ($ExpectedVersion) {
+        return $ExpectedVersion
+    }
+
+    $cargoToml = Join-Path $PSScriptRoot '..' 'Cargo.toml' | Resolve-Path
+    $match = [regex]::Match(
+        (Get-Content -LiteralPath $cargoToml.Path -Raw),
+        '(?m)^\[workspace\.package\].*?^version\s*=\s*"([^"]+)"',
+        [System.Text.RegularExpressions.RegexOptions]::Singleline
+    )
+    if (-not $match.Success) {
+        throw 'cannot derive the release version from Cargo.toml'
+    }
+    return $match.Groups[1].Value
+}
+
+function Get-CleanMountRegistry {
+    param([string]$HomePath)
+
+    $registryPath = Join-Path $HomePath 'run\providers\winfsp-mounts.json'
+    if (-not (Test-Path -LiteralPath $registryPath -PathType Leaf)) {
+        return @()
+    }
+    return @((Get-Content -LiteralPath $registryPath -Raw | ConvertFrom-Json).mounts)
+}
+
+function Assert-ProcessesDrained {
+    param([string[]]$ProcessNames, [string]$Stage)
+
+    $deadline = [DateTime]::UtcNow.AddSeconds(30)
+    do {
+        $remaining = @(Get-Process -Name $ProcessNames -ErrorAction SilentlyContinue)
+        if ($remaining.Count -eq 0) {
+            Write-Host "Astrid processes drained after $stage"
+            return
+        }
+        Start-Sleep -Milliseconds 500
+    } while ([DateTime]::UtcNow -lt $deadline)
+
+    $paths = @($remaining | ForEach-Object {
+        $process = Get-CimInstance -ClassName Win32_Process -Filter "ProcessId=$($_.Id)"
+        "$($_.Id) $($process.ExecutablePath)"
+    })
+    throw "Astrid processes survived $stage : $($paths -join '; ')"
+}
+
+function Assert-ExtractedProcess {
+    param([string]$ExtractionRoot, [string]$ProcessName, [string]$Stage)
+
+    $prefix = $ExtractionRoot.TrimEnd('\') + '\'
+    $processes = @(Get-Process -Name $ProcessName -ErrorAction SilentlyContinue)
+    if ($processes.Count -eq 0) {
+        throw "$ProcessName was not running during $stage"
+    }
+    foreach ($process in $processes) {
+        $record = Get-CimInstance -ClassName Win32_Process -Filter "ProcessId=$($process.Id)"
+        if (-not $record.ExecutablePath -or
+            -not $record.ExecutablePath.StartsWith($prefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+            throw "$ProcessName did not execute from the extracted release root during ${stage}: $($record.ExecutablePath)"
+        }
+    }
+}
+
+function Assert-PrivateInstallAcl {
+    param([string]$InstallRoot)
+
+    $acl = Get-Acl -LiteralPath $InstallRoot
+    if (-not $acl.AreAccessRulesProtected) {
+        throw 'installed Astrid directory inherited its ACL'
+    }
+
+    $currentUser = [System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value
+    $allowed = @(
+        $currentUser,
+        'S-1-5-18',
+        'S-1-5-32-544'
+    )
+    foreach ($rule in @($acl.Access)) {
+        if ($rule.AccessControlType -ne [System.Security.AccessControl.AccessControlType]::Allow) {
+            continue
+        }
+        $sid = Get-SidValue -Identity $rule.IdentityReference
+        if ($allowed -notcontains $sid) {
+            throw "installed Astrid directory exposes content to '$sid'"
+        }
+    }
+    foreach ($sid in $allowed) {
+        $fullControl = @($acl.Access | Where-Object {
+            $_.AccessControlType -eq [System.Security.AccessControl.AccessControlType]::Allow -and
+            (Get-SidValue -Identity $_.IdentityReference) -eq $sid -and
+            ($_.FileSystemRights -band [System.Security.AccessControl.FileSystemRights]::FullControl) -ne 0
+        })
+        if ($fullControl.Count -eq 0) {
+            throw "installed Astrid directory lacks full control for '$sid'"
+        }
+    }
+}
+
+function Copy-RunDiagnostics {
+    param([string]$HomePath, [string]$DiagnosticsPath)
+
+    $logRoot = Join-Path $HomePath 'log'
+    if (Test-Path -LiteralPath $logRoot) {
+        Copy-Item -LiteralPath $logRoot -Destination (Join-Path $DiagnosticsPath 'astrid-log') -Recurse -Force
+    }
+}
+
+function Save-CommandOutput {
+    param([string]$Path, [object]$Value)
+
+    $Value | Out-String | Set-Content -LiteralPath $Path -Encoding ascii
+}
+
+$certRoot = $env:CERT_ROOT
+$astridHome = $env:ASTRID_HOME
+$diagnostics = $env:DIAGNOSTICS
+$repositoryRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..')).Path
+$expectedPrefix = Join-Path ([System.IO.Path]::GetFullPath($env:RUNNER_TEMP)) 'windows-archive-cert-'
+if (-not ([System.IO.Path]::GetFullPath($certRoot)).StartsWith(
+        $expectedPrefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw "certification root is outside the workflow throwaway boundary: $certRoot"
+}
+if (-not ([System.IO.Path]::GetFullPath($astridHome)).StartsWith(
+        [System.IO.Path]::GetFullPath($certRoot), [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw "ASTRID_HOME is outside the throwaway certification root: $astridHome"
+}
+if ([string]::IsNullOrWhiteSpace($astridHome)) {
+    throw 'ASTRID_HOME is required for archive certification'
+}
+
+Push-Location $repositoryRoot
+$extracted = $false
+$started = $false
+$mounted = $false
+$mountId = ''
+$mountpoint = Join-Path $certRoot 'astrid-mount'
+$extractRoot = Join-Path $certRoot 'extracted'
+$installRoot = Join-Path $certRoot 'installed'
+$processNames = @('astrid', 'astrid-daemon', 'astrid-storage-provider-winfsp')
+$transcript = Join-Path $diagnostics 'certification-transcript.txt'
+$mountedFile = $null
+$transcriptStarted = $false
+$reader = $null
+
+try {
+    New-Item -ItemType Directory -Path $certRoot, $astridHome, $diagnostics -Force | Out-Null
+    Start-Transcript -LiteralPath $transcript | Out-Null
+    $transcriptStarted = $true
+
+    $sourceHead = (git rev-parse 'HEAD^{commit}').Trim()
+    if ($ExpectedSourceCommit -and $sourceHead -ne $ExpectedSourceCommit) {
+        throw "certification source moved: expected $ExpectedSourceCommit, found $sourceHead"
+    }
+    $dirty = @(git status --porcelain)
+    if ($dirty.Count -ne 0) {
+        throw "certification checkout is dirty: $($dirty -join '; ')"
+    }
+
+    $version = Get-ExpectedVersion
+    $expectedArchive = "astrid-$version-x86_64-pc-windows-msvc.tar.gz"
+    $archiveName = [System.IO.Path]::GetFileName($ArchivePath)
+    if ($archiveName -ne $expectedArchive) {
+        throw "archive name does not bind version and target: $archiveName (expected $expectedArchive)"
+    }
+    $archiveSha256 = Get-Sha256 -Path $ArchivePath
+    if ($archiveSha256 -ne $ExpectedArchiveSha256) {
+        throw "archive SHA-256 changed before extraction: $archiveSha256"
+    }
+    $unexpectedProcesses = @(Get-Process -Name $processNames -ErrorAction SilentlyContinue)
+    if ($unexpectedProcesses.Count -ne 0) {
+        throw 'Astrid processes were already present before archive certification'
+    }
+
+    New-Item -ItemType Directory -Path $extractRoot -Force | Out-Null
+    tar -xzf $ArchivePath -C $extractRoot
+    $extractionDirectories = @(
+        Get-ChildItem -LiteralPath $extractRoot -Directory -Force |
+            Where-Object { $_.Name -like 'astrid-*-x86_64-pc-windows-msvc' }
+    )
+    if ($extractionDirectories.Count -ne 1) {
+        throw "archive extraction did not produce one target-bound root: $($extractionDirectories.Count)"
+    }
+    $releaseRoot = Join-Path $extractRoot $extractionDirectories[0].Name
+    $redirected = @(
+        Get-ChildItem -LiteralPath $releaseRoot -Recurse -Force |
+            Where-Object { ($_.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0 }
+    )
+    if ($redirected.Count -ne 0) {
+        throw 'the extracted release archive contains a redirected member'
+    }
+
+    $trustedNames = @(
+        'astrid.exe',
+        'astrid-daemon.exe',
+        'astrid-build.exe',
+        'astrid-emit.exe',
+        'astrid-storage-provider-winfsp.exe',
+        'winfsp-x64.dll',
+        'winfsp-2.1.25156.msi',
+        'install-windows.ps1',
+        'uninstall-windows.ps1'
+    )
+    $bytesManifest = [ordered]@{}
+    foreach ($name in $trustedNames) {
+        $extractedPath = Join-Path $releaseRoot $name
+        Assert-RegularFile -Path $extractedPath -Description "extracted $name"
+        $bytesManifest[$name] = Get-Sha256 -Path $extractedPath
+    }
+    if ($bytesManifest['winfsp-2.1.25156.msi'] -ne
+        '073A70E00F77423E34BED98B86E600DEF93393BA5822204FAC57A29324DB9F7A') {
+        throw 'extracted WinFsp MSI does not match the trusted pinned digest'
+    }
+    foreach ($scriptName in @('install-windows.ps1', 'uninstall-windows.ps1')) {
+        $sourceScript = Join-Path $repositoryRoot "scripts\$scriptName"
+        Assert-SameFileBytes -Expected $sourceScript -Actual (Join-Path $releaseRoot $scriptName) `
+            -Description "$scriptName trusted source bytes"
+    }
+    ($bytesManifest | ConvertTo-Json -Depth 3) |
+        Set-Content -LiteralPath (Join-Path $diagnostics 'archive-bytes.sha256.json') -Encoding ascii
+
+    & (Join-Path $releaseRoot 'install-windows.ps1') -InstallDir $installRoot
+    $markerPath = Join-Path $installRoot 'astrid-install.json'
+    Assert-RegularFile -Path $markerPath -Description 'private install marker'
+    $marker = Get-Content -LiteralPath $markerPath -Raw | ConvertFrom-Json
+    if ($marker.product -ne 'astrid' -or
+        $marker.winfsp_installed_by_astrid -ne $true -or
+        $marker.winfsp_installer -ne 'winfsp-2.1.25156.msi') {
+        throw 'private installation marker has unexpected contents'
+    }
+    Assert-PrivateInstallAcl -InstallRoot $installRoot
+    $expectedInstalled = @($trustedNames + 'astrid-install.json')
+    $installedItems = @(Get-ChildItem -LiteralPath $installRoot -File -Force)
+    $installedNames = @($installedItems | ForEach-Object { $_.Name } | Sort-Object)
+    $expectedSorted = @($expectedInstalled | Sort-Object)
+    if (($installedNames -join "`n") -ne ($expectedSorted -join "`n")) {
+        throw "private installation contains unauthorized files: $($installedNames -join ', ')"
+    }
+    foreach ($name in $trustedNames) {
+        Assert-SameFileBytes -Expected (Join-Path $releaseRoot $name) `
+            -Actual (Join-Path $installRoot $name) -Description "installed $name"
+    }
+
+    $winFspRegistry = Get-ItemProperty -LiteralPath 'HKLM:\SOFTWARE\WOW6432Node\WinFsp' -ErrorAction Stop
+    if ([string]::IsNullOrWhiteSpace($winFspRegistry.InstallDir)) {
+        throw 'installed WinFsp did not publish its installation root'
+    }
+    $systemWinFspDll = Join-Path $winFspRegistry.InstallDir 'bin\winfsp-x64.dll'
+    Assert-RegularFile -Path $systemWinFspDll -Description 'installed WinFsp runtime DLL'
+    $winFspVersion = [version](Get-Item -LiteralPath $systemWinFspDll).VersionInfo.FileVersion
+    if ($winFspVersion -lt [version]'2.1.25156') {
+        throw "installed WinFsp is older than the pinned runtime: $winFspVersion"
+    }
+    Assert-SameFileBytes -Expected (Join-Path $releaseRoot 'winfsp-x64.dll') `
+        -Actual $systemWinFspDll -Description 'installed WinFsp runtime DLL'
+
+    $cli = Join-Path $releaseRoot 'astrid.exe'
+    Push-Location $certRoot
+    & $cli --principal default start
+    $started = $true
+    Assert-ExtractedProcess -ExtractionRoot $releaseRoot -ProcessName 'astrid-daemon' `
+        -Stage 'daemon startup'
+
+    $mountOutput = (& $cli --principal default storage mount --as default --read-write $mountpoint 2>&1 | Out-String).Trim()
+    Save-CommandOutput -Path (Join-Path $diagnostics 'storage-mount.log') -Value $mountOutput
+    Write-Host $mountOutput
+    $mountMatch = [regex]::Match($mountOutput, '^mounted ([0-9a-f-]{36}) at ')
+    if (-not $mountMatch.Success) {
+        throw "storage mount did not return a mounted identity: $mountOutput"
+    }
+    $mountId = $mountMatch.Groups[1].Value
+    $mounted = $true
+    Assert-ExtractedProcess -ExtractionRoot $releaseRoot -ProcessName 'astrid-daemon' `
+        -Stage 'mounted volume'
+    Assert-ExtractedProcess -ExtractionRoot $releaseRoot `
+        -ProcessName 'astrid-storage-provider-winfsp' -Stage 'mounted volume'
+
+    $sentinel = "windows-archive-cert-$([guid]::NewGuid().ToString('N'))"
+    $mountedFile = Join-Path $mountpoint 'certification.txt'
+    Set-Content -LiteralPath $mountedFile -Value $sentinel -NoNewline -Encoding ascii
+    $firstRead = Get-Content -LiteralPath $mountedFile -Raw
+    if ($firstRead -ne $sentinel) {
+        throw 'first read from the mounted release volume returned unexpected bytes'
+    }
+
+    $reopenStream = [System.IO.File]::Open(
+        $mountedFile,
+        [System.IO.FileMode]::Open,
+        [System.IO.FileAccess]::Read,
+        [System.IO.FileShare]::Read
+    )
+    try {
+        $reader = [System.IO.StreamReader]::new($reopenStream)
+        $reopened = $reader.ReadToEnd()
+        if ($reopened -ne $sentinel) {
+            throw 'reopened read from the mounted release volume returned unexpected bytes'
+        }
+    } finally {
+        if ($reader) {
+            $reader.Dispose()
+        }
+        $reopenStream.Dispose()
+    }
+
+    $syncOutput = (& $cli --principal default storage sync $mountpoint 2>&1 | Out-String).Trim()
+    Save-CommandOutput -Path (Join-Path $diagnostics 'storage-sync.log') -Value $syncOutput
+    if ($syncOutput -ne "synced $mountId") {
+        throw "storage sync did not acknowledge the certification mount: $syncOutput"
+    }
+    $statusOutput = (& $cli --principal default storage status $mountpoint 2>&1 | Out-String).Trim()
+    Save-CommandOutput -Path (Join-Path $diagnostics 'storage-status.log') -Value $statusOutput
+    Write-Host $statusOutput
+    if ($statusOutput -notlike "mount $mountId at $mountpoint*" -or
+        $statusOutput -notlike '*ReadWrite*' -or
+        $statusOutput -notlike '*dirty=False*') {
+        throw "storage status did not show a clean read-write certification mount: $statusOutput"
+    }
+
+    $unmountOutput = (& $cli --principal default storage unmount $mountpoint 2>&1 | Out-String).Trim()
+    Save-CommandOutput -Path (Join-Path $diagnostics 'storage-unmount.log') -Value $unmountOutput
+    if ($unmountOutput -ne "unmounted $mountId") {
+        throw "storage unmount did not acknowledge the certification mount: $unmountOutput"
+    }
+    $mounted = $false
+    if (Test-Path -LiteralPath $mountpoint) {
+        throw 'provider-created Windows mountpoint survived unmount'
+    }
+    Assert-ProcessesDrained -ProcessNames @('astrid-storage-provider-winfsp') -Stage 'volume unmount'
+
+    & $cli --principal default stop
+    $started = $false
+    Assert-ProcessesDrained -ProcessNames $processNames -Stage 'daemon stop'
+    $remainingMounts = Get-CleanMountRegistry -HomePath $astridHome
+    if ($remainingMounts.Count -ne 0) {
+        throw "WinFsp provider registry retained a mount after unmount: $($remainingMounts.Count)"
+    }
+    $remainingControls = @(
+        Get-ChildItem -LiteralPath (Join-Path $astridHome 'run\providers') -Filter '*.control' -Force -ErrorAction SilentlyContinue
+    )
+    if ($remainingControls.Count -ne 0) {
+        throw "WinFsp provider control endpoints survived unmount: $($remainingControls.Count)"
+    }
+
+    & (Join-Path $releaseRoot 'uninstall-windows.ps1') -InstallDir $installRoot
+    if (Test-Path -LiteralPath $installRoot) {
+        throw 'private Astrid installation survived uninstall'
+    }
+    Assert-ProcessesDrained -ProcessNames $processNames -Stage 'uninstall'
+
+    $winFspAfterUninstall = Get-ItemProperty -LiteralPath 'HKLM:\SOFTWARE\WOW6432Node\WinFsp' -ErrorAction Stop
+    if ([string]::IsNullOrWhiteSpace($winFspAfterUninstall.InstallDir) -or
+        -not (Test-Path -LiteralPath (Join-Path $winFspAfterUninstall.InstallDir 'bin\winfsp-x64.dll') -PathType Leaf)) {
+        throw 'bundled uninstall removed the authorized shared WinFsp runtime'
+    }
+
+    $receipt = [ordered]@{
+        result = 'passed'
+        source_commit = $sourceHead
+        archive = $archiveName
+        archive_sha256 = $archiveSha256
+        mount_id = $mountId
+        winfsp_version = $winFspVersion.ToString()
+    }
+    ($receipt | ConvertTo-Json -Depth 3) |
+        Set-Content -LiteralPath (Join-Path $diagnostics 'certification-receipt.json') -Encoding ascii
+    Write-Host "Windows x86_64 release archive certification passed: $archiveSha256"
+} finally {
+    if (-not $mounted -and $mountedFile -and -not (Test-Path -LiteralPath $mountedFile)) {
+        Set-Content -LiteralPath (Join-Path $diagnostics 'post-unmount.txt') -Value 'absent' -Encoding ascii
+    }
+    $copyStatus = 0
+    if ($mounted -and $releaseRoot -and (Test-Path -LiteralPath $releaseRoot)) {
+        try {
+            $cleanupOutput = (& (Join-Path $releaseRoot 'astrid.exe') --principal default storage unmount $mountpoint 2>&1 | Out-String)
+            Write-Host $cleanupOutput
+        } catch {
+            Write-Warning "certification cleanup mount failed: $_"
+            $copyStatus = 1
+        }
+    }
+    if ($started -and $releaseRoot -and (Test-Path -LiteralPath $releaseRoot)) {
+        try {
+            & (Join-Path $releaseRoot 'astrid.exe') --principal default stop
+        } catch {
+            Write-Warning "certification cleanup stop failed: $_"
+            $copyStatus = 1
+        }
+    }
+    Assert-ProcessesDrained -ProcessNames $processNames -Stage 'failure cleanup'
+    if ($astridHome -and (Test-Path -LiteralPath $astridHome)) {
+        try {
+            Copy-RunDiagnostics -HomePath $astridHome -DiagnosticsPath $diagnostics
+        } catch {
+            Write-Warning "could not copy runtime diagnostics: $_"
+            $copyStatus = 1
+        }
+    }
+    if ($transcriptStarted) {
+        try {
+            Stop-Transcript | Out-Null
+        } catch {
+        }
+    }
+    Pop-Location
+    if ($copyStatus -ne 0) {
+        throw 'certification cleanup could not preserve all diagnostics or drain all processes'
+    }
+}


### PR DESCRIPTION
## Linked Issue

Tracking #1818. Historical context: #1710.

## Summary

Rejected Windows x86_64 release-archive certification experiment.

Review found that the Windows daemon could not perform the claimed lifecycle and that the reusable workflow did not certify the produced release archive. Windows publication is excluded from Astrid 2026.9.0 and parked under #1818. This PR is preserved as evidence and must not be merged.

## Changes

- Adds a proposed Windows release-archive certification workflow.
- Adds a PowerShell archive-install test harness.
- Does not provide valid Windows release certification.

## Verification

- Independent review rejected the certification claim.
- No Windows archive is part of the 2026.9.0 release inventory.

## AI / Tool Assistance

Assisted-by: Codex:GLM-5.3 Flash

AI assistance was used for the experiment. The maintainer owns the rejection and parked disposition.

## Checklist

- [x] Later-release tracking issue identified
- [x] Rejection reason disclosed
- [ ] Ready to merge

