### PR TITLE
fix(gateway): linearize paired-bearer revocation at HTTP 204

### DIFF
--- a/changes/1665.fixed.md
+++ b/changes/1665.fixed.md
@@ -1,0 +1,9 @@
+Paired-bearer device revocation now requires a durable, monotonic gateway
+fence before returning HTTP 204. A successful normal publication acknowledges
+204; a maximum-epoch tombstone fallback preserves the fence across restart but
+still reports HTTP 500. If both writes fail, only the current process keeps an
+in-memory fail-closed fence. Startup hydration aborts when revocation KV is
+unavailable or corrupt, while a healthy empty KV cannot reconstruct a fence
+lost to both writes. Existing and refreshed bearers are rejected immediately,
+while a strictly newer bearer issued after a same-key re-pair is accepted.
+Standalone no-KV operation remains intentionally non-durable. Refs #1665

--- a/crates/astrid-gateway/src/revocations.rs
+++ b/crates/astrid-gateway/src/revocations.rs
@@ -16,13 +16,19 @@
 //! KV namespace [`REVOCATION_NAMESPACE`]. Updates use compare-and-swap/max
 //! semantics so concurrent gateway instances cannot move an epoch backwards.
 //! The old `etc/gateway-revocations.json` is accepted only as an explicit,
-//! one-time migration source and is removed after durable KV read-back.
+//! one-time migration source and is removed after durable KV read-back. A
+//! successful CAS, or a successful maximum-epoch fallback write after a CAS
+//! error, is restart-durable. If both writes fail, callers retain only a
+//! process-local maximum fence and must surface the persistence error; startup
+//! fails closed when KV is unavailable or corrupt, but an otherwise healthy
+//! empty KV cannot reconstruct that lost fence.
 //!
 //! Concurrency: writes are rare (admin deletes), reads are frequent
 //! (every authenticated request). Backed by `std::sync::RwLock`; the
 //! critical sections are non-`await`-blocking by construction.
 
 use std::collections::HashMap;
+use std::hash::BuildHasher;
 use std::io::Read;
 use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
@@ -146,8 +152,10 @@ pub async fn record_principal_max(
                 // unconditional maximum-epoch tombstone: this intentionally
                 // sacrifices alias reuse until operator repair, but it is
                 // monotonic under every concurrent writer and survives a
-                // restart. If the fallback write also fails, propagate the
-                // durability loss to the watcher as before.
+                // restart when this fallback write succeeds. If the fallback
+                // write also fails, no durable fence exists; propagate that
+                // loss so the caller can retain only a process-local fence and
+                // avoid claiming restart durability.
                 store
                     .set(REVOCATION_NAMESPACE, &key, encode_epoch(u64::MAX))
                     .await
@@ -164,6 +172,13 @@ pub async fn record_principal_max(
 
 /// Record the maximum device revocation epoch durably using the same CAS/max
 /// rule as principal revocations.
+///
+/// A successful CAS, or a successful maximum-epoch fallback write after a
+/// CAS error, leaves a fence that startup hydration can restore. The function
+/// still returns an error after any CAS error so the HTTP caller withholds
+/// `204`, even when the fallback tombstone succeeded. If both writes fail,
+/// there is no durable fence; the caller may install a process-local maximum,
+/// but a later healthy empty KV cannot reconstruct it.
 pub async fn record_device_max(
     store: &dyn KvStore,
     key_id: &str,
@@ -200,8 +215,11 @@ pub async fn record_device_max(
             Err(cas_error) => {
                 // Same fail-closed durability rule as principal deletion.
                 // MAX cannot be moved backward by a later CAS writer, so a
-                // persistence-path fault cannot resurrect this device bearer
-                // after restart.
+                // successful fallback write is restart-durable. If this set
+                // also fails, no durable fence exists; the caller still gets
+                // the error and can retain only an in-memory MAX for the
+                // current process. Hydration aborts while KV is unavailable or
+                // corrupt, while an empty healthy KV cannot recreate the key.
                 store
                     .set(REVOCATION_NAMESPACE, &key, encode_epoch(u64::MAX))
                     .await
@@ -210,10 +228,69 @@ pub async fn record_device_max(
                             "write device revocation {key_id}: CAS failed: {cas_error}; fail-closed tombstone failed: {fallback_error}"
                         )
                     })?;
-                return Ok(u64::MAX);
+                // The tombstone keeps every bearer fail-closed, but the
+                // caller must still observe the publication failure. In
+                // particular, the HTTP revoke path cannot acknowledge 204
+                // when its normal CAS durability path faulted.
+                return Err(anyhow::anyhow!(
+                    "write device revocation {key_id}: CAS failed: {cas_error}; fail-closed tombstone installed"
+                ));
             },
         }
     }
+}
+
+fn publish_device_epoch<S: BuildHasher>(
+    revoked_key_ids: &RwLock<HashMap<String, u64, S>>,
+    key_id: &str,
+    epoch: u64,
+) -> u64 {
+    let mut guard = revoked_key_ids
+        .write()
+        .expect("revoked-key-id map poisoned — fail-stop");
+    let previous = guard.get(key_id).copied().unwrap_or(0);
+    let published = previous.max(epoch);
+    if published > previous {
+        guard.insert(key_id.to_owned(), published);
+    }
+    published
+}
+
+/// Publish a device revocation fence for the HTTP edge.
+///
+/// Durable KV publication is completed before the in-memory map is updated,
+/// so a successful caller can expose HTTP 204 only after both the live gateway
+/// and a future restart have the same monotonic fence. If durable publication
+/// fails, an in-memory `u64::MAX` fence is still installed before the error is
+/// returned; callers must surface that error instead of acknowledging revoke.
+/// When CAS fails but the MAX fallback succeeds, the live MAX is also
+/// restart-durable. When both writes fail, only the current process has that
+/// MAX; a later start against unavailable or corrupt KV must abort hydration,
+/// while a healthy empty KV cannot reconstruct the fence. Without a KV backend
+/// (standalone operation), the requested epoch is intentionally in-memory-only
+/// and carries no restart durability claim; callers that need a degraded
+/// fail-closed fence can pass `u64::MAX` as the epoch.
+pub async fn apply_device_revocation<S: BuildHasher>(
+    revoked_key_ids: &RwLock<HashMap<String, u64, S>>,
+    storage: Option<&dyn KvStore>,
+    key_id: &str,
+    epoch: u64,
+) -> anyhow::Result<u64> {
+    if key_id.is_empty() || key_id.contains('/') {
+        anyhow::bail!("invalid device revocation key id");
+    }
+
+    let durable_epoch = match storage {
+        Some(store) => match record_device_max(store, key_id, epoch).await {
+            Ok(epoch) => epoch,
+            Err(error) => {
+                publish_device_epoch(revoked_key_ids, key_id, u64::MAX);
+                return Err(error);
+            },
+        },
+        None => epoch,
+    };
+    Ok(publish_device_epoch(revoked_key_ids, key_id, durable_epoch))
 }
 
 /// Load all durable principal and device epochs from the fixed control
@@ -428,9 +505,11 @@ pub fn spawn_watcher(
                     Ok(epoch) => epoch,
                     Err(error) => {
                         // Preserve a fail-closed in-memory fence even when
-                        // both CAS and tombstone writes fail. A restart with
-                        // the same unavailable backend fails hydration rather
-                        // than exposing the listener without the fence.
+                        // both CAS and tombstone writes fail. A fresh start
+                        // against the same unavailable or corrupt backend
+                        // fails hydration rather than exposing the listener;
+                        // an empty healthy backend cannot reconstruct this
+                        // process-local fence.
                         tracing::error!(
                             error = %error,
                             principal = %principal,
@@ -475,10 +554,12 @@ pub fn spawn_watcher(
 /// bearer is rejected at the HTTP edge immediately (the kernel cap-gate already
 /// fails it closed — this is defense in depth on the bearer).
 ///
-/// Detached: terminates when the bus is dropped (daemon shutdown). In-memory
-/// only — a revoked key never needs to survive a restart because the profile
-/// it was removed from is the source of truth and the bearer's TTL bounds the
-/// window regardless.
+/// Detached: terminates when the bus is dropped (daemon shutdown). With a
+/// control KV, a successful CAS or MAX fallback is restored by startup
+/// hydration. If both writes fail, the helper reports an error after installing
+/// only a process-local MAX; startup aborts on unavailable/corrupt KV, while a
+/// healthy empty KV cannot reconstruct that fence. Without a control KV, the
+/// live watcher fence is intentionally non-durable.
 ///
 /// # Panics
 /// Panics if the `revoked_key_ids` `RwLock` is poisoned — same fail-stop
@@ -534,36 +615,32 @@ pub fn spawn_key_revocation_watcher(
                         .duration_since(std::time::UNIX_EPOCH)
                         .map_or(0, |d| d.as_secs())
                 });
-            let durable_epoch = if let Some(storage) = storage.as_deref() {
-                match record_device_max(storage, key_id, ts_epoch).await {
-                    Ok(epoch) => epoch,
-                    Err(error) => {
-                        tracing::error!(
-                            error = %error,
-                            key_id = %key_id,
-                            "device revocation KV write failed; running in degraded in-memory mode"
-                        );
-                        u64::MAX
-                    },
-                }
+            let requested_epoch = if storage.is_some() {
+                ts_epoch
             } else {
-                tracing::error!(
-                    key_id = %key_id,
-                    "device revocation storage is unavailable; running in degraded in-memory mode"
-                );
+                // Without a durable backend, preserve the watcher's historic
+                // fail-closed behavior rather than allowing a future bearer
+                // to pass the gateway after the kernel removed its key.
                 u64::MAX
             };
+            let durable_epoch = match apply_device_revocation(
+                &revoked_key_ids,
+                storage.as_deref(),
+                key_id,
+                requested_epoch,
+            )
+            .await
             {
-                let mut guard = revoked_key_ids
-                    .write()
-                    .expect("revoked-key-id map poisoned — fail-stop");
-                // Idempotent: a duplicate / replayed revoke event must not move
-                // the epoch backward (which could resurrect a dead bearer).
-                let prev = guard.get(key_id).copied().unwrap_or(0);
-                if durable_epoch > prev {
-                    guard.insert(key_id.to_string(), durable_epoch);
-                }
-            }
+                Ok(epoch) => epoch,
+                Err(error) => {
+                    tracing::error!(
+                        error = %error,
+                        key_id = %key_id,
+                        "device revocation KV write failed; running with an in-memory fail-closed fence"
+                    );
+                    continue;
+                },
+            };
             tracing::info!(key_id = %key_id, revoked_at_epoch = durable_epoch, "device bearer revocation recorded");
         }
     });

--- a/crates/astrid-gateway/src/routes/principals.rs
+++ b/crates/astrid-gateway/src/routes/principals.rs
@@ -533,7 +533,12 @@ pub async fn delete_principal_device(
         .await
         .map_err(daemon_internal)?;
     match resp {
-        AdminResponseBody::PairDeviceRevoked { .. } => Ok(StatusCode::NO_CONTENT),
+        AdminResponseBody::PairDeviceRevoked { key_id } => {
+            let epoch = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map_or(0, |duration| duration.as_secs());
+            acknowledge_device_revocation(&state, &key_id, epoch).await
+        },
         // The kernel returns a bad-input error for an unknown key_id or a
         // missing principal — both surface to the client as 404.
         AdminResponseBody::Error(msg)
@@ -544,6 +549,34 @@ pub async fn delete_principal_device(
         AdminResponseBody::Error(msg) => Err(GatewayError::Forbidden { reason: msg }),
         other => Err(unexpected(other)),
     }
+}
+
+/// Complete the post-kernel acknowledgement for a successful
+/// [`AdminResponseBody::PairDeviceRevoked`] response.
+///
+/// The kernel has already removed the public key when this helper runs. The
+/// gateway only emits HTTP 204 after the same monotonic device fence is
+/// durably published and installed in its live map. Keeping this narrow step
+/// separate also lets persistence-failure tests exercise the HTTP boundary
+/// without fabricating a kernel admin client.
+pub async fn acknowledge_device_revocation(
+    state: &GatewayState,
+    key_id: &str,
+    epoch: u64,
+) -> GatewayResult<StatusCode> {
+    crate::revocations::apply_device_revocation(
+        &state.revoked_key_ids,
+        state.storage_kv.as_deref(),
+        key_id,
+        epoch,
+    )
+    .await
+    .map_err(|error| {
+        GatewayError::Internal(anyhow::anyhow!(
+            "persist device revocation fence for {key_id}: {error}"
+        ))
+    })?;
+    Ok(StatusCode::NO_CONTENT)
 }
 
 // ── Helpers ──────────────────────────────────────────────────────

--- a/crates/astrid-gateway/src/state.rs
+++ b/crates/astrid-gateway/src/state.rs
@@ -219,8 +219,14 @@ pub struct GatewayState {
     /// the same id, so a bearer minted *after* a re-pair (`iat` > the recorded
     /// epoch) authenticates again instead of being dead forever — and the map
     /// is not a permanent, unbounded deny-list.
-    /// Deliberately in-memory only: a restart re-derives correctness from the
-    /// (now key-less) profile, and the bearer's own expiry bounds the window.
+    /// A normal CAS publication or a successful MAX fallback is persisted in
+    /// the kernel-owned control KV before an HTTP revoke returns 204 and is
+    /// hydrated before the listener is exposed, so a restart preserves that
+    /// fail-closed fence. If both writes fail, the HTTP revoke returns an
+    /// error and only the current process retains an in-memory MAX; startup
+    /// aborts when KV is unavailable or corrupt, while a healthy empty KV
+    /// cannot reconstruct the lost fence. With `storage_kv = None`, this map
+    /// is intentionally non-durable and carries no restart guarantee.
     pub revoked_key_ids: Arc<RwLock<HashMap<String, u64>>>,
     /// Live audit-log handle backing `GET /api/sys/audit`. `Some`
     /// when the gateway is spawned by `astrid-daemon` (which holds
@@ -364,8 +370,10 @@ impl GatewayState {
     /// Hydrate principal and device revocation epochs from the authoritative
     /// kernel control KV before the HTTP listener is exposed. A legacy JSON
     /// index is imported exactly once when present and then retired after KV
-    /// receipt/read-back verification. Standalone route tests without a KV
-    /// remain usable only when no legacy file exists.
+    /// receipt/read-back verification. Any list/get error or malformed value
+    /// aborts startup before an unfenced listener can be exposed. Standalone
+    /// route tests without a KV remain usable only when no legacy file exists;
+    /// that no-KV mode is intentionally non-durable across restart.
     ///
     /// # Panics
     ///

--- a/crates/astrid-gateway/tests/revocation_persistence.rs
+++ b/crates/astrid-gateway/tests/revocation_persistence.rs
@@ -4,7 +4,9 @@
 //! restart.  These tests inject a KV CAS failure while the audit watcher
 //! handles the delete, then hydrate a fresh gateway from the same backend.
 //! The durable path falls back to a maximum-epoch tombstone, so the same
-//! backend can hydrate a fresh gateway without resurrecting the bearer.
+//! backend can hydrate a fresh gateway without resurrecting the bearer. A
+//! dual write failure is covered separately: the live process is fenced, but
+//! an empty healthy backend cannot reconstruct that in-memory-only fence.
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -14,6 +16,7 @@ use astrid_core::PrincipalId;
 use astrid_events::{AstridEvent, EventBus, EventMetadata};
 use astrid_gateway::GatewayConfig;
 use astrid_gateway::auth::{mint_bearer, mint_bearer_scoped, verify_bearer};
+use astrid_gateway::error::GatewayError;
 use astrid_gateway::routes;
 use astrid_gateway::routes::distribution::{DistributionInfo, OnboardingFields};
 use astrid_gateway::state::{GatewayState, SigningMaterial};
@@ -21,24 +24,41 @@ use astrid_storage::{KvStore, MemoryKvStore, StorageError, StorageResult};
 use async_trait::async_trait;
 use axum::body::Body;
 use axum::http::{Request, StatusCode, header};
+use axum::response::IntoResponse;
+use base64::Engine as _;
+use ed25519_dalek::{Signer as _, SigningKey};
 use tower::ServiceExt;
 
-/// A durable backend whose compare-and-swap path can be failed on demand.
+/// A durable backend whose write and read paths can be failed independently.
 /// Revocation writes use CAS/max semantics, so failing only CAS exercises the
-/// exact persistence boundary without disturbing hydration reads.
+/// fallback tombstone path while leaving hydration reads available. Failing
+/// both writes exercises the boundary where only the live process can retain
+/// a fail-closed fence; failing reads then proves startup aborts closed.
 #[derive(Debug, Default)]
 struct FailingCasStore {
     inner: MemoryKvStore,
     fail_cas: AtomicBool,
+    fail_set: AtomicBool,
+    fail_reads: AtomicBool,
 }
 
 #[async_trait]
 impl KvStore for FailingCasStore {
     async fn get(&self, namespace: &str, key: &str) -> StorageResult<Option<Vec<u8>>> {
+        if self.fail_reads.load(Ordering::Acquire) {
+            return Err(StorageError::Connection(
+                "injected revocation read failure".to_owned(),
+            ));
+        }
         self.inner.get(namespace, key).await
     }
 
     async fn set(&self, namespace: &str, key: &str, value: Vec<u8>) -> StorageResult<()> {
+        if self.fail_set.load(Ordering::Acquire) {
+            return Err(StorageError::Internal(
+                "injected revocation set failure".to_owned(),
+            ));
+        }
         self.inner.set(namespace, key, value).await
     }
 
@@ -51,6 +71,11 @@ impl KvStore for FailingCasStore {
     }
 
     async fn list_keys(&self, namespace: &str) -> StorageResult<Vec<String>> {
+        if self.fail_reads.load(Ordering::Acquire) {
+            return Err(StorageError::Connection(
+                "injected revocation list failure".to_owned(),
+            ));
+        }
         self.inner.list_keys(namespace).await
     }
 
@@ -109,6 +134,29 @@ fn clone_signing(signing: &SigningMaterial) -> SigningMaterial {
     }
 }
 
+fn scoped_bearer_at(
+    signer: &SigningKey,
+    principal: &PrincipalId,
+    key_id: &str,
+    issued_at_epoch: u64,
+    lifetime_secs: u64,
+) -> String {
+    let expires_at_epoch = issued_at_epoch.saturating_add(lifetime_secs);
+    let message = format!("{principal}:{issued_at_epoch}:{expires_at_epoch}:{key_id}");
+    let signature = signer.sign(message.as_bytes());
+    let principal_segment =
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(principal.as_str());
+    let issued_segment =
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(issued_at_epoch.to_string());
+    let expires_segment =
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(expires_at_epoch.to_string());
+    let key_segment = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(key_id);
+    format!(
+        "{principal_segment}.{issued_segment}.{expires_segment}.{key_segment}.{}",
+        hex::encode(signature.to_bytes())
+    )
+}
+
 fn publish_audit(bus: &EventBus, value: serde_json::Value) {
     let message = astrid_events::ipc::IpcMessage::new(
         astrid_events::ipc::Topic::from_raw(astrid_gateway::routes::events::AUDIT_TOPIC),
@@ -135,6 +183,22 @@ async fn assert_refresh_is_unauthorized(state: Arc<GatewayState>, bearer: &str) 
         response.status(),
         StatusCode::UNAUTHORIZED,
         "a bearer revoked before restart must not refresh after hydration"
+    );
+}
+
+async fn assert_auth_me_status(state: Arc<GatewayState>, bearer: &str, expected: StatusCode) {
+    let router = routes::build(state);
+    let request = Request::builder()
+        .method("GET")
+        .uri("/api/auth/me")
+        .header(header::AUTHORIZATION, format!("Bearer {bearer}"))
+        .body(Body::empty())
+        .expect("auth/me request");
+    let response = router.oneshot(request).await.expect("auth/me response");
+    assert_eq!(
+        response.status(),
+        expected,
+        "GET /api/auth/me should expose the revocation fence"
     );
 }
 
@@ -213,6 +277,261 @@ async fn principal_delete_cas_failure_does_not_resurrect_bearer_after_restart() 
         "principal deletion must remain durable when the watcher CAS fails"
     );
     assert_refresh_is_unauthorized(restarted, &bearer).await;
+}
+
+#[tokio::test]
+async fn http_revoke_204_linearizes_before_watcher() {
+    let store = Arc::new(FailingCasStore::default());
+    let signing = SigningMaterial::fresh();
+    let principal = PrincipalId::new("alice").expect("principal");
+    let key_id = "deadbeefcafe0001";
+    let first = state_with(
+        clone_signing(&signing),
+        Arc::clone(&store),
+        Arc::new(RwLock::new(HashMap::new())),
+        Arc::new(RwLock::new(HashMap::new())),
+    );
+
+    // Keep all claims in the past/current second and choose the fence
+    // explicitly. This proves the at-or-before rule without relying on a
+    // scheduler delay or the audit watcher.
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock after UNIX_EPOCH")
+        .as_secs();
+    let fence = now.saturating_sub(1);
+    let old_bearer = scoped_bearer_at(
+        &signing.signer,
+        &principal,
+        key_id,
+        fence.saturating_sub(1),
+        3600,
+    );
+    let refreshed_bearer = scoped_bearer_at(&signing.signer, &principal, key_id, fence, 3600);
+    assert!(verify_bearer(&first, &old_bearer).is_ok());
+    assert!(verify_bearer(&first, &refreshed_bearer).is_ok());
+
+    // This is the HTTP handler's fence publication, with no audit event and
+    // no watcher task running. A 204-equivalent helper call must publish both
+    // durable and live state before its future resolves.
+    let published = astrid_gateway::routes::principals::acknowledge_device_revocation(
+        first.as_ref(),
+        key_id,
+        fence,
+    )
+    .await
+    .expect("device revocation fence persists");
+    assert_eq!(published, StatusCode::NO_CONTENT);
+    assert!(verify_bearer(&first, &old_bearer).is_err());
+    assert!(verify_bearer(&first, &refreshed_bearer).is_err());
+    assert_auth_me_status(Arc::clone(&first), &old_bearer, StatusCode::UNAUTHORIZED).await;
+    assert_auth_me_status(
+        Arc::clone(&first),
+        &refreshed_bearer,
+        StatusCode::UNAUTHORIZED,
+    )
+    .await;
+    assert_refresh_is_unauthorized(Arc::clone(&first), &old_bearer).await;
+    assert_refresh_is_unauthorized(Arc::clone(&first), &refreshed_bearer).await;
+
+    // A legitimate re-pair has a strictly newer issuance epoch and remains
+    // valid even though it uses the same deterministic key_id.
+    let repaired_bearer = scoped_bearer_at(
+        &signing.signer,
+        &principal,
+        key_id,
+        fence.saturating_add(1),
+        3600,
+    );
+    assert!(verify_bearer(&first, &repaired_bearer).is_ok());
+    assert_auth_me_status(Arc::clone(&first), &repaired_bearer, StatusCode::OK).await;
+
+    // A fresh gateway process must hydrate the same durable fence and keep
+    // rejecting both pre-fence bearers without any watcher activity.
+    let restarted = state_with(
+        clone_signing(&signing),
+        Arc::clone(&store),
+        Arc::new(RwLock::new(HashMap::new())),
+        Arc::new(RwLock::new(HashMap::new())),
+    );
+    restarted
+        .hydrate_revocations()
+        .await
+        .expect("restart hydration");
+    assert!(verify_bearer(&restarted, &old_bearer).is_err());
+    assert!(verify_bearer(&restarted, &refreshed_bearer).is_err());
+    assert!(verify_bearer(&restarted, &repaired_bearer).is_ok());
+    assert_auth_me_status(
+        Arc::clone(&restarted),
+        &old_bearer,
+        StatusCode::UNAUTHORIZED,
+    )
+    .await;
+    assert_auth_me_status(
+        Arc::clone(&restarted),
+        &refreshed_bearer,
+        StatusCode::UNAUTHORIZED,
+    )
+    .await;
+    assert_auth_me_status(Arc::clone(&restarted), &repaired_bearer, StatusCode::OK).await;
+    assert_refresh_is_unauthorized(Arc::clone(&restarted), &old_bearer).await;
+    assert_refresh_is_unauthorized(restarted, &refreshed_bearer).await;
+}
+
+#[tokio::test]
+async fn http_revoke_persist_failure_is_not_204_and_stays_fail_closed() {
+    let store = Arc::new(FailingCasStore::default());
+    store.fail_cas.store(true, Ordering::Release);
+    let signing = SigningMaterial::fresh();
+    let principal = PrincipalId::new("alice").expect("principal");
+    let key_id = "deadbeefcafe0001";
+    let first = state_with(
+        clone_signing(&signing),
+        Arc::clone(&store),
+        Arc::new(RwLock::new(HashMap::new())),
+        Arc::new(RwLock::new(HashMap::new())),
+    );
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock after UNIX_EPOCH")
+        .as_secs();
+    let fence = now.saturating_sub(1);
+    let old_bearer = scoped_bearer_at(
+        &signing.signer,
+        &principal,
+        key_id,
+        fence.saturating_sub(1),
+        3600,
+    );
+    let refreshed_bearer = scoped_bearer_at(&signing.signer, &principal, key_id, fence, 3600);
+    let newer_bearer = scoped_bearer_at(
+        &signing.signer,
+        &principal,
+        key_id,
+        fence.saturating_add(1),
+        3600,
+    );
+    assert!(verify_bearer(&first, &old_bearer).is_ok());
+    assert!(verify_bearer(&first, &refreshed_bearer).is_ok());
+    assert!(verify_bearer(&first, &newer_bearer).is_ok());
+
+    // The kernel has already acknowledged PairDeviceRevoked, but the
+    // gateway must not translate a failed durable fence publication into
+    // HTTP 204. The fallback MAX tombstone is live and durable instead.
+    let result = astrid_gateway::routes::principals::acknowledge_device_revocation(
+        first.as_ref(),
+        key_id,
+        fence,
+    )
+    .await;
+    assert!(matches!(&result, Err(GatewayError::Internal(_))));
+    let error = result.expect_err("CAS failure must prevent a 204 acknowledgement");
+    assert_eq!(
+        error.into_response().status(),
+        StatusCode::INTERNAL_SERVER_ERROR
+    );
+    assert_eq!(
+        first
+            .revoked_key_ids
+            .read()
+            .expect("revoked key map")
+            .get(key_id),
+        Some(&u64::MAX),
+        "CAS failure must install a live fail-closed fence"
+    );
+    let (_, persisted_devices) = astrid_gateway::revocations::load_from_store(&*store)
+        .await
+        .expect("read MAX tombstone");
+    assert_eq!(persisted_devices.get(key_id), Some(&u64::MAX));
+    for bearer in [&old_bearer, &refreshed_bearer, &newer_bearer] {
+        assert_auth_me_status(Arc::clone(&first), bearer, StatusCode::UNAUTHORIZED).await;
+    }
+
+    let restarted = state_with(
+        clone_signing(&signing),
+        Arc::clone(&store),
+        Arc::new(RwLock::new(HashMap::new())),
+        Arc::new(RwLock::new(HashMap::new())),
+    );
+    restarted
+        .hydrate_revocations()
+        .await
+        .expect("restart hydration");
+    for bearer in [&old_bearer, &refreshed_bearer, &newer_bearer] {
+        assert_auth_me_status(Arc::clone(&restarted), bearer, StatusCode::UNAUTHORIZED).await;
+    }
+}
+
+#[tokio::test]
+async fn http_revoke_double_persist_failure_aborts_restart_hydration() {
+    let store = Arc::new(FailingCasStore::default());
+    store.fail_cas.store(true, Ordering::Release);
+    store.fail_set.store(true, Ordering::Release);
+    let signing = SigningMaterial::fresh();
+    let key_id = "deadbeefcafe0001";
+    let first = state_with(
+        clone_signing(&signing),
+        Arc::clone(&store),
+        Arc::new(RwLock::new(HashMap::new())),
+        Arc::new(RwLock::new(HashMap::new())),
+    );
+
+    // Both durable publication attempts fail. The HTTP edge must surface
+    // that loss instead of acknowledging the kernel's successful revoke.
+    let result = astrid_gateway::routes::principals::acknowledge_device_revocation(
+        first.as_ref(),
+        key_id,
+        1_700_000_500,
+    )
+    .await;
+    assert!(matches!(&result, Err(GatewayError::Internal(_))));
+    let error = result.expect_err("dual persistence failure must prevent 204");
+    assert_eq!(
+        error.into_response().status(),
+        StatusCode::INTERNAL_SERVER_ERROR
+    );
+    assert_eq!(
+        first
+            .revoked_key_ids
+            .read()
+            .expect("revoked key map")
+            .get(key_id),
+        Some(&u64::MAX),
+        "dual persistence failure must install a live fail-closed fence"
+    );
+
+    // The failed set() left the backend empty; the live map above is not
+    // durable evidence. Reads still work for this explicit empty-store check.
+    let (_, persisted_devices) = astrid_gateway::revocations::load_from_store(&*store)
+        .await
+        .expect("empty backend remains readable");
+    assert_eq!(
+        persisted_devices.get(key_id),
+        None,
+        "dual persistence failure must not claim a durable tombstone"
+    );
+
+    // A restart has fresh maps and must refuse to hydrate while the backend
+    // is unavailable/corrupt, rather than exposing an unfenced listener.
+    store.fail_reads.store(true, Ordering::Release);
+    let restarted = state_with(
+        clone_signing(&signing),
+        Arc::clone(&store),
+        Arc::new(RwLock::new(HashMap::new())),
+        Arc::new(RwLock::new(HashMap::new())),
+    );
+    assert!(
+        restarted.hydrate_revocations().await.is_err(),
+        "restart hydration must abort when revocation KV reads fail"
+    );
+    assert!(
+        restarted
+            .revoked_key_ids
+            .read()
+            .expect("fresh revoked key map")
+            .is_empty(),
+        "restart evidence must come from hydration, not the first process map"
+    );
 }
 
 #[tokio::test]

--- a/scripts/e2e/runtime-harness.sh
+++ b/scripts/e2e/runtime-harness.sh
@@ -595,6 +595,24 @@ PY
     "$ARTIFACTS/paired-refresh-me-after-revoke.json")"
   assert_status "revoked refreshed paired bearer denied" "$status" 401
 
+  # Re-pair the same public key after revocation. The kernel accepts the new
+  # registration and returns the same deterministic key_id; the Rust
+  # regression pins the strictly-newer issuance rule without relying on a
+  # wall-clock sleep in this runtime harness.
+  status="$(http_status POST /api/auth/pair-device "$user_bearer" \
+    '{"expires_secs":120,"label":"regular-user phone re-pair","scope":"use-only"}' \
+    "$ARTIFACTS/agent-pair-device-repair-issue.json")"
+  assert_status "agent pair-device re-pair issue" "$status" 200
+  local repaired_pair_token repaired_paired_bearer repaired_key_id
+  repaired_pair_token="$(json_field "$ARTIFACTS/agent-pair-device-repair-issue.json" token)"
+  status="$(http_status POST /api/auth/pair-device/redeem "" \
+    "{\"token\":\"$repaired_pair_token\",\"public_key\":\"$paired_pubkey\"}" \
+    "$ARTIFACTS/agent-pair-device-repair-redeem.json")"
+  assert_status "agent pair-device re-pair redeem" "$status" 200
+  repaired_paired_bearer="$(json_field "$ARTIFACTS/agent-pair-device-repair-redeem.json" session_token)"
+  repaired_key_id="$(json_field "$ARTIFACTS/agent-pair-device-repair-redeem.json" key_id)"
+  [[ "$repaired_key_id" == "$paired_key_id" ]] || fail "re-pair key_id $repaired_key_id did not match revoked key_id $paired_key_id"
+
   status="$(http_status POST /api/auth/redeem "" \
     "{\"token\":\"$agent_invite\",\"public_key\":\"$paired_pubkey\",\"display_name\":\"reuse\"}" \
     "$ARTIFACTS/agent-invite-reuse-denied.json")"
@@ -804,6 +822,12 @@ PY
   status="$(http_status GET /api/auth/me "$user_bearer" "" "$ARTIFACTS/restart-agent-me.json")"
   assert_status "restart agent auth/me" "$status" 200
   json_assert_field_equals "$ARTIFACTS/restart-agent-me.json" principal "$user_principal"
+  status="$(http_status GET /api/auth/me "$paired_bearer" "" \
+    "$ARTIFACTS/restart-paired-me-after-revoke.json")"
+  assert_status "restart revoked paired bearer denied" "$status" 401
+  status="$(http_status GET /api/auth/me "$refreshed_paired_bearer" "" \
+    "$ARTIFACTS/restart-paired-refresh-me-after-revoke.json")"
+  assert_status "restart revoked refreshed paired bearer denied" "$status" 401
   status="$(http_status POST /api/auth/refresh "$user_bearer" "" "$ARTIFACTS/restart-agent-refresh.json")"
   assert_status "restart agent refresh" "$status" 200
   local restart_user_bearer
@@ -933,14 +957,14 @@ PY
   note "collecting scoped audit artifacts"
   collect_audit_artifacts "$restart_user_bearer" "$ops_bearer" "$user_principal" "$ops_principal" \
     "$paired_key_id" "$user_bearer" "$ops_bearer" "$paired_bearer" "$refreshed_paired_bearer" \
-    "$restart_user_bearer" "$agent_invite" "$pair_token"
+    "$repaired_paired_bearer" "$restart_user_bearer" "$agent_invite" "$pair_token" "$repaired_pair_token"
   status="$(http_status GET /metrics "" "" "$ARTIFACTS/final-metrics.txt")"
   assert_status "final metrics scrape" "$status" 200
   json_assert_metrics_contract "$ARTIFACTS/final-metrics.txt" \
     "$user_principal" "$ops_principal" "$user_session" "$ops_session" "$paired_key_id"
   assert_runtime_log_contract "$ARTIFACTS/daemon.log" "$ASTRID_HOME/log" -- \
     "$user_bearer" "$ops_bearer" "$paired_bearer" "$refreshed_paired_bearer" \
-    "$restart_user_bearer" "$agent_invite" "$pair_token"
+    "$repaired_paired_bearer" "$restart_user_bearer" "$agent_invite" "$pair_token" "$repaired_pair_token"
 
   redaction_check "$sentinel"
   redaction_check "$user_secret"


### PR DESCRIPTION
## Linked Issue

Closes #1665

## Summary

Device revocation now publishes a monotonic gateway fence before HTTP 204. Old and previously refreshed paired bearers are rejected immediately, including after restart when the fence was durably stored. A same-key re-pair with a strictly newer issuance is accepted. Persistence faults withhold 204.

This is the canonical `main` integration of the already accepted linearization. Release-main Runtime E2E still proves the outcome is absent: after paired-device DELETE returns 204, `GET /api/auth/me` with that bearer can still return 200.

## Changes

- DELETE `/api/sys/principals/{id}/devices/{key_id}` waits for kernel `PairDeviceRevoked`, then publishes the durable device fence before returning 204.
- `GET /api/auth/me` is the re-pair exit gate: `iat <= fence` is 401; a strictly newer same-key bearer is 200, including after hydration.
- CAS persistence faults install a live `u64::MAX` fence and, when the fallback write succeeds, a durable MAX tombstone; the HTTP path returns 500 rather than 204.
- If both CAS and the MAX fallback write fail, only the current process keeps the live MAX fence. Startup hydration aborts when revocation KV is unavailable or corrupt.
- Runtime E2E keeps DELETE 204, immediate 401s, restart 401s, and same-key re-pair redeem. The strictly-newer `/api/auth/me` rule is pinned by a deterministic gateway regression rather than a harness sleep.

## Claim boundary

Restart fail-closed is claimed for a normal durable fence and for a successful fallback MAX tombstone. Dual write loss is claimed only as: HTTP 500, current-process live MAX, and startup abort while revocation KV stays unreadable. This PR does not reconstruct a fence from a later-healthy empty KV after both writes were lost, and standalone no-KV mode is intentionally non-durable. The dual-write-loss test is not reconstruction of a lost durable event.

## Verification

- Focused: `cargo test -p astrid-gateway --test revocation_persistence`
  - `http_revoke_204_linearizes_before_watcher`
  - `http_revoke_persist_failure_is_not_204_and_stays_fail_closed`
  - `http_revoke_double_persist_failure_aborts_restart_hydration`
- `cargo test -p astrid-gateway`
- `cargo clippy -p astrid-gateway --all-targets -- -D warnings`
- Runtime E2E via `scripts/e2e/runtime-harness.sh` must remain a CI gate. Do not skip, weaken, or relabel it.

## AI / Tool Assistance

Assisted-by: Codex:glm-5.3-flash

A coding agent ported the already accepted gateway revocation linearization, changelog fragment, persistence-failure regressions, and Runtime E2E harness updates onto current `main`. The maintainer inspected blob identity against the accepted implementation, signatures/DCO, focused HTTP/persistence tests, and the unweakened Runtime E2E gate.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/{issue}.{kind}.md` (docs/CI-only may skip; release PRs roll fragments into the version section instead of adding one)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
