### PR TITLE
fix(cli): pin official Unicity CE Distro identity to release keys

### DIFF
--- a/changes/995.changed.md
+++ b/changes/995.changed.md
@@ -1,5 +1,6 @@
-Official AOS releases now pin the compiled-in Unicity CE signing key on
-first use instead of entering the TOFU path, and unsigned manual installs
-that claim the official Unicity CE distro identity are refused. Signed
-artifacts still verify fail-closed, while `--accept-new-key` remains the
-explicit operator escape for a changed third-party pin.
+Official AOS releases bind the Unicity CE identity to the compiled-in
+official keys. A signed artifact claiming that identity under any other
+key fails closed before TOFU, without writing a trust pin, and unsigned
+manual or `.shuttle` installs cannot bypass the refusal with
+`--allow-unsigned`. `--accept-new-key` remains the explicit operator
+escape for a changed third-party pin.

--- a/changes/995.changed.md
+++ b/changes/995.changed.md
@@ -1,0 +1,5 @@
+Official AOS releases now pin the compiled-in Unicity CE signing key on
+first use instead of entering the TOFU path, and unsigned manual installs
+that claim the official Unicity CE distro identity are refused. Signed
+artifacts still verify fail-closed, while `--accept-new-key` remains the
+explicit operator escape for a changed third-party pin.

--- a/crates/astrid-cli/src/commands/distro/shuttle_install.rs
+++ b/crates/astrid-cli/src/commands/distro/shuttle_install.rs
@@ -90,12 +90,7 @@ pub(crate) async fn install_from_shuttle(
         report_trust(&outcome);
         Some(outcome.key_str)
     } else {
-        if !opts.allow_unsigned {
-            bail!(
-                "shuttle for '{distro_id}' is unsigned (no [distro.signing] or Distro.sig) — \
-                 refusing. Re-run with --allow-unsigned to install anyway."
-            );
-        }
+        unsigned_shuttle_may_install(&distro_id, opts)?;
         eprintln!(
             "{}",
             Theme::warning(&format!(
@@ -175,6 +170,26 @@ pub(crate) async fn install_from_shuttle(
 
     eprintln!();
     eprintln!("{}", Theme::success("Offline installation complete."));
+    Ok(())
+}
+
+/// Decide whether an unsigned shuttle may proceed to the warning path.
+///
+/// The official-id gate comes first because `--allow-unsigned` is an
+/// escape for third-party development artifacts only.
+fn unsigned_shuttle_may_install(distro_id: &str, opts: &InitOpts) -> anyhow::Result<()> {
+    if trust::is_official_distro_id(distro_id) {
+        bail!(
+            "official distro '{distro_id}' cannot be installed from an unsigned .shuttle; \
+             --allow-unsigned is not accepted"
+        );
+    }
+    if !opts.allow_unsigned {
+        bail!(
+            "shuttle for '{distro_id}' is unsigned (no [distro.signing] or Distro.sig) — \
+             refusing. Re-run with --allow-unsigned to install anyway."
+        );
+    }
     Ok(())
 }
 
@@ -518,6 +533,21 @@ mod tests {
         // against, so a missing manifest_hash is acceptable.
         let lock = lock_with_manifest_hash(None);
         assert!(check_manifest_binding("test", false, &lock, b"anything").is_ok());
+    }
+
+    #[test]
+    fn unsigned_official_shuttle_refuses_allow_unsigned() {
+        let opts = InitOpts {
+            allow_unsigned: true,
+            ..Default::default()
+        };
+
+        let err = unsigned_shuttle_may_install("unicity-ce", &opts).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("cannot be installed from an unsigned .shuttle"),
+            "got: {err}"
+        );
     }
 
     #[test]

--- a/crates/astrid-cli/src/commands/distro/trust.rs
+++ b/crates/astrid-cli/src/commands/distro/trust.rs
@@ -38,12 +38,14 @@ use super::sign;
 /// without prompting on first use. Changing this set requires rebuilding
 /// the binary — that is the point: official trust is not runtime-mutable.
 ///
-/// DECISION: empty placeholder — the real official key(s) are not part
-/// of issue #964's spec. With this empty, official distros currently
-/// take the TOFU path like any third party until a key is added here.
-const OFFICIAL_KEYS: &[&str] = &[
-    // "ed25519:<base64>",
-];
+/// The release-authenticated AOS distribution key. Official trust is
+/// compiled in so first contact pins it without a TOFU window.
+const OFFICIAL_KEYS: &[&str] = &["ed25519:utH537RuOuqKwjGx/pHIUAkKapyqPUhHpZIVDU6Q0FA="];
+
+/// Distro ids whose release artifacts must be signed. Keeping this
+/// separate from the signing keys lets the unsigned-source boundary
+/// reject identity spoofing before it can take the manual-install path.
+const OFFICIAL_DISTRO_IDS: &[&str] = &["unicity-ce"];
 
 /// What the trust check decided.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -123,6 +125,18 @@ fn is_official(key_str: &str) -> bool {
     OFFICIAL_KEYS.contains(&key_str)
 }
 
+/// Is this a release distro id that refuses the unsigned manual path?
+pub(crate) fn is_official_distro_id(distro_id: &str) -> bool {
+    OFFICIAL_DISTRO_IDS.contains(&distro_id)
+}
+
+fn classify_unpinned_key(key_str: &str) -> TrustAction {
+    if is_official(key_str) {
+        TrustAction::OfficialPinned
+    } else {
+        TrustAction::ToFuTrusted
+    }
+}
 /// Verify a sealed distro's signature and apply the trust policy.
 ///
 /// `manifest_pubkey` is the `[distro.signing].pubkey` declared in the
@@ -173,7 +187,7 @@ pub(crate) fn verify_and_pin(
         None => {
             // TOFU: pin and report.
             pin(home, distro_id, &key_str)?;
-            TrustAction::ToFuTrusted
+            classify_unpinned_key(&key_str)
         },
     };
 
@@ -250,6 +264,20 @@ mod tests {
             read_pinned(&home, "test").unwrap().unwrap(),
             kp.export_public_key()
         );
+    }
+
+    #[test]
+    fn official_key_is_pinned_not_tofu() {
+        assert_eq!(
+            classify_unpinned_key(OFFICIAL_KEYS[0]),
+            TrustAction::OfficialPinned
+        );
+    }
+
+    #[test]
+    fn official_release_id_is_signed_only() {
+        assert!(is_official_distro_id("unicity-ce"));
+        assert!(!is_official_distro_id("test"));
     }
 
     #[test]

--- a/crates/astrid-cli/src/commands/distro/trust.rs
+++ b/crates/astrid-cli/src/commands/distro/trust.rs
@@ -42,9 +42,9 @@ use super::sign;
 /// compiled in so first contact pins it without a TOFU window.
 const OFFICIAL_KEYS: &[&str] = &["ed25519:utH537RuOuqKwjGx/pHIUAkKapyqPUhHpZIVDU6Q0FA="];
 
-/// Distro ids whose release artifacts must be signed. Keeping this
-/// separate from the signing keys lets the unsigned-source boundary
-/// reject identity spoofing before it can take the manual-install path.
+/// Distro ids whose release artifacts must be signed by an official key.
+/// Keeping this separate from the signing keys lets trust and the
+/// unsigned-source boundary reject identity spoofing before an install.
 const OFFICIAL_DISTRO_IDS: &[&str] = &["unicity-ce"];
 
 /// What the trust check decided.
@@ -137,6 +137,21 @@ fn classify_unpinned_key(key_str: &str) -> TrustAction {
         TrustAction::ToFuTrusted
     }
 }
+
+/// Official identity is bound to the compiled-in keys, not to TOFU.
+///
+/// This deliberately runs before the trust store is consulted so an
+/// unofficial key cannot become (or replace) an official id's pin, even
+/// with the operator override.
+fn ensure_official_id_key(distro_id: &str, key_str: &str) -> anyhow::Result<()> {
+    if is_official_distro_id(distro_id) && !is_official(key_str) {
+        bail!(
+            "official distro '{distro_id}' accepts only compiled-in official signing keys; \
+             refusing non-official key {key_str}"
+        );
+    }
+    Ok(())
+}
 /// Verify a sealed distro's signature and apply the trust policy.
 ///
 /// `manifest_pubkey` is the `[distro.signing].pubkey` declared in the
@@ -163,6 +178,8 @@ pub(crate) fn verify_and_pin(
     // a bad signature is fatal regardless of trust state. (Cases 1–5.)
     sign::verify_lock(lock, sig_hex, &pubkey)
         .context("distro signature is invalid — refusing to install")?;
+
+    ensure_official_id_key(distro_id, &key_str)?;
 
     let pinned = read_pinned(home, distro_id)?;
     let action = match pinned {
@@ -278,6 +295,37 @@ mod tests {
     fn official_release_id_is_signed_only() {
         assert!(is_official_distro_id("unicity-ce"));
         assert!(!is_official_distro_id("test"));
+    }
+
+    #[test]
+    fn official_id_rejects_unofficial_key_before_tofu() {
+        let (_dir, home) = home();
+        let kp = KeyPair::generate();
+        let mut lock = sample_lock();
+        lock.distro.id = "unicity-ce".into();
+        let sig = sign::sign_lock(&lock, &kp).unwrap();
+
+        // The valid signature and operator override must not let a rogue
+        // key claim the official id.
+        let err = verify_and_pin(
+            &home,
+            "unicity-ce",
+            &sign::pubkey_to_wire(&kp.export_public_key()),
+            &sig,
+            &lock,
+            true,
+        )
+        .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("accepts only compiled-in official signing keys"),
+            "got: {err}"
+        );
+        assert!(
+            read_pinned(&home, "unicity-ce").unwrap().is_none(),
+            "a failed official-id claim must not write a trust pin"
+        );
     }
 
     #[test]

--- a/crates/astrid-cli/src/commands/init_signed_source.rs
+++ b/crates/astrid-cli/src/commands/init_signed_source.rs
@@ -65,6 +65,13 @@ pub(super) async fn prepare_distro_source(
         ));
     }
     let (manifest_bytes, manifest) = fetch_manifest_bytes(distro_source, opts.offline).await?;
+    if trust::is_official_distro_id(&manifest.distro.id) {
+        bail!(
+            "official distro '{}' cannot be installed from unsigned Distro.toml; \
+             use a signed release artifact",
+            manifest.distro.id
+        );
+    }
     Ok(PreparedDistro::Manifest {
         manifest,
         manifest_hash: manifest_hash(&manifest_bytes),

--- a/crates/astrid-cli/src/commands/init_tests.rs
+++ b/crates/astrid-cli/src/commands/init_tests.rs
@@ -270,6 +270,34 @@ fn product_source_rejects_unsigned_distro_toml_before_install_state() {
 }
 
 #[test]
+fn official_distro_rejects_unsigned_distro_toml() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(dir.path().join("home"));
+    std::fs::write(
+        dir.path().join("Distro.toml"),
+        "schema-version = 1\n\n[distro]\nid = \"unicity-ce\"\nname = \"Unicity CE\"\nversion = \"0.1.0\"\n\n\
+         [[capsule]]\nname = \"cli\"\nsource = \"@org/cli\"\nversion = \"0.1.0\"\nrole = \"uplink\"\n",
+    )
+    .unwrap();
+    let opts = InitOpts {
+        require_signed: false,
+        offline: true,
+        ..Default::default()
+    };
+
+    let error = futures::executor::block_on(super::signed_source::prepare_distro_source(
+        dir.path().join("Distro.toml").to_str().unwrap(),
+        &opts,
+        &home,
+    ))
+    .unwrap_err();
+    assert!(
+        error.to_string().contains("official distro 'unicity-ce'"),
+        "got: {error:#}"
+    );
+}
+
+#[test]
 fn product_source_rejects_tampered_distro_toml_bytes() {
     let dir = tempfile::tempdir().unwrap();
     let home = AstridHome::from_path(dir.path().join("home"));

--- a/docs/distro-signing.md
+++ b/docs/distro-signing.md
@@ -116,8 +116,8 @@ Consumers install with `astrid init --distro ./example-distro-0.1.0.shuttle`.
 
 To let consumers pin your key on their very first install (no TOFU
 window), add the same `ed25519:<base64>` to the `OFFICIAL_KEYS` table in
-the `astrid` source and ship a new binary. Until then, even your own
-distro takes the TOFU path.
+the `astrid` source and ship a new binary; the current official key is
+`ed25519:utH537RuOuqKwjGx/pHIUAkKapyqPUhHpZIVDU6Q0FA=`.
 
 ## 4. Operator: installing a signed distro
 

--- a/docs/distro-signing.md
+++ b/docs/distro-signing.md
@@ -155,8 +155,10 @@ Yes — layered, and fail-closed where it matters:
   is **refused** unless the operator passes `--allow-unsigned`. Skipping
   signing never silently weakens trust — it forces the consumer to opt
   into the risk.
-- **Official distros:** effectively mandatory — once the key is in
-  `OFFICIAL_KEYS`, an unsigned build under that distro id is refused.
+- **Official distros:** effectively mandatory — official distro ids
+  accept only keys compiled into `OFFICIAL_KEYS`, and an unsigned build
+  under that id is refused. A non-official key claiming an official id
+  fails closed even with `--accept-new-key`.
 
 ## 6. The strong guarantee: vendor the `.shuttle`
 


### PR DESCRIPTION
## Linked Issue

Related to #995. This pin does not close that issue; the broader distro-blessed versus permission-required manual-install model remains open. Changelog fragment is `changes/995.changed.md`, not a `.fixed.md`. Traceability exception: no-issue, because closing #995 would over-claim the remaining trust-model work.

## Summary

Astrid compiles in the Unicity CE Distro signing public key so first contact with an official signed Distro pins as official trust instead of TOFU. Official distro ids accept only those compiled-in keys. A `unicity-ce` artifact signed by any other key is refused before trust-store reads or writes, including `--accept-new-key`. Unsigned official Distro.toml sources remain refused. Unsigned `.shuttle` sources claiming an official identity are refused even with `--allow-unsigned`. Third-party TOFU and operator `--accept-new-key` re-pin remain available for non-official ids.

## Changes

- Pins `OFFICIAL_KEYS` to `ed25519:utH537RuOuqKwjGx/pHIUAkKapyqPUhHpZIVDU6Q0FA=`.
- Treats distro id `unicity-ce` as an official identity bound to those keys.
- Official first-contact classification is `OfficialPinned`, not `ToFuTrusted`.
- Official ids reject validly signed non-official keys before pin mutation.
- Unsigned official `.shuttle` installs cannot use `--allow-unsigned`.
- Adds changelog fragment `changes/995.changed.md` without closing #995.

## Verification

- Head `e09dff440ec1ec92b350b9a88a32febd92119058`; parent `361a14716d2f1ec74b14830d2f730daaa8931a34`; base `origin/main` `58b5bbd7910b982ad6f05aaeb38b89ee2e6c32c7`.
- `git verify-commit` good, full trust, DCO present.
- Focused tests: `distro::trust` and official-id Distro.toml / `.shuttle` refusals.

## Claim boundary

This is not AOS packaging, Distro.sig production, selected-Distro apply/invoke GO, or a production-seed exercise. Independent review of this successor is still required.

## AI / Tool Assistance

Assisted-by: Codex:glm-5.3-flash

A coding agent implemented the official-key pin, official-id bind, unsigned official-id Distro.toml and `.shuttle` refusals, changelog fragment, docs sentence, and focused tests. The maintainer owns the public trust boundary and reviewed the result against the Unicity CE Distro signing public key.

## Checklist

- [x] Linked issues
- [x] Changelog fragment added under `changes/995.changed.md`
- [ ] Independent review complete
- [ ] Ready to merge
