### PR TITLE
fix(cli): require preinstalled Distro signing pins

### DIFF
--- a/changes/995.changed.md
+++ b/changes/995.changed.md
@@ -1,6 +1,6 @@
-Distro signing-key trust is now generic and pin-first. A signed source
-or `.shuttle` verifies only against an already-installed matching
-per-distro pin; a missing pin fails closed without creating one, and
-`--accept-new-key` rotates only an existing differing pin. Product
-`astrid distro apply` remains signed-only, while ordinary third-party
-init and shuttle installs retain the explicit `--allow-unsigned` escape.
+Distro signing-key trust now distinguishes product and ordinary signed
+paths. Product `astrid distro apply` remains pin-first: a missing pin
+fails closed, even with `--accept-new-key`. Ordinary signed init and
+`.shuttle` installs restore first-use trust and write the pin. Existing
+matching pins still verify directly; differing pins require explicit
+rotation.

--- a/changes/995.changed.md
+++ b/changes/995.changed.md
@@ -1,6 +1,6 @@
-Official AOS releases bind the Unicity CE identity to the compiled-in
-official keys. A signed artifact claiming that identity under any other
-key fails closed before TOFU, without writing a trust pin, and unsigned
-manual or `.shuttle` installs cannot bypass the refusal with
-`--allow-unsigned`. `--accept-new-key` remains the explicit operator
-escape for a changed third-party pin.
+Distro signing-key trust is now generic and pin-first. A signed source
+or `.shuttle` verifies only against an already-installed matching
+per-distro pin; a missing pin fails closed without creating one, and
+`--accept-new-key` rotates only an existing differing pin. Product
+`astrid distro apply` remains signed-only, while ordinary third-party
+init and shuttle installs retain the explicit `--allow-unsigned` escape.

--- a/changes/995.changed.md
+++ b/changes/995.changed.md
@@ -3,4 +3,6 @@ paths. Product `astrid distro apply` remains pin-first: a missing pin
 fails closed, even with `--accept-new-key`. Ordinary signed init and
 `.shuttle` installs restore first-use trust and write the pin. Existing
 matching pins still verify directly; differing pins require explicit
-rotation.
+rotation. Unsigned `.shuttle` installs require the explicit
+`--allow-unsigned` opt-in; plain `Distro.toml` init remains unsigned by
+design.

--- a/changes/995.removed.md
+++ b/changes/995.removed.md
@@ -1,0 +1,3 @@
+Removed compiled official distro ids and official signing-key lists.
+Distro trust is now generic per-distro pin state with no runtime identity
+bound to a compiled vendor key set.

--- a/crates/astrid-cli/src/commands/distro/shuttle_install.rs
+++ b/crates/astrid-cli/src/commands/distro/shuttle_install.rs
@@ -79,6 +79,7 @@ pub(crate) async fn install_from_shuttle(
     // 3. Trust gate. A sealed `.shuttle` is a remote-origin artifact:
     //    a missing signature is refused unless --allow-unsigned.
     let signer = if let (Some(signing), Some(sig_hex)) = (&manifest.distro.signing, &sig) {
+        let policy = trust_policy(opts);
         let outcome = trust::verify_and_pin(
             &home,
             &distro_id,
@@ -86,6 +87,7 @@ pub(crate) async fn install_from_shuttle(
             sig_hex,
             &lock,
             opts.accept_new_key,
+            policy,
         )?;
         report_trust(&outcome);
         Some(outcome.key_str)
@@ -182,6 +184,15 @@ fn unsigned_shuttle_may_install(distro_id: &str, opts: &InitOpts) -> anyhow::Res
         );
     }
     Ok(())
+}
+
+/// Product apply is pin-first; ordinary signed shuttles may first-pin.
+fn trust_policy(opts: &InitOpts) -> trust::TrustPolicy {
+    if opts.require_signed {
+        trust::TrustPolicy::RequireExistingPin
+    } else {
+        trust::TrustPolicy::TofuFirstPin
+    }
 }
 
 /// Install each selected capsule from the verified mirror and return
@@ -328,6 +339,10 @@ fn report_trust(outcome: &trust::TrustOutcome) {
         trust::TrustAction::PinnedMatch => {
             format!("signature verified against pinned key {}", outcome.key_str)
         },
+        trust::TrustAction::ToFuTrusted => format!(
+            "trusting key {} on first use — verify it out of band",
+            outcome.key_str
+        ),
         trust::TrustAction::NewKeyAccepted => {
             format!(
                 "re-pinned to new key {} (--accept-new-key)",
@@ -428,6 +443,107 @@ mod tests {
         assert!(sign::verify_lock(&lock, &sig, &kp.export_public_key()).is_ok());
         // Capsule-hash gate.
         assert!(verify_capsule_hashes(&mirror, &lock).is_ok());
+    }
+
+    fn signed_shuttle_trust_inputs(
+        dir: &Path,
+        shuttle_path: &Path,
+    ) -> (
+        tempfile::TempDir,
+        DistroLock,
+        String,
+        String,
+        std::path::PathBuf,
+    ) {
+        let mirror = dir.join("trust-mirror");
+        shuttle::unpack(shuttle_path, &mirror).unwrap();
+        let manifest = std::fs::read_to_string(mirror.join(shuttle::MANIFEST_NAME)).unwrap();
+        let manifest = parse_manifest(&manifest).unwrap();
+        let lock_text = std::fs::read_to_string(mirror.join(shuttle::LOCK_NAME)).unwrap();
+        let lock: DistroLock = toml::from_str(&lock_text).unwrap();
+        let sig = std::fs::read_to_string(mirror.join(shuttle::SIG_NAME)).unwrap();
+        let home = tempfile::tempdir().unwrap();
+        let astrid_home = AstridHome::from_path(home.path());
+        let pin_path = astrid_home
+            .root()
+            .join("trust")
+            .join(format!("{}.pub", manifest.distro.id));
+        (
+            home,
+            lock,
+            sig,
+            manifest.distro.signing.unwrap().pubkey,
+            pin_path,
+        )
+    }
+
+    #[test]
+    fn ordinary_signed_shuttle_pins_on_first_use() {
+        let dir = tempfile::tempdir().unwrap();
+        let (shuttle_path, kp) = make_signed_shuttle(dir.path(), b"FAKE CAPSULE");
+        let (home, lock, sig, pubkey, pin_path) =
+            signed_shuttle_trust_inputs(dir.path(), &shuttle_path);
+        let opts = InitOpts {
+            require_signed: false,
+            ..Default::default()
+        };
+        let astrid_home = AstridHome::from_path(home.path());
+
+        let first = trust::verify_and_pin(
+            &astrid_home,
+            "test",
+            &pubkey,
+            &sig,
+            &lock,
+            false,
+            trust_policy(&opts),
+        )
+        .unwrap();
+        let second = trust::verify_and_pin(
+            &astrid_home,
+            "test",
+            &pubkey,
+            &sig,
+            &lock,
+            false,
+            trust_policy(&opts),
+        )
+        .unwrap();
+
+        assert_eq!(first.action, trust::TrustAction::ToFuTrusted);
+        assert_eq!(second.action, trust::TrustAction::PinnedMatch);
+        assert_eq!(
+            std::fs::read_to_string(&pin_path).unwrap(),
+            format!("{}\n", sign::pubkey_to_wire(&kp.export_public_key()))
+        );
+    }
+
+    #[test]
+    fn product_signed_shuttle_missing_pin_fails_closed() {
+        let dir = tempfile::tempdir().unwrap();
+        let (shuttle_path, _) = make_signed_shuttle(dir.path(), b"FAKE CAPSULE");
+        let (home, lock, sig, pubkey, pin_path) =
+            signed_shuttle_trust_inputs(dir.path(), &shuttle_path);
+        let opts = InitOpts {
+            require_signed: true,
+            accept_new_key: true,
+            ..Default::default()
+        };
+        let astrid_home = AstridHome::from_path(home.path());
+
+        let error = trust::verify_and_pin(
+            &astrid_home,
+            "test",
+            &pubkey,
+            &sig,
+            &lock,
+            opts.accept_new_key,
+            trust_policy(&opts),
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("no signing-key pin"));
+        assert!(!pin_path.exists());
     }
 
     #[test]

--- a/crates/astrid-cli/src/commands/distro/shuttle_install.rs
+++ b/crates/astrid-cli/src/commands/distro/shuttle_install.rs
@@ -174,16 +174,7 @@ pub(crate) async fn install_from_shuttle(
 }
 
 /// Decide whether an unsigned shuttle may proceed to the warning path.
-///
-/// The official-id gate comes first because `--allow-unsigned` is an
-/// escape for third-party development artifacts only.
 fn unsigned_shuttle_may_install(distro_id: &str, opts: &InitOpts) -> anyhow::Result<()> {
-    if trust::is_official_distro_id(distro_id) {
-        bail!(
-            "official distro '{distro_id}' cannot be installed from an unsigned .shuttle; \
-             --allow-unsigned is not accepted"
-        );
-    }
     if !opts.allow_unsigned {
         bail!(
             "shuttle for '{distro_id}' is unsigned (no [distro.signing] or Distro.sig) — \
@@ -337,13 +328,6 @@ fn report_trust(outcome: &trust::TrustOutcome) {
         trust::TrustAction::PinnedMatch => {
             format!("signature verified against pinned key {}", outcome.key_str)
         },
-        trust::TrustAction::OfficialPinned => {
-            format!("verified and pinned official key {}", outcome.key_str)
-        },
-        trust::TrustAction::ToFuTrusted => format!(
-            "trusting key {} on first use — verify it out of band",
-            outcome.key_str
-        ),
         trust::TrustAction::NewKeyAccepted => {
             format!(
                 "re-pinned to new key {} (--accept-new-key)",
@@ -533,21 +517,6 @@ mod tests {
         // against, so a missing manifest_hash is acceptable.
         let lock = lock_with_manifest_hash(None);
         assert!(check_manifest_binding("test", false, &lock, b"anything").is_ok());
-    }
-
-    #[test]
-    fn unsigned_official_shuttle_refuses_allow_unsigned() {
-        let opts = InitOpts {
-            allow_unsigned: true,
-            ..Default::default()
-        };
-
-        let err = unsigned_shuttle_may_install("unicity-ce", &opts).unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("cannot be installed from an unsigned .shuttle"),
-            "got: {err}"
-        );
     }
 
     #[test]

--- a/crates/astrid-cli/src/commands/distro/trust.rs
+++ b/crates/astrid-cli/src/commands/distro/trust.rs
@@ -1,8 +1,9 @@
 //! Distro signing-key trust store and verification policy.
 //!
-//! Trust is per-distro and pinned before use. The store lives at
-//! `~/.astrid/trust/<distro-id>.pub`, one file per distro, containing a
-//! single `ed25519:<base64>` line.
+//! Trust is per-distro. Product paths require the pin to exist before
+//! use; ordinary signed paths may create the first pin. The store lives
+//! at `$ASTRID_HOME/trust/<distro-id>.pub`, one file per distro,
+//! containing a single `ed25519:<base64>` line.
 //!
 //! ## Threat model
 //!
@@ -14,9 +15,10 @@
 //!   signature under a different key is a hard fail (defends against a
 //!   compromised-mirror swapping the maintainer key) unless the operator
 //!   explicitly opts in with `--accept-new-key`.
-//! - A **missing** pin is never created implicitly. This closes the
-//!   first-contact window: the operator installs the key out of band,
-//!   then installs the distro.
+//! - A **missing** pin fails closed on product paths. Ordinary signed
+//!   init and shuttle paths trust a valid first key on first use and
+//!   write the pin, while keeping the first-contact choice visible in
+//!   operator output.
 //!
 //! ## Not a chain of trust (yet)
 //!
@@ -38,9 +40,23 @@ use super::sign;
 pub(crate) enum TrustAction {
     /// Signature valid against the already-pinned key.
     PinnedMatch,
+    /// Ordinary signed path saw a valid key with no prior pin and wrote
+    /// the first pin.
+    ToFuTrusted,
     /// Signature valid but key differed from the pin; operator passed
     /// `--accept-new-key` → re-pinned.
     NewKeyAccepted,
+}
+
+/// Whether the verifier may create the first pin.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TrustPolicy {
+    /// Product and other explicit signed paths fail closed when no pin
+    /// exists; the operator installs it out of band first.
+    RequireExistingPin,
+    /// Ordinary signed init and shuttle paths may trust and pin the
+    /// first valid key.
+    TofuFirstPin,
 }
 
 /// Outcome of a successful trust check.
@@ -121,6 +137,7 @@ pub(crate) fn verify_and_pin(
     sig_hex: &str,
     lock: &DistroLock,
     accept_new_key: bool,
+    policy: TrustPolicy,
 ) -> anyhow::Result<TrustOutcome> {
     let pubkey = sign::parse_pubkey(manifest_pubkey)?;
     let key_str = sign::pubkey_to_wire(&pubkey);
@@ -146,12 +163,16 @@ pub(crate) fn verify_and_pin(
             write_pin(home, distro_id, &key_str)?;
             TrustAction::NewKeyAccepted
         },
-        None => {
+        None if policy == TrustPolicy::RequireExistingPin => {
             bail!(
                 "distro '{distro_id}' has no signing-key pin at {} — install the operator-verified \
                  key before use; this path does not create a first-use pin",
                 trust_path(home, distro_id).display()
             );
+        },
+        None => {
+            write_pin(home, distro_id, &key_str)?;
+            TrustAction::ToFuTrusted
         },
     };
 
@@ -239,6 +260,7 @@ mod tests {
             &sig,
             &lock,
             false,
+            TrustPolicy::RequireExistingPin,
         )
         .unwrap();
 
@@ -250,7 +272,7 @@ mod tests {
     }
 
     #[test]
-    fn missing_pin_fails_closed_without_writing_a_pin() {
+    fn product_missing_pin_fails_closed_without_writing_a_pin() {
         let (_d, home) = home();
         let kp = KeyPair::generate();
         let lock = sample_lock();
@@ -264,6 +286,7 @@ mod tests {
                 &sig,
                 &lock,
                 accept_new_key,
+                TrustPolicy::RequireExistingPin,
             )
             .unwrap_err();
             assert!(err.to_string().contains("no signing-key pin"), "got: {err}");
@@ -288,6 +311,7 @@ mod tests {
             &sig2,
             &lock,
             false,
+            TrustPolicy::RequireExistingPin,
         )
         .unwrap_err();
         assert!(err.to_string().contains("pinned"), "got: {err}");
@@ -313,6 +337,7 @@ mod tests {
             &sig2,
             &lock,
             true,
+            TrustPolicy::RequireExistingPin,
         )
         .unwrap();
         assert_eq!(out.action, TrustAction::NewKeyAccepted);
@@ -339,6 +364,7 @@ mod tests {
             &sig,
             &tampered,
             true, // even with override
+            TrustPolicy::RequireExistingPin,
         )
         .unwrap_err();
         assert!(err.to_string().contains("invalid"), "got: {err}");
@@ -382,9 +408,35 @@ mod tests {
                 &sig,
                 &tampered,
                 true,
+                TrustPolicy::RequireExistingPin,
             )
             .unwrap_err();
             assert!(err.to_string().contains("invalid"), "got: {err}");
         }
+    }
+
+    #[test]
+    fn ordinary_missing_pin_performs_first_use_tofu() {
+        let (_d, home) = home();
+        let kp = KeyPair::generate();
+        let lock = sample_lock();
+        let sig = sign::sign_lock(&lock, &kp).unwrap();
+
+        let out = verify_and_pin(
+            &home,
+            "test",
+            &sign::pubkey_to_wire(&kp.export_public_key()),
+            &sig,
+            &lock,
+            false,
+            TrustPolicy::TofuFirstPin,
+        )
+        .unwrap();
+
+        assert_eq!(out.action, TrustAction::ToFuTrusted);
+        assert_eq!(
+            read_pinned(&home, "test").unwrap().unwrap(),
+            kp.export_public_key()
+        );
     }
 }

--- a/crates/astrid-cli/src/commands/distro/trust.rs
+++ b/crates/astrid-cli/src/commands/distro/trust.rs
@@ -1,9 +1,8 @@
 //! Distro signing-key trust store and verification policy.
 //!
-//! Trust is per-distro and pinned on first use (TOFU), with a small set
-//! of compiled-in official keys that pin without prompting. The store
-//! lives at `~/.astrid/trust/<distro-id>.pub`, one file per distro,
-//! containing a single `ed25519:<base64>` line.
+//! Trust is per-distro and pinned before use. The store lives at
+//! `~/.astrid/trust/<distro-id>.pub`, one file per distro, containing a
+//! single `ed25519:<base64>` line.
 //!
 //! ## Threat model
 //!
@@ -15,9 +14,9 @@
 //!   signature under a different key is a hard fail (defends against a
 //!   compromised-mirror swapping the maintainer key) unless the operator
 //!   explicitly opts in with `--accept-new-key`.
-//! - An **official** key (compiled in) pins without prompting.
-//! - A **third-party** key with no prior pin is trusted on first use and
-//!   pinned, with the key reported so the operator can verify out of band.
+//! - A **missing** pin is never created implicitly. This closes the
+//!   first-contact window: the operator installs the key out of band,
+//!   then installs the distro.
 //!
 //! ## Not a chain of trust (yet)
 //!
@@ -34,28 +33,11 @@ use astrid_crypto::PublicKey;
 use super::lock::DistroLock;
 use super::sign;
 
-/// Built-in official signing keys. A key here pins
-/// without prompting on first use. Changing this set requires rebuilding
-/// the binary — that is the point: official trust is not runtime-mutable.
-///
-/// The release-authenticated AOS distribution key. Official trust is
-/// compiled in so first contact pins it without a TOFU window.
-const OFFICIAL_KEYS: &[&str] = &["ed25519:utH537RuOuqKwjGx/pHIUAkKapyqPUhHpZIVDU6Q0FA="];
-
-/// Distro ids whose release artifacts must be signed by an official key.
-/// Keeping this separate from the signing keys lets trust and the
-/// unsigned-source boundary reject identity spoofing before an install.
-const OFFICIAL_DISTRO_IDS: &[&str] = &["unicity-ce"];
-
 /// What the trust check decided.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum TrustAction {
     /// Signature valid against the already-pinned key.
     PinnedMatch,
-    /// No prior pin; key is an official key → verified and pinned.
-    OfficialPinned,
-    /// No prior pin; third-party key → trusted on first use and pinned.
-    ToFuTrusted,
     /// Signature valid but key differed from the pin; operator passed
     /// `--accept-new-key` → re-pinned.
     NewKeyAccepted,
@@ -93,7 +75,7 @@ fn read_pinned(home: &AstridHome, distro_id: &str) -> anyhow::Result<Option<Publ
 }
 
 /// Pin `key_str` for `distro_id`, atomically.
-fn pin(home: &AstridHome, distro_id: &str, key_str: &str) -> anyhow::Result<()> {
+fn write_pin(home: &AstridHome, distro_id: &str, key_str: &str) -> anyhow::Result<()> {
     let path = trust_path(home, distro_id);
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)
@@ -120,38 +102,6 @@ fn pin(home: &AstridHome, distro_id: &str, key_str: &str) -> anyhow::Result<()> 
     Ok(())
 }
 
-/// Is `key_str` one of the compiled-in official keys?
-fn is_official(key_str: &str) -> bool {
-    OFFICIAL_KEYS.contains(&key_str)
-}
-
-/// Is this a release distro id that refuses the unsigned manual path?
-pub(crate) fn is_official_distro_id(distro_id: &str) -> bool {
-    OFFICIAL_DISTRO_IDS.contains(&distro_id)
-}
-
-fn classify_unpinned_key(key_str: &str) -> TrustAction {
-    if is_official(key_str) {
-        TrustAction::OfficialPinned
-    } else {
-        TrustAction::ToFuTrusted
-    }
-}
-
-/// Official identity is bound to the compiled-in keys, not to TOFU.
-///
-/// This deliberately runs before the trust store is consulted so an
-/// unofficial key cannot become (or replace) an official id's pin, even
-/// with the operator override.
-fn ensure_official_id_key(distro_id: &str, key_str: &str) -> anyhow::Result<()> {
-    if is_official_distro_id(distro_id) && !is_official(key_str) {
-        bail!(
-            "official distro '{distro_id}' accepts only compiled-in official signing keys; \
-             refusing non-official key {key_str}"
-        );
-    }
-    Ok(())
-}
 /// Verify a sealed distro's signature and apply the trust policy.
 ///
 /// `manifest_pubkey` is the `[distro.signing].pubkey` declared in the
@@ -162,6 +112,7 @@ fn ensure_official_id_key(distro_id: &str, key_str: &str) -> anyhow::Result<()> 
 ///
 /// - signature does not verify (no override),
 /// - key differs from the pin and `accept_new_key` is false,
+/// - no trust pin exists,
 /// - malformed key/signature.
 pub(crate) fn verify_and_pin(
     home: &AstridHome,
@@ -179,8 +130,6 @@ pub(crate) fn verify_and_pin(
     sign::verify_lock(lock, sig_hex, &pubkey)
         .context("distro signature is invalid — refusing to install")?;
 
-    ensure_official_id_key(distro_id, &key_str)?;
-
     let pinned = read_pinned(home, distro_id)?;
     let action = match pinned {
         Some(pin_key) if pin_key == pubkey => TrustAction::PinnedMatch,
@@ -194,17 +143,15 @@ pub(crate) fn verify_and_pin(
                     key_str,
                 );
             }
-            pin(home, distro_id, &key_str)?;
+            write_pin(home, distro_id, &key_str)?;
             TrustAction::NewKeyAccepted
         },
-        None if is_official(&key_str) => {
-            pin(home, distro_id, &key_str)?;
-            TrustAction::OfficialPinned
-        },
         None => {
-            // TOFU: pin and report.
-            pin(home, distro_id, &key_str)?;
-            classify_unpinned_key(&key_str)
+            bail!(
+                "distro '{distro_id}' has no signing-key pin at {} — install the operator-verified \
+                 key before use; this path does not create a first-use pin",
+                trust_path(home, distro_id).display()
+            );
         },
     };
 
@@ -266,90 +213,26 @@ mod tests {
         }
     }
 
-    #[test]
-    fn tofu_pins_on_first_use() {
-        let (_d, home) = home();
-        let kp = KeyPair::generate();
-        let pubkey = sign::pubkey_to_wire(&kp.export_public_key());
-        let lock = sample_lock();
-        let sig = sign::sign_lock(&lock, &kp).unwrap();
-
-        let out = verify_and_pin(&home, "test", &pubkey, &sig, &lock, false).unwrap();
-        assert_eq!(out.action, TrustAction::ToFuTrusted);
-        // Pinned now.
-        assert_eq!(
-            read_pinned(&home, "test").unwrap().unwrap(),
-            kp.export_public_key()
-        );
-    }
-
-    #[test]
-    fn official_key_is_pinned_not_tofu() {
-        assert_eq!(
-            classify_unpinned_key(OFFICIAL_KEYS[0]),
-            TrustAction::OfficialPinned
-        );
-    }
-
-    #[test]
-    fn official_release_id_is_signed_only() {
-        assert!(is_official_distro_id("unicity-ce"));
-        assert!(!is_official_distro_id("test"));
-    }
-
-    #[test]
-    fn official_id_rejects_unofficial_key_before_tofu() {
-        let (_dir, home) = home();
-        let kp = KeyPair::generate();
-        let mut lock = sample_lock();
-        lock.distro.id = "unicity-ce".into();
-        let sig = sign::sign_lock(&lock, &kp).unwrap();
-
-        // The valid signature and operator override must not let a rogue
-        // key claim the official id.
-        let err = verify_and_pin(
-            &home,
-            "unicity-ce",
-            &sign::pubkey_to_wire(&kp.export_public_key()),
-            &sig,
-            &lock,
-            true,
+    fn seed_pin(home: &AstridHome, distro_id: &str, kp: &KeyPair) {
+        let path = home.root().join("trust").join(format!("{distro_id}.pub"));
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &path,
+            format!("{}\n", sign::pubkey_to_wire(&kp.export_public_key())),
         )
-        .unwrap_err();
-
-        assert!(
-            err.to_string()
-                .contains("accepts only compiled-in official signing keys"),
-            "got: {err}"
-        );
-        assert!(
-            read_pinned(&home, "unicity-ce").unwrap().is_none(),
-            "a failed official-id claim must not write a trust pin"
-        );
+        .unwrap();
     }
 
     #[test]
-    fn pinned_match_proceeds() {
+    fn existing_matching_pin_verifies_without_implicit_write() {
         let (_d, home) = home();
         let kp = KeyPair::generate();
-        let pubkey = sign::pubkey_to_wire(&kp.export_public_key());
+        seed_pin(&home, "test", &kp);
+        let before = std::fs::read_to_string(trust_path(&home, "test")).unwrap();
         let lock = sample_lock();
         let sig = sign::sign_lock(&lock, &kp).unwrap();
 
-        verify_and_pin(&home, "test", &pubkey, &sig, &lock, false).unwrap();
-        let out = verify_and_pin(&home, "test", &pubkey, &sig, &lock, false).unwrap();
-        assert_eq!(out.action, TrustAction::PinnedMatch);
-    }
-
-    #[test]
-    fn wrong_pinned_key_hard_fails_without_override() {
-        let (_d, home) = home();
-        let kp = KeyPair::generate();
-        let lock = sample_lock();
-
-        // Pin kp first.
-        let sig = sign::sign_lock(&lock, &kp).unwrap();
-        verify_and_pin(
+        let out = verify_and_pin(
             &home,
             "test",
             &sign::pubkey_to_wire(&kp.export_public_key()),
@@ -358,6 +241,42 @@ mod tests {
             false,
         )
         .unwrap();
+
+        assert_eq!(out.action, TrustAction::PinnedMatch);
+        assert_eq!(
+            std::fs::read_to_string(trust_path(&home, "test")).unwrap(),
+            before
+        );
+    }
+
+    #[test]
+    fn missing_pin_fails_closed_without_writing_a_pin() {
+        let (_d, home) = home();
+        let kp = KeyPair::generate();
+        let lock = sample_lock();
+        let sig = sign::sign_lock(&lock, &kp).unwrap();
+
+        for accept_new_key in [false, true] {
+            let err = verify_and_pin(
+                &home,
+                "test",
+                &sign::pubkey_to_wire(&kp.export_public_key()),
+                &sig,
+                &lock,
+                accept_new_key,
+            )
+            .unwrap_err();
+            assert!(err.to_string().contains("no signing-key pin"), "got: {err}");
+            assert!(!trust_path(&home, "test").exists());
+        }
+    }
+
+    #[test]
+    fn wrong_pinned_key_hard_fails_without_override() {
+        let (_d, home) = home();
+        let kp = KeyPair::generate();
+        let lock = sample_lock();
+        seed_pin(&home, "test", &kp);
 
         // A different key, validly signing, must be refused.
         let kp2 = KeyPair::generate();
@@ -372,6 +291,10 @@ mod tests {
         )
         .unwrap_err();
         assert!(err.to_string().contains("pinned"), "got: {err}");
+        assert_eq!(
+            read_pinned(&home, "test").unwrap().unwrap(),
+            kp.export_public_key()
+        );
     }
 
     #[test]
@@ -379,16 +302,7 @@ mod tests {
         let (_d, home) = home();
         let kp = KeyPair::generate();
         let lock = sample_lock();
-        let sig = sign::sign_lock(&lock, &kp).unwrap();
-        verify_and_pin(
-            &home,
-            "test",
-            &sign::pubkey_to_wire(&kp.export_public_key()),
-            &sig,
-            &lock,
-            false,
-        )
-        .unwrap();
+        seed_pin(&home, "test", &kp);
 
         let kp2 = KeyPair::generate();
         let sig2 = sign::sign_lock(&lock, &kp2).unwrap();
@@ -428,5 +342,49 @@ mod tests {
         )
         .unwrap_err();
         assert!(err.to_string().contains("invalid"), "got: {err}");
+    }
+
+    #[test]
+    fn signed_lock_substitution_fails_without_override() {
+        let (_d, home) = home();
+        let kp = KeyPair::generate();
+        seed_pin(&home, "test", &kp);
+        let lock = sample_lock();
+        let sig = sign::sign_lock(&lock, &kp).unwrap();
+
+        let wrong_hash = {
+            let mut tampered = sample_lock();
+            tampered.manifest_hash = Some("blake3:TAMPERED".into());
+            tampered
+        };
+        let wrong_member_hash = {
+            let mut tampered = sample_lock();
+            tampered.capsules[0].hash = "blake3:TAMPERED".into();
+            tampered
+        };
+        let extra_member = {
+            let mut tampered = sample_lock();
+            tampered.capsules.push(LockedCapsule {
+                name: "extra".into(),
+                version: "0.1.0".into(),
+                source: "@org/extra".into(),
+                hash: "blake3:abc".into(),
+                resolved_ref: Some("v0.1.0".into()),
+            });
+            tampered
+        };
+
+        for tampered in [wrong_hash, wrong_member_hash, extra_member] {
+            let err = verify_and_pin(
+                &home,
+                "test",
+                &sign::pubkey_to_wire(&kp.export_public_key()),
+                &sig,
+                &tampered,
+                true,
+            )
+            .unwrap_err();
+            assert!(err.to_string().contains("invalid"), "got: {err}");
+        }
     }
 }

--- a/crates/astrid-cli/src/commands/init_signed_source.rs
+++ b/crates/astrid-cli/src/commands/init_signed_source.rs
@@ -286,6 +286,7 @@ fn verify_signed_manifest(
         sig_hex,
         lock,
         accept_new_key,
+        trust::TrustPolicy::RequireExistingPin,
     )?;
     tracing::info!(
         distro = %manifest.distro.id,

--- a/crates/astrid-cli/src/commands/init_signed_source.rs
+++ b/crates/astrid-cli/src/commands/init_signed_source.rs
@@ -61,17 +61,10 @@ pub(super) async fn prepare_distro_source(
     }
     if opts.require_signed {
         return Ok(PreparedDistro::Signed(
-            fetch_signed_manifest(distro_source, opts.offline, home).await?,
+            fetch_signed_manifest(distro_source, opts.offline, opts.accept_new_key, home).await?,
         ));
     }
     let (manifest_bytes, manifest) = fetch_manifest_bytes(distro_source, opts.offline).await?;
-    if trust::is_official_distro_id(&manifest.distro.id) {
-        bail!(
-            "official distro '{}' cannot be installed from unsigned Distro.toml; \
-             use a signed release artifact",
-            manifest.distro.id
-        );
-    }
     Ok(PreparedDistro::Manifest {
         manifest,
         manifest_hash: manifest_hash(&manifest_bytes),
@@ -177,6 +170,7 @@ fn parse_manifest_bytes(bytes: Vec<u8>) -> anyhow::Result<(Vec<u8>, DistroManife
 async fn fetch_signed_manifest(
     source: &str,
     offline: bool,
+    accept_new_key: bool,
     home: &AstridHome,
 ) -> anyhow::Result<SignedDistroBundle> {
     let (manifest_bytes, manifest) = fetch_manifest_bytes(source, offline).await?;
@@ -195,8 +189,14 @@ async fn fetch_signed_manifest(
         "Distro.sig exceeds size limit"
     );
     let sig_hex = std::str::from_utf8(&sig_bytes).context("Distro.sig is not valid UTF-8")?;
-    let pinned_refs =
-        verify_signed_manifest(home, &manifest, &manifest_hash, &lock, sig_hex, false)?;
+    let pinned_refs = verify_signed_manifest(
+        home,
+        &manifest,
+        &manifest_hash,
+        &lock,
+        sig_hex,
+        accept_new_key,
+    )?;
 
     Ok(SignedDistroBundle {
         manifest,

--- a/crates/astrid-cli/src/commands/init_tests.rs
+++ b/crates/astrid-cli/src/commands/init_tests.rs
@@ -178,7 +178,9 @@ fn distro_source_resolution_full_url() {
 
 use super::super::distro::manifest::{DistroCapsule, VariableDef};
 
-fn signed_source_fixture(dir: &std::path::Path) -> (std::path::PathBuf, Vec<u8>, String) {
+fn signed_source_fixture(
+    dir: &std::path::Path,
+) -> (std::path::PathBuf, Vec<u8>, String, astrid_crypto::KeyPair) {
     let keypair = astrid_crypto::KeyPair::generate();
     let pubkey = super::super::distro::sign::pubkey_to_wire(&keypair.export_public_key());
     let bytes = format!(
@@ -213,14 +215,22 @@ fn signed_source_fixture(dir: &std::path::Path) -> (std::path::PathBuf, Vec<u8>,
     )
     .unwrap();
     std::fs::write(dir.join("Distro.sig"), sig).unwrap();
-    (dir.join("Distro.toml"), bytes, manifest_hash)
+    (dir.join("Distro.toml"), bytes, manifest_hash, keypair)
+}
+
+fn seed_pin(home: &AstridHome, keypair: &astrid_crypto::KeyPair) {
+    let trust_dir = home.root().join("trust");
+    std::fs::create_dir_all(&trust_dir).unwrap();
+    let pubkey = super::super::distro::sign::pubkey_to_wire(&keypair.export_public_key());
+    std::fs::write(trust_dir.join("test.pub"), format!("{pubkey}\n")).unwrap();
 }
 
 #[test]
 fn product_source_prepares_signed_distro_toml_without_shuttle_suffix() {
     let dir = tempfile::tempdir().unwrap();
     let home = AstridHome::from_path(dir.path().join("home"));
-    let (source, bytes, expected_hash) = signed_source_fixture(dir.path());
+    let (source, bytes, expected_hash, keypair) = signed_source_fixture(dir.path());
+    seed_pin(&home, &keypair);
     let opts = InitOpts {
         require_signed: true,
         offline: true,
@@ -241,6 +251,64 @@ fn product_source_prepares_signed_distro_toml_without_shuttle_suffix() {
     assert_eq!(
         bundle.lock.manifest_hash.as_deref(),
         Some(expected_hash.as_str())
+    );
+}
+
+#[test]
+fn product_source_missing_pin_fails_closed_without_writing_a_pin() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(dir.path().join("home"));
+    let (source, _, _, _) = signed_source_fixture(dir.path());
+
+    for accept_new_key in [false, true] {
+        let opts = InitOpts {
+            require_signed: true,
+            offline: true,
+            accept_new_key,
+            ..Default::default()
+        };
+
+        let error = futures::executor::block_on(super::signed_source::prepare_distro_source(
+            source.to_str().unwrap(),
+            &opts,
+            &home,
+        ))
+        .unwrap_err();
+        assert!(
+            error.to_string().contains("no signing-key pin"),
+            "got: {error:#}"
+        );
+    }
+    assert!(!home.root().join("trust").join("test.pub").exists());
+}
+
+#[test]
+fn product_source_rotates_only_an_existing_differing_pin() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(dir.path().join("home"));
+    let (source, _, _, keypair) = signed_source_fixture(dir.path());
+    seed_pin(&home, &astrid_crypto::KeyPair::generate());
+    let opts = InitOpts {
+        require_signed: true,
+        offline: true,
+        accept_new_key: true,
+        ..Default::default()
+    };
+
+    futures::executor::block_on(super::signed_source::prepare_distro_source(
+        source.to_str().unwrap(),
+        &opts,
+        &home,
+    ))
+    .unwrap();
+
+    let rotated = std::fs::read_to_string(home.root().join("trust").join("test.pub")).unwrap();
+    assert_eq!(
+        rotated,
+        format!(
+            "{}\n",
+            super::super::distro::sign::pubkey_to_wire(&keypair.export_public_key())
+        )
     );
 }
 
@@ -270,38 +338,10 @@ fn product_source_rejects_unsigned_distro_toml_before_install_state() {
 }
 
 #[test]
-fn official_distro_rejects_unsigned_distro_toml() {
-    let dir = tempfile::tempdir().unwrap();
-    let home = AstridHome::from_path(dir.path().join("home"));
-    std::fs::write(
-        dir.path().join("Distro.toml"),
-        "schema-version = 1\n\n[distro]\nid = \"unicity-ce\"\nname = \"Unicity CE\"\nversion = \"0.1.0\"\n\n\
-         [[capsule]]\nname = \"cli\"\nsource = \"@org/cli\"\nversion = \"0.1.0\"\nrole = \"uplink\"\n",
-    )
-    .unwrap();
-    let opts = InitOpts {
-        require_signed: false,
-        offline: true,
-        ..Default::default()
-    };
-
-    let error = futures::executor::block_on(super::signed_source::prepare_distro_source(
-        dir.path().join("Distro.toml").to_str().unwrap(),
-        &opts,
-        &home,
-    ))
-    .unwrap_err();
-    assert!(
-        error.to_string().contains("official distro 'unicity-ce'"),
-        "got: {error:#}"
-    );
-}
-
-#[test]
 fn product_source_rejects_tampered_distro_toml_bytes() {
     let dir = tempfile::tempdir().unwrap();
     let home = AstridHome::from_path(dir.path().join("home"));
-    let (source, bytes, _) = signed_source_fixture(dir.path());
+    let (source, bytes, _, _) = signed_source_fixture(dir.path());
     let mut tampered = bytes.clone();
     tampered.extend_from_slice(b"\n# tampered after sealing\n");
     std::fs::write(&source, tampered).unwrap();
@@ -327,7 +367,7 @@ fn product_source_rejects_tampered_distro_toml_bytes() {
 fn product_source_rejects_tampered_signature() {
     let dir = tempfile::tempdir().unwrap();
     let home = AstridHome::from_path(dir.path().join("home"));
-    let (source, _, _) = signed_source_fixture(dir.path());
+    let (source, _, _, _) = signed_source_fixture(dir.path());
     std::fs::write(dir.path().join("Distro.sig"), "00").unwrap();
     let opts = InitOpts {
         require_signed: true,
@@ -348,7 +388,7 @@ fn product_source_rejects_tampered_signature() {
 fn signed_lock_cannot_add_undeclared_member() {
     let dir = tempfile::tempdir().unwrap();
     let home = AstridHome::from_path(dir.path().join("home"));
-    let (source, bytes, expected_hash) = signed_source_fixture(dir.path());
+    let (source, bytes, expected_hash, _) = signed_source_fixture(dir.path());
     let keypair = astrid_crypto::KeyPair::generate();
     let lock = super::super::distro::lock::DistroLock {
         schema_version: 1,

--- a/docs/distro-signing.md
+++ b/docs/distro-signing.md
@@ -39,18 +39,19 @@ identity makes repeated composition reproducible and reusable through Muninn.
 Private secrets and per-principal writable state are excluded from the shared
 image and remain separate principal-owned roots.
 
-## 2. Trust: pre-installed pins and rotation
+## 2. Trust: pins, first use, and rotation
 
-Trust is per-distro and lives at `~/.astrid/trust/<distro-id>.pub` (one
+Trust is per-distro and lives at `$ASTRID_HOME/trust/<distro-id>.pub` (one
 pinned `ed25519:<base64>` per distro id):
 
-- **Before first install** → install the operator-verified key at the
-  trust path. The verifier never creates a pin on first contact.
+- **Product `astrid distro apply`** → install the operator-verified key
+  at the trust path before use. A missing pin fails closed, even with
+  `--accept-new-key`.
+- **Ordinary signed init or `.shuttle`** → a valid key with no prior pin
+  is trusted on first use, written to the trust path, and reported.
 - **A later install signed by a *different* key** → hard fail. Re-pin
   only with `--accept-new-key`, and only if you trust the new key.
 - **An invalid signature** → hard fail, no override.
-- **A missing pin** → hard fail for every signed path, including product
-  `astrid distro apply`.
 
 This catches a *key swap* (attacker uses their own key). It does **not**
 catch *key theft* (attacker uses the real stolen key) — for that, see §6
@@ -115,9 +116,11 @@ Consumers install with `astrid init --distro ./example-distro-0.1.0.shuttle`.
 ### 3.5 Publish the trust pin
 
 Publish the exact `ed25519:<base64>` value through an out-of-band
-channel your operators trust. Before installing, each operator writes
-that one line to `~/.astrid/trust/<distro-id>.pub`. Do not mail the key
-through the same channel that serves the release.
+channel your operators trust. Product operators write that one line to
+`$ASTRID_HOME/trust/<distro-id>.pub` before install (`~/.astrid` is the
+default example). Ordinary signed installs can create this pin on first
+use. Do not mail the key through the same channel that serves the
+release.
 
 ## 4. Operator: installing a signed distro
 
@@ -142,7 +145,7 @@ Relevant flags:
 | `--yes` | Non-interactive: take group defaults, resolve variables from `--var` / `ASTRID_VAR_<KEY>` / manifest defaults, error if a required one is unset. |
 | `--offline` | Forbid all network. A non-local capsule source is a hard error. |
 | `--allow-unsigned` | For an ordinary third-party init or `.shuttle`, install a distro that ships no signature (see §5). Product `astrid distro apply` rejects it. |
-| `--accept-new-key` | Re-pin when a valid signature is under a key different from an existing pin. A missing pin still fails closed. |
+| `--accept-new-key` | Re-pin when a valid signature is under a key different from an existing pin. A missing pin fails closed on product Apply. |
 
 ## 5. Is signing optional?
 
@@ -157,7 +160,7 @@ Yes — layered, and fail-closed where it matters:
   weakens trust — it forces the consumer to opt into the risk.
 - **Product Apply:** signed-only. `--allow-unsigned` is rejected, and a
   signed artifact is installed only when its key already matches the
-  operator-installed pin. No signed path performs TOFU.
+  operator-installed pin. Product Apply performs no TOFU.
 
 ## 6. The strong guarantee: vendor the `.shuttle`
 

--- a/docs/distro-signing.md
+++ b/docs/distro-signing.md
@@ -39,18 +39,18 @@ identity makes repeated composition reproducible and reusable through Muninn.
 Private secrets and per-principal writable state are excluded from the shared
 image and remain separate principal-owned roots.
 
-## 2. Trust: TOFU, pinning, official keys
+## 2. Trust: pre-installed pins and rotation
 
 Trust is per-distro and lives at `~/.astrid/trust/<distro-id>.pub` (one
 pinned `ed25519:<base64>` per distro id):
 
-- **First install of a third-party distro** → trust-on-first-use: the
-  key is pinned and reported so you can verify it out of band.
-- **Official distros** → their key is compiled into the `astrid` binary
-  (`OFFICIAL_KEYS`) and pins on first contact with no TOFU window.
+- **Before first install** → install the operator-verified key at the
+  trust path. The verifier never creates a pin on first contact.
 - **A later install signed by a *different* key** → hard fail. Re-pin
   only with `--accept-new-key`, and only if you trust the new key.
 - **An invalid signature** → hard fail, no override.
+- **A missing pin** → hard fail for every signed path, including product
+  `astrid distro apply`.
 
 This catches a *key swap* (attacker uses their own key). It does **not**
 catch *key theft* (attacker uses the real stolen key) — for that, see §6
@@ -112,12 +112,12 @@ rejected by `seal` — those require building from source. Pin a
 Attach the `.shuttle` to the GitHub release (or host it anywhere).
 Consumers install with `astrid init --distro ./example-distro-0.1.0.shuttle`.
 
-### 3.5 Make it an *official* key (first-contact pinning)
+### 3.5 Publish the trust pin
 
-To let consumers pin your key on their very first install (no TOFU
-window), add the same `ed25519:<base64>` to the `OFFICIAL_KEYS` table in
-the `astrid` source and ship a new binary; the current official key is
-`ed25519:utH537RuOuqKwjGx/pHIUAkKapyqPUhHpZIVDU6Q0FA=`.
+Publish the exact `ed25519:<base64>` value through an out-of-band
+channel your operators trust. Before installing, each operator writes
+that one line to `~/.astrid/trust/<distro-id>.pub`. Do not mail the key
+through the same channel that serves the release.
 
 ## 4. Operator: installing a signed distro
 
@@ -135,14 +135,14 @@ tampered, unsigned, or mismatched bundle installs nothing. Capsule
 installation itself is sequential and not transactional, so a failure
 partway through can leave earlier capsules installed.
 
-Relevant flags (also on `astrid distro apply`):
+Relevant flags:
 
 | Flag | Effect |
 |------|--------|
 | `--yes` | Non-interactive: take group defaults, resolve variables from `--var` / `ASTRID_VAR_<KEY>` / manifest defaults, error if a required one is unset. |
 | `--offline` | Forbid all network. A non-local capsule source is a hard error. |
-| `--allow-unsigned` | Install a distro that ships no signature (see §5). |
-| `--accept-new-key` | Re-pin when a valid signature is under a key different from the pinned one. |
+| `--allow-unsigned` | For an ordinary third-party init or `.shuttle`, install a distro that ships no signature (see §5). Product `astrid distro apply` rejects it. |
+| `--accept-new-key` | Re-pin when a valid signature is under a key different from an existing pin. A missing pin still fails closed. |
 
 ## 5. Is signing optional?
 
@@ -151,14 +151,13 @@ Yes — layered, and fail-closed where it matters:
 - **Producing:** optional. No `[distro.signing]` / no `--key` → an
   unsigned distro. Local development (`astrid init --distro ./Distro.toml`) stays
   frictionless.
-- **Consuming:** fail-closed. A sealed/remote artifact with no signature
-  is **refused** unless the operator passes `--allow-unsigned`. Skipping
-  signing never silently weakens trust — it forces the consumer to opt
-  into the risk.
-- **Official distros:** effectively mandatory — official distro ids
-  accept only keys compiled into `OFFICIAL_KEYS`, and an unsigned build
-  under that id is refused. A non-official key claiming an official id
-  fails closed even with `--accept-new-key`.
+- **Consuming ordinary artifacts:** fail-closed by default. A
+  sealed/remote artifact with no signature is **refused** unless the
+  operator passes `--allow-unsigned`. Skipping signing never silently
+  weakens trust — it forces the consumer to opt into the risk.
+- **Product Apply:** signed-only. `--allow-unsigned` is rejected, and a
+  signed artifact is installed only when its key already matches the
+  operator-installed pin. No signed path performs TOFU.
 
 ## 6. The strong guarantee: vendor the `.shuttle`
 

--- a/docs/distro-signing.md
+++ b/docs/distro-signing.md
@@ -144,7 +144,7 @@ Relevant flags:
 |------|--------|
 | `--yes` | Non-interactive: take group defaults, resolve variables from `--var` / `ASTRID_VAR_<KEY>` / manifest defaults, error if a required one is unset. |
 | `--offline` | Forbid all network. A non-local capsule source is a hard error. |
-| `--allow-unsigned` | For an ordinary third-party init or `.shuttle`, install a distro that ships no signature (see §5). Product `astrid distro apply` rejects it. |
+| `--allow-unsigned` | For an ordinary `.shuttle`, install a distro archive that ships no signature (see §5). Ordinary plain-TOML init does not consult this flag. Product `astrid distro apply` rejects it. |
 | `--accept-new-key` | Re-pin when a valid signature is under a key different from an existing pin. A missing pin fails closed on product Apply. |
 
 ## 5. Is signing optional?
@@ -154,10 +154,12 @@ Yes — layered, and fail-closed where it matters:
 - **Producing:** optional. No `[distro.signing]` / no `--key` → an
   unsigned distro. Local development (`astrid init --distro ./Distro.toml`) stays
   frictionless.
-- **Consuming ordinary artifacts:** fail-closed by default. A
-  sealed/remote artifact with no signature is **refused** unless the
+- **Consuming unsigned `.shuttle`:** fail-closed by default. An
+  ordinary `.shuttle` that ships no signature is **refused** unless the
   operator passes `--allow-unsigned`. Skipping signing never silently
-  weakens trust — it forces the consumer to opt into the risk.
+  weakens this path — it forces the consumer to opt into the risk.
+- **Plain `Distro.toml` init:** remains unsigned by design. It does not
+  consult `--allow-unsigned`.
 - **Product Apply:** signed-only. `--allow-unsigned` is rejected, and a
   signed artifact is installed only when its key already matches the
   operator-installed pin. Product Apply performs no TOFU.


### PR DESCRIPTION
## Linked Issue

Related to #995. This change does not close that issue; the broader distro-blessed versus permission-required manual-install model remains open. Changelog fragments are `changes/995.changed.md` and newly added `changes/995.removed.md`. Traceability exception: no-issue, because closing #995 would over-claim remaining trust-model work.

## Summary

Remove compiled vendor Distro identities and keys from Astrid. Signed Distro verification stays generic: `Distro.sig` over `Distro.lock` covering exact `Distro.toml` bytes and member hashes, checked against `$ASTRID_HOME/trust/<distro-id>.pub` (`~/.astrid` is the default home).

Product `astrid distro apply` remains signed-only and pin-first: a missing pin fails closed, including with `--accept-new-key`, and does not create a pin. Ordinary signed init/`.shuttle` restores first-use trust and writes the pin. Existing matching pins continue as a pin match. `--accept-new-key` rotates only an existing differing pin. `--allow-unsigned` is the unsigned `.shuttle` escape only, is rejected on product apply, and does not gate ordinary plain-`Distro.toml` init (that path remains unsigned by design).

## Changes

- Deletes compiled official keys, official Distro ids, and official-id special cases.
- Splits trust policy: product/`require_signed` paths require an existing matching pin; ordinary signed shuttle/init may create the first pin.
- Product `astrid distro apply` still rejects `--allow-unsigned`.
- Documents that `--allow-unsigned` applies only to unsigned `.shuttle` archives and that plain `Distro.toml` init remains unsigned by design.
- Updates `docs/distro-signing.md` and #995 changelog fragments without closing #995.

## Verification

- Head `31db0e5abc257a6bc40b1e91028470693ea5b119`; parent `74137df210e449342bce91f8404be8c0f223ce02`; base `origin/main` `52885e8a85c0e63ea4d8ac1f962d6bf84a3bae52`.
- Unique range is the Distro trust/docs/test/changelog files above. Unique added lines contain no vendor Distro ids or compiled keys.
- `git verify-commit` good, full trust, DCO present.
- Focused coverage includes product missing-pin fail-closed (including `--accept-new-key`), ordinary signed-shuttle first-use trust, existing-pin success, mismatched-pin fail-closed, rotation of an existing pin, invalid signature, and signed-content substitution.

## Claim boundary

This does not provision operator pins, authenticate an AOS release, or prove selected-Distro apply/invoke. Independent exact-head review is still required.

## AI / Tool Assistance

Assisted-by: Codex:glm-5.3-flash

A coding agent implemented the generic Distro trust correction, changelog fragments, docs update, and focused tests. The maintainer owns the public trust boundary and reviewed the unique range against the no-vendor-identity contract.

## Checklist

- [x] Linked issues
- [x] Changelog fragment added under `changes/995.removed.md`
- [ ] Independent review complete
- [ ] Ready to merge
