### PR TITLE
fix(config): remove host-side model configuration

### DIFF
--- a/changes/1828.changed.md
+++ b/changes/1828.changed.md
@@ -1,0 +1,7 @@
+Astrid host configuration no longer contains an inert LLM provider model
+section, provider/API URL/API key fields, or provider environment fallbacks.
+Model execution and provider selection belong to principal-scoped capsules and
+the model registry. Legacy host `[model]` configuration now fails with migration
+guidance instead of being silently ignored, and provider credentials are never
+loaded into core. The interactive TUI starts without a host model label and
+continues to receive the active model through registry IPC. Closes #1828

--- a/crates/astrid-cli/src/bootstrap.rs
+++ b/crates/astrid-cli/src/bootstrap.rs
@@ -15,6 +15,9 @@ use crate::formatter::OutputFormat;
 use crate::socket_client;
 use crate::theme;
 
+/// The host owns no model identity. Registry IPC owns the first real label.
+const INITIAL_TUI_MODEL_LABEL: &str = "";
+
 /// Ensure `~/.astrid/` exists without selecting product composition.
 #[allow(clippy::unused_async)]
 pub(crate) async fn ensure_global_config() -> Result<()> {
@@ -253,19 +256,17 @@ pub(crate) async fn run_or_connect(
         },
     };
 
-    let model_name = astrid_config::Config::load_with_layout(
-        workspace_root.as_deref(),
-        crate::workspace_layout::current(),
-    )
-    .ok()
-    .map_or_else(|| "unknown".to_string(), |r| r.config.model.model);
-
-    crate::commands::chat::run_chat(&mut client, &session_id, &model_name, format).await
+    crate::commands::chat::run_chat(&mut client, &session_id, INITIAL_TUI_MODEL_LABEL, format).await
 }
 
 #[cfg(test)]
 mod tests {
-    use super::selected_workspace_root;
+    use super::{INITIAL_TUI_MODEL_LABEL, selected_workspace_root};
+
+    #[test]
+    fn interactive_tui_starts_without_a_host_model_label() {
+        assert_eq!(INITIAL_TUI_MODEL_LABEL, "");
+    }
 
     #[test]
     fn explicit_workspace_root_wins_over_current_directory() {

--- a/crates/astrid-cli/src/commands/config.rs
+++ b/crates/astrid-cli/src/commands/config.rs
@@ -102,10 +102,7 @@ pub(crate) fn show_paths() -> Result<()> {
     }
 
     println!("\nEnvironment variable fallbacks:");
-    println!("  ANTHROPIC_API_KEY  -> model.api_key");
-    println!("  ANTHROPIC_MODEL    -> model.model");
     println!("  ASTRID_LOG_LEVEL -> logging.level");
-    println!("  ASTRID_MODEL     -> model.model");
     println!("  ASTRID_WORKSPACE_MODE -> workspace.mode");
 
     Ok(())

--- a/crates/astrid-cli/src/tui/mod.rs
+++ b/crates/astrid-cli/src/tui/mod.rs
@@ -4,6 +4,8 @@
 
 pub(crate) mod headless;
 mod input;
+#[cfg(test)]
+mod registry_label_tests;
 mod render;
 pub(crate) mod state;
 mod theme;

--- a/crates/astrid-cli/src/tui/registry_label_tests.rs
+++ b/crates/astrid-cli/src/tui/registry_label_tests.rs
@@ -1,0 +1,41 @@
+use astrid_types::Topic;
+use astrid_types::ipc::{IpcMessage, IpcPayload};
+
+use super::handle_daemon_event;
+use super::state::App;
+
+fn app() -> App {
+    App::new("workspace".to_owned(), String::new(), "00000000".to_owned())
+}
+
+#[test]
+fn active_model_changed_updates_empty_host_label() {
+    let mut app = app();
+    let message = IpcMessage::new(
+        Topic::from_raw("registry.v1.active_model_changed"),
+        IpcPayload::Custom {
+            data: serde_json::json!({"id": "capsule/model"}),
+        },
+        uuid::Uuid::nil(),
+    );
+
+    handle_daemon_event(&mut app, &message);
+
+    assert_eq!(app.model_name, "capsule/model");
+}
+
+#[test]
+fn set_active_model_response_updates_empty_host_label() {
+    let mut app = app();
+    let message = IpcMessage::new(
+        Topic::from_raw("registry.v1.response.set_active_model"),
+        IpcPayload::Custom {
+            data: serde_json::json!({"active_model": {"id": "capsule/model"}}),
+        },
+        uuid::Uuid::nil(),
+    );
+
+    handle_daemon_event(&mut app, &message);
+
+    assert_eq!(app.model_name, "capsule/model");
+}

--- a/crates/astrid-config/README.md
+++ b/crates/astrid-config/README.md
@@ -16,7 +16,7 @@ From highest to lowest priority:
 1. **Workspace** (`{workspace}/.astrid/config.toml`) - untrusted input, restricted
 2. **User** (`~/.astrid/config.toml`)
 3. **System** (`/etc/astrid/config.toml`)
-4. **Environment variables** (`ASTRID_*`, `ANTHROPIC_*`) - fallback only, applied to fields no config file set
+4. **Environment variables** (`ASTRID_*`) - fallback only, applied to fields no config file set
 5. **Embedded defaults** (`defaults.toml` compiled into the binary)
 
 ## Workspace restriction enforcement
@@ -27,22 +27,25 @@ After merging the workspace layer, a hard enforcement pass runs against the pre-
 - **Security can only tighten.** `require_signatures` can only become true; `approval_timeout_secs` can only decrease; `workspace.mode` and `escape_policy` can only move to a stricter level.
 - **Deny-lists can only grow.** Workspace can add to `workspace.never_allow` but cannot remove entries.
 - **Allow-lists cannot expand.** Workspace cannot add entries to `workspace.auto_allow_read` or `auto_allow_write`.
-- **API keys cannot be overridden.** `model.api_key` and `model.api_url` from workspace are reverted.
 - **Server injection blocked.** Workspace cannot add new MCP server definitions.
 
 Violations are logged and silently reverted. The agent never sees the hostile values.
 
 ## Variable expansion
 
-`${VAR}` references in workspace config are restricted to `ASTRID_*` and `ANTHROPIC_*` prefixes. `${AWS_SECRET_ACCESS_KEY}` is left unresolved. This prevents a workspace config from exfiltrating arbitrary environment variables into fields the agent can read.
+`${VAR}` references in workspace config are restricted to the `ASTRID_*` prefix. `${AWS_SECRET_ACCESS_KEY}` and provider credentials such as `ANTHROPIC_API_KEY` are left unresolved. This prevents a workspace config from exfiltrating arbitrary environment variables into fields the agent can read.
+
+## Model ownership
+
+Host configuration has no `[model]` section. Model selection and provider execution belong to principal-scoped capsules, their capsule `[env]` configuration, and the model registry. A legacy host `[model]` table fails loading with migration guidance instead of being ignored.
 
 ## Validation
 
-Post-merge validation checks: supported providers (`claude`, `openai`, `openai-compat`, `zai`, `unknown`), temperature range (0.0-1.0), token bounds (1-16M), budget invariants (per-action cannot exceed session), zero-value timeout guards, and valid enum strings.
+Post-merge validation checks: budget invariants (per-action cannot exceed session), zero-value timeout guards, and valid enum strings.
 
 ## Credential redaction
 
-`ModelConfig` has a custom `Serialize` that omits `api_key` and `api_url`. `Debug` replaces credential values with presence booleans. `ServerSection` redacts environment variable values. Credentials never appear in logs, config dumps, or serialized output.
+`ServerSection` redacts environment variable values. Credentials never appear in logs, config dumps, or serialized output.
 
 ## Field-level provenance
 
@@ -52,7 +55,7 @@ Post-merge validation checks: supported providers (`claude`, `openai`, `openai-c
 
 | Type | Role |
 |---|---|
-| `Config` | Root struct. 21 sections: model, runtime, security, budget, rate_limits, servers, audit, keys, workspace, git, hooks, logging, gateway, timeouts, sessions, subagents, retry, spark, uplinks, identity. |
+| `Config` | Root struct. 20 sections: runtime, security, budget, rate_limits, servers, audit, keys, workspace, git, hooks, logging, gateway, timeouts, sessions, subagents, retry, spark, uplinks, identity. |
 | `Config::load(workspace_root)` | Full precedence chain with restriction enforcement and validation. |
 | `Config::load_with_home(workspace_root, astrid_home)` | Explicit home override for tests and containers. |
 | `ResolvedConfig` | `Config` + `FieldSources` + list of loaded file paths. |

--- a/crates/astrid-config/src/defaults.toml
+++ b/crates/astrid-config/src/defaults.toml
@@ -7,43 +7,8 @@
 # 1. Selected project config — can only tighten security
 # 2. User config (~/.astrid/config.toml)
 # 3. System config (/etc/astrid/config.toml)
-# 4. Environment variables (ASTRID_*, ANTHROPIC_*) — fallback only, not override
+# 4. Environment variables (ASTRID_*) — fallback only, not override
 # 5. This defaults file (embedded in binary)
-
-# ============================================================================
-# Model Configuration
-# ============================================================================
-# Controls which LLM provider and model to use, along with generation settings.
-
-[model]
-# LLM provider to use. Currently supported: "claude"
-provider = "unknown"
-
-# Model identifier. Examples:
-# - "claude-sonnet-4-20250514" (Claude Sonnet 4)
-# - "claude-opus-4-6" (Claude Opus 4.6)
-# - "claude-sonnet-4-5-20250929" (Claude Sonnet 4.5)
-model = "unknown"
-
-# API key for the provider. If not set here, will be read from:
-# - ANTHROPIC_API_KEY environment variable (for Claude)
-# - OPENAI_API_KEY environment variable (for OpenAI, future)
-# api_key = ""
-
-# Custom API endpoint URL. Leave empty to use provider's default.
-# Useful for proxies, local models, or alternative endpoints.
-# api_url = ""
-
-# Maximum tokens to generate per response
-max_tokens = 4096
-
-# Sampling temperature (0.0-1.0). Higher = more random, lower = more deterministic
-temperature = 0.7
-
-# Pricing information for budget tracking (USD per million tokens)
-[model.pricing]
-input_per_million = 3.0
-output_per_million = 15.0
 
 # ============================================================================
 # Runtime Configuration

--- a/crates/astrid-config/src/env.rs
+++ b/crates/astrid-config/src/env.rs
@@ -16,24 +16,8 @@ struct EnvMapping {
     field_path: &'static str,
 }
 
-/// All supported `ASTRID_*` and legacy `ANTHROPIC_*` env var mappings.
+/// All supported `ASTRID_*` env var mappings.
 const ENV_MAPPINGS: &[EnvMapping] = &[
-    EnvMapping {
-        var_name: "ASTRID_MODEL_PROVIDER",
-        field_path: "model.provider",
-    },
-    EnvMapping {
-        var_name: "ASTRID_MODEL_API_KEY",
-        field_path: "model.api_key",
-    },
-    EnvMapping {
-        var_name: "ASTRID_MODEL_API_URL",
-        field_path: "model.api_url",
-    },
-    EnvMapping {
-        var_name: "ASTRID_MODEL",
-        field_path: "model.model",
-    },
     EnvMapping {
         var_name: "ASTRID_LOG_LEVEL",
         field_path: "logging.level",
@@ -89,25 +73,6 @@ const ENV_MAPPINGS: &[EnvMapping] = &[
         var_name: "ASTRID_RATE_LIMITS_CAPSULE_RELOAD_PER_MIN",
         field_path: "rate_limits.capsule_reload_per_min",
     },
-    // Standard Anthropic SDK env vars.
-    EnvMapping {
-        var_name: "ANTHROPIC_API_KEY",
-        field_path: "model.api_key",
-    },
-    EnvMapping {
-        var_name: "ANTHROPIC_MODEL",
-        field_path: "model.model",
-    },
-    // Z.AI env var.
-    EnvMapping {
-        var_name: "ZAI_API_KEY",
-        field_path: "model.api_key",
-    },
-    // OpenAI env var.
-    EnvMapping {
-        var_name: "OPENAI_API_KEY",
-        field_path: "model.api_key",
-    },
 ];
 
 /// Apply environment variable fallbacks to fields that were **not** set by
@@ -144,7 +109,7 @@ pub fn apply_env_fallbacks<S: ::std::hash::BuildHasher>(
 }
 
 /// Resolve `${VAR}` references in the workspace layer, restricted to only
-/// `ASTRID_*` and `ANTHROPIC_*` prefixed environment variables.
+/// `ASTRID_*` prefixed environment variables.
 ///
 /// This prevents a malicious workspace config from exfiltrating sensitive
 /// env vars like `${AWS_SECRET_ACCESS_KEY}` into fields sent to the LLM.
@@ -154,7 +119,7 @@ pub fn resolve_env_references_restricted<S: ::std::hash::BuildHasher>(
 ) {
     let restricted: HashMap<String, String> = env_vars
         .iter()
-        .filter(|(k, _)| k.starts_with("ASTRID_") || k.starts_with("ANTHROPIC_"))
+        .filter(|(k, _)| k.starts_with("ASTRID_"))
         .map(|(k, v)| (k.clone(), v.clone()))
         .collect();
     resolve_env_references(val, &restricted);
@@ -274,14 +239,8 @@ fn set_field_from_string(root: &mut toml::Value, path: &str, val: &str) {
 /// based on the field path.
 fn coerce_to_toml_value(path: &str, val: &str) -> toml::Value {
     // Known float fields.
-    if matches!(
-        path,
-        "budget.session_max_usd"
-            | "budget.per_action_max_usd"
-            | "model.pricing.input_per_million"
-            | "model.pricing.output_per_million"
-            | "model.temperature"
-    ) && let Ok(f) = val.parse::<f64>()
+    if matches!(path, "budget.session_max_usd" | "budget.per_action_max_usd")
+        && let Ok(f) = val.parse::<f64>()
     {
         return toml::Value::Float(f);
     }
@@ -289,8 +248,7 @@ fn coerce_to_toml_value(path: &str, val: &str) -> toml::Value {
     // Known integer fields.
     if matches!(
         path,
-        "model.max_tokens"
-            | "security.approval_timeout_secs"
+        "security.approval_timeout_secs"
             | "budget.warn_at_percent"
             | "rate_limits.elicitation_per_server_per_min"
             | "rate_limits.max_pending_requests"
@@ -397,8 +355,8 @@ mod tests {
 
     #[test]
     fn test_coerce_integer() {
-        let v = coerce_to_toml_value("model.max_tokens", "8192");
-        assert_eq!(v.as_integer().unwrap(), 8192);
+        let v = coerce_to_toml_value("security.approval_timeout_secs", "300");
+        assert_eq!(v.as_integer().unwrap(), 300);
     }
 
     #[test]
@@ -409,19 +367,27 @@ mod tests {
 
     #[test]
     fn test_coerce_string_default() {
-        let v = coerce_to_toml_value("model.provider", "openai");
-        assert_eq!(v.as_str().unwrap(), "openai");
+        let v = coerce_to_toml_value("workspace.mode", "safe");
+        assert_eq!(v.as_str().unwrap(), "safe");
     }
 
     #[test]
-    fn test_legacy_anthropic_api_key() {
-        let mut merged: toml::Value = toml::from_str("[model]").unwrap();
+    fn test_provider_api_keys_are_not_host_fallbacks() {
+        let mut merged: toml::Value = toml::from_str("[logging]\nlevel = \"info\"").unwrap();
         let mut sources = FieldSources::new();
-        let env = make_env(&[("ANTHROPIC_API_KEY", "sk-ant-test")]);
+        let env = make_env(&[
+            ("ANTHROPIC_API_KEY", "sk-ant-test"),
+            ("OPENAI_API_KEY", "sk-openai-test"),
+            ("ASTRID_MODEL_PROVIDER", "claude"),
+            ("ASTRID_MODEL_API_KEY", "sk-astrid-test"),
+        ]);
 
-        apply_env_fallbacks(&mut merged, &mut sources, &env);
+        let count = apply_env_fallbacks(&mut merged, &mut sources, &env);
 
-        assert_eq!(merged["model"]["api_key"].as_str().unwrap(), "sk-ant-test");
+        assert_eq!(count, 0);
+        assert!(!merged.as_table().unwrap().contains_key("model"));
+        assert!(!sources.contains_key("model.api_key"));
+        assert!(!sources.contains_key("model.provider"));
     }
 
     // ---- Restricted ${VAR} resolution tests ----
@@ -443,26 +409,29 @@ description = "${HOME}""#,
     #[test]
     fn test_workspace_can_access_astrid_var() {
         let mut val: toml::Value = toml::from_str(
-            r#"[model]
-model = "${ASTRID_MODEL}""#,
+            r#"[runtime]
+            system_prompt = "${ASTRID_NOTE}""#,
         )
         .unwrap();
-        let env = make_env(&[("ASTRID_MODEL", "claude-opus-4-6")]);
+        let env = make_env(&[("ASTRID_NOTE", "hello")]);
         resolve_env_references_restricted(&mut val, &env);
 
-        assert_eq!(val["model"]["model"].as_str().unwrap(), "claude-opus-4-6");
+        assert_eq!(val["runtime"]["system_prompt"].as_str().unwrap(), "hello");
     }
 
     #[test]
-    fn test_workspace_can_access_anthropic_var() {
+    fn test_workspace_cannot_access_anthropic_var() {
         let mut val: toml::Value = toml::from_str(
-            r#"[model]
-api_key = "${ANTHROPIC_API_KEY}""#,
+            r#"[logging]
+            level = "${ANTHROPIC_API_KEY}""#,
         )
         .unwrap();
         let env = make_env(&[("ANTHROPIC_API_KEY", "sk-ant-test")]);
         resolve_env_references_restricted(&mut val, &env);
 
-        assert_eq!(val["model"]["api_key"].as_str().unwrap(), "sk-ant-test");
+        assert_eq!(
+            val["logging"]["level"].as_str().unwrap(),
+            "${ANTHROPIC_API_KEY}"
+        );
     }
 }

--- a/crates/astrid-config/src/lib.rs
+++ b/crates/astrid-config/src/lib.rs
@@ -12,7 +12,10 @@
 //! // Load with full precedence chain (defaults → system → user → workspace → env).
 //! let resolved = Config::load(Some(std::path::Path::new("."))).unwrap();
 //! let config = resolved.config;
-//! println!("Using model: {}", config.model.model);
+//! println!(
+//!     "Max context tokens: {}",
+//!     config.runtime.max_context_tokens
+//! );
 //! ```
 //!
 //! # Configuration Precedence
@@ -22,7 +25,7 @@
 //! 1. **Workspace** (selected project state config) — can only *tighten* security
 //! 2. **User** (`~/.astrid/config.toml`)
 //! 3. **System** (`/etc/astrid/config.toml`)
-//! 4. **Environment variables** (`ASTRID_*`, `ANTHROPIC_*`) — fallback only
+//! 4. **Environment variables** (`ASTRID_*`) — fallback only
 //! 5. **Embedded defaults** (`defaults.toml` compiled into binary)
 //!
 //! Workspace file discovery accepts the runtime's validated

--- a/crates/astrid-config/src/loader.rs
+++ b/crates/astrid-config/src/loader.rs
@@ -87,6 +87,7 @@ pub fn load_with_layout(
     // 2. System config (/etc/astrid/config.toml).
     let system_path = PathBuf::from("/etc/astrid/config.toml");
     if let Some(overlay) = try_load_file(&system_path)? {
+        reject_legacy_model_section(&overlay, &system_path.display().to_string())?;
         deep_merge_tracking(
             &mut merged,
             &overlay,
@@ -108,6 +109,7 @@ pub fn load_with_layout(
     };
 
     if let Some((overlay, path)) = user_config {
+        reject_legacy_model_section(&overlay, &path.display().to_string())?;
         deep_merge_tracking(
             &mut merged,
             &overlay,
@@ -145,8 +147,10 @@ pub fn load_with_layout(
                 source,
             })?;
         if let Some(mut overlay) = workspace_overlay {
+            reject_legacy_model_section(&overlay, &ws_path.display().to_string())?;
+
             // Resolve ${VAR} references in workspace overlay with restricted
-            // env vars (only ASTRID_* and ANTHROPIC_*). This prevents a
+            // env vars (only ASTRID_*). This prevents a
             // malicious workspace config from exfiltrating sensitive env vars.
             resolve_env_references_restricted(&mut overlay, &env_vars);
 
@@ -228,10 +232,19 @@ pub fn load_file(path: &Path) -> ConfigResult<Config> {
         source: e,
     })?;
 
-    let config: Config = toml::from_str(&content).map_err(|e| ConfigError::ParseError {
+    let value: toml::Value = toml::from_str(&content).map_err(|e| ConfigError::ParseError {
         path: path.display().to_string(),
         source: e,
     })?;
+    reject_legacy_model_section(&value, &path.display().to_string())?;
+
+    let config: Config =
+        value
+            .try_into()
+            .map_err(|e: toml::de::Error| ConfigError::ParseError {
+                path: path.display().to_string(),
+                source: e,
+            })?;
 
     validate::validate(&config)?;
     Ok(config)
@@ -329,6 +342,24 @@ fn validate_astrid_home(raw_path: &str, home_dir: &Path) -> Option<PathBuf> {
     Some(canonical)
 }
 
+/// Reject host-owned model configuration before any credential can be merged.
+///
+/// Model execution is capsule-owned. The old host `[model]` table is not a
+/// compatibility surface: accepting it would either silently ignore operator
+/// settings or carry provider credentials through the host config pipeline.
+fn reject_legacy_model_section(config: &toml::Value, path: &str) -> ConfigResult<()> {
+    if config.get("model").is_some() {
+        return Err(ConfigError::ValidationError {
+            field: "model".to_owned(),
+            message: format!(
+                "legacy host [model] in {path} is no longer supported; move model/provider \
+                 selection to a principal-scoped capsule using capsule [env] and the model registry"
+            ),
+        });
+    }
+    Ok(())
+}
+
 /// Determine the user's home directory.
 fn home_directory() -> ConfigResult<PathBuf> {
     directories::BaseDirs::new()
@@ -359,7 +390,7 @@ mod tests {
     #[test]
     fn test_defaults_parse() {
         let val: toml::Value = toml::from_str(DEFAULTS_TOML).unwrap();
-        assert!(val.as_table().unwrap().contains_key("model"));
+        assert!(!val.as_table().unwrap().contains_key("model"));
         assert!(val.as_table().unwrap().contains_key("runtime"));
         assert!(val.as_table().unwrap().contains_key("security"));
     }
@@ -367,8 +398,7 @@ mod tests {
     #[test]
     fn test_defaults_deserialize_to_config() {
         let config: Config = toml::from_str(DEFAULTS_TOML).unwrap();
-        assert_eq!(config.model.provider, "unknown");
-        assert_eq!(config.model.max_tokens, 4096);
+        assert_eq!(config.runtime.max_context_tokens, 100_000);
         assert!((config.budget.session_max_usd - 100.0).abs() < f64::EPSILON);
         assert_eq!(config.timeouts.request_secs, 120);
         assert_eq!(config.timeouts.daemon_ready_secs, 600);
@@ -393,12 +423,12 @@ mod tests {
         std::fs::create_dir_all(&alternate_dir).unwrap();
         std::fs::write(
             default_dir.join("config.toml"),
-            "[model]\nprovider = \"openai\"\n",
+            "[runtime]\nsystem_prompt = \"default\"\n",
         )
         .unwrap();
         std::fs::write(
             alternate_dir.join("config.toml"),
-            "[model]\nprovider = \"claude\"\n",
+            "[runtime]\nsystem_prompt = \"alternate\"\n",
         )
         .unwrap();
 
@@ -406,7 +436,7 @@ mod tests {
         let resolved =
             load_with_layout(Some(workspace.path()), Some(home.path()), &layout).unwrap();
 
-        assert_eq!(resolved.config.model.provider, "claude");
+        assert_eq!(resolved.config.runtime.system_prompt, "alternate");
         assert!(
             resolved
                 .loaded_files
@@ -471,7 +501,7 @@ mod tests {
         let outside = tempfile::tempdir().unwrap();
         std::fs::write(
             outside.path().join("config.toml"),
-            "[model]\nprovider = \"claude\"\n",
+            "[runtime]\nsystem_prompt = \"outside\"\n",
         )
         .unwrap();
         symlink(outside.path(), workspace.path().join(".alternate-runtime")).unwrap();
@@ -490,7 +520,7 @@ mod tests {
         let state = workspace.path().join(".alternate-runtime");
         std::fs::create_dir(&state).unwrap();
         let outside = tempfile::NamedTempFile::new().unwrap();
-        std::fs::write(outside.path(), "[model]\nprovider = \"claude\"\n").unwrap();
+        std::fs::write(outside.path(), "[runtime]\nsystem_prompt = \"outside\"\n").unwrap();
         symlink(outside.path(), state.join("config.toml")).unwrap();
 
         let layout = WorkspaceLayout::new(".alternate-runtime").unwrap();
@@ -518,16 +548,16 @@ mod tests {
         std::fs::write(
             home_astrid.join("config.toml"),
             r#"
-            [model]
-            provider = "home"
+            [runtime]
+            system_prompt = "home"
             "#,
         )
         .unwrap();
         std::fs::write(
             astrid_home.path().join("config.toml"),
             r#"
-            [model]
-            provider = "astrid-home"
+            [runtime]
+            system_prompt = "astrid-home"
             "#,
         )
         .unwrap();
@@ -551,9 +581,9 @@ mod tests {
     fn test_record_defaults() {
         let val: toml::Value = toml::from_str(
             r#"
-            [model]
-            provider = "claude"
-            max_tokens = 4096
+            [runtime]
+            system_prompt = "seed"
+            keep_recent_count = 10
         "#,
         )
         .unwrap();
@@ -561,57 +591,75 @@ mod tests {
         let mut sources = FieldSources::new();
         record_defaults(&val, "", &mut sources);
 
-        assert_eq!(sources.get("model.provider"), Some(&ConfigLayer::Defaults));
         assert_eq!(
-            sources.get("model.max_tokens"),
+            sources.get("runtime.system_prompt"),
+            Some(&ConfigLayer::Defaults)
+        );
+        assert_eq!(
+            sources.get("runtime.keep_recent_count"),
             Some(&ConfigLayer::Defaults)
         );
     }
 
-    // ---- Step 1: Debug/Serialize redaction ----
+    // ---- Legacy host model configuration ----
 
     #[test]
-    fn test_model_config_debug_redacts_api_key() {
-        use crate::types::ModelConfig;
-        let cfg = ModelConfig {
-            api_key: Some("sk-secret-12345".to_owned()),
-            api_url: Some("https://my-proxy.example.com".to_owned()),
-            ..ModelConfig::default()
-        };
+    fn legacy_user_model_section_fails_with_migration_guidance() {
+        let astrid_home = tempfile::tempdir().unwrap();
+        std::fs::write(
+            astrid_home.path().join("config.toml"),
+            r#"
+            [model]
+            provider = "claude"
+            api_key = "sk-host-secret"
+            "#,
+        )
+        .unwrap();
 
-        let debug_str = format!("{cfg:?}");
-        assert!(
-            !debug_str.contains("sk-secret-12345"),
-            "Debug output must not contain API key value"
-        );
-        assert!(
-            !debug_str.contains("my-proxy.example.com"),
-            "Debug output must not contain API URL value"
-        );
-        assert!(debug_str.contains("has_api_key: true"));
-        assert!(debug_str.contains("has_api_url: true"));
+        let result = load_with_layout(None, Some(astrid_home.path()), &WorkspaceLayout::default());
+
+        let error = result.unwrap_err().to_string();
+        assert!(error.contains("legacy host [model]"));
+        assert!(error.contains("principal-scoped capsule"));
+        assert!(error.contains("model registry"));
+        assert!(!error.contains("sk-host-secret"));
     }
 
     #[test]
-    fn test_model_config_serialize_omits_api_key() {
-        use crate::types::ModelConfig;
-        let cfg = ModelConfig {
-            api_key: Some("sk-secret-12345".to_owned()),
-            api_url: Some("https://my-proxy.example.com".to_owned()),
-            ..ModelConfig::default()
-        };
+    fn legacy_workspace_model_section_fails_before_env_resolution() {
+        let home = tempfile::tempdir().unwrap();
+        let workspace = tempfile::tempdir().unwrap();
+        let state = workspace.path().join(".astrid");
+        std::fs::create_dir_all(&state).unwrap();
+        std::fs::write(
+            state.join("config.toml"),
+            r#"
+            [model]
+            api_key = "${ANTHROPIC_API_KEY}"
+            "#,
+        )
+        .unwrap();
 
-        let json = serde_json::to_string(&cfg).unwrap();
-        assert!(
-            !json.contains("sk-secret-12345"),
-            "Serialized output must not contain API key"
+        let result = load_with_layout(
+            Some(workspace.path()),
+            Some(home.path()),
+            &WorkspaceLayout::default(),
         );
-        assert!(
-            !json.contains("my-proxy.example.com"),
-            "Serialized output must not contain API URL"
-        );
-        assert!(!json.contains("api_key"));
-        assert!(!json.contains("api_url"));
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn legacy_model_section_fails_single_file_load() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, "[model]\napi_key = \"sk-host-secret\"\n").unwrap();
+
+        let error = load_file(&path).unwrap_err().to_string();
+
+        assert!(error.contains("legacy host [model]"));
+        assert!(error.contains("capsule [env]"));
+        assert!(!error.contains("sk-host-secret"));
     }
 
     #[test]

--- a/crates/astrid-config/src/merge/restrict.rs
+++ b/crates/astrid-config/src/merge/restrict.rs
@@ -126,24 +126,6 @@ pub fn enforce_restrictions(
         "workspace.auto_allow_write",
     );
 
-    // model.api_key: workspace cannot override.
-    block_workspace_override(
-        merged,
-        baseline,
-        workspace_layer,
-        &["model", "api_key"],
-        "model.api_key",
-    );
-
-    // model.api_url: workspace cannot override.
-    block_workspace_override(
-        merged,
-        baseline,
-        workspace_layer,
-        &["model", "api_url"],
-        "model.api_url",
-    );
-
     // hooks.allow_wasm_hooks: cannot enable (only disable).
     enforce_bool_only_false(
         merged,

--- a/crates/astrid-config/src/merge/tests.rs
+++ b/crates/astrid-config/src/merge/tests.rs
@@ -8,15 +8,15 @@ fn layered_values_preserve_datetime_and_stable_text() {
         [metadata]
         created = 1979-05-27T00:32:00-07:00
 
-        [model]
-        provider = "claude"
+        [runtime]
+        system_prompt = "base"
     "#,
     )
     .unwrap();
     let overlay: toml::Value = toml::from_str(
         r"
-        [model]
-        max_tokens = 8192
+        [runtime]
+        keep_recent_count = 3
     ",
     )
     .unwrap();
@@ -37,9 +37,9 @@ fn layered_values_preserve_datetime_and_stable_text() {
             "[metadata]\n",
             "created = 1979-05-27T00:32:00-07:00\n",
             "\n",
-            "[model]\n",
-            "max_tokens = 8192\n",
-            "provider = \"claude\"\n",
+            "[runtime]\n",
+            "keep_recent_count = 3\n",
+            "system_prompt = \"base\"\n",
         )
     );
 }
@@ -48,17 +48,17 @@ fn layered_values_preserve_datetime_and_stable_text() {
 fn test_deep_merge_scalars() {
     let mut base: toml::Value = toml::from_str(
         r#"
-        [model]
-        provider = "claude"
-        max_tokens = 4096
+        [runtime]
+        system_prompt = "base"
+        keep_recent_count = 10
     "#,
     )
     .unwrap();
 
     let overlay: toml::Value = toml::from_str(
         r"
-        [model]
-        max_tokens = 8192
+        [runtime]
+        keep_recent_count = 3
     ",
     )
     .unwrap();
@@ -66,25 +66,25 @@ fn test_deep_merge_scalars() {
     deep_merge(&mut base, &overlay);
 
     let table = base.as_table().unwrap();
-    let model = table["model"].as_table().unwrap();
-    assert_eq!(model["provider"].as_str().unwrap(), "claude");
-    assert_eq!(model["max_tokens"].as_integer().unwrap(), 8192);
+    let runtime = table["runtime"].as_table().unwrap();
+    assert_eq!(runtime["system_prompt"].as_str().unwrap(), "base");
+    assert_eq!(runtime["keep_recent_count"].as_integer().unwrap(), 3);
 }
 
 #[test]
 fn test_deep_merge_new_keys() {
     let mut base: toml::Value = toml::from_str(
         r#"
-        [model]
-        provider = "claude"
+        [runtime]
+        system_prompt = "base"
     "#,
     )
     .unwrap();
 
     let overlay: toml::Value = toml::from_str(
         r#"
-        [model]
-        api_key = "sk-test"
+        [logging]
+        level = "debug"
         [budget]
         session_max_usd = 50.0
     "#,
@@ -94,8 +94,8 @@ fn test_deep_merge_new_keys() {
     deep_merge(&mut base, &overlay);
 
     let table = base.as_table().unwrap();
-    let model = table["model"].as_table().unwrap();
-    assert_eq!(model["api_key"].as_str().unwrap(), "sk-test");
+    let logging = table["logging"].as_table().unwrap();
+    assert_eq!(logging["level"].as_str().unwrap(), "debug");
     assert!(table.contains_key("budget"));
 }
 
@@ -103,17 +103,17 @@ fn test_deep_merge_new_keys() {
 fn test_deep_merge_tracking() {
     let mut base: toml::Value = toml::from_str(
         r#"
-        [model]
-        provider = "claude"
-        max_tokens = 4096
+        [runtime]
+        system_prompt = "base"
+        keep_recent_count = 10
     "#,
     )
     .unwrap();
 
     let overlay: toml::Value = toml::from_str(
         r"
-        [model]
-        max_tokens = 8192
+        [runtime]
+        keep_recent_count = 3
     ",
     )
     .unwrap();
@@ -121,8 +121,11 @@ fn test_deep_merge_tracking() {
     let mut sources = FieldSources::new();
     deep_merge_tracking(&mut base, &overlay, "", &ConfigLayer::User, &mut sources);
 
-    assert_eq!(sources.get("model.max_tokens"), Some(&ConfigLayer::User));
-    assert!(!sources.contains_key("model.provider"));
+    assert_eq!(
+        sources.get("runtime.keep_recent_count"),
+        Some(&ConfigLayer::User)
+    );
+    assert!(!sources.contains_key("runtime.system_prompt"));
 }
 
 // ---- Original restriction tests ----
@@ -377,57 +380,6 @@ fn test_approval_timeout_cannot_increase() {
 }
 
 #[test]
-fn test_api_key_cannot_be_overridden_by_workspace() {
-    let baseline: toml::Value = toml::from_str(
-        r#"
-        [model]
-        api_key = "sk-real-key"
-    "#,
-    )
-    .unwrap();
-
-    let workspace: toml::Value = toml::from_str(
-        r#"
-        [model]
-        api_key = "sk-malicious-key"
-    "#,
-    )
-    .unwrap();
-
-    let mut merged = baseline.clone();
-    deep_merge(&mut merged, &workspace);
-    enforce_restrictions(&mut merged, &baseline, &workspace);
-
-    assert_eq!(merged["model"]["api_key"].as_str().unwrap(), "sk-real-key");
-}
-
-#[test]
-fn test_api_url_cannot_be_overridden_by_workspace() {
-    let baseline: toml::Value = toml::from_str(
-        r#"
-        [model]
-        provider = "claude"
-    "#,
-    )
-    .unwrap();
-
-    let workspace: toml::Value = toml::from_str(
-        r#"
-        [model]
-        api_url = "https://evil-proxy.com"
-    "#,
-    )
-    .unwrap();
-
-    let mut merged = baseline.clone();
-    deep_merge(&mut merged, &workspace);
-    enforce_restrictions(&mut merged, &baseline, &workspace);
-
-    // api_url should have been removed since baseline didn't have it.
-    assert!(merged["model"].as_table().unwrap().get("api_url").is_none());
-}
-
-#[test]
 fn test_capsule_local_egress_cannot_be_set_by_workspace() {
     // A widening SSRF-airlock exemption must be operator-only: a workspace
     // layer cannot introduce it.
@@ -499,7 +451,7 @@ fn test_capsule_local_egress_workspace_cannot_widen_operator_value() {
 
 #[test]
 fn test_uplinks_cannot_be_introduced_by_workspace() {
-    let baseline: toml::Value = toml::from_str("[model]\nprovider = \"unknown\"\n").unwrap();
+    let baseline: toml::Value = toml::from_str("[runtime]\nsystem_prompt = \"base\"\n").unwrap();
     let workspace: toml::Value = toml::from_str(
         r#"
         [[uplinks]]
@@ -1095,7 +1047,7 @@ fn test_allow_command_hooks_cannot_enable() {
 
 #[test]
 fn test_set_nested_no_panic_on_missing_table() {
-    let mut val: toml::Value = toml::from_str("[model]\nprovider = \"unknown\"").unwrap();
+    let mut val: toml::Value = toml::from_str("[runtime]\nsystem_prompt = \"base\"").unwrap();
     // This should not panic — the intermediate "nonexistent" table is missing.
     set_nested(
         &mut val,
@@ -1103,5 +1055,5 @@ fn test_set_nested_no_panic_on_missing_table() {
         toml::Value::Boolean(true),
     );
     // Value should be unchanged.
-    assert_eq!(val["model"]["provider"].as_str().unwrap(), "unknown");
+    assert_eq!(val["runtime"]["system_prompt"].as_str().unwrap(), "base");
 }

--- a/crates/astrid-config/src/show.rs
+++ b/crates/astrid-config/src/show.rs
@@ -193,7 +193,8 @@ mod tests {
 
         let output = resolved.show(ShowFormat::Toml, None).unwrap();
         assert!(output.contains("Resolved Astrid Configuration"));
-        assert!(output.contains("provider"));
+        assert!(output.contains("max_context_tokens"));
+        assert!(!output.contains("provider"));
     }
 
     #[test]
@@ -217,10 +218,9 @@ mod tests {
             loaded_files: Vec::new(),
         };
 
-        let output = resolved.show(ShowFormat::Toml, Some("model")).unwrap();
-        assert!(output.contains("unknown"));
-        // Should NOT contain budget or other sections.
-        assert!(!output.contains("session_max_usd"));
+        let result = resolved.show(ShowFormat::Toml, Some("model"));
+
+        assert!(result.is_err());
     }
 
     #[test]

--- a/crates/astrid-config/src/types.rs
+++ b/crates/astrid-config/src/types.rs
@@ -8,7 +8,6 @@
 
 use std::collections::HashMap;
 
-use serde::ser::SerializeStruct;
 use serde::{Deserialize, Serialize};
 
 // ---------------------------------------------------------------------------
@@ -22,8 +21,6 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Config {
-    /// LLM model selection and pricing.
-    pub model: ModelConfig,
     /// Runtime behaviour (context limits, summarisation).
     pub runtime: RuntimeSection,
     /// Signature requirements and approval timeout.
@@ -69,103 +66,6 @@ pub struct Config {
     pub uplinks: Vec<UplinkConfig>,
     /// Pre-configured platform identity links applied at every startup.
     pub identity: IdentitySection,
-}
-
-// ---------------------------------------------------------------------------
-// ModelConfig
-// ---------------------------------------------------------------------------
-
-/// LLM provider selection, endpoint, and token pricing.
-#[derive(Clone, Deserialize)]
-#[serde(default)]
-pub struct ModelConfig {
-    /// Provider identifier (e.g. `"claude"`, `"openai"`).
-    pub provider: String,
-    /// Model name sent to the provider API.
-    pub model: String,
-    /// API key. Prefer environment variables over storing this in a file.
-    #[serde(skip_serializing)]
-    pub api_key: Option<String>,
-    /// Base URL for the provider API (overrides the default endpoint).
-    #[serde(skip_serializing)]
-    pub api_url: Option<String>,
-    /// Maximum tokens to request per completion.
-    pub max_tokens: usize,
-    /// Sampling temperature.
-    pub temperature: f64,
-    /// Context window size in tokens. When set, overrides the provider's
-    /// built-in default for the model. Useful for OpenAI-compatible providers
-    /// where the model name is not recognized.
-    pub context_window: Option<usize>,
-    /// Token pricing used for budget tracking.
-    pub pricing: PricingConfig,
-}
-
-impl std::fmt::Debug for ModelConfig {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ModelConfig")
-            .field("provider", &self.provider)
-            .field("model", &self.model)
-            .field("has_api_key", &self.api_key.is_some())
-            .field("has_api_url", &self.api_url.is_some())
-            .field("max_tokens", &self.max_tokens)
-            .field("temperature", &self.temperature)
-            .field("context_window", &self.context_window)
-            .field("pricing", &self.pricing)
-            .finish()
-    }
-}
-
-impl Serialize for ModelConfig {
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut state = serializer.serialize_struct("ModelConfig", 6)?;
-        state.serialize_field("provider", &self.provider)?;
-        state.serialize_field("model", &self.model)?;
-        // api_key and api_url are intentionally omitted.
-        state.serialize_field("max_tokens", &self.max_tokens)?;
-        state.serialize_field("temperature", &self.temperature)?;
-        state.serialize_field("context_window", &self.context_window)?;
-        state.serialize_field("pricing", &self.pricing)?;
-        state.end()
-    }
-}
-
-impl Default for ModelConfig {
-    fn default() -> Self {
-        Self {
-            provider: "unknown".to_owned(),
-            model: "unknown".to_owned(),
-            api_key: None,
-            api_url: None,
-            max_tokens: 4096,
-            temperature: 0.7,
-            context_window: None,
-            pricing: PricingConfig::default(),
-        }
-    }
-}
-
-// ---------------------------------------------------------------------------
-// PricingConfig
-// ---------------------------------------------------------------------------
-
-/// Per-token pricing used to compute spend against budget limits.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(default)]
-pub struct PricingConfig {
-    /// USD cost per 1 million input tokens.
-    pub input_per_million: f64,
-    /// USD cost per 1 million output tokens.
-    pub output_per_million: f64,
-}
-
-impl Default for PricingConfig {
-    fn default() -> Self {
-        Self {
-            input_per_million: 3.0,
-            output_per_million: 15.0,
-        }
-    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/astrid-config/src/validate.rs
+++ b/crates/astrid-config/src/validate.rs
@@ -15,7 +15,6 @@ use crate::types::Config;
 ///
 /// Returns the first validation error found.
 pub fn validate(config: &Config) -> ConfigResult<()> {
-    validate_model(config)?;
     validate_budget(config)?;
     validate_workspace(config)?;
     validate_git(config)?;
@@ -27,59 +26,6 @@ pub fn validate(config: &Config) -> ConfigResult<()> {
     validate_retry(config)?;
     validate_audit(config)?;
     validate_rate_limits(config)?;
-    Ok(())
-}
-
-/// Maximum allowed `max_tokens` value (16 million).
-const MAX_TOKENS_UPPER_BOUND: usize = 16_000_000;
-
-fn validate_model(config: &Config) -> ConfigResult<()> {
-    let m = &config.model;
-
-    if !matches!(
-        m.provider.as_str(),
-        "claude" | "openai" | "openai-compat" | "zai" | "unknown"
-    ) {
-        return Err(ConfigError::ValidationError {
-            field: "model.provider".to_owned(),
-            message: format!(
-                "unsupported provider '{}'; expected one of: claude, openai, openai-compat, zai, unknown",
-                m.provider
-            ),
-        });
-    }
-
-    if !(0.0..=1.0).contains(&m.temperature) {
-        return Err(ConfigError::ValidationError {
-            field: "model.temperature".to_owned(),
-            message: format!(
-                "temperature {} is out of range; must be between 0.0 and 1.0",
-                m.temperature
-            ),
-        });
-    }
-
-    if m.max_tokens == 0 || m.max_tokens > MAX_TOKENS_UPPER_BOUND {
-        return Err(ConfigError::ValidationError {
-            field: "model.max_tokens".to_owned(),
-            message: format!("max_tokens must be between 1 and {MAX_TOKENS_UPPER_BOUND}"),
-        });
-    }
-
-    if !m.pricing.input_per_million.is_finite() || m.pricing.input_per_million <= 0.0 {
-        return Err(ConfigError::ValidationError {
-            field: "model.pricing.input_per_million".to_owned(),
-            message: "input_per_million must be a finite positive number".to_owned(),
-        });
-    }
-
-    if !m.pricing.output_per_million.is_finite() || m.pricing.output_per_million <= 0.0 {
-        return Err(ConfigError::ValidationError {
-            field: "model.pricing.output_per_million".to_owned(),
-            message: "output_per_million must be a finite positive number".to_owned(),
-        });
-    }
-
     Ok(())
 }
 
@@ -431,21 +377,6 @@ mod tests {
     }
 
     #[test]
-    fn test_invalid_provider() {
-        let mut config = Config::default();
-        config.model.provider = "grok".to_owned();
-        let err = validate(&config).unwrap_err();
-        assert!(matches!(err, ConfigError::ValidationError { .. }));
-    }
-
-    #[test]
-    fn test_invalid_temperature() {
-        let mut config = Config::default();
-        config.model.temperature = 1.5;
-        assert!(validate(&config).is_err());
-    }
-
-    #[test]
     fn test_invalid_budget() {
         let mut config = Config::default();
         config.budget.per_action_max_usd = 200.0;
@@ -583,27 +514,6 @@ mod tests {
     }
 
     #[test]
-    fn test_zero_max_tokens() {
-        let mut config = Config::default();
-        config.model.max_tokens = 0;
-        assert!(validate(&config).is_err());
-    }
-
-    #[test]
-    fn test_negative_pricing() {
-        let mut config = Config::default();
-        config.model.pricing.input_per_million = -1.0;
-        assert!(validate(&config).is_err());
-    }
-
-    #[test]
-    fn test_zero_pricing_rejected() {
-        let mut config = Config::default();
-        config.model.pricing.input_per_million = 0.0;
-        assert!(validate(&config).is_err());
-    }
-
-    #[test]
     fn test_nan_budget_rejected() {
         let mut config = Config::default();
         config.budget.session_max_usd = f64::NAN;
@@ -625,23 +535,9 @@ mod tests {
     }
 
     #[test]
-    fn test_nan_pricing_rejected() {
-        let mut config = Config::default();
-        config.model.pricing.output_per_million = f64::NAN;
-        assert!(validate(&config).is_err());
-    }
-
-    #[test]
     fn test_budget_upper_bound() {
         let mut config = Config::default();
         config.budget.session_max_usd = 20_000.0;
-        assert!(validate(&config).is_err());
-    }
-
-    #[test]
-    fn test_max_tokens_upper_bound() {
-        let mut config = Config::default();
-        config.model.max_tokens = 100_000_000;
         assert!(validate(&config).is_err());
     }
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -6,7 +6,7 @@ Astrid uses a layered configuration system powered by TOML. Configuration is loa
 2. **System Config** (`/etc/astrid/config.toml`)
 3. **User Config** (`~/.astrid/config.toml` or `$ASTRID_HOME/config.toml`)
 4. **Workspace Config** (`.astrid/config.toml` in the project root — can only **tighten** security, never loosen)
-5. **Environment Variables** (`ASTRID_*`, `ANTHROPIC_*` — fill in unset fields only, do not override)
+5. **Environment Variables** (`ASTRID_*` — fill in unset fields only, do not override)
 
 ## Connectors
 
@@ -48,34 +48,9 @@ method = "admin"
 
 ## Model
 
-Configure the LLM provider and model parameters.
+Host configuration has no model section. Model selection and provider execution are owned by principal-scoped capsules. Configure capsule-specific provider settings in that capsule's `[env]`, then select and discover models through the model registry.
 
-```toml
-[model]
-provider = "claude"
-model = "claude-sonnet-4-20250514"
-max_tokens = 4096
-temperature = 0.7
-# api_key = ""  # Optional: use env var ANTHROPIC_API_KEY instead
-# api_url = ""  # Optional: custom endpoint for proxies or local models
-# context_window = 200000  # Optional: override provider's context window size
-
-[model.pricing]
-input_per_million = 3.0
-output_per_million = 15.0
-```
-
-| Field | Type | Description |
-|---|---|---|
-| `provider` | string | The model provider (e.g., `"claude"`). |
-| `model` | string | The model identifier sent to the API. |
-| `max_tokens` | integer | Maximum tokens to generate per response. |
-| `temperature` | float | Sampling temperature (0.0 - 1.0). |
-| `api_key` | string | (Optional) API key. Prefer env var `ANTHROPIC_API_KEY`. |
-| `api_url` | string | (Optional) Base URL for proxies or alternative endpoints. |
-| `context_window` | integer | (Optional) Override the provider's default context window size. |
-| `pricing.input_per_million` | float | USD per million input tokens (for budget tracking). |
-| `pricing.output_per_million` | float | USD per million output tokens (for budget tracking). |
+Legacy host `[model]` configuration is rejected with migration guidance. It is not silently ignored, and provider credentials are never loaded into core host configuration.
 
 ## Runtime
 


### PR DESCRIPTION
## Linked Issue

Closes #1828

## Summary

Removes Astrid core's inert host-side LLM provider configuration. Model execution and provider selection belong to principal-scoped capsules and the model registry, not host runtime configuration.

Legacy host `[model]` fails closed with actionable capsule-migration guidance and never loads provider credentials into core. The TUI starts without a host model label and learns the active model through existing registry IPC.

This is an intentional public `astrid-config` API removal for the 2026.9.0 train. It does not bump the crate version.

## Changes

- Deletes `Config.model`, `ModelConfig`, `PricingConfig`, and their public exports.
- Deletes host provider/model/API-key/API-URL environment fallbacks and model-specific validation, defaults, merge restrictions, CLI help, and configuration documentation.
- Rejects a legacy host `[model]` table before merge so credentials cannot enter typed `Config`.
- Removes the bootstrap-only host model label read.
- Updates `config show` so a requested `[model]` section fails closed.
- Adds a registry-driven TUI label regression proving IPC still updates the model label from an empty host start.

## Preserve

- Capsule-owned `[env]` model/provider configuration
- Principal SecretStore
- Registry IPC and gateway `/api/models`
- Provider capsules, React/model discovery
- Runtime context/HTTP/budget policy
- Historical changelog entries
- Landed client-config plane (`ASTRID_CLIENT_CONFIG_PATH`); that remains #1816

## Verification

- Unique range is one signed commit on `2e94dbc`.
- Focused: `astrid-config` tests, CLI/TUI label regression, fmt, Clippy `-D warnings`.
- Independent exact-head review is required. This is source/config-surface work, not daemon/kernel/gateway execution proof.
- No version bump and no Distro apply / AOS layout change in this vehicle.

## AI / Tool Assistance

Assisted-by: Codex:glm-5.3-flash

A coding agent implemented the host `[model]` removal, fail-closed legacy loader, `config show` updates, TUI empty-label start, changelog fragment, and focused tests. The maintainer owns the public `astrid-config` API boundary and reviewed the result against #1828.

## Checklist

- [x] Linked issues
- [x] Changelog fragment added under `changes/1828.changed.md`
- [ ] Independent review complete
- [ ] Ready to merge
