### PR TITLE
fix(distro): resolve relative local capsule members

### DIFF
--- a/changes/1195.changed.md
+++ b/changes/1195.changed.md
@@ -1,0 +1,5 @@
+Authenticated signed `Distro.toml` files can now declare relative
+`capsules/*.capsule` members. Seal and apply resolve those archives from the
+authenticated manifest directory, fail closed on missing, non-regular, or
+escaping paths, and preserve the exact signed manifest and signature bytes.
+GitHub `@org/repo` capsule sources remain unchanged. Closes #1195

--- a/changes/1195.changed.md
+++ b/changes/1195.changed.md
@@ -4,4 +4,4 @@ authenticated manifest directory, fail closed on missing, non-regular, or
 escaping paths, and preserve the exact signed manifest and signature bytes.
 Bare `Distro.toml` paths are rooted in the current directory before seal or
 signed apply resolves their members.
-GitHub `@org/repo` capsule sources remain unchanged. Closes #1195
+Relative `../bundle/Distro.toml` manifests can resolve their local members without losing traversal or 50 MB protections. GitHub `@org/repo` capsule sources remain unchanged. Closes #1195

--- a/changes/1195.changed.md
+++ b/changes/1195.changed.md
@@ -2,4 +2,6 @@ Authenticated signed `Distro.toml` files can now declare relative
 `capsules/*.capsule` members. Seal and apply resolve those archives from the
 authenticated manifest directory, fail closed on missing, non-regular, or
 escaping paths, and preserve the exact signed manifest and signature bytes.
+Bare `Distro.toml` paths are rooted in the current directory before seal or
+signed apply resolves their members.
 GitHub `@org/repo` capsule sources remain unchanged. Closes #1195

--- a/changes/1195.fixed.md
+++ b/changes/1195.fixed.md
@@ -2,3 +2,9 @@
 from the kernel-admitted signed Distro lock. The new `self:distro:grant`
 operation is lock-digest fenced, fail-closed, resumable, and distinct from
 capsule installation.
+
+Authenticated signed `Distro.toml` files can now declare relative
+`capsules/*.capsule` members. Seal and apply resolve those archives from the
+authenticated manifest directory, fail closed on missing, non-regular, or
+escaping paths, and preserve the exact signed manifest and signature bytes.
+GitHub `@org/repo` capsule sources remain unchanged. Closes #1195

--- a/changes/1195.fixed.md
+++ b/changes/1195.fixed.md
@@ -2,9 +2,3 @@
 from the kernel-admitted signed Distro lock. The new `self:distro:grant`
 operation is lock-digest fenced, fail-closed, resumable, and distinct from
 capsule installation.
-
-Authenticated signed `Distro.toml` files can now declare relative
-`capsules/*.capsule` members. Seal and apply resolve those archives from the
-authenticated manifest directory, fail closed on missing, non-regular, or
-escaping paths, and preserve the exact signed manifest and signature bytes.
-GitHub `@org/repo` capsule sources remain unchanged. Closes #1195

--- a/crates/astrid-cli/src/commands/distro/local_source.rs
+++ b/crates/astrid-cli/src/commands/distro/local_source.rs
@@ -11,6 +11,26 @@ pub(crate) fn is_local_capsule_source(source: &str) -> bool {
     source.ends_with(".capsule") && !source.contains("://") && parse_github_source(source).is_none()
 }
 
+/// Root a local authenticated manifest in the caller's current directory.
+///
+/// A bare `Distro.toml` has an empty parent, so resolve the authenticated
+/// path once before any sibling or member resolution.
+pub(crate) fn normalize_authenticated_manifest_path(
+    manifest_path: &Path,
+) -> anyhow::Result<PathBuf> {
+    if manifest_path.is_absolute() {
+        return Ok(manifest_path.to_path_buf());
+    }
+
+    let current_dir = std::env::current_dir().with_context(|| {
+        format!(
+            "failed to resolve current directory for authenticated manifest {}",
+            manifest_path.display()
+        )
+    })?;
+    Ok(current_dir.join(manifest_path))
+}
+
 /// Resolve a local `.capsule` member against the authenticated manifest.
 ///
 /// `Ok(None)` means the source belongs to the caller's remote resolver.
@@ -84,6 +104,14 @@ mod tests {
             .unwrap()
             .join("capsules/member.capsule");
         assert_eq!(resolved, expected);
+    }
+
+    #[test]
+    fn normalizes_bare_manifest_path_to_current_directory() {
+        let current_dir = std::env::current_dir().unwrap();
+        let manifest_path =
+            normalize_authenticated_manifest_path(Path::new("Distro.toml")).unwrap();
+        assert_eq!(manifest_path, current_dir.join("Distro.toml"));
     }
 
     #[test]

--- a/crates/astrid-cli/src/commands/distro/local_source.rs
+++ b/crates/astrid-cli/src/commands/distro/local_source.rs
@@ -1,0 +1,159 @@
+//! Manifest-relative capsule archive resolution.
+
+use std::path::{Component, Path, PathBuf};
+
+use anyhow::{Context, bail};
+use astrid_capsule_install::github_source::parse_github_source;
+
+/// Whether a capsule source is resolved from the authenticated manifest's
+/// filesystem root rather than GitHub.
+pub(crate) fn is_local_capsule_source(source: &str) -> bool {
+    source.ends_with(".capsule") && !source.contains("://") && parse_github_source(source).is_none()
+}
+
+/// Resolve a local `.capsule` member against the authenticated manifest.
+///
+/// `Ok(None)` means the source belongs to the caller's remote resolver.
+/// The returned path is canonicalized so the subsequent copy and hash cover
+/// the same filesystem object that passed containment checks.
+pub(crate) fn resolve_local_capsule_archive(
+    source: &str,
+    manifest_path: Option<&Path>,
+) -> anyhow::Result<Option<PathBuf>> {
+    if !is_local_capsule_source(source) {
+        return Ok(None);
+    }
+    let Some(manifest_path) = manifest_path else {
+        bail!(
+            "local capsule source {source:?} requires a local authenticated Distro.toml; \
+             remote manifests cannot resolve relative members"
+        );
+    };
+
+    let root = manifest_path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("Distro.toml has no parent directory"))?;
+    let source_path = Path::new(source);
+    let candidate = if source_path.is_absolute() {
+        source_path.to_path_buf()
+    } else {
+        root.join(source_path)
+    };
+    if candidate
+        .components()
+        .any(|component| matches!(component, Component::ParentDir))
+    {
+        bail!("local capsule source {source:?} escapes the authenticated Distro.toml directory");
+    }
+
+    let canonical_root = root
+        .canonicalize()
+        .with_context(|| format!("failed to resolve Distro.toml directory {}", root.display()))?;
+    let canonical_path = candidate
+        .canonicalize()
+        .with_context(|| format!("failed to resolve local capsule source {source:?}"))?;
+    if !canonical_path.starts_with(&canonical_root) {
+        bail!("local capsule source {source:?} escapes the authenticated Distro.toml directory");
+    }
+    let metadata = std::fs::metadata(&canonical_path)
+        .with_context(|| format!("failed to stat local capsule source {source:?}"))?;
+    if !metadata.is_file() {
+        bail!("local capsule source {source:?} is not a regular file");
+    }
+
+    Ok(Some(canonical_path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_relative_member_from_manifest_parent() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = dir.path().join("Distro.toml");
+        std::fs::create_dir_all(dir.path().join("capsules")).unwrap();
+        std::fs::write(dir.path().join("capsules/member.capsule"), b"member").unwrap();
+
+        let resolved = resolve_local_capsule_archive("capsules/member.capsule", Some(&manifest))
+            .unwrap()
+            .unwrap();
+        let expected = dir
+            .path()
+            .canonicalize()
+            .unwrap()
+            .join("capsules/member.capsule");
+        assert_eq!(resolved, expected);
+    }
+
+    #[test]
+    fn missing_relative_member_fails_closed() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = dir.path().join("Distro.toml");
+        std::fs::write(&manifest, "schema-version = 1\n").unwrap();
+
+        let err =
+            resolve_local_capsule_archive("capsules/missing.capsule", Some(&manifest)).unwrap_err();
+        assert!(err.to_string().contains("missing.capsule"));
+    }
+
+    #[test]
+    fn traversal_fails_closed() {
+        let dir = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let manifest = dir.path().join("nested/Distro.toml");
+        std::fs::create_dir_all(manifest.parent().unwrap()).unwrap();
+        std::fs::write(&manifest, "schema-version = 1\n").unwrap();
+        std::fs::write(outside.path().join("outside.capsule"), b"outside").unwrap();
+
+        let err = resolve_local_capsule_archive("../outside.capsule", Some(&manifest)).unwrap_err();
+        assert!(err.to_string().contains("escapes"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_escape_fails_closed() {
+        let dir = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let manifest = dir.path().join("Distro.toml");
+        std::fs::write(&manifest, "schema-version = 1\n").unwrap();
+        std::fs::create_dir_all(dir.path().join("capsules")).unwrap();
+        std::fs::write(outside.path().join("outside.capsule"), b"outside").unwrap();
+        std::os::unix::fs::symlink(
+            outside.path().join("outside.capsule"),
+            dir.path().join("capsules/member.capsule"),
+        )
+        .unwrap();
+
+        let err =
+            resolve_local_capsule_archive("capsules/member.capsule", Some(&manifest)).unwrap_err();
+        assert!(err.to_string().contains("escapes"));
+    }
+
+    #[test]
+    fn non_regular_archive_fails_closed() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = dir.path().join("Distro.toml");
+        std::fs::write(&manifest, "schema-version = 1\n").unwrap();
+        std::fs::create_dir_all(dir.path().join("capsules/member.capsule")).unwrap();
+
+        let err =
+            resolve_local_capsule_archive("capsules/member.capsule", Some(&manifest)).unwrap_err();
+        assert!(err.to_string().contains("not a regular file"));
+    }
+
+    #[test]
+    fn github_source_remains_remote() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = dir.path().join("Distro.toml");
+
+        let resolved = resolve_local_capsule_archive("@org/repo", Some(&manifest)).unwrap();
+        assert_eq!(resolved, None);
+    }
+
+    #[test]
+    fn local_member_on_remote_manifest_fails_closed() {
+        let err = resolve_local_capsule_archive("capsules/member.capsule", None).unwrap_err();
+        assert!(err.to_string().contains("local authenticated Distro.toml"));
+    }
+}

--- a/crates/astrid-cli/src/commands/distro/local_source.rs
+++ b/crates/astrid-cli/src/commands/distro/local_source.rs
@@ -5,6 +5,8 @@ use std::path::{Component, Path, PathBuf};
 use anyhow::{Context, bail};
 use astrid_capsule_install::github_source::parse_github_source;
 
+use super::shuttle::MAX_MEMBER_BYTES;
+
 /// Whether a capsule source is resolved from the authenticated manifest's
 /// filesystem root rather than GitHub.
 pub(crate) fn is_local_capsule_source(source: &str) -> bool {
@@ -59,7 +61,7 @@ pub(crate) fn resolve_local_capsule_archive(
     } else {
         root.join(source_path)
     };
-    if candidate
+    if source_path
         .components()
         .any(|component| matches!(component, Component::ParentDir))
     {
@@ -79,6 +81,13 @@ pub(crate) fn resolve_local_capsule_archive(
         .with_context(|| format!("failed to stat local capsule source {source:?}"))?;
     if !metadata.is_file() {
         bail!("local capsule source {source:?} is not a regular file");
+    }
+    if metadata.len() > MAX_MEMBER_BYTES {
+        bail!(
+            "local capsule source {source:?} is {} bytes, exceeding the \
+             {MAX_MEMBER_BYTES}-byte member limit",
+            metadata.len()
+        );
     }
 
     Ok(Some(canonical_path))
@@ -136,6 +145,44 @@ mod tests {
 
         let err = resolve_local_capsule_archive("../outside.capsule", Some(&manifest)).unwrap_err();
         assert!(err.to_string().contains("escapes"));
+    }
+
+    #[test]
+    fn resolves_member_when_manifest_path_contains_parent_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = dir.path().join("cwd/../bundle/Distro.toml");
+        std::fs::create_dir_all(dir.path().join("cwd")).unwrap();
+        std::fs::create_dir_all(dir.path().join("bundle/capsules")).unwrap();
+        std::fs::write(&manifest, "schema-version = 1\n").unwrap();
+        std::fs::write(dir.path().join("bundle/capsules/member.capsule"), b"member").unwrap();
+
+        let resolved = resolve_local_capsule_archive("capsules/member.capsule", Some(&manifest))
+            .unwrap()
+            .unwrap();
+        let expected = dir
+            .path()
+            .canonicalize()
+            .unwrap()
+            .join("bundle/capsules/member.capsule");
+        assert_eq!(resolved, expected);
+    }
+
+    #[test]
+    fn oversized_member_fails_closed() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = dir.path().join("Distro.toml");
+        std::fs::create_dir_all(dir.path().join("capsules")).unwrap();
+        std::fs::write(&manifest, "schema-version = 1\n").unwrap();
+        let archive = dir.path().join("capsules/member.capsule");
+        let file = std::fs::File::create(&archive).unwrap();
+        file.set_len(MAX_MEMBER_BYTES + 1).unwrap();
+        drop(file);
+
+        let staging = tempfile::tempdir().unwrap();
+        let err =
+            resolve_local_capsule_archive("capsules/member.capsule", Some(&manifest)).unwrap_err();
+        assert!(err.to_string().contains("member limit"), "got: {err}");
+        assert!(!staging.path().join("member.capsule").exists());
     }
 
     #[cfg(unix)]

--- a/crates/astrid-cli/src/commands/distro/mod.rs
+++ b/crates/astrid-cli/src/commands/distro/mod.rs
@@ -4,6 +4,7 @@
 //! The lockfile (`Distro.lock`) pins exact resolved versions and BLAKE3 hashes
 //! for reproducible installs.
 
+pub(crate) mod local_source;
 pub(crate) mod lock;
 pub(crate) mod manifest;
 pub(crate) mod seal;

--- a/crates/astrid-cli/src/commands/distro/seal.rs
+++ b/crates/astrid-cli/src/commands/distro/seal.rs
@@ -14,6 +14,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, bail};
 
+use super::local_source::normalize_authenticated_manifest_path;
 use super::local_source::resolve_local_capsule_archive;
 use super::lock::{DistroLock, DistroLockMeta, LockedCapsule, manifest_hash};
 use super::manifest::{DistroCapsule, DistroManifest, parse_manifest};
@@ -29,7 +30,7 @@ use crate::theme::Theme;
 /// file holding the 32 raw ed25519 secret-key bytes.
 pub(crate) async fn run_seal(distro: &str, output: &Path, key: &Path) -> anyhow::Result<()> {
     // 1. Load the manifest, keeping the verbatim bytes for hashing.
-    let manifest_path = resolve_manifest_path(distro)?;
+    let manifest_path = normalize_authenticated_manifest_path(&resolve_manifest_path(distro)?)?;
     let manifest_bytes = std::fs::read(&manifest_path)
         .with_context(|| format!("failed to read {}", manifest_path.display()))?;
     let manifest_text =
@@ -208,6 +209,40 @@ fn load_signing_key(path: &Path) -> anyhow::Result<astrid_crypto::KeyPair> {
 mod tests {
     use super::*;
 
+    struct CurrentDirGuard(PathBuf);
+
+    impl CurrentDirGuard {
+        fn set(path: &Path) -> Self {
+            let original = std::env::current_dir().unwrap();
+            std::env::set_current_dir(path).unwrap();
+            Self(original)
+        }
+    }
+
+    fn run_bare_cwd_child(child_name: &str, marker: &str) {
+        let result_dir = tempfile::tempdir().unwrap();
+        let result_path = result_dir.path().join("result");
+        let output = std::process::Command::new(std::env::current_exe().unwrap())
+            .args(["--exact", "--nocapture", child_name])
+            .env("ASTRID_BARE_CWD_TEST", "1")
+            .env("ASTRID_BARE_CWD_RESULT", &result_path)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "child failed: {}\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(std::fs::read_to_string(result_path).unwrap(), marker);
+    }
+
+    impl Drop for CurrentDirGuard {
+        fn drop(&mut self) {
+            std::env::set_current_dir(&self.0).unwrap();
+        }
+    }
+
     #[test]
     fn load_signing_key_rejects_wrong_length() {
         let dir = tempfile::tempdir().unwrap();
@@ -226,7 +261,18 @@ mod tests {
     }
 
     #[test]
-    fn seal_resolves_local_members_from_manifest_parent() {
+    fn seal_resolves_local_members_from_bare_manifest_path_in_cwd() {
+        run_bare_cwd_child(
+            "commands::distro::seal::tests::seal_bare_manifest_path_child",
+            "BARE_MANIFEST_SEAL_OK",
+        );
+    }
+
+    #[test]
+    fn seal_bare_manifest_path_child() {
+        if std::env::var("ASTRID_BARE_CWD_TEST").as_deref() != Ok("1") {
+            return;
+        }
         let dir = tempfile::tempdir().unwrap();
         let output_dir = tempfile::tempdir().unwrap();
         let capsule_bytes = b"local capsule bytes".to_vec();
@@ -246,9 +292,9 @@ mod tests {
         let key = dir.path().join("fixture.key");
         std::fs::write(&key, keypair.secret_key_bytes()).unwrap();
 
-        // The test process cwd is the package directory, not `dir`.
+        let _current_dir = CurrentDirGuard::set(dir.path());
         futures::executor::block_on(run_seal(
-            dir.path().join("Distro.toml").to_str().unwrap(),
+            "Distro.toml",
             &output_dir.path().join("local.shuttle"),
             &key,
         ))
@@ -274,6 +320,11 @@ mod tests {
         sign::verify_lock(&lock, &sig, &keypair.export_public_key()).unwrap();
         let packed = std::fs::read(shuttle::capsule_mirror_path(mirror.path(), "member")).unwrap();
         assert_eq!(packed, capsule_bytes);
+        std::fs::write(
+            std::env::var("ASTRID_BARE_CWD_RESULT").unwrap(),
+            "BARE_MANIFEST_SEAL_OK",
+        )
+        .unwrap();
     }
 
     #[test]

--- a/crates/astrid-cli/src/commands/distro/seal.rs
+++ b/crates/astrid-cli/src/commands/distro/seal.rs
@@ -14,8 +14,9 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, bail};
 
+use super::local_source::resolve_local_capsule_archive;
 use super::lock::{DistroLock, DistroLockMeta, LockedCapsule, manifest_hash};
-use super::manifest::{DistroManifest, parse_manifest};
+use super::manifest::{DistroCapsule, DistroManifest, parse_manifest};
 use super::shuttle::{self, ShuttleContent, ShuttleEntry};
 use super::sign;
 use crate::commands::capsule::install::resolve_capsule_to_file;
@@ -57,20 +58,9 @@ pub(crate) async fn run_seal(distro: &str, output: &Path, key: &Path) -> anyhow:
     for cap in &manifest.capsules {
         eprintln!("  resolving {} ({})", cap.name, cap.source);
         let dest = capsules_stage.join(format!("{}.capsule", cap.name));
-        // The ref recorded in the lock is the one resolution ACTUALLY
-        // returned (GitHub's release `tag_name`), never a guess derived
-        // from the manifest's declared fields — so a signed shuttle's
-        // lock attests the ref that was truly fetched. The `name` hint
-        // selects the right `<name>.capsule` when a source ships several.
-        let resolved_ref = resolve_capsule_to_file(
-            &cap.source,
-            (!cap.version.is_empty()).then_some(cap.version.as_str()),
-            cap.tag.as_deref(),
-            Some(&cap.name),
-            &dest,
-        )
-        .await
-        .with_context(|| format!("failed to resolve capsule {}", cap.name))?;
+        let resolved_ref = stage_capsule(cap, &manifest_path, &dest)
+            .await
+            .with_context(|| format!("failed to resolve capsule {}", cap.name))?;
 
         // Hash the staged file once for the lock. The capsule bytes are NOT
         // held in memory beyond this — `pack` streams the staged file in
@@ -86,7 +76,7 @@ pub(crate) async fn run_seal(distro: &str, output: &Path, key: &Path) -> anyhow:
             version: cap.version.clone(),
             source: cap.source.clone(),
             hash,
-            resolved_ref: Some(resolved_ref),
+            resolved_ref,
         });
         capsule_entries.push(ShuttleEntry {
             path: shuttle::capsule_member_path(&cap.name),
@@ -148,6 +138,39 @@ pub(crate) async fn run_seal(distro: &str, output: &Path, key: &Path) -> anyhow:
     Ok(())
 }
 
+/// Stage one manifest member, preferring authenticated local archives.
+async fn stage_capsule(
+    capsule: &DistroCapsule,
+    manifest_path: &Path,
+    dest: &Path,
+) -> anyhow::Result<Option<String>> {
+    if let Some(local_source) = resolve_local_capsule_archive(&capsule.source, Some(manifest_path))?
+    {
+        std::fs::copy(&local_source, dest).with_context(|| {
+            format!(
+                "failed to copy local capsule from {}",
+                local_source.display()
+            )
+        })?;
+        return Ok(None);
+    }
+
+    // The ref recorded in the lock is the one resolution ACTUALLY
+    // returned (GitHub's release `tag_name`), never a guess derived
+    // from the manifest's declared fields — so a signed shuttle's
+    // lock attests the ref that was truly fetched. The `name` hint
+    // selects the right `<name>.capsule` when a source ships several.
+    resolve_capsule_to_file(
+        &capsule.source,
+        (!capsule.version.is_empty()).then_some(capsule.version.as_str()),
+        capsule.tag.as_deref(),
+        Some(&capsule.name),
+        dest,
+    )
+    .await
+    .map(Some)
+}
+
 /// Resolve a seal `distro` argument to a `Distro.toml` path.
 fn resolve_manifest_path(distro: &str) -> anyhow::Result<PathBuf> {
     let p = Path::new(distro);
@@ -200,5 +223,88 @@ mod tests {
         std::fs::write(dir.path().join("Distro.toml"), "x").unwrap();
         let p = resolve_manifest_path(dir.path().to_str().unwrap()).unwrap();
         assert!(p.ends_with("Distro.toml"));
+    }
+
+    #[test]
+    fn seal_resolves_local_members_from_manifest_parent() {
+        let dir = tempfile::tempdir().unwrap();
+        let output_dir = tempfile::tempdir().unwrap();
+        let capsule_bytes = b"local capsule bytes".to_vec();
+        std::fs::create_dir_all(dir.path().join("capsules")).unwrap();
+        std::fs::write(dir.path().join("capsules/member.capsule"), &capsule_bytes).unwrap();
+
+        let keypair = astrid_crypto::KeyPair::generate();
+        let pubkey = sign::pubkey_to_wire(&keypair.export_public_key());
+        let manifest = format!(
+            "schema-version = 1\n\n\
+             [distro]\nid = \"local-test\"\nname = \"Local Test\"\nversion = \"0.1.0\"\n\n\
+             [distro.signing]\npubkey = \"{pubkey}\"\n\n\
+             [[capsule]]\nname = \"member\"\nsource = \"capsules/member.capsule\"\n\
+             version = \"1.0.0\"\nrole = \"uplink\"\n"
+        );
+        std::fs::write(dir.path().join("Distro.toml"), &manifest).unwrap();
+        let key = dir.path().join("fixture.key");
+        std::fs::write(&key, keypair.secret_key_bytes()).unwrap();
+
+        // The test process cwd is the package directory, not `dir`.
+        futures::executor::block_on(run_seal(
+            dir.path().join("Distro.toml").to_str().unwrap(),
+            &output_dir.path().join("local.shuttle"),
+            &key,
+        ))
+        .unwrap();
+
+        let mirror = tempfile::tempdir().unwrap();
+        shuttle::unpack(&output_dir.path().join("local.shuttle"), mirror.path()).unwrap();
+        let sealed_manifest = std::fs::read(mirror.path().join(shuttle::MANIFEST_NAME)).unwrap();
+        assert_eq!(sealed_manifest, manifest.into_bytes());
+        let lock: DistroLock = toml::from_str(
+            &std::fs::read_to_string(mirror.path().join(shuttle::LOCK_NAME)).unwrap(),
+        )
+        .unwrap();
+        let expected_hash = format!("blake3:{}", blake3::hash(&capsule_bytes).to_hex());
+        assert_eq!(lock.capsules[0].source, "capsules/member.capsule");
+        assert_eq!(lock.capsules[0].hash, expected_hash);
+        assert_eq!(lock.capsules[0].resolved_ref, None);
+        assert_eq!(
+            lock.manifest_hash.as_deref(),
+            Some(manifest_hash(&sealed_manifest).as_str())
+        );
+        let sig = std::fs::read_to_string(mirror.path().join(shuttle::SIG_NAME)).unwrap();
+        sign::verify_lock(&lock, &sig, &keypair.export_public_key()).unwrap();
+        let packed = std::fs::read(shuttle::capsule_mirror_path(mirror.path(), "member")).unwrap();
+        assert_eq!(packed, capsule_bytes);
+    }
+
+    #[test]
+    fn seal_fails_closed_when_relative_member_is_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let keypair = astrid_crypto::KeyPair::generate();
+        let pubkey = sign::pubkey_to_wire(&keypair.export_public_key());
+        std::fs::write(
+            dir.path().join("Distro.toml"),
+            format!(
+                "schema-version = 1\n\n\
+                 [distro]\nid = \"local-test\"\nname = \"Local Test\"\nversion = \"0.1.0\"\n\n\
+                 [distro.signing]\npubkey = \"{pubkey}\"\n\n\
+                 [[capsule]]\nname = \"member\"\nsource = \"capsules/member.capsule\"\n\
+                 version = \"1.0.0\"\nrole = \"uplink\"\n"
+            ),
+        )
+        .unwrap();
+        let key = dir.path().join("fixture.key");
+        std::fs::write(&key, keypair.secret_key_bytes()).unwrap();
+
+        let err = futures::executor::block_on(run_seal(
+            dir.path().join("Distro.toml").to_str().unwrap(),
+            &dir.path().join("missing.shuttle"),
+            &key,
+        ))
+        .unwrap_err();
+        assert!(
+            format!("{err:#}").contains("member.capsule"),
+            "got: {err:#}"
+        );
+        assert!(!dir.path().join("missing.shuttle").exists());
     }
 }

--- a/crates/astrid-cli/src/commands/distro/seal.rs
+++ b/crates/astrid-cli/src/commands/distro/seal.rs
@@ -358,4 +358,61 @@ mod tests {
         );
         assert!(!dir.path().join("missing.shuttle").exists());
     }
+
+    #[test]
+    fn seal_resolves_member_from_parent_manifest_path() {
+        run_bare_cwd_child(
+            "commands::distro::seal::tests::seal_resolves_member_from_parent_manifest_path_child",
+            "PARENT_MANIFEST_SEAL_OK",
+        );
+    }
+
+    #[test]
+    fn seal_resolves_member_from_parent_manifest_path_child() {
+        if std::env::var("ASTRID_BARE_CWD_TEST").as_deref() != Ok("1") {
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let bundle = dir.path().join("bundle");
+        let cwd = dir.path().join("cwd");
+        let capsule_bytes = b"local capsule bytes".to_vec();
+        std::fs::create_dir_all(bundle.join("capsules")).unwrap();
+        std::fs::create_dir_all(&cwd).unwrap();
+        std::fs::write(bundle.join("capsules/member.capsule"), &capsule_bytes).unwrap();
+
+        let keypair = astrid_crypto::KeyPair::generate();
+        let pubkey = sign::pubkey_to_wire(&keypair.export_public_key());
+        let manifest = format!(
+            "schema-version = 1\n\n\
+             [distro]\nid = \"local-test\"\nname = \"Local Test\"\nversion = \"0.1.0\"\n\n\
+             [distro.signing]\npubkey = \"{pubkey}\"\n\n\
+             [[capsule]]\nname = \"member\"\nsource = \"capsules/member.capsule\"\n\
+             version = \"1.0.0\"\nrole = \"uplink\"\n"
+        );
+        std::fs::write(bundle.join("Distro.toml"), &manifest).unwrap();
+        let key = bundle.join("fixture.key");
+        std::fs::write(&key, keypair.secret_key_bytes()).unwrap();
+
+        let _current_dir = CurrentDirGuard::set(&cwd);
+        let output = dir.path().join("local.shuttle");
+        futures::executor::block_on(run_seal("../bundle/Distro.toml", &output, &key)).unwrap();
+
+        let mirror = tempfile::tempdir().unwrap();
+        shuttle::unpack(&output, mirror.path()).unwrap();
+        let sealed_manifest = std::fs::read(mirror.path().join(shuttle::MANIFEST_NAME)).unwrap();
+        assert_eq!(sealed_manifest, manifest.into_bytes());
+        let lock: DistroLock = toml::from_str(
+            &std::fs::read_to_string(mirror.path().join(shuttle::LOCK_NAME)).unwrap(),
+        )
+        .unwrap();
+        let expected_hash = format!("blake3:{}", blake3::hash(&capsule_bytes).to_hex());
+        assert_eq!(lock.capsules[0].hash, expected_hash);
+        let packed = std::fs::read(shuttle::capsule_mirror_path(mirror.path(), "member")).unwrap();
+        assert_eq!(packed, capsule_bytes);
+        std::fs::write(
+            std::env::var("ASTRID_BARE_CWD_RESULT").unwrap(),
+            "PARENT_MANIFEST_SEAL_OK",
+        )
+        .unwrap();
+    }
 }

--- a/crates/astrid-cli/src/commands/distro/shuttle.rs
+++ b/crates/astrid-cli/src/commands/distro/shuttle.rs
@@ -43,7 +43,7 @@ pub(crate) const CAPSULES_DIR: &str = "capsules";
 
 /// Upper bound on a single unpacked `.shuttle` member (50 MB), matching
 /// the capsule-download ceiling. Defends against decompression bombs.
-const MAX_MEMBER_BYTES: u64 = 50 * 1024 * 1024;
+pub(crate) const MAX_MEMBER_BYTES: u64 = 50 * 1024 * 1024;
 
 /// Whether a member of `len` bytes is within the per-member size cap.
 ///

--- a/crates/astrid-cli/src/commands/init.rs
+++ b/crates/astrid-cli/src/commands/init.rs
@@ -183,7 +183,7 @@ pub(crate) async fn run_init(distro_source: &str, opts: &InitOpts) -> anyhow::Re
     let selected = if let Some(bundle) = &signed_bundle {
         let staging = tempfile::tempdir().context("create signed capsule staging")?;
         let resolved =
-            signed_source::resolve_signed_capsules(&selected, &bundle.lock, staging.path()).await?;
+            signed_source::resolve_signed_capsules(&selected, bundle, staging.path()).await?;
         // Keep the verified artifacts alive through the install below.
         _capsule_staging = Some(staging);
         resolved

--- a/crates/astrid-cli/src/commands/init_signed_source.rs
+++ b/crates/astrid-cli/src/commands/init_signed_source.rs
@@ -6,7 +6,9 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, bail};
 use astrid_core::dirs::AstridHome;
 
-use super::super::distro::local_source::resolve_local_capsule_archive;
+use super::super::distro::local_source::{
+    normalize_authenticated_manifest_path, resolve_local_capsule_archive,
+};
 use super::super::distro::lock::{DistroLock, manifest_hash};
 use super::super::distro::manifest::{DistroCapsule, DistroManifest, parse_manifest};
 use super::super::distro::trust;
@@ -184,10 +186,17 @@ async fn fetch_signed_manifest(
     home: &AstridHome,
 ) -> anyhow::Result<SignedDistroBundle> {
     let source_path = PathBuf::from(source);
-    let local_manifest_path = source_path.is_file().then_some(source_path);
-    let (manifest_bytes, manifest) = fetch_manifest_bytes(source, offline).await?;
+    let local_manifest_path = source_path
+        .is_file()
+        .then(|| normalize_authenticated_manifest_path(&source_path))
+        .transpose()?;
+    let source = local_manifest_path
+        .as_deref()
+        .and_then(Path::to_str)
+        .map_or_else(|| source.to_owned(), str::to_owned);
+    let (manifest_bytes, manifest) = fetch_manifest_bytes(&source, offline).await?;
     let manifest_hash = manifest_hash(&manifest_bytes);
-    let lock_bytes = fetch_signed_member(source, offline, "Distro.lock").await?;
+    let lock_bytes = fetch_signed_member(&source, offline, "Distro.lock").await?;
     anyhow::ensure!(
         lock_bytes.len() <= 1024 * 1024,
         "Distro.lock exceeds 1 MB limit"
@@ -195,7 +204,7 @@ async fn fetch_signed_manifest(
     let lock_text = std::str::from_utf8(&lock_bytes).context("Distro.lock is not valid UTF-8")?;
     let lock: DistroLock =
         toml::from_str(lock_text).context("failed to parse signed Distro.lock")?;
-    let sig_bytes = fetch_signed_member(source, offline, "Distro.sig").await?;
+    let sig_bytes = fetch_signed_member(&source, offline, "Distro.sig").await?;
     anyhow::ensure!(
         sig_bytes.len() <= 64 * 1024,
         "Distro.sig exceeds size limit"

--- a/crates/astrid-cli/src/commands/init_signed_source.rs
+++ b/crates/astrid-cli/src/commands/init_signed_source.rs
@@ -30,10 +30,10 @@ pub(super) struct SignedDistroBundle {
 pub(super) enum PreparedDistro {
     Shuttle,
     Manifest {
-        manifest: DistroManifest,
+        manifest: Box<DistroManifest>,
         manifest_hash: String,
     },
-    Signed(SignedDistroBundle),
+    Signed(Box<SignedDistroBundle>),
 }
 
 /// Split an authenticated source into its install inputs.
@@ -45,10 +45,10 @@ pub(super) fn unpack_prepared(
         PreparedDistro::Manifest {
             manifest,
             manifest_hash,
-        } => (manifest, manifest_hash, None),
+        } => (*manifest, manifest_hash, None),
         PreparedDistro::Signed(bundle) => {
             let manifest = bundle.manifest.clone();
-            (manifest, bundle.manifest_hash.clone(), Some(bundle))
+            (manifest, bundle.manifest_hash.clone(), Some(*bundle))
         },
     }
 }
@@ -63,13 +63,13 @@ pub(super) async fn prepare_distro_source(
         return Ok(PreparedDistro::Shuttle);
     }
     if opts.require_signed {
-        return Ok(PreparedDistro::Signed(
+        return Ok(PreparedDistro::Signed(Box::new(
             fetch_signed_manifest(distro_source, opts.offline, opts.accept_new_key, home).await?,
-        ));
+        )));
     }
     let (manifest_bytes, manifest) = fetch_manifest_bytes(distro_source, opts.offline).await?;
     Ok(PreparedDistro::Manifest {
-        manifest,
+        manifest: Box::new(manifest),
         manifest_hash: manifest_hash(&manifest_bytes),
     })
 }

--- a/crates/astrid-cli/src/commands/init_signed_source.rs
+++ b/crates/astrid-cli/src/commands/init_signed_source.rs
@@ -1,11 +1,12 @@
 //! Authenticate selected Distro sources before `init` mutates runtime state.
 
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, bail};
 use astrid_core::dirs::AstridHome;
 
+use super::super::distro::local_source::resolve_local_capsule_archive;
 use super::super::distro::lock::{DistroLock, manifest_hash};
 use super::super::distro::manifest::{DistroCapsule, DistroManifest, parse_manifest};
 use super::super::distro::trust;
@@ -20,6 +21,8 @@ pub(super) struct SignedDistroBundle {
     pub(super) manifest_hash: String,
     /// Maintainer-resolved refs from the signed lock, keyed by capsule name.
     pub(super) pinned_refs: HashMap<String, String>,
+    /// The local manifest whose parent authenticates relative members.
+    pub(super) manifest_path: Option<PathBuf>,
 }
 
 /// A source after authentication and before runtime mutation.
@@ -74,10 +77,11 @@ pub(super) async fn prepare_distro_source(
 /// Resolve each member to bytes and prove those bytes match the signed lock.
 pub(super) async fn resolve_signed_capsules(
     selected: &[DistroCapsule],
-    lock: &DistroLock,
+    bundle: &SignedDistroBundle,
     staging: &Path,
 ) -> anyhow::Result<Vec<DistroCapsule>> {
-    let signed_by_name: HashMap<&str, &super::super::distro::lock::LockedCapsule> = lock
+    let signed_by_name: HashMap<&str, &super::super::distro::lock::LockedCapsule> = bundle
+        .lock
         .capsules
         .iter()
         .map(|capsule| (capsule.name.as_str(), capsule))
@@ -92,9 +96,17 @@ pub(super) async fn resolve_signed_capsules(
             })?;
         let pinned_tag = signed.resolved_ref.as_deref().or(capsule.tag.as_deref());
         let archive_path = staging.join(format!("{}.capsule", capsule.name));
-        if is_local_capsule_archive(&capsule.source) {
-            std::fs::copy(&capsule.source, &archive_path)
-                .with_context(|| format!("copy signed capsule {}", capsule.name))?;
+        if let Some(local_source) =
+            resolve_local_capsule_archive(&capsule.source, bundle.manifest_path.as_deref())
+                .with_context(|| format!("resolve signed capsule {}", capsule.name))?
+        {
+            std::fs::copy(&local_source, &archive_path).with_context(|| {
+                format!(
+                    "copy signed capsule {} from {}",
+                    capsule.name,
+                    local_source.display()
+                )
+            })?;
         } else {
             if capsule.source.starts_with('.') || capsule.source.starts_with('/') {
                 bail!(
@@ -116,22 +128,20 @@ pub(super) async fn resolve_signed_capsules(
         let bytes = std::fs::read(&archive_path)
             .with_context(|| format!("read resolved capsule {}", capsule.name))?;
         let actual = manifest_hash(&bytes);
-        anyhow::ensure!(
-            signed.hash == actual,
-            "capsule '{}' hash mismatch: signed lock has {}, resolved artifact has {actual}",
-            capsule.name,
-            signed.hash
-        );
+        if signed.hash != actual {
+            std::fs::remove_file(&archive_path)
+                .with_context(|| format!("discard hash-mismatched capsule {}", capsule.name))?;
+            anyhow::bail!(
+                "capsule '{}' hash mismatch: signed lock has {}, resolved artifact has {actual}",
+                capsule.name,
+                signed.hash
+            );
+        }
         let mut member = capsule.clone();
         member.source = archive_path.to_string_lossy().into_owned();
         resolved.push(member);
     }
     Ok(resolved)
-}
-
-fn is_local_capsule_archive(source: &str) -> bool {
-    let path = Path::new(source);
-    path.is_file() && source.ends_with(".capsule")
 }
 
 /// Resolve a distro source to its exact bytes and parse those bytes once.
@@ -173,6 +183,8 @@ async fn fetch_signed_manifest(
     accept_new_key: bool,
     home: &AstridHome,
 ) -> anyhow::Result<SignedDistroBundle> {
+    let source_path = PathBuf::from(source);
+    let local_manifest_path = source_path.is_file().then_some(source_path);
     let (manifest_bytes, manifest) = fetch_manifest_bytes(source, offline).await?;
     let manifest_hash = manifest_hash(&manifest_bytes);
     let lock_bytes = fetch_signed_member(source, offline, "Distro.lock").await?;
@@ -203,6 +215,7 @@ async fn fetch_signed_manifest(
         lock,
         manifest_hash,
         pinned_refs,
+        manifest_path: local_manifest_path,
     })
 }
 

--- a/crates/astrid-cli/src/commands/init_tests.rs
+++ b/crates/astrid-cli/src/commands/init_tests.rs
@@ -218,11 +218,174 @@ fn signed_source_fixture(
     (dir.join("Distro.toml"), bytes, manifest_hash, keypair)
 }
 
-fn seed_pin(home: &AstridHome, keypair: &astrid_crypto::KeyPair) {
+fn seed_distro_pin(home: &AstridHome, distro_id: &str, keypair: &astrid_crypto::KeyPair) {
     let trust_dir = home.root().join("trust");
     std::fs::create_dir_all(&trust_dir).unwrap();
     let pubkey = super::super::distro::sign::pubkey_to_wire(&keypair.export_public_key());
-    std::fs::write(trust_dir.join("test.pub"), format!("{pubkey}\n")).unwrap();
+    std::fs::write(
+        trust_dir.join(format!("{distro_id}.pub")),
+        format!("{pubkey}\n"),
+    )
+    .unwrap();
+}
+
+fn seed_pin(home: &AstridHome, keypair: &astrid_crypto::KeyPair) {
+    seed_distro_pin(home, "test", keypair);
+}
+
+fn signed_local_source_fixture(
+    dir: &std::path::Path,
+    capsule_bytes: &[u8],
+) -> (std::path::PathBuf, Vec<u8>, String, astrid_crypto::KeyPair) {
+    std::fs::create_dir_all(dir.join("capsules")).unwrap();
+    std::fs::write(dir.join("capsules/member.capsule"), capsule_bytes).unwrap();
+    let keypair = astrid_crypto::KeyPair::generate();
+    let pubkey = super::super::distro::sign::pubkey_to_wire(&keypair.export_public_key());
+    let bytes = format!(
+        "schema-version = 1\n\n\
+         [distro]\nid = \"local-test\"\nname = \"Local Test\"\nversion = \"0.1.0\"\n\n\
+         [distro.signing]\npubkey = \"{pubkey}\"\n\n\
+         [[capsule]]\nname = \"member\"\nsource = \"capsules/member.capsule\"\n\
+         version = \"1.0.0\"\nrole = \"uplink\"\n"
+    )
+    .into_bytes();
+    let capsule_hash = format!("blake3:{}", blake3::hash(capsule_bytes).to_hex());
+    let manifest_hash = manifest_hash(&bytes);
+    let lock = super::super::distro::lock::DistroLock {
+        schema_version: 1,
+        distro: super::super::distro::lock::DistroLockMeta {
+            id: "local-test".into(),
+            version: "0.1.0".into(),
+            resolved_at: "2026-01-01T00:00:00Z".into(),
+        },
+        capsules: vec![super::super::distro::lock::LockedCapsule {
+            name: "member".into(),
+            version: "1.0.0".into(),
+            source: "capsules/member.capsule".into(),
+            hash: capsule_hash,
+            resolved_ref: None,
+        }],
+        manifest_hash: Some(manifest_hash.clone()),
+    };
+    let sig = super::super::distro::sign::sign_lock(&lock, &keypair).unwrap();
+    std::fs::write(dir.join("Distro.toml"), &bytes).unwrap();
+    std::fs::write(
+        dir.join("Distro.lock"),
+        toml::to_string_pretty(&lock).unwrap(),
+    )
+    .unwrap();
+    std::fs::write(dir.join("Distro.sig"), sig).unwrap();
+    (dir.join("Distro.toml"), bytes, manifest_hash, keypair)
+}
+
+async fn prepared_local_signed_fixture(
+    dir: &std::path::Path,
+    capsule_bytes: &[u8],
+) -> (super::signed_source::SignedDistroBundle, Vec<u8>, String) {
+    let home = AstridHome::from_path(dir.join("home"));
+    let (source, bytes, expected_hash, keypair) = signed_local_source_fixture(dir, capsule_bytes);
+    seed_distro_pin(&home, "local-test", &keypair);
+    let opts = InitOpts {
+        require_signed: true,
+        offline: true,
+        ..Default::default()
+    };
+    let super::PreparedDistro::Signed(bundle) =
+        super::signed_source::prepare_distro_source(source.to_str().unwrap(), &opts, &home)
+            .await
+            .unwrap()
+    else {
+        panic!("signed local Distro.toml must prepare a signed bundle");
+    };
+    (bundle, bytes, expected_hash)
+}
+
+#[test]
+fn signed_apply_resolves_relative_member_from_manifest_parent() {
+    let dir = tempfile::tempdir().unwrap();
+    let capsule_bytes = b"local signed capsule".to_vec();
+    let (bundle, _, expected_hash) =
+        futures::executor::block_on(prepared_local_signed_fixture(dir.path(), &capsule_bytes));
+    assert_eq!(
+        bundle.manifest_path.as_deref(),
+        Some(dir.path().join("Distro.toml").as_path())
+    );
+
+    let staging = tempfile::tempdir().unwrap();
+    let resolved = futures::executor::block_on(super::signed_source::resolve_signed_capsules(
+        &bundle.manifest.capsules,
+        &bundle,
+        staging.path(),
+    ))
+    .unwrap();
+    let staged = staging.path().join("member.capsule");
+    assert_eq!(resolved[0].source, staged.to_string_lossy());
+    assert_eq!(std::fs::read(&staged).unwrap(), capsule_bytes);
+    assert_eq!(bundle.manifest_hash, expected_hash);
+}
+
+#[test]
+fn signed_apply_fails_closed_on_missing_relative_member() {
+    let dir = tempfile::tempdir().unwrap();
+    let (bundle, _, _) =
+        futures::executor::block_on(prepared_local_signed_fixture(dir.path(), b"member"));
+    std::fs::remove_file(dir.path().join("capsules/member.capsule")).unwrap();
+    let staging = tempfile::tempdir().unwrap();
+
+    let err = futures::executor::block_on(super::signed_source::resolve_signed_capsules(
+        &bundle.manifest.capsules,
+        &bundle,
+        staging.path(),
+    ))
+    .unwrap_err();
+    assert!(
+        format!("{err:#}").contains("member.capsule"),
+        "got: {err:#}"
+    );
+    assert!(!staging.path().join("member.capsule").exists());
+}
+
+#[test]
+fn signed_apply_fails_closed_on_member_escape() {
+    let dir = tempfile::tempdir().unwrap();
+    let (bundle, _, _) =
+        futures::executor::block_on(prepared_local_signed_fixture(dir.path(), b"member"));
+    std::fs::remove_file(dir.path().join("capsules/member.capsule")).unwrap();
+    let outside = tempfile::tempdir().unwrap();
+    std::fs::write(outside.path().join("outside.capsule"), b"outside").unwrap();
+    std::os::unix::fs::symlink(
+        outside.path().join("outside.capsule"),
+        dir.path().join("capsules/member.capsule"),
+    )
+    .unwrap();
+    let staging = tempfile::tempdir().unwrap();
+
+    let err = futures::executor::block_on(super::signed_source::resolve_signed_capsules(
+        &bundle.manifest.capsules,
+        &bundle,
+        staging.path(),
+    ))
+    .unwrap_err();
+    assert!(format!("{err:#}").contains("escapes"), "got: {err:#}");
+    assert!(!staging.path().join("member.capsule").exists());
+}
+
+#[test]
+fn signed_apply_rejects_post_verification_substitution() {
+    let dir = tempfile::tempdir().unwrap();
+    let (bundle, _, _) =
+        futures::executor::block_on(prepared_local_signed_fixture(dir.path(), b"member"));
+    std::fs::write(dir.path().join("capsules/member.capsule"), b"substituted").unwrap();
+    let staging = tempfile::tempdir().unwrap();
+
+    let err = futures::executor::block_on(super::signed_source::resolve_signed_capsules(
+        &bundle.manifest.capsules,
+        &bundle,
+        staging.path(),
+    ))
+    .unwrap_err();
+    assert!(err.to_string().contains("hash mismatch"), "got: {err}");
+    assert!(!staging.path().join("member.capsule").exists());
 }
 
 #[test]

--- a/crates/astrid-cli/src/commands/init_tests.rs
+++ b/crates/astrid-cli/src/commands/init_tests.rs
@@ -425,6 +425,57 @@ fn signed_apply_resolves_relative_member_from_manifest_parent() {
 }
 
 #[test]
+fn signed_apply_resolves_member_from_parent_manifest_path() {
+    run_bare_cwd_child(
+        "commands::init::tests::signed_apply_resolves_member_from_parent_manifest_path_child",
+        "PARENT_MANIFEST_APPLY_OK",
+    );
+}
+
+#[test]
+fn signed_apply_resolves_member_from_parent_manifest_path_child() {
+    if std::env::var("ASTRID_BARE_CWD_TEST").as_deref() != Ok("1") {
+        return;
+    }
+    let dir = tempfile::tempdir().unwrap();
+    let bundle = dir.path().join("bundle");
+    let cwd = dir.path().join("cwd");
+    let capsule_bytes = b"local signed capsule".to_vec();
+    std::fs::create_dir_all(&cwd).unwrap();
+
+    let _current_dir = CurrentDirGuard::set(&cwd);
+    let (bundle_state, bytes, expected_hash) = futures::executor::block_on(
+        prepared_local_signed_fixture_with_source(&bundle, &capsule_bytes, "../bundle/Distro.toml"),
+    );
+    let expected_manifest_path = std::env::current_dir()
+        .unwrap()
+        .join("../bundle/Distro.toml");
+
+    assert_eq!(bundle_state.manifest_hash, expected_hash);
+    assert_eq!(bundle_state.manifest_hash, manifest_hash(&bytes));
+    assert_eq!(
+        bundle_state.manifest_path.as_deref(),
+        Some(expected_manifest_path.as_path())
+    );
+
+    let staging = tempfile::tempdir().unwrap();
+    let resolved = futures::executor::block_on(super::signed_source::resolve_signed_capsules(
+        &bundle_state.manifest.capsules,
+        &bundle_state,
+        staging.path(),
+    ))
+    .unwrap();
+    let staged = staging.path().join("member.capsule");
+    assert_eq!(std::fs::read(&staged).unwrap(), capsule_bytes);
+    assert_eq!(resolved[0].source, staged.to_string_lossy());
+    std::fs::write(
+        std::env::var("ASTRID_BARE_CWD_RESULT").unwrap(),
+        "PARENT_MANIFEST_APPLY_OK",
+    )
+    .unwrap();
+}
+
+#[test]
 fn signed_apply_fails_closed_on_missing_relative_member() {
     let dir = tempfile::tempdir().unwrap();
     let (bundle, _, _) =

--- a/crates/astrid-cli/src/commands/init_tests.rs
+++ b/crates/astrid-cli/src/commands/init_tests.rs
@@ -297,7 +297,7 @@ async fn prepared_local_signed_fixture(
     else {
         panic!("signed local Distro.toml must prepare a signed bundle");
     };
-    (bundle, bytes, expected_hash)
+    (*bundle, bytes, expected_hash)
 }
 
 #[test]
@@ -345,6 +345,7 @@ fn signed_apply_fails_closed_on_missing_relative_member() {
     assert!(!staging.path().join("member.capsule").exists());
 }
 
+#[cfg(unix)]
 #[test]
 fn signed_apply_fails_closed_on_member_escape() {
     let dir = tempfile::tempdir().unwrap();

--- a/crates/astrid-cli/src/commands/init_tests.rs
+++ b/crates/astrid-cli/src/commands/init_tests.rs
@@ -4,6 +4,40 @@
 
 use super::*;
 
+struct CurrentDirGuard(std::path::PathBuf);
+
+impl CurrentDirGuard {
+    fn set(path: &std::path::Path) -> Self {
+        let original = std::env::current_dir().unwrap();
+        std::env::set_current_dir(path).unwrap();
+        Self(original)
+    }
+}
+
+impl Drop for CurrentDirGuard {
+    fn drop(&mut self) {
+        std::env::set_current_dir(&self.0).unwrap();
+    }
+}
+
+fn run_bare_cwd_child(child_name: &str, marker: &str) {
+    let result_dir = tempfile::tempdir().unwrap();
+    let result_path = result_dir.path().join("result");
+    let output = std::process::Command::new(std::env::current_exe().unwrap())
+        .args(["--exact", "--nocapture", child_name])
+        .env("ASTRID_BARE_CWD_TEST", "1")
+        .env("ASTRID_BARE_CWD_RESULT", &result_path)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "child failed: {}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(std::fs::read_to_string(result_path).unwrap(), marker);
+}
+
 #[test]
 fn batch_install_rejects_reported_identity_mismatch() {
     let expected = astrid_capsule::capsule::CapsuleId::new("expected-capsule").unwrap();
@@ -282,8 +316,21 @@ async fn prepared_local_signed_fixture(
     dir: &std::path::Path,
     capsule_bytes: &[u8],
 ) -> (super::signed_source::SignedDistroBundle, Vec<u8>, String) {
+    prepared_local_signed_fixture_with_source(
+        dir,
+        capsule_bytes,
+        dir.join("Distro.toml").to_str().unwrap(),
+    )
+    .await
+}
+
+async fn prepared_local_signed_fixture_with_source(
+    dir: &std::path::Path,
+    capsule_bytes: &[u8],
+    source: &str,
+) -> (super::signed_source::SignedDistroBundle, Vec<u8>, String) {
     let home = AstridHome::from_path(dir.join("home"));
-    let (source, bytes, expected_hash, keypair) = signed_local_source_fixture(dir, capsule_bytes);
+    let (_, bytes, expected_hash, keypair) = signed_local_source_fixture(dir, capsule_bytes);
     seed_distro_pin(&home, "local-test", &keypair);
     let opts = InitOpts {
         require_signed: true,
@@ -291,13 +338,66 @@ async fn prepared_local_signed_fixture(
         ..Default::default()
     };
     let super::PreparedDistro::Signed(bundle) =
-        super::signed_source::prepare_distro_source(source.to_str().unwrap(), &opts, &home)
+        super::signed_source::prepare_distro_source(source, &opts, &home)
             .await
             .unwrap()
     else {
         panic!("signed local Distro.toml must prepare a signed bundle");
     };
     (*bundle, bytes, expected_hash)
+}
+
+#[test]
+fn signed_apply_prepares_and_resolves_bare_manifest_path_in_cwd() {
+    run_bare_cwd_child(
+        "commands::init::tests::signed_apply_bare_manifest_path_child",
+        "BARE_MANIFEST_APPLY_OK",
+    );
+}
+
+#[test]
+fn signed_apply_bare_manifest_path_child() {
+    if std::env::var("ASTRID_BARE_CWD_TEST").as_deref() != Ok("1") {
+        return;
+    }
+    let dir = tempfile::tempdir().unwrap();
+    let capsule_bytes = b"local signed capsule".to_vec();
+
+    let _current_dir = CurrentDirGuard::set(dir.path());
+    let prepared = futures::executor::block_on(prepared_local_signed_fixture_with_source(
+        dir.path(),
+        &capsule_bytes,
+        "Distro.toml",
+    ));
+    let (bundle, bytes, expected_hash) = prepared;
+    assert_eq!(bundle.manifest_hash, expected_hash);
+    assert_eq!(bundle.manifest_hash, manifest_hash(&bytes));
+    assert_eq!(
+        bundle.manifest_path.as_deref(),
+        Some(
+            dir.path()
+                .canonicalize()
+                .unwrap()
+                .join("Distro.toml")
+                .as_path()
+        )
+    );
+
+    let staging = tempfile::tempdir().unwrap();
+    let resolved = futures::executor::block_on(super::signed_source::resolve_signed_capsules(
+        &bundle.manifest.capsules,
+        &bundle,
+        staging.path(),
+    ))
+    .unwrap();
+    let staged = staging.path().join("member.capsule");
+    assert_eq!(std::fs::read(&staged).unwrap(), capsule_bytes);
+    assert_eq!(resolved[0].source, staged.to_string_lossy());
+    std::fs::write(
+        std::env::var("ASTRID_BARE_CWD_RESULT").unwrap(),
+        "BARE_MANIFEST_APPLY_OK",
+    )
+    .unwrap();
 }
 
 #[test]

--- a/docs/distro-signing.md
+++ b/docs/distro-signing.md
@@ -103,6 +103,11 @@ compile), records the **actually-resolved** ref + BLAKE3 in the lock,
 signs the lock, and packs a deterministic archive (re-sealing identical
 inputs yields byte-identical output).
 
+Relative `capsules/<name>.capsule` sources resolve from the directory
+containing `Distro.toml`, so a manifest and its member archives can travel
+together. Local members have no Git ref to record; GitHub `@org/repo`
+sources continue to use released GitHub assets.
+
 Distros are **release-only**: a capsule pinned to `branch`/`rev` is
 rejected by `seal` — those require building from source. Pin a
 `version` or `tag`; for a bleeding-edge capsule, build it and use

--- a/e2e/cli-scenarios.toml
+++ b/e2e/cli-scenarios.toml
@@ -536,9 +536,9 @@ reason = "Remote distro update requires network release state; CI covers local l
 [commands."distro seal"]
 scenario = "distro_lifecycle"
 status = "covered"
-mode = "bounded_failure"
+mode = "filesystem"
 principal = "local_cli"
-reason = "The current seal resolver only accepts GitHub-backed capsule sources; the harness asserts that local archive sources fail before any network fetch."
+reason = "The harness seals authenticated relative capsules/*.capsule members from the Distro.toml directory and asserts that absolute sources escaping that directory fail closed."
 
 [commands."init"]
 scenario = "distro_onboarding"

--- a/scripts/e2e/runtime-cli-smoke.sh
+++ b/scripts/e2e/runtime-cli-smoke.sh
@@ -340,7 +340,8 @@ run_cli_distro_seal_smoke() {
   registry_version="$(capsule_archive_version "$registry_archive")"
   local distro_dir="$ARTIFACTS/cli-distro-seal"
   local key="$distro_dir/signing.key"
-  mkdir -p "$distro_dir"
+  mkdir -p "$distro_dir/capsules"
+  cp "$registry_archive" "$distro_dir/capsules/astrid-capsule-registry.capsule"
   cat > "$distro_dir/Distro.toml" <<EOF
 schema-version = 1
 
@@ -351,7 +352,7 @@ version = "0.1.0"
 
 [[capsule]]
 name = "astrid-capsule-registry"
-source = "$registry_archive"
+source = "capsules/astrid-capsule-registry.capsule"
 version = "$registry_version"
 role = "uplink"
 EOF
@@ -359,9 +360,29 @@ EOF
 import sys
 open(sys.argv[1], "wb").write(bytes(range(32)))
 PY
-  assert_cli_exit_contains "cli-distro-seal-local-source" 1 \
-    "seal can only resolve GitHub-backed capsule sources" \
+
+  assert_cli_exit_contains "cli-distro-seal-relative-source" 0 "Sealed" \
     distro seal "$distro_dir/Distro.toml" --output "$distro_dir/e2e.shuttle" --key "$key"
+
+  local escape_dir="$ARTIFACTS/cli-distro-seal-escape"
+  mkdir -p "$escape_dir"
+  cat > "$escape_dir/Distro.toml" <<EOF
+schema-version = 1
+
+[distro]
+id = "e2e-seal-escape"
+name = "E2E Seal Escape"
+version = "0.1.0"
+
+[[capsule]]
+name = "astrid-capsule-registry"
+source = "$registry_archive"
+version = "$registry_version"
+role = "uplink"
+EOF
+  assert_cli_exit_contains "cli-distro-seal-escape-source" 1 \
+    "escapes the authenticated Distro.toml directory" \
+    distro seal "$escape_dir/Distro.toml" --output "$escape_dir/e2e.shuttle" --key "$key"
 }
 
 run_cli_daemon_lifecycle_smoke() {


### PR DESCRIPTION
## Linked Issue

Closes #1195. Canonical signed Distro apply remains incomplete until authenticated `Distro.toml` members of the form `capsules/*.capsule` resolve from the manifest parent for both seal and apply.

## Summary

Seal and signed apply now resolve relative local capsule archives from the authenticated `Distro.toml` parent directory. Bare or relative `Distro.toml` paths are rooted in the caller working directory at ingestion, so `astrid distro seal Distro.toml` and signed apply `--distro Distro.toml` use that same parent. A parent-containing caller path such as `../bundle/Distro.toml` still resolves `capsules/*.capsule` from that authenticated parent. Member bytes stay hash-bound to the signed lock. Traversal, symlink escape, missing members, non-regular files, oversized local members above the existing 50 MB archive ceiling, and post-verification substitution fail closed. GitHub `@org/repo` capsule sources are unchanged.

This restacks the relative-source change onto the generic pin-first Distro trust already on main. Product `astrid distro apply` still requires an existing matching `$ASTRID_HOME/trust/<distro-id>.pub` and does not introduce vendor Distro identities.

## Changes

- Adds `local_source` resolution used by seal and signed apply.
- Resolves `capsules/*.capsule` against the authenticated manifest parent.
- Roots bare/relative Distro.toml paths in the current directory at ingestion.
- Rejects declared member traversal rather than false-rejecting a parent-containing Distro.toml path.
- Enforces the existing 50 MB member ceiling on local archives before copy.
- Rejects missing, non-regular, escaping, and substituted local members.
- Documents the relative-member layout in `docs/distro-signing.md`.
- Adds `changes/1195.changed.md` for the relative-member outcome.
- Updates Runtime CLI seal smoke to the canonical relative layout, with a separate absolute-escape falsifier.
- Boxes `PreparedDistro::Signed` (and the unsigned `Manifest` payload) so Windows CLI clippy stays silent.

## Verification

- Head `7b0c8781b7c1c9521a4ae048360d21cb82312e55`; parent of the unique range is `79707fcefa5d1470f0709f5d69473a0c288730e2` (`origin/main`).
- Unique range: `local_source.rs`, `seal.rs`, `mod.rs`, `init.rs`, `init_signed_source.rs`, `init_tests.rs`, `docs/distro-signing.md`, `changes/1195.changed.md`, `scripts/e2e/runtime-cli-smoke.sh`, `e2e/cli-scenarios.toml`, and `shuttle.rs` only to share `MAX_MEMBER_BYTES`.
- `git verify-commit` good, full trust, DCO present.
- Focused coverage: relative-member seal success, missing member, signed apply relative resolution, apply missing member, symlink escape, post-verification substitution, traversal, non-regular file, GitHub-source passthrough, remote-manifest local-member rejection, cwd-relative bare `Distro.toml` seal/apply, parent-containing Distro.toml seal/apply, and oversized local-member fail-closed. Product pin-first tests remain. Runtime CLI smoke expects relative-member `Sealed` success plus fail-closed escape.

## Claim boundary

This does not provision operator pins, authenticate an AOS release, or prove selected-Distro apply/invoke through AOS. Independent exact-head review is still required. Local Windows-target clippy cannot reach Astrid code on macOS because third-party C build scripts need MSVC headers; the Windows filesystem job remains the authoritative lint/test gate.

## AI / Tool Assistance

Assisted-by: Codex:glm-5.3-flash

A coding agent restacked the relative local-capsule resolution onto current main, then repaired changelog process, Runtime CLI seal fixtures, Windows enum size, Unix-only test compilation, bare Distro.toml ingestion, parent-containing Distro.toml member resolution, and the shared 50 MB local-member ceiling. The maintainer owns the public Distro contract and reviewed the unique range against the generic pin-first trust already on main.

## Checklist

- [x] Linked issues
- [x] Changelog fragment added under `changes/1195.changed.md`
- [ ] Independent review complete
