### PR TITLE
fix(cli): bind signed Distro.toml apply to caller grants

### DIFF
--- a/changes/1195.fixed.md
+++ b/changes/1195.fixed.md
@@ -1,0 +1,4 @@
+`astrid distro apply` now completes a mandatory caller-scoped self grant
+from the kernel-admitted signed Distro lock. The new `self:distro:grant`
+operation is lock-digest fenced, fail-closed, resumable, and distinct from
+capsule installation.

--- a/crates/astrid-cli/src/cli.rs
+++ b/crates/astrid-cli/src/cli.rs
@@ -539,8 +539,8 @@ pub(crate) enum SessionCommands {
 pub(crate) enum DistroCommands {
     /// Apply a distro to the active or specified agent.
     Apply {
-        /// Signed Distro bundle containing `Distro.toml`, `Distro.lock`,
-        /// `Distro.sig`, and capsule artifacts.
+        /// Selected signed `Distro.toml` with its `Distro.lock` and `Distro.sig`
+        /// sidecars, or a signed `.shuttle` package.
         name: Option<String>,
         /// Target agent (defaults to active context).
         #[arg(short, long)]

--- a/crates/astrid-cli/src/cli.rs
+++ b/crates/astrid-cli/src/cli.rs
@@ -539,7 +539,8 @@ pub(crate) enum SessionCommands {
 pub(crate) enum DistroCommands {
     /// Apply a distro to the active or specified agent.
     Apply {
-        /// Distro source (`@owner/repo`, URL, local Distro.toml, or .shuttle).
+        /// Signed Distro bundle containing `Distro.toml`, `Distro.lock`,
+        /// `Distro.sig`, and capsule artifacts.
         name: Option<String>,
         /// Target agent (defaults to active context).
         #[arg(short, long)]

--- a/crates/astrid-cli/src/cli_distro_tests.rs
+++ b/crates/astrid-cli/src/cli_distro_tests.rs
@@ -49,8 +49,8 @@ fn distro_help_lists_only_supported_sources_and_the_launcher_exception() {
     assert_eq!(
         apply_name_help.as_deref(),
         Some(
-            "Signed Distro bundle containing `Distro.toml`, `Distro.lock`, \
-             `Distro.sig`, and capsule artifacts"
+            "Selected signed `Distro.toml` with its `Distro.lock` and `Distro.sig` \
+             sidecars, or a signed `.shuttle` package"
         )
     );
 }

--- a/crates/astrid-cli/src/cli_distro_tests.rs
+++ b/crates/astrid-cli/src/cli_distro_tests.rs
@@ -48,7 +48,10 @@ fn distro_help_lists_only_supported_sources_and_the_launcher_exception() {
     );
     assert_eq!(
         apply_name_help.as_deref(),
-        Some("Distro source (`@owner/repo`, URL, local Distro.toml, or .shuttle)")
+        Some(
+            "Signed Distro bundle containing `Distro.toml`, `Distro.lock`, \
+             `Distro.sig`, and capsule artifacts"
+        )
     );
 }
 

--- a/crates/astrid-cli/src/commands/distro/lock.rs
+++ b/crates/astrid-cli/src/commands/distro/lock.rs
@@ -203,13 +203,26 @@ pub(crate) async fn write_lock_to_daemon(
     }
 }
 
-/// Check if a lockfile is fresh (name and version match the manifest).
-pub(crate) fn is_lock_fresh(lock: &DistroLock, manifest: &DistroManifest) -> bool {
-    lock.distro.id == manifest.distro.id && lock.distro.version == manifest.distro.version
+/// Check whether a lock is fresh for the exact authenticated manifest bytes.
+///
+/// A legacy unbound lock is deliberately stale so it can never satisfy the
+/// caller-only `DistroSelfGrant` admission gate.
+pub(crate) fn is_lock_fresh(
+    lock: &DistroLock,
+    manifest: &DistroManifest,
+    manifest_hash: &str,
+) -> bool {
+    lock.distro.id == manifest.distro.id
+        && lock.distro.version == manifest.distro.version
+        && lock.manifest_hash.as_deref() == Some(manifest_hash)
 }
 
 /// Create a new lockfile from resolved capsule data.
-pub(crate) fn create_lock(manifest: &DistroManifest, capsules: Vec<LockedCapsule>) -> DistroLock {
+pub(crate) fn create_lock(
+    manifest: &DistroManifest,
+    manifest_hash: &str,
+    capsules: Vec<LockedCapsule>,
+) -> DistroLock {
     DistroLock {
         schema_version: manifest.schema_version,
         distro: DistroLockMeta {
@@ -218,7 +231,7 @@ pub(crate) fn create_lock(manifest: &DistroManifest, capsules: Vec<LockedCapsule
             resolved_at: chrono::Utc::now().to_rfc3339(),
         },
         capsules,
-        manifest_hash: None,
+        manifest_hash: Some(manifest_hash.to_string()),
     }
 }
 
@@ -319,7 +332,7 @@ role = "uplink"
             capsules: vec![],
             manifest_hash: None,
         };
-        assert!(is_lock_fresh(&lock, &manifest));
+        assert!(!is_lock_fresh(&lock, &manifest, "blake3:manifest"));
     }
 
     #[test]
@@ -352,7 +365,35 @@ role = "uplink"
             capsules: vec![],
             manifest_hash: None,
         };
-        assert!(!is_lock_fresh(&lock, &manifest));
+        assert!(!is_lock_fresh(&lock, &manifest, "blake3:manifest"));
+    }
+
+    #[test]
+    fn lock_is_fresh_only_for_matching_manifest_bytes() {
+        let manifest = super::super::manifest::parse_manifest(
+            r#"
+schema-version = 1
+
+[distro]
+id = "test"
+name = "Test"
+version = "0.1.0"
+
+[[capsule]]
+name = "cli"
+source = "@org/cli"
+version = "0.1.0"
+role = "uplink"
+"#,
+        )
+        .unwrap();
+        let bytes = b"schema-version = 1\n";
+        let hash = manifest_hash(bytes);
+        let mut lock = create_lock(&manifest, &hash, Vec::new());
+        assert_eq!(lock.manifest_hash.as_deref(), Some(hash.as_str()));
+        assert!(is_lock_fresh(&lock, &manifest, &hash));
+        lock.manifest_hash = Some("blake3:tampered".into());
+        assert!(!is_lock_fresh(&lock, &manifest, &hash));
     }
 
     #[test]

--- a/crates/astrid-cli/src/commands/init.rs
+++ b/crates/astrid-cli/src/commands/init.rs
@@ -53,7 +53,12 @@ pub(crate) struct InitOpts {
     /// `init` installs capsules but attaches no grants and
     /// prints the manual `agent modify` command for discoverability.
     pub(crate) grant_capsules: bool,
+    /// Require the signed self-contained Distro artifact used by product
+    /// Apply. Ordinary `init` retains its legacy source support.
+    pub(crate) require_signed: bool,
 }
+
+pub(crate) use grant::apply_self_grant;
 
 /// Parse `--var KEY=VALUE` strings into a map.
 ///
@@ -72,6 +77,33 @@ pub(crate) fn parse_cli_vars(raw: &[String]) -> anyhow::Result<HashMap<String, S
     Ok(map)
 }
 
+/// Enforce source and trust gates before this flow can create runtime state.
+fn validate_install_source(
+    distro_source: &str,
+    opts: &InitOpts,
+    operator: &astrid_core::PrincipalId,
+    target: &astrid_core::PrincipalId,
+) -> anyhow::Result<bool> {
+    let shuttle_install = distro_source.ends_with(".shuttle");
+    if opts.require_signed && !shuttle_install {
+        bail!(
+            "astrid distro apply requires a signed .shuttle Distro bundle containing Distro.toml; \
+             an unsigned manifest is not accepted"
+        );
+    }
+    // `--grant-capsules` is not wired for `.shuttle`; fail rather than silently
+    // skip the requested grants and point at the legacy manual command.
+    if shuttle_install && opts.grant_capsules {
+        bail!(
+            "--grant-capsules is not supported for .shuttle installs yet — \
+             install first, then grant with `astrid --principal {operator} \
+             agent modify {target} \
+             --add-capsule <name>` for each installed capsule."
+        );
+    }
+    Ok(shuttle_install)
+}
+
 /// Run the init flow: workspace setup + distro-based capsule installation.
 pub(crate) async fn run_init(distro_source: &str, opts: &InitOpts) -> anyhow::Result<()> {
     let home = AstridHome::resolve()?;
@@ -83,19 +115,7 @@ pub(crate) async fn run_init(distro_source: &str, opts: &InitOpts) -> anyhow::Re
     // the flag can never be silently honoured without a distro.
     grant::validate_grant_capsules(opts.grant_capsules, !distro_source.is_empty())?;
 
-    let shuttle_install = distro_source.ends_with(".shuttle");
-    // Offline, signed, self-contained install path. `--grant-capsules` is not
-    // wired for `.shuttle` archives (the installed set isn't threaded back
-    // here); fail loud rather than silently skip the grant the operator asked
-    // for, pointing at the manual path.
-    if shuttle_install && opts.grant_capsules {
-        bail!(
-            "--grant-capsules is not supported for .shuttle installs yet — \
-             install first, then grant with `astrid --principal {operator} \
-             agent modify {target} \
-             --add-capsule <name>` for each installed capsule."
-        );
-    }
+    let shuttle_install = validate_install_source(distro_source, opts, &operator, &target)?;
 
     // The kernel must admit a fresh home and publish its migration ledger
     // before the CLI creates any v2 layout state. Init spans multiple admin

--- a/crates/astrid-cli/src/commands/init.rs
+++ b/crates/astrid-cli/src/commands/init.rs
@@ -18,9 +18,15 @@ use super::distro::lock::{
     write_lock_to_daemon,
 };
 #[cfg(test)]
-use super::distro::lock::{load_lock, write_lock};
-use super::distro::manifest::{DistroCapsule, DistroManifest, parse_manifest};
+use super::distro::lock::{load_lock, manifest_hash, write_lock};
+use super::distro::manifest::DistroCapsule;
+use super::distro::manifest::DistroManifest;
 use crate::theme::Theme;
+
+#[path = "init_signed_source.rs"]
+mod signed_source;
+
+use signed_source::{PreparedDistro, prepare_distro_source, unpack_prepared};
 
 /// Options controlling the init / `distro apply` flow.
 ///
@@ -77,7 +83,7 @@ pub(crate) fn parse_cli_vars(raw: &[String]) -> anyhow::Result<HashMap<String, S
     Ok(map)
 }
 
-/// Enforce source and trust gates before this flow can create runtime state.
+/// Enforce source flags before this flow can create runtime state.
 fn validate_install_source(
     distro_source: &str,
     opts: &InitOpts,
@@ -85,12 +91,6 @@ fn validate_install_source(
     target: &astrid_core::PrincipalId,
 ) -> anyhow::Result<bool> {
     let shuttle_install = distro_source.ends_with(".shuttle");
-    if opts.require_signed && !shuttle_install {
-        bail!(
-            "astrid distro apply requires a signed .shuttle Distro bundle containing Distro.toml; \
-             an unsigned manifest is not accepted"
-        );
-    }
     // `--grant-capsules` is not wired for `.shuttle`; fail rather than silently
     // skip the requested grants and point at the legacy manual command.
     if shuttle_install && opts.grant_capsules {
@@ -115,7 +115,11 @@ pub(crate) async fn run_init(distro_source: &str, opts: &InitOpts) -> anyhow::Re
     // the flag can never be silently honoured without a distro.
     grant::validate_grant_capsules(opts.grant_capsules, !distro_source.is_empty())?;
 
-    let shuttle_install = validate_install_source(distro_source, opts, &operator, &target)?;
+    let prepared = {
+        let operator = operator.clone();
+        validate_install_source(distro_source, opts, &operator, &target)?;
+        prepare_distro_source(distro_source, opts, &home).await?
+    };
 
     // The kernel must admit a fresh home and publish its migration ledger
     // before the CLI creates any v2 layout state. Init spans multiple admin
@@ -128,7 +132,7 @@ pub(crate) async fn run_init(distro_source: &str, opts: &InitOpts) -> anyhow::Re
         grant::preflight_grants(&operator, &target).await?;
     }
 
-    if shuttle_install {
+    if matches!(prepared, PreparedDistro::Shuttle) {
         home.ensure()?;
         let _provisioning_lock = grant::ProvisioningLock::acquire(&home, &target)?;
         init_workspace()?;
@@ -143,9 +147,7 @@ pub(crate) async fn run_init(distro_source: &str, opts: &InitOpts) -> anyhow::Re
     // under the resolved principal's home, matching bootstrap's auto-init
     // freshness check (`should_auto_init`) so a scoped principal isn't
     // re-provisioned on every run.
-    // Fetch and parse the distro manifest. Network is forbidden under
-    // --offline unless the source resolves to a local file.
-    let manifest = fetch_and_parse_manifest(distro_source, opts.offline).await?;
+    let (manifest, expected_manifest_hash, signed_bundle) = unpack_prepared(prepared);
 
     // Enforce the distro's CLI-version floor BEFORE any prompting or install.
     // The manifest is fetched from the repo `main` tip, so a distro that bumps
@@ -153,30 +155,7 @@ pub(crate) async fn run_init(distro_source: &str, opts: &InitOpts) -> anyhow::Re
     // on an older CLI; fail fast with an actionable upgrade message instead.
     super::distro::validate::enforce_astrid_version(&manifest)?;
 
-    // Check lock freshness AFTER parsing manifest (need manifest to compare).
-    if let Some(existing_lock) = load_lock_from_daemon(&target).await?
-        && is_lock_fresh(&existing_lock, &manifest)
-        && let Some(installed) =
-            grant::validated_grant_set_for_reuse(&target, &existing_lock.capsules).await
-    {
-        eprintln!(
-            "{}",
-            Theme::info(&format!(
-                "{} is already installed (Distro.lock is up to date)",
-                manifest
-                    .distro
-                    .pretty_name
-                    .as_deref()
-                    .unwrap_or(&manifest.distro.name),
-            ))
-        );
-        // Idempotent grant path: a re-run with `--grant-capsules` on an
-        // already-installed principal still (re-)applies grants for the
-        // locked capsule set. `apply_set_delta` dedups kernel-side, so a
-        // principal that already holds them reports "no change" rather than
-        // erroring or duplicating — and this is also how a first run whose
-        // grant step failed (daemon was down) recovers on re-run.
-        grant::apply_or_hint_grants(&operator, &target, &installed, opts.grant_capsules).await?;
+    if reuse_fresh_lock(&manifest, &expected_manifest_hash, &operator, &target, opts).await? {
         return Ok(());
     }
 
@@ -200,6 +179,18 @@ pub(crate) async fn run_init(distro_source: &str, opts: &InitOpts) -> anyhow::Re
     let schema_version = manifest.schema_version;
 
     let selected = select_capsules(manifest.capsules, opts.yes)?;
+    let _capsule_staging;
+    let selected = if let Some(bundle) = &signed_bundle {
+        let staging = tempfile::tempdir().context("create signed capsule staging")?;
+        let resolved =
+            signed_source::resolve_signed_capsules(&selected, &bundle.lock, staging.path()).await?;
+        // Keep the verified artifacts alive through the install below.
+        _capsule_staging = Some(staging);
+        resolved
+    } else {
+        _capsule_staging = None;
+        selected
+    };
 
     // Collect variables needed by selected capsules.
     let vars = collect_variables(&variables, &selected, opts.yes, &opts.vars)?;
@@ -214,7 +205,13 @@ pub(crate) async fn run_init(distro_source: &str, opts: &InitOpts) -> anyhow::Re
     // per capsule that actually installed — failures are reported and
     // dropped, so `locked.len()` is the true success count.
     let total = selected.len();
-    let locked = install_capsules(&selected, opts.offline, &target).await?;
+    let locked = install_capsules(
+        &selected,
+        opts.offline,
+        &target,
+        signed_bundle.as_ref().map(|bundle| &bundle.pinned_refs),
+    )
+    .await?;
     let succeeded = locked.len();
 
     // Provisioning honesty: a run where every selected install FAILED must
@@ -251,7 +248,13 @@ pub(crate) async fn run_init(distro_source: &str, opts: &InitOpts) -> anyhow::Re
     // a manifest-declared string the installer didn't land (security stance:
     // grants derive from what was installed, on explicit `--grant-capsules`).
     let installed_names: Vec<String> = locked.iter().map(|c| c.name.clone()).collect();
-    let lock = create_lock_from_parts(schema_version, &distro_id, &distro_version, locked);
+    let lock = create_lock_from_parts(
+        schema_version,
+        &distro_id,
+        &distro_version,
+        &expected_manifest_hash,
+        locked,
+    );
     let wrote_lock = persist_lock_if_earned_daemon(&target, total, succeeded, &lock).await?;
 
     eprintln!();
@@ -308,6 +311,38 @@ fn init_workspace() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Reuse a fresh, install-verified lock only after enforcing manifest binding.
+async fn reuse_fresh_lock(
+    manifest: &DistroManifest,
+    manifest_hash: &str,
+    operator: &astrid_core::PrincipalId,
+    target: &astrid_core::PrincipalId,
+    opts: &InitOpts,
+) -> anyhow::Result<bool> {
+    if let Some(existing_lock) = load_lock_from_daemon(target).await?
+        && is_lock_fresh(&existing_lock, manifest, manifest_hash)
+        && let Some(installed) =
+            grant::validated_grant_set_for_reuse(target, &existing_lock.capsules).await
+    {
+        eprintln!(
+            "{}",
+            Theme::info(&format!(
+                "{} is already installed (Distro.lock is up to date)",
+                manifest
+                    .distro
+                    .pretty_name
+                    .as_deref()
+                    .unwrap_or(&manifest.distro.name),
+            ))
+        );
+        // A fresh lock does not imply a successful historical grant. This is
+        // the lock-fresh retry path; self grant is idempotent and never widens.
+        grant::apply_or_hint_grants(operator, target, &installed, opts.grant_capsules).await?;
+        return Ok(true);
+    }
+    Ok(false)
+}
+
 /// Resolve an explicit remote distro source string to a URL.
 ///
 /// - `@org/repo` → `https://raw.githubusercontent.com/org/repo/main/Distro.toml`
@@ -315,7 +350,7 @@ fn init_workspace() -> anyhow::Result<()> {
 ///
 /// A bare name has no provenance and is rejected rather than being silently
 /// assigned to an organization by the neutral runtime.
-fn resolve_distro_url(source: &str) -> anyhow::Result<String> {
+pub(super) fn resolve_distro_url(source: &str) -> anyhow::Result<String> {
     if source.starts_with("http://") || source.starts_with("https://") {
         Ok(source.to_string())
     } else if let Some(repo_path) = source.strip_prefix('@') {
@@ -337,63 +372,6 @@ fn resolve_distro_url(source: &str) -> anyhow::Result<String> {
             "distro source '{source}' must use @owner/repo, a URL, a local Distro.toml path, or a .shuttle archive"
         )
     }
-}
-
-/// Resolve a distro source string to a manifest URL or path, then parse it.
-///
-/// When `offline` is set, only a local file is acceptable — any source
-/// that would require a network fetch is a hard error.
-async fn fetch_and_parse_manifest(source: &str, offline: bool) -> anyhow::Result<DistroManifest> {
-    // Local file path.
-    let path = std::path::Path::new(source);
-    if path.exists() && path.is_file() {
-        let content = std::fs::read_to_string(path)
-            .with_context(|| format!("failed to read {}", path.display()))?;
-        return parse_manifest(&content);
-    }
-
-    if offline {
-        bail!(
-            "--offline: '{source}' is not a local file and network fetch is forbidden \
-             (use a Distro.toml path or a .shuttle archive)"
-        );
-    }
-
-    let url = resolve_distro_url(source)?;
-
-    eprintln!("Fetching distro manifest...");
-
-    let client = reqwest::Client::builder()
-        .user_agent("astrid-cli")
-        .timeout(std::time::Duration::from_secs(30))
-        .build()?;
-
-    let response = client
-        .get(&url)
-        .send()
-        .await
-        .context("failed to fetch distro manifest")?;
-
-    if !response.status().is_success() {
-        bail!(
-            "failed to fetch distro manifest from {url} (HTTP {})",
-            response.status(),
-        );
-    }
-
-    // Stream response body with 1 MB limit to prevent abuse from untrusted URLs.
-    let mut bytes = Vec::new();
-    let mut response = response;
-    while let Some(chunk) = response.chunk().await? {
-        bytes.extend_from_slice(&chunk);
-        anyhow::ensure!(
-            bytes.len() <= 1024 * 1024,
-            "distro manifest exceeds 1 MB limit",
-        );
-    }
-    let content = std::str::from_utf8(&bytes).context("distro manifest contains invalid UTF-8")?;
-
-    parse_manifest(content)
 }
 
 /// Parse a comma-separated multi-select entry into a deduped, ordered list
@@ -675,6 +653,7 @@ fn create_lock_from_parts(
     schema_version: u32,
     distro_id: &str,
     distro_version: &str,
+    manifest_hash: &str,
     capsules: Vec<LockedCapsule>,
 ) -> DistroLock {
     DistroLock {
@@ -685,7 +664,7 @@ fn create_lock_from_parts(
             resolved_at: chrono::Utc::now().to_rfc3339(),
         },
         capsules,
-        manifest_hash: None,
+        manifest_hash: Some(manifest_hash.to_string()),
     }
 }
 
@@ -737,6 +716,7 @@ async fn install_capsules(
     selected: &[DistroCapsule],
     offline: bool,
     principal: &astrid_core::PrincipalId,
+    pinned_refs: Option<&HashMap<String, String>>,
 ) -> anyhow::Result<Vec<LockedCapsule>> {
     if offline {
         for cap in selected {
@@ -766,7 +746,13 @@ async fn install_capsules(
         pb.set_message(cap.name.clone());
 
         let expected = CapsuleId::new(cap.name.clone())?;
-        let refspec = super::capsule::install::RefSpec::from_capsule(cap);
+        let mut pinned_capsule = cap.clone();
+        if let Some(resolved_ref) = pinned_refs.and_then(|refs| refs.get(&cap.name)) {
+            pinned_capsule
+                .tag
+                .get_or_insert_with(|| resolved_ref.clone());
+        }
+        let refspec = super::capsule::install::RefSpec::from_capsule(&pinned_capsule);
         // The installer returns the ref it ACTUALLY resolved and fetched
         // (`Some` for GitHub sources, `None` for local paths). Record
         // that — never a guess derived from the manifest fields — so the
@@ -790,7 +776,9 @@ async fn install_capsules(
                 continue;
             },
         };
-        let verified = match validate_batch_install(&expected, &cap.version, outcome) {
+        let expected_ref = pinned_refs.and_then(|refs| refs.get(&cap.name).map(String::as_str));
+        let verified = match validate_batch_install(&expected, &cap.version, expected_ref, outcome)
+        {
             Ok(verified) => verified,
             Err(e) => {
                 eprintln!("\n  Failed to install {}: {e}", cap.name);
@@ -842,6 +830,7 @@ struct VerifiedBatchInstall {
 fn validate_batch_install(
     expected: &CapsuleId,
     declared_version: &str,
+    expected_ref: Option<&str>,
     outcome: super::capsule::install::BatchInstallOutcome,
 ) -> anyhow::Result<VerifiedBatchInstall> {
     if outcome.installed.len() != 1 {
@@ -870,6 +859,14 @@ fn validate_batch_install(
         bail!(
             "capsule '{expected}' release selector declared version {declared_version}, but the installed manifest reports {}",
             installed.version
+        );
+    }
+    if let Some(expected_ref) = expected_ref
+        && outcome.resolved_ref.as_deref() != Some(expected_ref)
+    {
+        bail!(
+            "capsule '{expected}' signed ref {expected_ref} did not match installed ref {:?}",
+            outcome.resolved_ref
         );
     }
     Ok(VerifiedBatchInstall {

--- a/crates/astrid-cli/src/commands/init_grant.rs
+++ b/crates/astrid-cli/src/commands/init_grant.rs
@@ -41,6 +41,36 @@ pub(super) fn validate_grant_capsules(
     Ok(())
 }
 
+/// Complete the mandatory second Distro Apply stage for the authenticated
+/// caller. The kernel derives both target and member set from its admitted
+/// lock; no capsule names cross this boundary.
+pub(crate) async fn apply_self_grant(caller: &PrincipalId) -> anyhow::Result<()> {
+    eprintln!(
+        "{}",
+        Theme::info(&format!("Granting Distro capsule access to '{caller}'..."))
+    );
+    let mut client = crate::admin_client::connect_for_workspace_as(caller.clone())
+        .await
+        .context("Distro install committed, but connecting for the self grant failed")?;
+    let body = client
+        .request(AdminRequestKind::DistroSelfGrant)
+        .await
+        .context("Distro install committed, but the self-grant request failed")?;
+    match crate::admin_client::into_result(body)? {
+        AdminResponseBody::Success(_) => {
+            eprintln!(
+                "{}",
+                Theme::success("Distro apply and self grant completed.")
+            );
+            Ok(())
+        },
+        other => bail!(
+            "Distro install committed, but the self grant failed unexpectedly: {other:?}; \
+             the installed set is not invokable until a retry completes"
+        ),
+    }
+}
+
 /// What the post-install grant step should do, given the flag and how many
 /// capsules installed. Explicit requests always exercise the kernel grant
 /// path; the CLI never infers privilege from a principal name.

--- a/crates/astrid-cli/src/commands/init_signed_source.rs
+++ b/crates/astrid-cli/src/commands/init_signed_source.rs
@@ -1,0 +1,343 @@
+//! Authenticate selected Distro sources before `init` mutates runtime state.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use anyhow::{Context, bail};
+use astrid_core::dirs::AstridHome;
+
+use super::super::distro::lock::{DistroLock, manifest_hash};
+use super::super::distro::manifest::{DistroCapsule, DistroManifest, parse_manifest};
+use super::super::distro::trust;
+use super::InitOpts;
+
+/// A selected signed source Distro after its authentication boundary.
+#[derive(Debug)]
+pub(super) struct SignedDistroBundle {
+    pub(super) manifest: DistroManifest,
+    pub(super) lock: DistroLock,
+    /// Exact raw `Distro.toml` bytes represented by `manifest_hash`.
+    pub(super) manifest_hash: String,
+    /// Maintainer-resolved refs from the signed lock, keyed by capsule name.
+    pub(super) pinned_refs: HashMap<String, String>,
+}
+
+/// A source after authentication and before runtime mutation.
+#[derive(Debug)]
+pub(super) enum PreparedDistro {
+    Shuttle,
+    Manifest {
+        manifest: DistroManifest,
+        manifest_hash: String,
+    },
+    Signed(SignedDistroBundle),
+}
+
+/// Split an authenticated source into its install inputs.
+pub(super) fn unpack_prepared(
+    prepared: PreparedDistro,
+) -> (DistroManifest, String, Option<SignedDistroBundle>) {
+    match prepared {
+        PreparedDistro::Shuttle => unreachable!("shuttle installs return before this branch"),
+        PreparedDistro::Manifest {
+            manifest,
+            manifest_hash,
+        } => (manifest, manifest_hash, None),
+        PreparedDistro::Signed(bundle) => {
+            let manifest = bundle.manifest.clone();
+            (manifest, bundle.manifest_hash.clone(), Some(bundle))
+        },
+    }
+}
+
+/// Authenticate a selected source before any runtime state is created.
+pub(super) async fn prepare_distro_source(
+    distro_source: &str,
+    opts: &InitOpts,
+    home: &AstridHome,
+) -> anyhow::Result<PreparedDistro> {
+    if distro_source.ends_with(".shuttle") {
+        return Ok(PreparedDistro::Shuttle);
+    }
+    if opts.require_signed {
+        return Ok(PreparedDistro::Signed(
+            fetch_signed_manifest(distro_source, opts.offline, home).await?,
+        ));
+    }
+    let (manifest_bytes, manifest) = fetch_manifest_bytes(distro_source, opts.offline).await?;
+    Ok(PreparedDistro::Manifest {
+        manifest,
+        manifest_hash: manifest_hash(&manifest_bytes),
+    })
+}
+
+/// Resolve each member to bytes and prove those bytes match the signed lock.
+pub(super) async fn resolve_signed_capsules(
+    selected: &[DistroCapsule],
+    lock: &DistroLock,
+    staging: &Path,
+) -> anyhow::Result<Vec<DistroCapsule>> {
+    let signed_by_name: HashMap<&str, &super::super::distro::lock::LockedCapsule> = lock
+        .capsules
+        .iter()
+        .map(|capsule| (capsule.name.as_str(), capsule))
+        .collect();
+    let mut resolved = Vec::with_capacity(selected.len());
+    for capsule in selected {
+        let signed = signed_by_name
+            .get(capsule.name.as_str())
+            .copied()
+            .ok_or_else(|| {
+                anyhow::anyhow!("selected capsule '{}' is not in signed lock", capsule.name)
+            })?;
+        let pinned_tag = signed.resolved_ref.as_deref().or(capsule.tag.as_deref());
+        let archive_path = staging.join(format!("{}.capsule", capsule.name));
+        if is_local_capsule_archive(&capsule.source) {
+            std::fs::copy(&capsule.source, &archive_path)
+                .with_context(|| format!("copy signed capsule {}", capsule.name))?;
+        } else {
+            if capsule.source.starts_with('.') || capsule.source.starts_with('/') {
+                bail!(
+                    "signed Distro member '{}' must resolve to a prebuilt .capsule archive",
+                    capsule.name
+                );
+            }
+            let _ = Some(
+                super::super::capsule::install::resolve_capsule_to_file(
+                    &capsule.source,
+                    (!capsule.version.is_empty()).then_some(capsule.version.as_str()),
+                    pinned_tag,
+                    Some(&capsule.name),
+                    &archive_path,
+                )
+                .await?,
+            );
+        }
+        let bytes = std::fs::read(&archive_path)
+            .with_context(|| format!("read resolved capsule {}", capsule.name))?;
+        let actual = manifest_hash(&bytes);
+        anyhow::ensure!(
+            signed.hash == actual,
+            "capsule '{}' hash mismatch: signed lock has {}, resolved artifact has {actual}",
+            capsule.name,
+            signed.hash
+        );
+        let mut member = capsule.clone();
+        member.source = archive_path.to_string_lossy().into_owned();
+        resolved.push(member);
+    }
+    Ok(resolved)
+}
+
+fn is_local_capsule_archive(source: &str) -> bool {
+    let path = Path::new(source);
+    path.is_file() && source.ends_with(".capsule")
+}
+
+/// Resolve a distro source to its exact bytes and parse those bytes once.
+async fn fetch_manifest_bytes(
+    source: &str,
+    offline: bool,
+) -> anyhow::Result<(Vec<u8>, DistroManifest)> {
+    let path = Path::new(source);
+    if path.exists() && path.is_file() {
+        let bytes =
+            std::fs::read(path).with_context(|| format!("failed to read {}", path.display()))?;
+        return parse_manifest_bytes(bytes);
+    }
+
+    if offline {
+        bail!(
+            "--offline: '{source}' is not a local file and network fetch is forbidden \
+             (use a Distro.toml path or a .shuttle archive)"
+        );
+    }
+
+    let url = super::resolve_distro_url(source)?;
+    eprintln!("Fetching Distro.toml...");
+    let bytes = fetch_url_bytes(&url, "Distro.toml", 1024 * 1024).await?;
+    parse_manifest_bytes(bytes)
+}
+
+fn parse_manifest_bytes(bytes: Vec<u8>) -> anyhow::Result<(Vec<u8>, DistroManifest)> {
+    anyhow::ensure!(bytes.len() <= 1024 * 1024, "Distro.toml exceeds 1 MB limit");
+    let content = std::str::from_utf8(&bytes).context("Distro.toml is not valid UTF-8")?;
+    let manifest = parse_manifest(content)?;
+    Ok((bytes, manifest))
+}
+
+/// Fetch the signed TOML, its maintainer lock, and existing lock signature.
+async fn fetch_signed_manifest(
+    source: &str,
+    offline: bool,
+    home: &AstridHome,
+) -> anyhow::Result<SignedDistroBundle> {
+    let (manifest_bytes, manifest) = fetch_manifest_bytes(source, offline).await?;
+    let manifest_hash = manifest_hash(&manifest_bytes);
+    let lock_bytes = fetch_signed_member(source, offline, "Distro.lock").await?;
+    anyhow::ensure!(
+        lock_bytes.len() <= 1024 * 1024,
+        "Distro.lock exceeds 1 MB limit"
+    );
+    let lock_text = std::str::from_utf8(&lock_bytes).context("Distro.lock is not valid UTF-8")?;
+    let lock: DistroLock =
+        toml::from_str(lock_text).context("failed to parse signed Distro.lock")?;
+    let sig_bytes = fetch_signed_member(source, offline, "Distro.sig").await?;
+    anyhow::ensure!(
+        sig_bytes.len() <= 64 * 1024,
+        "Distro.sig exceeds size limit"
+    );
+    let sig_hex = std::str::from_utf8(&sig_bytes).context("Distro.sig is not valid UTF-8")?;
+    let pinned_refs =
+        verify_signed_manifest(home, &manifest, &manifest_hash, &lock, sig_hex, false)?;
+
+    Ok(SignedDistroBundle {
+        manifest,
+        lock,
+        manifest_hash,
+        pinned_refs,
+    })
+}
+
+/// Read a lock/sig sibling locally or at its matching remote path.
+async fn fetch_signed_member(
+    source: &str,
+    offline: bool,
+    file_name: &str,
+) -> anyhow::Result<Vec<u8>> {
+    let manifest_path = Path::new(source);
+    if manifest_path.exists() && manifest_path.is_file() {
+        let path = manifest_path
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("Distro.toml has no parent directory"))?
+            .join(file_name);
+        return std::fs::read(&path)
+            .with_context(|| format!("failed to read signed source member {}", path.display()));
+    }
+
+    if offline {
+        bail!(
+            "--offline: signed source member {file_name} is not local and network access is forbidden"
+        );
+    }
+
+    let mut url = url::Url::parse(&super::resolve_distro_url(source)?)?;
+    url.path_segments_mut()
+        .map_err(|()| anyhow::anyhow!("signed source URL cannot contain path segments"))?
+        .pop()
+        .push(file_name);
+    fetch_url_bytes(url.as_str(), file_name, 1024 * 1024).await
+}
+
+async fn fetch_url_bytes(url: &str, name: &str, limit: usize) -> anyhow::Result<Vec<u8>> {
+    let client = reqwest::Client::builder()
+        .user_agent("astrid-cli")
+        .timeout(std::time::Duration::from_secs(30))
+        .build()?;
+    let response = client
+        .get(url)
+        .send()
+        .await
+        .with_context(|| format!("failed to fetch {name}"))?;
+    if !response.status().is_success() {
+        bail!(
+            "failed to fetch {name} from {url} (HTTP {})",
+            response.status()
+        );
+    }
+    let mut bytes = Vec::new();
+    let mut response = response;
+    while let Some(chunk) = response.chunk().await? {
+        bytes.extend_from_slice(&chunk);
+        anyhow::ensure!(bytes.len() <= limit, "{name} exceeds size limit");
+    }
+    Ok(bytes)
+}
+
+/// Bind exact TOML bytes into the signed lock, then verify that lock.
+fn verify_signed_manifest(
+    home: &AstridHome,
+    manifest: &DistroManifest,
+    manifest_hash: &str,
+    lock: &DistroLock,
+    sig_hex: &str,
+    accept_new_key: bool,
+) -> anyhow::Result<HashMap<String, String>> {
+    if lock.manifest_hash.as_deref() != Some(manifest_hash) {
+        bail!(
+            "signed Distro.toml does not match Distro.lock manifest_hash; refusing to resolve members"
+        );
+    }
+    validate_signed_member_sets(manifest, lock)?;
+    let signing = manifest.distro.signing.as_ref().ok_or_else(|| {
+        anyhow::anyhow!("signed Distro.toml has no [distro.signing] configuration")
+    })?;
+    let outcome = trust::verify_and_pin(
+        home,
+        &manifest.distro.id,
+        &signing.pubkey,
+        sig_hex,
+        lock,
+        accept_new_key,
+    )?;
+    tracing::info!(
+        distro = %manifest.distro.id,
+        action = ?outcome.action,
+        "authenticated source Distro"
+    );
+
+    Ok(lock
+        .capsules
+        .iter()
+        .filter_map(|capsule| {
+            capsule
+                .resolved_ref
+                .clone()
+                .map(|resolved_ref| (capsule.name.clone(), resolved_ref))
+        })
+        .collect())
+}
+
+/// Require the signed lock to describe exactly the authenticated TOML members.
+fn validate_signed_member_sets(manifest: &DistroManifest, lock: &DistroLock) -> anyhow::Result<()> {
+    if lock.schema_version != manifest.schema_version
+        || lock.distro.id != manifest.distro.id
+        || lock.distro.version != manifest.distro.version
+    {
+        bail!("Distro.lock identity does not match the signed Distro.toml");
+    }
+
+    let declared: HashMap<&str, &DistroCapsule> = manifest
+        .capsules
+        .iter()
+        .map(|capsule| (capsule.name.as_str(), capsule))
+        .collect();
+    anyhow::ensure!(
+        declared.len() == manifest.capsules.len() && lock.capsules.len() == declared.len(),
+        "signed Distro.lock members do not match Distro.toml declarations"
+    );
+    for capsule in &lock.capsules {
+        let declared_capsule = declared
+            .get(capsule.name.as_str())
+            .copied()
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "signed Distro.lock contains undeclared capsule '{}'",
+                    capsule.name
+                )
+            })?;
+        if capsule.source != declared_capsule.source || capsule.version != declared_capsule.version
+        {
+            bail!(
+                "signed Distro.lock entry '{}' does not match Distro.toml",
+                capsule.name
+            );
+        }
+        anyhow::ensure!(
+            !capsule.hash.is_empty(),
+            "signed Distro.lock entry '{}' has no capsule hash",
+            capsule.name
+        );
+    }
+    Ok(())
+}

--- a/crates/astrid-cli/src/commands/init_tests.rs
+++ b/crates/astrid-cli/src/commands/init_tests.rs
@@ -10,6 +10,7 @@ fn batch_install_rejects_reported_identity_mismatch() {
     let err = validate_batch_install(
         &expected,
         "1.0.0",
+        None,
         super::super::capsule::install::BatchInstallOutcome {
             installed: vec![super::super::capsule::install::InstalledCapsuleOutcome {
                 id: astrid_capsule::capsule::CapsuleId::new("wrong-capsule").unwrap(),
@@ -30,6 +31,7 @@ fn batch_install_accepts_actual_version_hash_and_ref() {
     let verified = validate_batch_install(
         &expected,
         "1.0.0",
+        None,
         super::super::capsule::install::BatchInstallOutcome {
             installed: vec![super::super::capsule::install::InstalledCapsuleOutcome {
                 id: expected.clone(),
@@ -51,6 +53,7 @@ fn batch_install_rejects_multiple_reported_capsules() {
     let err = validate_batch_install(
         &expected,
         "1.0.0",
+        None,
         super::super::capsule::install::BatchInstallOutcome {
             installed: vec![
                 super::super::capsule::install::InstalledCapsuleOutcome {
@@ -77,6 +80,7 @@ fn batch_install_rejects_declared_version_mismatch() {
     let err = validate_batch_install(
         &expected,
         "1.0.0",
+        None,
         super::super::capsule::install::BatchInstallOutcome {
             installed: vec![super::super::capsule::install::InstalledCapsuleOutcome {
                 id: expected.clone(),
@@ -173,6 +177,189 @@ fn distro_source_resolution_full_url() {
 // ---- Part A: headless selection / variable resolution ----
 
 use super::super::distro::manifest::{DistroCapsule, VariableDef};
+
+fn signed_source_fixture(dir: &std::path::Path) -> (std::path::PathBuf, Vec<u8>, String) {
+    let keypair = astrid_crypto::KeyPair::generate();
+    let pubkey = super::super::distro::sign::pubkey_to_wire(&keypair.export_public_key());
+    let bytes = format!(
+        "schema-version = 1\n\n\
+         [distro]\nid = \"test\"\nname = \"Test\"\nversion = \"0.1.0\"\n\n\
+         [distro.signing]\npubkey = \"{pubkey}\"\n\n\
+         [[capsule]]\nname = \"cli\"\nsource = \"@org/cli\"\nversion = \"0.1.0\"\nrole = \"uplink\"\n"
+    )
+    .into_bytes();
+    let manifest_hash = manifest_hash(&bytes);
+    let lock = super::super::distro::lock::DistroLock {
+        schema_version: 1,
+        distro: super::super::distro::lock::DistroLockMeta {
+            id: "test".into(),
+            version: "0.1.0".into(),
+            resolved_at: "2026-01-01T00:00:00Z".into(),
+        },
+        capsules: vec![super::super::distro::lock::LockedCapsule {
+            name: "cli".into(),
+            version: "0.1.0".into(),
+            source: "@org/cli".into(),
+            hash: format!("blake3:{}", "a".repeat(64)),
+            resolved_ref: Some("v0.1.0".into()),
+        }],
+        manifest_hash: Some(manifest_hash.clone()),
+    };
+    let sig = super::super::distro::sign::sign_lock(&lock, &keypair).unwrap();
+    std::fs::write(dir.join("Distro.toml"), &bytes).unwrap();
+    std::fs::write(
+        dir.join("Distro.lock"),
+        toml::to_string_pretty(&lock).unwrap(),
+    )
+    .unwrap();
+    std::fs::write(dir.join("Distro.sig"), sig).unwrap();
+    (dir.join("Distro.toml"), bytes, manifest_hash)
+}
+
+#[test]
+fn product_source_prepares_signed_distro_toml_without_shuttle_suffix() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(dir.path().join("home"));
+    let (source, bytes, expected_hash) = signed_source_fixture(dir.path());
+    let opts = InitOpts {
+        require_signed: true,
+        offline: true,
+        ..Default::default()
+    };
+
+    let prepared = futures::executor::block_on(super::signed_source::prepare_distro_source(
+        source.to_str().unwrap(),
+        &opts,
+        &home,
+    ))
+    .unwrap();
+    let super::PreparedDistro::Signed(bundle) = prepared else {
+        panic!("signed Distro.toml must use the source bundle path");
+    };
+    assert_eq!(bundle.manifest_hash, expected_hash);
+    assert_eq!(bundle.manifest_hash, manifest_hash(&bytes));
+    assert_eq!(
+        bundle.lock.manifest_hash.as_deref(),
+        Some(expected_hash.as_str())
+    );
+}
+
+#[test]
+fn product_source_rejects_unsigned_distro_toml_before_install_state() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(dir.path().join("home"));
+    std::fs::write(
+        dir.path().join("Distro.toml"),
+        "schema-version = 1\n\n[distro]\nid = \"test\"\nname = \"Test\"\nversion = \"0.1.0\"\n\n\
+         [[capsule]]\nname = \"cli\"\nsource = \"@org/cli\"\nversion = \"0.1.0\"\nrole = \"uplink\"\n",
+    )
+    .unwrap();
+    let opts = InitOpts {
+        require_signed: true,
+        offline: true,
+        ..Default::default()
+    };
+
+    let error = futures::executor::block_on(super::signed_source::prepare_distro_source(
+        dir.path().join("Distro.toml").to_str().unwrap(),
+        &opts,
+        &home,
+    ))
+    .unwrap_err();
+    assert!(error.to_string().contains("Distro.lock"), "got: {error:#}");
+}
+
+#[test]
+fn product_source_rejects_tampered_distro_toml_bytes() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(dir.path().join("home"));
+    let (source, bytes, _) = signed_source_fixture(dir.path());
+    let mut tampered = bytes.clone();
+    tampered.extend_from_slice(b"\n# tampered after sealing\n");
+    std::fs::write(&source, tampered).unwrap();
+    let opts = InitOpts {
+        require_signed: true,
+        offline: true,
+        ..Default::default()
+    };
+
+    let error = futures::executor::block_on(super::signed_source::prepare_distro_source(
+        source.to_str().unwrap(),
+        &opts,
+        &home,
+    ))
+    .unwrap_err();
+    assert!(
+        error.to_string().contains("manifest_hash"),
+        "got: {error:#}"
+    );
+}
+
+#[test]
+fn product_source_rejects_tampered_signature() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(dir.path().join("home"));
+    let (source, _, _) = signed_source_fixture(dir.path());
+    std::fs::write(dir.path().join("Distro.sig"), "00").unwrap();
+    let opts = InitOpts {
+        require_signed: true,
+        offline: true,
+        ..Default::default()
+    };
+
+    let error = futures::executor::block_on(super::signed_source::prepare_distro_source(
+        source.to_str().unwrap(),
+        &opts,
+        &home,
+    ))
+    .unwrap_err();
+    assert!(error.to_string().contains("signature"));
+}
+
+#[test]
+fn signed_lock_cannot_add_undeclared_member() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(dir.path().join("home"));
+    let (source, bytes, expected_hash) = signed_source_fixture(dir.path());
+    let keypair = astrid_crypto::KeyPair::generate();
+    let lock = super::super::distro::lock::DistroLock {
+        schema_version: 1,
+        distro: super::super::distro::lock::DistroLockMeta {
+            id: "test".into(),
+            version: "0.1.0".into(),
+            resolved_at: "2026-01-01T00:00:00Z".into(),
+        },
+        capsules: vec![super::super::distro::lock::LockedCapsule {
+            name: "undeclared".into(),
+            version: "0.1.0".into(),
+            source: "@org/undeclared".into(),
+            hash: format!("blake3:{}", "a".repeat(64)),
+            resolved_ref: None,
+        }],
+        manifest_hash: Some(expected_hash),
+    };
+    let sig = super::super::distro::sign::sign_lock(&lock, &keypair).unwrap();
+    std::fs::write(
+        dir.path().join("Distro.lock"),
+        toml::to_string_pretty(&lock).unwrap(),
+    )
+    .unwrap();
+    std::fs::write(dir.path().join("Distro.sig"), sig).unwrap();
+    let opts = InitOpts {
+        require_signed: true,
+        offline: true,
+        ..Default::default()
+    };
+
+    let error = futures::executor::block_on(super::signed_source::prepare_distro_source(
+        source.to_str().unwrap(),
+        &opts,
+        &home,
+    ))
+    .unwrap_err();
+    assert!(error.to_string().contains("undeclared capsule"));
+    assert_eq!(super::manifest_hash(&bytes), lock.manifest_hash.unwrap());
+}
 
 fn cap(name: &str, group: Option<&str>, default: bool) -> DistroCapsule {
     DistroCapsule {
@@ -282,7 +469,7 @@ async fn offline_refuses_remote_capsule_source() {
     // A local Distro.toml with a remote @org/repo capsule must not
     // silently fetch under --offline.
     let selected = vec![cap("llm", None, false)]; // source "@org/llm"
-    let err = install_capsules(&selected, true, &astrid_core::PrincipalId::default())
+    let err = install_capsules(&selected, true, &astrid_core::PrincipalId::default(), None)
         .await
         .unwrap_err();
     assert!(err.to_string().contains("--offline"), "got: {err}");
@@ -352,7 +539,14 @@ fn should_write_lock_gates_on_success() {
 fn partial_run_leaves_no_lock_for_retry() {
     let dir = tempfile::tempdir().unwrap();
     let lock_path = dir.path().join("distro.lock");
-    let lock = create_lock_from_parts(1, "example-distro", "1.0.0", Vec::new());
+    let lock = create_lock_from_parts(
+        1,
+        "example-distro",
+        "1.0.0",
+        "blake3:manifest-bytes",
+        Vec::new(),
+    );
+    assert_eq!(lock.manifest_hash.as_deref(), Some("blake3:manifest-bytes"));
 
     // Partial (3 of 5): no lock written, returns false.
     let wrote = persist_lock_if_earned(&lock_path, 5, 3, &lock).unwrap();

--- a/crates/astrid-cli/src/dispatch.rs
+++ b/crates/astrid-cli/src/dispatch.rs
@@ -518,7 +518,9 @@ async fn dispatch_distro(command: DistroCommands) -> Result<ExitCode> {
                 require_signed: true,
             };
             commands::init::run_init(&distro, &opts).await?;
-            commands::init::apply_self_grant(&opts.target_principal).await?;
+            if apply_self_grant_required(&distro) {
+                commands::init::apply_self_grant(&opts.target_principal).await?;
+            }
             Ok(ExitCode::SUCCESS)
         },
         DistroCommands::Show { agent } => {
@@ -561,6 +563,12 @@ async fn dispatch_distro(command: DistroCommands) -> Result<ExitCode> {
             Ok(ExitCode::SUCCESS)
         },
     }
+}
+
+/// Source-manifest apply completes with `DistroSelfGrant`; `.shuttle` remains a
+/// packaging/install vehicle and must never gain grant authority in this path.
+fn apply_self_grant_required(distro_source: &str) -> bool {
+    !distro_source.ends_with(".shuttle")
 }
 
 fn dispatch_wit(command: &WitCommands) -> Result<ExitCode> {
@@ -886,5 +894,11 @@ mod tests {
                 .to_string()
                 .contains("--allow-unsigned is not acceptance")
         );
+    }
+
+    #[test]
+    fn self_grant_follows_source_manifests_but_not_shuttle_packages() {
+        assert!(apply_self_grant_required("/tmp/product/Distro.toml"));
+        assert!(!apply_self_grant_required("/tmp/product.shuttle"));
     }
 }

--- a/crates/astrid-cli/src/dispatch.rs
+++ b/crates/astrid-cli/src/dispatch.rs
@@ -208,6 +208,7 @@ async fn dispatch_subcommand(
                     .transpose()?
                     .unwrap_or_else(crate::principal::current),
                 grant_capsules,
+                require_signed: false,
             };
             commands::init::run_init(&distro, &opts).await?;
             commands::self_update::ensure_path_setup()?;
@@ -495,6 +496,11 @@ async fn dispatch_distro(command: DistroCommands) -> Result<ExitCode> {
                     &[tracker_657()],
                 ));
             }
+            if allow_unsigned {
+                anyhow::bail!(
+                    "astrid distro apply requires a signed Distro; --allow-unsigned is not acceptance"
+                );
+            }
             let distro = non_empty_distro_source(name).ok_or_else(|| {
                 anyhow::anyhow!(
                     "astrid distro apply requires an explicit distro source: @owner/repo, URL, local Distro.toml, or .shuttle; Astrid Runtime does not choose a product distro"
@@ -508,10 +514,11 @@ async fn dispatch_distro(command: DistroCommands) -> Result<ExitCode> {
                 vars: commands::init::parse_cli_vars(&vars)?,
                 target_principal: crate::principal::current(),
                 // `distro apply` has no `--grant-capsules` surface; granting
-                // stays on `astrid init`. Capsules install without grants here.
                 grant_capsules: false,
+                require_signed: true,
             };
             commands::init::run_init(&distro, &opts).await?;
+            commands::init::apply_self_grant(&opts.target_principal).await?;
             Ok(ExitCode::SUCCESS)
         },
         DistroCommands::Show { agent } => {
@@ -858,5 +865,26 @@ mod tests {
                 "astrid distro apply requires an explicit distro source: @owner/repo, URL, local Distro.toml, or .shuttle; Astrid Runtime does not choose a product distro"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn distro_apply_rejects_unsigned_acceptance_before_install() {
+        let error = dispatch_distro(DistroCommands::Apply {
+            name: Some("/tmp/product.shuttle".into()),
+            agent: None,
+            yes: true,
+            offline: true,
+            allow_unsigned: true,
+            accept_new_key: false,
+            vars: Vec::new(),
+        })
+        .await
+        .expect_err("--allow-unsigned must not make Distro apply acceptance-capable");
+
+        assert!(
+            error
+                .to_string()
+                .contains("--allow-unsigned is not acceptance")
+        );
     }
 }

--- a/crates/astrid-core/src/capability_grammar.rs
+++ b/crates/astrid-core/src/capability_grammar.rs
@@ -408,6 +408,14 @@ pub const CAPABILITY_CATALOG: &[CapabilityInfo] = {
             scope: Self_,
             danger: Safe,
         },
+        CapabilityInfo {
+            id: "self:distro:grant",
+            label: "Apply distro capsule grants (self)",
+            description: "Grant the caller the exact capsule set already admitted in its own signed Distro lock. Installation and authority granting remain separate operations.",
+            category: Capsule,
+            scope: Self_,
+            danger: Elevated,
+        },
         // ── Agents (principals) ──
         CapabilityInfo {
             id: "agent:create",
@@ -707,7 +715,7 @@ pub fn known_capabilities_list() -> &'static [&'static str] {
 /// in the same commit that adds a new capability so a kernel
 /// addition without updating the catalog fails the consuming
 /// crate's tests.
-pub const KNOWN_CAPABILITIES_COUNT: usize = 45;
+pub const KNOWN_CAPABILITIES_COUNT: usize = 46;
 
 const _: () = assert!(
     CAPABILITY_CATALOG.len() == KNOWN_CAPABILITIES_COUNT,

--- a/crates/astrid-core/src/capability_registry.rs
+++ b/crates/astrid-core/src/capability_registry.rs
@@ -120,68 +120,8 @@ const CAPABILITY_REGISTRY_REVISION_1_IDS: [&str; 51] = [
 pub const CAPABILITY_REGISTRY_REVISION_1: CapabilityRegistryRevision =
     CapabilityRegistryRevision::new(NonZeroU32::MIN);
 
-/// Exact capability IDs in capability-registry revision 2.
-///
-/// Revision 2 is the smallest expansion of the frozen revision-1 authority
-/// registry: it adds only the dedicated Distro self-grant operation.
-const CAPABILITY_REGISTRY_REVISION_2_IDS: [&str; 52] = [
-    "system:shutdown",
-    "system:status",
-    "capsule:install",
-    "self:capsule:install",
-    "capsule:reload",
-    "self:capsule:reload",
-    "capsule:remove",
-    "self:capsule:remove",
-    "self:workspace:promote",
-    "self:workspace:rollback",
-    "capsule:list",
-    "self:capsule:list",
-    "self:distro:grant",
-    "agent:create",
-    "agent:create:inherit",
-    "agent:create:clone",
-    "agent:delete",
-    "agent:enable",
-    "agent:disable",
-    "agent:modify",
-    "agent:list",
-    "self:agent:list",
-    "quota:set",
-    "self:quota:set",
-    "quota:get",
-    "self:quota:get",
-    "group:create",
-    "group:delete",
-    "group:modify",
-    "group:list",
-    "self:group:list",
-    "caps:grant",
-    "caps:revoke",
-    "caps:token:mint",
-    "caps:token:revoke",
-    "caps:token:list",
-    "invite:issue",
-    "invite:redeem",
-    "invite:list",
-    "invite:revoke",
-    "audit:read_all",
-    "self:approval:respond",
-    "self:auth:pair",
-    "self:auth:pair:admin",
-    "auth:pair:redeem",
-    "auth:pair",
-    "system:resources:unbounded",
-    "net_bind",
-    "uplink",
-    "capsule:access:any",
-    "authority:profile:manage",
-    "authority:repair",
-];
-
 /// Schema revision for the 52-ID authority registry.
-pub const CAPABILITY_REGISTRY_REVISION_2: CapabilityRegistryRevision =
-    CapabilityRegistryRevision::new(NonZeroU32::new(2).expect("non-zero"));
+pub const CAPABILITY_REGISTRY_REVISION_2: CapabilityRegistryRevision = revision_2::REVISION;
 
 #[derive(Clone, Copy)]
 struct RevisionSemantics {
@@ -213,10 +153,7 @@ pub fn capability_registry_revision_1() -> Result<CapabilityRegistryManifest, Au
 /// any definition fails registry validation.
 pub fn capability_registry_revision_2() -> Result<CapabilityRegistryManifest, AuthorityRegistryError>
 {
-    capability_registry(
-        CAPABILITY_REGISTRY_REVISION_2,
-        &CAPABILITY_REGISTRY_REVISION_2_IDS,
-    )
+    capability_registry(CAPABILITY_REGISTRY_REVISION_2, &revision_2::IDS)
 }
 
 fn capability_registry(

--- a/crates/astrid-core/src/capability_registry.rs
+++ b/crates/astrid-core/src/capability_registry.rs
@@ -17,6 +17,7 @@ use util::{
 };
 
 mod revision_1;
+mod revision_2;
 mod util;
 
 const ENTRY_DIGEST_DOMAIN: &[u8] = b"astrid-capability-entry\0";
@@ -119,6 +120,69 @@ const CAPABILITY_REGISTRY_REVISION_1_IDS: [&str; 51] = [
 pub const CAPABILITY_REGISTRY_REVISION_1: CapabilityRegistryRevision =
     CapabilityRegistryRevision::new(NonZeroU32::MIN);
 
+/// Exact capability IDs in capability-registry revision 2.
+///
+/// Revision 2 is the smallest expansion of the frozen revision-1 authority
+/// registry: it adds only the dedicated Distro self-grant operation.
+const CAPABILITY_REGISTRY_REVISION_2_IDS: [&str; 52] = [
+    "system:shutdown",
+    "system:status",
+    "capsule:install",
+    "self:capsule:install",
+    "capsule:reload",
+    "self:capsule:reload",
+    "capsule:remove",
+    "self:capsule:remove",
+    "self:workspace:promote",
+    "self:workspace:rollback",
+    "capsule:list",
+    "self:capsule:list",
+    "self:distro:grant",
+    "agent:create",
+    "agent:create:inherit",
+    "agent:create:clone",
+    "agent:delete",
+    "agent:enable",
+    "agent:disable",
+    "agent:modify",
+    "agent:list",
+    "self:agent:list",
+    "quota:set",
+    "self:quota:set",
+    "quota:get",
+    "self:quota:get",
+    "group:create",
+    "group:delete",
+    "group:modify",
+    "group:list",
+    "self:group:list",
+    "caps:grant",
+    "caps:revoke",
+    "caps:token:mint",
+    "caps:token:revoke",
+    "caps:token:list",
+    "invite:issue",
+    "invite:redeem",
+    "invite:list",
+    "invite:revoke",
+    "audit:read_all",
+    "self:approval:respond",
+    "self:auth:pair",
+    "self:auth:pair:admin",
+    "auth:pair:redeem",
+    "auth:pair",
+    "system:resources:unbounded",
+    "net_bind",
+    "uplink",
+    "capsule:access:any",
+    "authority:profile:manage",
+    "authority:repair",
+];
+
+/// Schema revision for the 52-ID authority registry.
+pub const CAPABILITY_REGISTRY_REVISION_2: CapabilityRegistryRevision =
+    CapabilityRegistryRevision::new(NonZeroU32::new(2).expect("non-zero"));
+
 #[derive(Clone, Copy)]
 struct RevisionSemantics {
     scope: CapabilityScope,
@@ -135,13 +199,42 @@ struct RevisionSemantics {
 /// any definition fails registry validation.
 pub fn capability_registry_revision_1() -> Result<CapabilityRegistryManifest, AuthorityRegistryError>
 {
-    let entries = CAPABILITY_REGISTRY_REVISION_1_IDS
-        .into_iter()
+    capability_registry(
+        CAPABILITY_REGISTRY_REVISION_1,
+        &CAPABILITY_REGISTRY_REVISION_1_IDS,
+    )
+}
+
+/// Build the content-addressed registry for the 52 fixed capability IDs.
+///
+/// # Errors
+///
+/// Returns an error if an ID lacks fixed semantics or display metadata, or if
+/// any definition fails registry validation.
+pub fn capability_registry_revision_2() -> Result<CapabilityRegistryManifest, AuthorityRegistryError>
+{
+    capability_registry(
+        CAPABILITY_REGISTRY_REVISION_2,
+        &CAPABILITY_REGISTRY_REVISION_2_IDS,
+    )
+}
+
+fn capability_registry(
+    revision: CapabilityRegistryRevision,
+    ids: &[&str],
+) -> Result<CapabilityRegistryManifest, AuthorityRegistryError> {
+    let entries = ids
+        .iter()
         .map(|id| {
             let semantics = revision_1_semantics(id).ok_or_else(|| {
                 AuthorityRegistryError::MissingRevisionDefinition { id: id.to_string() }
             })?;
-            let danger = revision_1::danger(id).ok_or_else(|| {
+            let danger = if revision == CAPABILITY_REGISTRY_REVISION_2 {
+                revision_2::danger(id)
+            } else {
+                revision_1::danger(id)
+            };
+            let danger = danger.ok_or_else(|| {
                 AuthorityRegistryError::MissingRevisionDisplayMetadata { id: id.to_string() }
             })?;
             RegisteredCapability::new(
@@ -156,7 +249,7 @@ pub fn capability_registry_revision_1() -> Result<CapabilityRegistryManifest, Au
         })
         .collect::<Result<Vec<_>, AuthorityRegistryError>>()?;
 
-    CapabilityRegistryManifest::new(CAPABILITY_REGISTRY_REVISION_1, entries)
+    CapabilityRegistryManifest::new(revision, entries)
 }
 
 fn revision_1_semantics(id: &str) -> Option<RevisionSemantics> {
@@ -188,6 +281,7 @@ fn revision_1_semantics(id: &str) -> Option<RevisionSemantics> {
         | "self:agent:list"
         | "self:group:list"
         | "self:quota:get"
+        | "self:distro:grant"
         | "self:approval:respond" => RevisionSemantics::new(Self_, &[Principal], true, false),
         "agent:create" | "agent:create:clone" | "agent:modify" => {
             RevisionSemantics::new(Global, &[Principal, Group, CapsulePackage], true, true)

--- a/crates/astrid-core/src/capability_registry/revision_2.rs
+++ b/crates/astrid-core/src/capability_registry/revision_2.rs
@@ -1,0 +1,8 @@
+use super::CapabilityDanger;
+
+pub(super) fn danger(id: &str) -> Option<CapabilityDanger> {
+    if id == "self:distro:grant" {
+        return Some(CapabilityDanger::Elevated);
+    }
+    super::revision_1::danger(id)
+}

--- a/crates/astrid-core/src/capability_registry/revision_2.rs
+++ b/crates/astrid-core/src/capability_registry/revision_2.rs
@@ -1,4 +1,69 @@
-use super::CapabilityDanger;
+use std::num::NonZeroU32;
+
+use super::{CapabilityDanger, CapabilityRegistryRevision};
+
+/// Exact capability IDs in capability-registry revision 2.
+///
+/// Revision 2 is the smallest expansion of the frozen revision-1 authority
+/// registry: it adds only the dedicated Distro self-grant operation.
+pub(super) const IDS: [&str; 52] = [
+    "system:shutdown",
+    "system:status",
+    "capsule:install",
+    "self:capsule:install",
+    "capsule:reload",
+    "self:capsule:reload",
+    "capsule:remove",
+    "self:capsule:remove",
+    "self:workspace:promote",
+    "self:workspace:rollback",
+    "capsule:list",
+    "self:capsule:list",
+    "self:distro:grant",
+    "agent:create",
+    "agent:create:inherit",
+    "agent:create:clone",
+    "agent:delete",
+    "agent:enable",
+    "agent:disable",
+    "agent:modify",
+    "agent:list",
+    "self:agent:list",
+    "quota:set",
+    "self:quota:set",
+    "quota:get",
+    "self:quota:get",
+    "group:create",
+    "group:delete",
+    "group:modify",
+    "group:list",
+    "self:group:list",
+    "caps:grant",
+    "caps:revoke",
+    "caps:token:mint",
+    "caps:token:revoke",
+    "caps:token:list",
+    "invite:issue",
+    "invite:redeem",
+    "invite:list",
+    "invite:revoke",
+    "audit:read_all",
+    "self:approval:respond",
+    "self:auth:pair",
+    "self:auth:pair:admin",
+    "auth:pair:redeem",
+    "auth:pair",
+    "system:resources:unbounded",
+    "net_bind",
+    "uplink",
+    "capsule:access:any",
+    "authority:profile:manage",
+    "authority:repair",
+];
+
+/// Schema revision for the 52-ID authority registry.
+pub(super) const REVISION: CapabilityRegistryRevision =
+    CapabilityRegistryRevision::new(NonZeroU32::new(2).expect("non-zero"));
 
 pub(super) fn danger(id: &str) -> Option<CapabilityDanger> {
     if id == "self:distro:grant" {

--- a/crates/astrid-core/src/capability_registry/tests.rs
+++ b/crates/astrid-core/src/capability_registry/tests.rs
@@ -52,7 +52,12 @@ fn capability_registry_revision_1_freezes_current_and_dormant_exact_ids() {
         .map(|entry| entry.id)
         .collect::<BTreeSet<_>>();
     assert_eq!(catalog.len(), KNOWN_CAPABILITIES_COUNT);
-    assert!(catalog.is_subset(&baseline));
+    let revision_1_catalog = {
+        let mut catalog = catalog.clone();
+        catalog.remove("self:distro:grant");
+        catalog
+    };
+    assert!(revision_1_catalog.is_subset(&baseline));
 
     let additions = baseline
         .difference(&catalog)
@@ -69,6 +74,55 @@ fn capability_registry_revision_1_freezes_current_and_dormant_exact_ids() {
             "authority:repair",
         ])
     );
+}
+
+#[test]
+fn capability_registry_revision_2_adds_only_distro_self_grant() {
+    let revision_1 = capability_registry_revision_1().unwrap();
+    let revision_2 = capability_registry_revision_2().unwrap();
+    let previous = revision_1
+        .entries()
+        .iter()
+        .map(|entry| entry.id().as_str())
+        .collect::<BTreeSet<_>>();
+    let current = revision_2
+        .entries()
+        .iter()
+        .map(|entry| entry.id().as_str())
+        .collect::<BTreeSet<_>>();
+
+    assert_eq!(revision_2.schema_revision(), CAPABILITY_REGISTRY_REVISION_2);
+    assert_eq!(revision_2.entries().len(), 52);
+    assert_eq!(
+        current.difference(&previous).copied().collect::<Vec<_>>(),
+        ["self:distro:grant"]
+    );
+    assert!(previous.difference(&current).next().is_none());
+    revision_2.verify().unwrap();
+}
+
+#[test]
+fn capability_registry_revision_2_preserves_catalog_scope_and_danger() {
+    let manifest = capability_registry_revision_2().unwrap();
+    for catalog_entry in CAPABILITY_CATALOG {
+        let registered = manifest
+            .entries()
+            .iter()
+            .find(|entry| entry.id().as_str() == catalog_entry.id)
+            .unwrap_or_else(|| panic!("missing catalog capability {}", catalog_entry.id));
+        assert_eq!(
+            registered.scope(),
+            catalog_entry.scope,
+            "{}",
+            catalog_entry.id
+        );
+        assert_eq!(
+            registered.danger(),
+            catalog_entry.danger,
+            "{}",
+            catalog_entry.id
+        );
+    }
 }
 
 #[test]
@@ -100,6 +154,9 @@ fn capability_registry_revision_1_contains_every_fixed_definition() {
 fn capability_registry_revision_1_preserves_catalog_scope_and_danger() {
     let manifest = capability_registry_revision_1().unwrap();
     for catalog_entry in CAPABILITY_CATALOG {
+        if catalog_entry.id == "self:distro:grant" {
+            continue;
+        }
         let registered = manifest
             .entries()
             .iter()
@@ -392,6 +449,31 @@ fn capability_registry_revision_1_digest_vectors_are_stable() {
     assert_eq!(
         manifest.digest().to_hex(),
         "111cf3fe35104ccd25767d3f0b85778c0bb2561d10016f56ac868de4607940e6"
+    );
+}
+
+#[test]
+fn capability_registry_revision_2_distro_self_grant_digest_is_stable() {
+    let revision_1 = capability_registry_revision_1().unwrap();
+    let revision_2 = capability_registry_revision_2().unwrap();
+    let added = revision_2
+        .entries()
+        .iter()
+        .find(|entry| entry.id().as_str() == "self:distro:grant")
+        .unwrap();
+    assert!(
+        !revision_1
+            .entries()
+            .iter()
+            .any(|entry| entry.id().as_str() == "self:distro:grant")
+    );
+    assert_eq!(
+        added.entry_digest().to_hex().as_str(),
+        "e7693d5a7054a15f5ddea24eabf5b1ba884c221a9f5fe9a241b9f1437b7a413e"
+    );
+    assert_eq!(
+        revision_2.digest().to_hex().as_str(),
+        "1dcbe2d457f510e0f425c5f6372977636196d654688067feb9ae64ec72892279"
     );
 }
 

--- a/crates/astrid-core/src/kernel_api/mod.rs
+++ b/crates/astrid-core/src/kernel_api/mod.rs
@@ -663,6 +663,13 @@ pub enum AdminRequestKind {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         expected_hash: Option<String>,
     },
+    /// Grant the authenticated caller invoke access to exactly the capsule
+    /// set in that caller's kernel-admitted Distro lock.
+    ///
+    /// The request deliberately carries no principal or capsule list: the
+    /// caller is the only target and the admitted lock is the only source of
+    /// member identities.
+    DistroSelfGrant,
     /// Create a custom group, validated through the same rules the boot
     /// loader applies to `groups.toml`.
     GroupCreate {

--- a/crates/astrid-kernel/src/kernel_router/admin/distro_handlers.rs
+++ b/crates/astrid-kernel/src/kernel_router/admin/distro_handlers.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use astrid_core::kernel_api::{AdminResponseBody, DistroProvenance};
 use astrid_core::principal::PrincipalId;
+use astrid_core::profile::{CapsuleGrant, PrincipalProfile};
 
 use crate::Kernel;
 
@@ -43,6 +44,7 @@ pub(super) async fn set(
     lock: DistroProvenance,
     expected_hash: Option<String>,
 ) -> AdminResponseBody {
+    let _guard = kernel.admin_write_lock.lock().await;
     if let Err(error) = validate(&lock) {
         return AdminResponseBody::Error(error);
     }
@@ -93,6 +95,101 @@ pub(super) async fn set(
     }
 }
 
+/// Grant the caller exactly its admitted Distro lock's capsule identities.
+///
+/// The caller is the only target and the kernel-owned lock is the only
+/// source of names. The digest is captured, then rechecked under the same
+/// admin write lock used by `DistroLockSet`, so a concurrent lock change
+/// cannot authorize a stale member set.
+pub(super) async fn self_grant(kernel: &Arc<Kernel>, caller: &PrincipalId) -> AdminResponseBody {
+    let observed = match load_lock(kernel, caller).await {
+        Ok(Some(lock)) => lock,
+        Ok(None) => return AdminResponseBody::Error("no admitted Distro lock".to_owned()),
+        Err(error) => return AdminResponseBody::Error(error),
+    };
+    if let Err(error) = validate(&observed) {
+        return AdminResponseBody::Error(error);
+    }
+    if observed.capsules.is_empty() {
+        return AdminResponseBody::Error("admitted Distro lock has no capsules".to_owned());
+    }
+    let Some(manifest_hash) = observed.manifest_hash.as_ref() else {
+        return AdminResponseBody::Error(
+            "admitted Distro lock has no manifest_hash binding".to_owned(),
+        );
+    };
+    let observed_digest = match lock_digest(&observed) {
+        Ok(digest) => digest,
+        Err(error) => return AdminResponseBody::Error(error),
+    };
+    let capsule_names: Vec<String> = observed
+        .capsules
+        .iter()
+        .map(|capsule| capsule.name.clone())
+        .collect();
+
+    let _guard = kernel.admin_write_lock.lock().await;
+    let current = match load_lock(kernel, caller).await {
+        Ok(Some(lock)) => lock,
+        Ok(None) => {
+            return AdminResponseBody::Error("Distro lock was removed concurrently".to_owned());
+        },
+        Err(error) => return AdminResponseBody::Error(error),
+    };
+    let current_digest = match lock_digest(&current) {
+        Ok(digest) => digest,
+        Err(error) => return AdminResponseBody::Error(error),
+    };
+    if current_digest != observed_digest {
+        return AdminResponseBody::Error(
+            "Distro lock changed concurrently; retry with the fresh admitted lock".to_owned(),
+        );
+    }
+    if current.manifest_hash.as_ref() != Some(manifest_hash) {
+        return AdminResponseBody::Error(
+            "Distro manifest_hash changed concurrently; retry with the fresh admitted lock"
+                .to_owned(),
+        );
+    }
+
+    let profile_path = super::handlers::principal_profile_path(kernel, caller);
+    if let Err(error) = super::handlers::require_principal_exists(caller, &profile_path) {
+        return AdminResponseBody::Error(error);
+    }
+    let mut profile = match PrincipalProfile::load_from_path(&profile_path) {
+        Ok(profile) => profile,
+        Err(error) => {
+            return AdminResponseBody::Error(format!("load principal profile: {error}"));
+        },
+    };
+    let changed = match super::handlers::apply_set_delta::<CapsuleGrant>(
+        &mut profile.capsules,
+        &capsule_names,
+        &[],
+    ) {
+        Ok(changed) => changed,
+        Err(error) => {
+            return AdminResponseBody::Error(format!("capsule grant delta rejected: {error}"));
+        },
+    };
+    if changed {
+        if let Err(error) = profile.validate() {
+            return AdminResponseBody::Error(format!("principal profile rejected: {error}"));
+        }
+        if let Err(error) = profile.save_to_path(&profile_path) {
+            return AdminResponseBody::Error(format!("save principal profile: {error}"));
+        }
+    }
+    kernel.profile_cache.invalidate(caller);
+    AdminResponseBody::Success(serde_json::json!({
+        "principal": caller.as_str(),
+        "capsules": profile.capsules,
+        "manifest_hash": manifest_hash,
+        "lock_digest": observed_digest,
+        "changed": changed,
+    }))
+}
+
 fn principal_store(
     kernel: &Arc<Kernel>,
     principal: &PrincipalId,
@@ -108,6 +205,32 @@ fn principal_store(
     store
         .principal_control_kv(uid, "distro")
         .map_err(|error| format!("open principal distro control namespace: {error}"))
+}
+
+async fn load_lock(
+    kernel: &Arc<Kernel>,
+    principal: &PrincipalId,
+) -> Result<Option<DistroProvenance>, String> {
+    let store = principal_store(kernel, principal)?;
+    let value = store
+        .get(KEY)
+        .await
+        .map_err(|error| format!("read distro provenance: {error}"))?;
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    if value.len() > MAX_BYTES {
+        return Err("distro provenance exceeds size limit".to_owned());
+    }
+    serde_json::from_slice(&value)
+        .map(Some)
+        .map_err(|error| format!("decode distro provenance: {error}"))
+}
+
+fn lock_digest(lock: &DistroProvenance) -> Result<String, String> {
+    serde_json::to_vec(lock)
+        .map(|encoded| digest(&encoded))
+        .map_err(|error| format!("encode distro provenance: {error}"))
 }
 
 fn validate(lock: &DistroProvenance) -> Result<(), String> {

--- a/crates/astrid-kernel/src/kernel_router/admin/distro_self_grant_tests.rs
+++ b/crates/astrid-kernel/src/kernel_router/admin/distro_self_grant_tests.rs
@@ -1,0 +1,301 @@
+use std::sync::Arc;
+
+use astrid_core::PrincipalId;
+use astrid_core::kernel_api::{AdminRequestKind, AdminResponseBody, DistroCapsuleProvenance};
+use astrid_core::profile::PrincipalProfile;
+use tempfile::TempDir;
+
+use super::handlers;
+use crate::Kernel;
+
+async fn fixture() -> (TempDir, Arc<Kernel>) {
+    let dir = tempfile::tempdir().unwrap();
+    let kernel =
+        crate::test_kernel_with_home(astrid_core::dirs::AstridHome::from_path(dir.path())).await;
+    (dir, kernel)
+}
+
+fn caller() -> PrincipalId {
+    PrincipalId::new("worker").unwrap()
+}
+
+async fn create_principal(kernel: &Arc<Kernel>, principal: &PrincipalId) {
+    let response = handlers::dispatch(
+        kernel,
+        &PrincipalId::default(),
+        AdminRequestKind::AgentCreate {
+            name: principal.as_str().to_owned(),
+            groups: Vec::new(),
+            grants: Vec::new(),
+            inherit_from: None,
+            clone_from: None,
+            allow_admin_clone: false,
+        },
+    )
+    .await;
+    assert!(
+        matches!(response, AdminResponseBody::Success(_)),
+        "{response:?}"
+    );
+}
+
+fn hash(seed: char) -> String {
+    format!("blake3:{}", seed.to_string().repeat(64))
+}
+
+fn lock(names: &[&str], manifest: Option<String>) -> astrid_core::kernel_api::DistroProvenance {
+    astrid_core::kernel_api::DistroProvenance {
+        schema_version: 1,
+        distro_id: "product".into(),
+        distro_version: "1.0.0".into(),
+        resolved_at: "2026-01-01T00:00:00Z".into(),
+        capsules: names
+            .iter()
+            .map(|name| DistroCapsuleProvenance {
+                name: (*name).into(),
+                version: "1.0.0".into(),
+                source: "@example/tool".into(),
+                hash: hash('a'),
+                resolved_ref: None,
+            })
+            .collect(),
+        manifest_hash: manifest,
+    }
+}
+
+async fn seed_lock(
+    kernel: &Arc<Kernel>,
+    principal: &PrincipalId,
+    provenance: astrid_core::kernel_api::DistroProvenance,
+) {
+    let uid = kernel.principal_directory.uid_for(principal).unwrap();
+    let store = kernel
+        .principal_store
+        .as_ref()
+        .unwrap()
+        .principal_control_kv(uid, "distro")
+        .unwrap();
+    let previous = store.get("provenance").await.unwrap();
+    let expected_hash = previous.map(|bytes| format!("blake3:{}", blake3::hash(&bytes).to_hex()));
+    let response = handlers::dispatch(
+        kernel,
+        &PrincipalId::default(),
+        AdminRequestKind::DistroLockSet {
+            principal: principal.clone(),
+            lock: provenance,
+            expected_hash,
+        },
+    )
+    .await;
+    assert!(
+        matches!(response, AdminResponseBody::Success(_)),
+        "{response:?}"
+    );
+}
+
+fn seed_profile(kernel: &Arc<Kernel>, principal: &PrincipalId, capsules: &[&str]) {
+    let profile = PrincipalProfile {
+        capsules: capsules.iter().map(|name| (*name).to_owned()).collect(),
+        ..PrincipalProfile::default()
+    };
+    profile
+        .save_to_path(&PrincipalProfile::path_for(&kernel.astrid_home, principal))
+        .unwrap();
+    kernel.profile_cache.invalidate(principal);
+}
+
+fn control_store(
+    kernel: &Arc<Kernel>,
+    principal: &PrincipalId,
+    namespace: &str,
+) -> astrid_storage::kv::ScopedKvStore {
+    let uid = kernel.principal_directory.uid_for(principal).unwrap();
+    astrid_storage::env::principal_env_store(
+        Arc::clone(&kernel.principal_store.as_ref().unwrap().kv()),
+        uid,
+        namespace,
+    )
+    .unwrap()
+}
+
+fn profile_text(kernel: &Arc<Kernel>, principal: &PrincipalId) -> String {
+    std::fs::read_to_string(PrincipalProfile::path_for(&kernel.astrid_home, principal)).unwrap()
+}
+
+fn capsules(response: AdminResponseBody) -> Vec<String> {
+    let AdminResponseBody::Success(value) = response else {
+        panic!("expected success");
+    };
+    serde_json::from_value(value["capsules"].clone()).unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn grants_exactly_admitted_lock_members_and_replays_without_widening() {
+    let (_dir, kernel) = fixture().await;
+    let principal = caller();
+    create_principal(&kernel, &principal).await;
+    seed_lock(
+        &kernel,
+        &principal,
+        lock(&["tool-a", "tool-b"], Some(hash('b'))),
+    )
+    .await;
+    seed_profile(&kernel, &principal, &["tool-outside"]);
+
+    let first = handlers::dispatch(&kernel, &principal, AdminRequestKind::DistroSelfGrant).await;
+    assert_eq!(
+        capsules(first),
+        ["tool-outside", "tool-a", "tool-b"].map(str::to_owned)
+    );
+    let replay = handlers::dispatch(&kernel, &principal, AdminRequestKind::DistroSelfGrant).await;
+    assert_eq!(
+        capsules(replay),
+        ["tool-outside", "tool-a", "tool-b"].map(str::to_owned)
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn missing_empty_or_unbound_locks_fail_closed() {
+    let (_dir, kernel) = fixture().await;
+    let principal = caller();
+    create_principal(&kernel, &principal).await;
+    let missing = handlers::dispatch(&kernel, &principal, AdminRequestKind::DistroSelfGrant).await;
+    assert!(
+        matches!(missing, AdminResponseBody::Error(message) if message.contains("no admitted"))
+    );
+
+    seed_lock(&kernel, &principal, lock(&[], Some(hash('b')))).await;
+    let empty = handlers::dispatch(&kernel, &principal, AdminRequestKind::DistroSelfGrant).await;
+    assert!(matches!(empty, AdminResponseBody::Error(message) if message.contains("no capsules")));
+
+    seed_lock(&kernel, &principal, lock(&["tool-a"], None)).await;
+    let unbound = handlers::dispatch(&kernel, &principal, AdminRequestKind::DistroSelfGrant).await;
+    assert!(
+        matches!(unbound, AdminResponseBody::Error(message) if message.contains("manifest_hash"))
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn caller_without_lock_cannot_use_another_principals_lock() {
+    let (_dir, kernel) = fixture().await;
+    let other = PrincipalId::new("other").unwrap();
+    create_principal(&kernel, &other).await;
+    seed_lock(&kernel, &other, lock(&["tool-a"], Some(hash('b')))).await;
+    create_principal(&kernel, &caller()).await;
+    let response = handlers::dispatch(&kernel, &caller(), AdminRequestKind::DistroSelfGrant).await;
+    assert!(
+        matches!(response, AdminResponseBody::Error(message) if message.contains("no admitted"))
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn lock_change_after_observation_fails_instead_of_granting_stale_set() {
+    let (_dir, kernel) = fixture().await;
+    let principal = caller();
+    create_principal(&kernel, &principal).await;
+    seed_lock(&kernel, &principal, lock(&["tool-a"], Some(hash('b')))).await;
+    seed_profile(&kernel, &principal, &[]);
+
+    let guard = kernel.admin_write_lock.lock().await;
+    let task = astrid_runtime::spawn({
+        let kernel = Arc::clone(&kernel);
+        let principal = principal.clone();
+        async move { handlers::dispatch(&kernel, &principal, AdminRequestKind::DistroSelfGrant).await }
+    });
+    astrid_runtime::time::sleep(std::time::Duration::from_millis(20)).await;
+
+    let uid = kernel.principal_directory.uid_for(&principal).unwrap();
+    let store = kernel
+        .principal_store
+        .as_ref()
+        .unwrap()
+        .principal_control_kv(uid, "distro")
+        .unwrap();
+    let previous = store.get("provenance").await.unwrap();
+    let changed = lock(&["tool-attacker"], Some(hash('c')));
+    let encoded = serde_json::to_vec(&changed).unwrap();
+    assert!(
+        store
+            .compare_and_swap("provenance", previous.as_deref(), encoded)
+            .await
+            .unwrap()
+    );
+    drop(guard);
+
+    let response = task.await.unwrap();
+    assert!(
+        matches!(response, AdminResponseBody::Error(message) if message.contains("changed concurrently"))
+    );
+    let profile = PrincipalProfile::load_required(&kernel.astrid_home, &principal).unwrap();
+    assert!(!profile.capsules.iter().any(|name| name == "tool-attacker"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn identical_artifacts_do_not_create_cross_principal_authority_or_storage() {
+    let (_dir, kernel) = fixture().await;
+    let principal_a = PrincipalId::new("tenant-a").unwrap();
+    let principal_b = PrincipalId::new("tenant-b").unwrap();
+    create_principal(&kernel, &principal_a).await;
+    create_principal(&kernel, &principal_b).await;
+    let shared = lock(&["shared-tool"], Some(hash('b')));
+    seed_lock(&kernel, &principal_a, shared.clone()).await;
+    seed_lock(&kernel, &principal_b, shared).await;
+    seed_profile(&kernel, &principal_a, &[]);
+    seed_profile(&kernel, &principal_b, &[]);
+    let b_store = control_store(&kernel, &principal_b, "probe-tool");
+    b_store.set("state", b"tenant-b".to_vec()).await.unwrap();
+
+    handlers::dispatch(&kernel, &principal_a, AdminRequestKind::DistroSelfGrant).await;
+
+    let profile_a = PrincipalProfile::load_required(&kernel.astrid_home, &principal_a).unwrap();
+    let profile_b = PrincipalProfile::load_required(&kernel.astrid_home, &principal_b).unwrap();
+    assert_eq!(profile_a.capsules, ["shared-tool"].map(str::to_owned));
+    assert!(profile_b.capsules.is_empty());
+    assert_eq!(
+        b_store.get("state").await.unwrap().as_deref(),
+        Some(b"tenant-b".as_slice())
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn tenant_a_lock_upgrade_does_not_mutate_tenant_b() {
+    let (_dir, kernel) = fixture().await;
+    let principal_a = PrincipalId::new("tenant-a").unwrap();
+    let principal_b = PrincipalId::new("tenant-b").unwrap();
+    create_principal(&kernel, &principal_a).await;
+    create_principal(&kernel, &principal_b).await;
+    let shared = lock(&["shared-tool"], Some(hash('b')));
+    seed_lock(&kernel, &principal_a, shared.clone()).await;
+    seed_lock(&kernel, &principal_b, shared).await;
+    seed_profile(&kernel, &principal_a, &["shared-tool"]);
+    seed_profile(&kernel, &principal_b, &["shared-tool"]);
+    let b_profile = profile_text(&kernel, &principal_b);
+    let b_store = control_store(&kernel, &principal_b, "probe-tool");
+    b_store.set("state", b"tenant-b".to_vec()).await.unwrap();
+
+    seed_lock(
+        &kernel,
+        &principal_a,
+        lock(&["upgraded-tool"], Some(hash('c'))),
+    )
+    .await;
+
+    let profile_a = PrincipalProfile::load_required(&kernel.astrid_home, &principal_a).unwrap();
+    let profile_b_after =
+        PrincipalProfile::load_required(&kernel.astrid_home, &principal_b).unwrap();
+    assert!(profile_a.capsules.iter().any(|name| name == "shared-tool"));
+    assert_eq!(profile_b_after.capsules, ["shared-tool"].map(str::to_owned));
+    assert_eq!(profile_text(&kernel, &principal_b), b_profile);
+    assert_eq!(
+        b_store.get("state").await.unwrap().as_deref(),
+        Some(b"tenant-b".as_slice())
+    );
+}
+
+#[test]
+fn distro_self_grant_wire_has_no_target_or_capsule_list() {
+    let value = serde_json::to_value(&AdminRequestKind::DistroSelfGrant).unwrap();
+    let params = value["params"].as_object();
+    assert_eq!(value["method"], "DistroSelfGrant");
+    assert!(params.is_none_or(serde_json::Map::is_empty));
+}

--- a/crates/astrid-kernel/src/kernel_router/admin/handlers/distro_dispatch.rs
+++ b/crates/astrid-kernel/src/kernel_router/admin/handlers/distro_dispatch.rs
@@ -1,0 +1,38 @@
+//! Dispatch for the Distro provenance admin family.
+
+use std::sync::Arc;
+
+use astrid_core::principal::PrincipalId;
+use astrid_events::kernel_api::{AdminRequestKind, AdminResponseBody};
+
+use crate::Kernel;
+
+/// Handle one already-authorized Distro request, if this module owns it.
+pub(super) async fn dispatch(
+    kernel: &Arc<Kernel>,
+    caller: &PrincipalId,
+    req: &AdminRequestKind,
+) -> Option<AdminResponseBody> {
+    match req {
+        AdminRequestKind::DistroLockGet { principal } => {
+            Some(super::super::distro_handlers::get(kernel, principal).await)
+        },
+        AdminRequestKind::DistroLockSet {
+            principal,
+            lock,
+            expected_hash,
+        } => Some(
+            super::super::distro_handlers::set(
+                kernel,
+                principal,
+                lock.clone(),
+                expected_hash.clone(),
+            )
+            .await,
+        ),
+        AdminRequestKind::DistroSelfGrant => {
+            Some(super::super::distro_handlers::self_grant(kernel, caller).await)
+        },
+        _ => None,
+    }
+}

--- a/crates/astrid-kernel/src/kernel_router/admin/handlers/mod.rs
+++ b/crates/astrid-kernel/src/kernel_router/admin/handlers/mod.rs
@@ -125,6 +125,7 @@ async fn dispatch_inner(
         | AdminRequestKind::EnvDelete { .. }
         | AdminRequestKind::DistroLockGet { .. }
         | AdminRequestKind::DistroLockSet { .. }
+        | AdminRequestKind::DistroSelfGrant
         | AdminRequestKind::GroupCreate { .. }
         | AdminRequestKind::GroupDelete { .. }
         | AdminRequestKind::GroupModify { .. }
@@ -205,6 +206,9 @@ async fn dispatch_policy(
             lock,
             expected_hash,
         } => super::distro_handlers::set(kernel, &principal, lock, expected_hash).await,
+        AdminRequestKind::DistroSelfGrant => {
+            super::distro_handlers::self_grant(kernel, caller).await
+        },
         AdminRequestKind::GroupCreate {
             name,
             capabilities,

--- a/crates/astrid-kernel/src/kernel_router/admin/handlers/mod.rs
+++ b/crates/astrid-kernel/src/kernel_router/admin/handlers/mod.rs
@@ -38,6 +38,7 @@ use tracing::{info, warn};
 
 use crate::kernel_router::AuthorizedRequest;
 
+mod distro_dispatch;
 mod env_handlers;
 use super::inheritance::copy_modify_env;
 use env_handlers::{EnvSetRequest, env_delete, env_list, env_set};
@@ -102,6 +103,9 @@ async fn dispatch_inner(
     device_key_id: Option<&str>,
     req: AdminRequestKind,
 ) -> AdminResponseBody {
+    if let Some(response) = distro_dispatch::dispatch(kernel, caller, &req).await {
+        return response;
+    }
     match req {
         req @ AdminRequestKind::AgentCreate { .. } => agent_create_from_req(kernel, req).await,
         AdminRequestKind::AgentDelete { principal } => {
@@ -198,17 +202,6 @@ async fn dispatch_policy(
             kind,
             scope,
         } => env_delete(kernel, principal, capsule, key, kind, scope).await,
-        AdminRequestKind::DistroLockGet { principal } => {
-            super::distro_handlers::get(kernel, &principal).await
-        },
-        AdminRequestKind::DistroLockSet {
-            principal,
-            lock,
-            expected_hash,
-        } => super::distro_handlers::set(kernel, &principal, lock, expected_hash).await,
-        AdminRequestKind::DistroSelfGrant => {
-            super::distro_handlers::self_grant(kernel, caller).await
-        },
         AdminRequestKind::GroupCreate {
             name,
             capabilities,

--- a/crates/astrid-kernel/src/kernel_router/admin/mod.rs
+++ b/crates/astrid-kernel/src/kernel_router/admin/mod.rs
@@ -28,6 +28,8 @@ mod audit_handlers;
 mod caps_tokens;
 mod distro_handlers;
 #[cfg(test)]
+mod distro_self_grant_tests;
+#[cfg(test)]
 mod enforcement_tests;
 mod group;
 pub(crate) mod handlers;
@@ -287,6 +289,7 @@ pub fn resolve_admin_scope(req: &AdminRequestKind, caller: &PrincipalId) -> Auth
         // EnvList is self-scoped when the target is the caller; the target
         // arm above handles cross-principal admin reads.
         | AdminRequestKind::PairDeviceIssue { .. }
+        | AdminRequestKind::DistroSelfGrant
         | AdminRequestKind::StorageMountStatus { .. }
         | AdminRequestKind::StorageMountSync { .. }
         | AdminRequestKind::StorageMountRevoke { .. }
@@ -362,6 +365,7 @@ pub fn required_capability_for_admin_request(
         (AdminRequestKind::AgentModify { .. }, _) => "agent:modify",
         (AdminRequestKind::AgentList, AuthorityScope::Self_) => "self:agent:list",
         (AdminRequestKind::AgentList, AuthorityScope::Global) => "agent:list",
+        (AdminRequestKind::DistroSelfGrant, _) => "self:distro:grant",
         (AdminRequestKind::QuotaSet { .. }, AuthorityScope::Self_) => "self:quota:set",
         (AdminRequestKind::QuotaSet { .. }, AuthorityScope::Global) => "quota:set",
         (
@@ -523,6 +527,7 @@ pub fn admin_request_method(req: &AdminRequestKind) -> &'static str {
         AdminRequestKind::EnvDelete { .. } => "admin.env.delete",
         AdminRequestKind::DistroLockGet { .. } => "admin.distro.lock.get",
         AdminRequestKind::DistroLockSet { .. } => "admin.distro.lock.set",
+        AdminRequestKind::DistroSelfGrant => "admin.distro.self.grant",
         AdminRequestKind::GroupCreate { .. } => "admin.group.create",
         AdminRequestKind::GroupDelete { .. } => "admin.group.delete",
         AdminRequestKind::GroupModify { .. } => "admin.group.modify",
@@ -670,6 +675,7 @@ pub fn admin_target_principal(req: &AdminRequestKind) -> Option<&PrincipalId> {
         AdminRequestKind::CapsTokenRevoke { .. }
         | AdminRequestKind::AgentCreate { .. }
         | AdminRequestKind::AgentList
+        | AdminRequestKind::DistroSelfGrant
         | AdminRequestKind::GroupCreate { .. }
         | AdminRequestKind::GroupDelete { .. }
         | AdminRequestKind::GroupModify { .. }

--- a/crates/astrid-kernel/src/kernel_router/admin/tests.rs
+++ b/crates/astrid-kernel/src/kernel_router/admin/tests.rs
@@ -99,6 +99,23 @@ fn agent_list_maps_self_to_self_prefix() {
 }
 
 #[test]
+fn distro_self_grant_is_caller_scoped_and_dedicated() {
+    let req = AdminRequestKind::DistroSelfGrant;
+    for scope in [AuthorityScope::Self_, AuthorityScope::Global] {
+        assert_eq!(
+            required_capability_for_admin_request(&req, scope),
+            "self:distro:grant"
+        );
+        assert_eq!(
+            resolve_admin_scope(&req, &pid("caller")),
+            AuthorityScope::Self_
+        );
+    }
+    assert_eq!(admin_request_method(&req), "admin.distro.self.grant");
+    assert!(admin_target_principal(&req).is_none());
+}
+
+#[test]
 fn pair_issue_mapping_requires_admin_only_for_unattenuated_scopes() {
     for scope in [
         PairScopeArg::Full,

--- a/crates/astrid-kernel/src/kernel_router/capability_catalog_tests.rs
+++ b/crates/astrid-kernel/src/kernel_router/capability_catalog_tests.rs
@@ -1,7 +1,7 @@
 //! Drift checks for enforcement capability mappings and registry definitions.
 
 use astrid_core::capability_grammar::known_capabilities;
-use astrid_core::capability_registry::capability_registry_revision_1;
+use astrid_core::capability_registry::capability_registry_revision_2;
 use std::collections::BTreeSet;
 
 use crate::kernel_router::admin::required_capability_for_admin_request;
@@ -9,8 +9,8 @@ use crate::kernel_router::test_util::{all_admin_request_variants, all_kernel_req
 use crate::kernel_router::{AuthorityScope, required_capability};
 
 #[test]
-fn registry_revision_1_covers_every_kernel_request_cap() {
-    let registry = capability_registry_revision_1().unwrap();
+fn registry_revision_2_covers_every_kernel_request_cap() {
+    let registry = capability_registry_revision_2().unwrap();
     let registered = registry
         .entries()
         .iter()
@@ -22,15 +22,15 @@ fn registry_revision_1_covers_every_kernel_request_cap() {
             let cap = required_capability(&req, scope);
             assert!(
                 registered.contains(cap),
-                "kernel returns capability {cap:?} without a registry revision 1 entry"
+                "kernel returns capability {cap:?} without a registry revision 2 entry"
             );
         }
     }
 }
 
 #[test]
-fn registry_revision_1_covers_every_admin_request_cap() {
-    let registry = capability_registry_revision_1().unwrap();
+fn registry_revision_2_covers_every_admin_request_cap() {
+    let registry = capability_registry_revision_2().unwrap();
     let registered = registry
         .entries()
         .iter()
@@ -42,14 +42,14 @@ fn registry_revision_1_covers_every_admin_request_cap() {
             let cap = required_capability_for_admin_request(req, scope);
             assert!(
                 registered.contains(cap),
-                "admin op returns capability {cap:?} without a registry revision 1 entry"
+                "admin op returns capability {cap:?} without a registry revision 2 entry"
             );
         }
     }
 }
 
 #[test]
-fn registry_revision_1_freezes_the_complete_role_partition() {
+fn registry_revision_2_freezes_the_complete_role_partition() {
     let primary = BTreeSet::from([
         "system:shutdown",
         "system:status",
@@ -69,6 +69,7 @@ fn registry_revision_1_freezes_the_complete_role_partition() {
         "agent:disable",
         "agent:modify",
         "self:agent:list",
+        "self:distro:grant",
         "quota:set",
         "self:quota:set",
         "quota:get",
@@ -125,7 +126,7 @@ fn registry_revision_1_freezes_the_complete_role_partition() {
         .into_iter()
         .flat_map(|class| class.iter().copied())
         .collect::<BTreeSet<_>>();
-    let revision = capability_registry_revision_1().unwrap();
+    let revision = capability_registry_revision_2().unwrap();
     let revision_ids = revision
         .entries()
         .iter()

--- a/crates/astrid-kernel/src/kernel_router/test_util.rs
+++ b/crates/astrid-kernel/src/kernel_router/test_util.rs
@@ -90,6 +90,7 @@ fn identity_and_policy_variants(principal: &PrincipalId) -> Vec<AdminRequestKind
             },
             expected_hash: None,
         },
+        AdminRequestKind::DistroSelfGrant,
         AdminRequestKind::GroupCreate {
             name: "group".into(),
             capabilities: vec![],

--- a/crates/astrid-uplink/src/admin_client.rs
+++ b/crates/astrid-uplink/src/admin_client.rs
@@ -60,6 +60,7 @@ pub const fn topic_suffix(req: &AdminRequestKind) -> &'static str {
         AdminRequestKind::EnvDelete { .. } => "env.delete",
         AdminRequestKind::DistroLockGet { .. } => "distro.lock.get",
         AdminRequestKind::DistroLockSet { .. } => "distro.lock.set",
+        AdminRequestKind::DistroSelfGrant => "distro.self.grant",
         AdminRequestKind::GroupCreate { .. } => "group.create",
         AdminRequestKind::GroupDelete { .. } => "group.delete",
         AdminRequestKind::GroupModify { .. } => "group.modify",

--- a/e2e/capability-scenarios.toml
+++ b/e2e/capability-scenarios.toml
@@ -84,6 +84,12 @@ status = "covered"
 allow = ["regular agent can list its own effective capsule surface"]
 deny = ["regular agent cannot use self:list to enumerate hidden default-principal metadata"]
 
+[capabilities."self:distro:grant"]
+scenario = "distro_self_grant"
+status = "mapped"
+allow = ["ordinary agent applying its own signed Distro lock receives exactly that lock's capsule identities"]
+deny = ["caller with no lock, an empty lock, an unbound lock, or a concurrently changed lock receives no grants"]
+
 [capabilities."agent:create"]
 scenario = "principal_crud"
 status = "covered"

--- a/e2e/runtime-scenario-specs.toml
+++ b/e2e/runtime-scenario-specs.toml
@@ -216,6 +216,16 @@ denial = ["network or host-mutating paths are waived or dry-run only"]
 state = ["only temp distro lock/seal files are written"]
 evidence = ["distro transcript, seal artifact, and waiver reasons"]
 
+[scenarios.distro_self_grant]
+status = "mapped"
+surfaces = ["cli", "capability"]
+auth = ["ordinary agent principal, not default/admin wildcard authority"]
+success = ["signed Distro apply completes install/lock admission and the caller-scoped exact-lock capsule grant"]
+denial = ["missing, empty, unbound, unsigned, target-split, and concurrently changed Distro locks fail closed without granting"]
+state = ["kernel-owned lock and caller profile remain separately committed; failed grant leaves members non-invokable"]
+evidence = ["kernel lock-digest and self-grant regression artifacts"]
+remaining = ["full disposable-host invoke matrix needs a live signed product fixture"]
+
 [scenarios.distro_onboarding]
 status = "covered"
 surfaces = ["cli"]


### PR DESCRIPTION
## Linked Issue

Closes #1195

## Summary

`astrid distro apply` for the authenticated current principal now completes as a fail-closed, resumable two-stage transaction: authenticate and install the selected signed Distro.toml member set, admit that caller-scoped lock, then grant the same principal invoke authority for exactly the lock's capsule identities.

The selected Distro.toml is the product identity. Distro.sig authenticates the resolved lock, and that lock must carry `manifest_hash` of the exact Distro.toml bytes used to resolve members. Those bytes are read once and hashed as-is; a suffix such as `.shuttle` is not a signature. Unsigned Distro.toml, `--allow-unsigned`, missing `manifest_hash`, and tampered TOML, signature, or undeclared members fail closed.

The grant is structurally self-scoped. There is no target-principal field, no omittable grant flag, and no route through global `agent modify` or `astrid init --grant-capsules`. Ordinary non-admin principals can invoke the declared member set after a successful apply. A committed install with a failed grant remains unusable and returns non-zero; retry on a fresh lock still performs or reconciles the grant.

`.shuttle` remains a packaging/install vehicle and does not receive DistroSelfGrant on this path.

There is no global agent, global capsule registry as authority, or global storage namespace. DistroSelfGrant may read and mutate only the authenticated caller's principal-scoped lock, grants, install state, and storage. Identical capsule bytes do not inherit authority across principals. Applying, granting, removing, or upgrading for principal A must not change principal B.

## Changes

- Adds `AdminRequestKind::DistroSelfGrant` as a unit variant with no target-principal field.
- Authorizes the operation with dedicated `self:distro:grant`, distinct from `self:capsule:install`.
- Product apply authenticates signed Distro.toml before runtime mutation, persists the once-read byte hash in the caller-scoped lock, and then self-grants that lock.
- Kernel reads the caller's admitted Distro lock and grants exactly `DistroProvenance.capsules[].name` onto `PrincipalProfile.capsules`.
- Binds the grant to the observed lock digest so a concurrent lock change cannot grant a different set.
- Distro apply never reports success until both install/lock and DistroSelfGrant complete.
- Distro apply rejects `--allow-unsigned` and does not set `grant_capsules`.

## Claim boundary

This is not rollback atomicity. Unsigned Distro.toml, missing `manifest_hash`, admin `*` wildcard, stored grant rows without a successful same-principal invoke, and default/admin evidence for an ordinary principal are not acceptance. Capsule-install resume, AOS layout, and version identity are out of this vehicle.

Independent review must confirm Distro.toml reaches the same kernel-admitted provenance/lock path as DistroSelfGrant. Do not redefine the product around `.shuttle`. Source-only or `.shuttle`-only execution cannot accept the release path.

## Verification

- Unique range is two signed commits on `2e94dbc`.
- Focused: capability-registry revision 2, DistroSelfGrant kernel tests including cross-principal lock/grant/upgrade/storage, signed-source byte-identity and tamper tests, CLI apply unsigned rejection, lock-fresh retry.
- Independent exact-head plus executable review is required. Source-only acceptance is not sufficient.
- Ordinary non-admin principal proof must apply a signed Distro.toml, reconcile the exact declared member set, and actually invoke at least one installed member as that same principal, with a second principal remaining unchanged. That disposable-home invoke matrix is not claimed here.

## AI / Tool Assistance

Assisted-by: Codex:glm-5.3-flash

A coding agent implemented the Distro apply self-grant path, capability-registry revision, kernel handler, signed Distro.toml authentication, CLI two-stage apply, changelog fragment, and falsifiers. The maintainer owns the authority boundary, public text, and merge decision.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/{issue}.{kind}.md` (docs/CI-only may skip; release PRs roll fragments into the version section instead of adding one)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
