### PR TITLE
fix(runtime): stop with exactly astrid.volume

### DIFF
--- a/.github/workflows/runtime-e2e.yml
+++ b/.github/workflows/runtime-e2e.yml
@@ -156,6 +156,6 @@ jobs:
         with:
           name: runtime-e2e-artifacts
           path: |
-            /tmp/astrid-runtime-e2e.*/artifacts/redacted-upload
-            ${{ runner.temp }}/astrid-runtime-e2e.*/artifacts/redacted-upload
+            /tmp/astrid-runtime-e2e-artifacts.*/redacted-upload
+            ${{ runner.temp }}/astrid-runtime-e2e-artifacts.*/redacted-upload
           if-no-files-found: ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,6 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ### Fixed
 
-- **Runtime restart now ignores stale host endpoints while rejecting special
-  entries in durable namespaces.**
-- **Graceful daemon restarts no longer rewind newer running files to the last
-  packed volume generation.** Shutdown publishes the live projection before
-  durable stores close, and startup admits a valid surviving projection before
-  restoring it from the volume.
-- **A failed stop projection pack now keeps host sidecars and returns an error
-  instead of reporting the runtime as stopped.**
 - **`astrid status` and `astrid mcp serve` no longer treat an unlinked
   `system.sock` as a stopped daemon.** If the recorded PID is still alive,
   status fails closed and MCP refuses to spawn a second kernel onto the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ### Fixed
 
+- **Graceful daemon restarts no longer rewind newer running files to the last
+  packed volume generation.** Shutdown publishes the live projection before
+  durable stores close, and startup admits a valid surviving projection before
+  restoring it from the volume.
+- **A failed stop projection pack now keeps host sidecars and returns an error
+  instead of reporting the runtime as stopped.**
 - **`astrid status` and `astrid mcp serve` no longer treat an unlinked
   `system.sock` as a stopped daemon.** If the recorded PID is still alive,
   status fails closed and MCP refuses to spawn a second kernel onto the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ### Fixed
 
+- **Runtime restart now ignores stale host endpoints while rejecting special
+  entries in durable namespaces.**
 - **Graceful daemon restarts no longer rewind newer running files to the last
   packed volume generation.** Shutdown publishes the live projection before
   durable stores close, and startup admits a valid surviving projection before

--- a/changes/1803.fixed.md
+++ b/changes/1803.fixed.md
@@ -32,5 +32,7 @@ without reinferring deletions after a retirement failure. Rebind a relocated
 active volume only through the trusted bootstrap-only path. Preflight the
 complete root before retirement removes any entry, and keep the receipt until
 publication and every retirement step succeed.
+Reject derived names that collide with prepared inputs or exact removals
+before an owner root can change.
 Require exactly one link on durable volume media and keep durable capsule
 materialization helpers in their own kernel module.

--- a/changes/1803.fixed.md
+++ b/changes/1803.fixed.md
@@ -23,10 +23,11 @@ Keep ordinary `.next` and `.migrating` files while excluding only canonical
 transaction staging names, and build the lifecycle capsule under the same
 runtime identity that later admits it.
 Keep the crash-recovery active-projection receipt private inside the durable
-volume, never materialize it on the host, and track ACTIVE and identity-bound
-RETIRING phases. Refuse arbitrary preboot host files that the volume does not
-prove were part of an interrupted run, rotate receipt inventory in the same
-catalog transaction as projected mutations, and restore published inventory
+volume, never materialize it on the host, and track ACTIVE and RETIRING phases
+bound to exact immutable object identities. Refuse arbitrary preboot host files
+that the volume does not prove were part of an interrupted run, derive rotated
+receipt identity after input preparation and commit it in the same catalog
+transaction as projected mutations, and restore published inventory
 without reinferring deletions after a retirement failure. Rebind a relocated
 active volume only through the trusted bootstrap-only path. Preflight the
 complete root before retirement removes any entry, and keep the receipt until

--- a/changes/1803.fixed.md
+++ b/changes/1803.fixed.md
@@ -24,8 +24,8 @@ transaction staging names, and build the lifecycle capsule under the same
 runtime identity that later admits it.
 
 Restore staged generations through a no-follow private-directory capability and
-keep an interrupted Active restore in Retiring state so a later reopen cannot
-adopt a partial host projection.
+roll back host files written by a failed restore so a later reopen cannot adopt
+a partial host projection.
 Keep the crash-recovery active-projection receipt private inside the durable
 volume, never materialize it on the host, and track ACTIVE and RETIRING phases
 bound to exact immutable object identities. Refuse arbitrary preboot host files

--- a/changes/1803.fixed.md
+++ b/changes/1803.fixed.md
@@ -23,10 +23,13 @@ Keep ordinary `.next` and `.migrating` files while excluding only canonical
 transaction staging names, and build the lifecycle capsule under the same
 runtime identity that later admits it.
 Keep the crash-recovery active-projection receipt private inside the durable
-volume, never materialize it on the host, and refuse arbitrary preboot host
-files that the volume does not prove were part of an interrupted run. Reconcile
-removed runtime names in the same atomic catalog transition as their surviving
-projection, preflight the complete root before retirement removes any entry,
-and keep the receipt until publication and every retirement step succeed.
+volume, never materialize it on the host, and track ACTIVE and identity-bound
+RETIRING phases. Refuse arbitrary preboot host files that the volume does not
+prove were part of an interrupted run, rotate receipt inventory in the same
+catalog transaction as projected mutations, and restore published inventory
+without reinferring deletions after a retirement failure. Rebind a relocated
+active volume only through the trusted bootstrap-only path. Preflight the
+complete root before retirement removes any entry, and keep the receipt until
+publication and every retirement step succeed.
 Require exactly one link on durable volume media and keep durable capsule
 materialization helpers in their own kernel module.

--- a/changes/1803.fixed.md
+++ b/changes/1803.fixed.md
@@ -41,7 +41,9 @@ after kernel runtime-tree admission and post-layout projection publication.
 A published v0.10.4 upgrade stop packs those post-cutover host records after that ACTIVE republication, then leaves only `astrid.volume`.
 Fail closed when a surviving host projection has no ACTIVE receipt except the enumerated pack-open staging journal regular file `var/content-staging/intents.v1.log`, confine
 restored projection names to root-relative normal components, and refuse
-RETIRING stop-pack when the host tree contains unreceipted files. Treat
-bootstrap-only host sentinels as volume-only state during restart so restoring
-a staged generation cannot publish a partial inventory, and admit catalog-backed
-test projections through the same ACTIVE boundary.
+RETIRING stop-pack when the host tree contains unreceipted files. Permit
+receipt-less bootstrap sentinels only during first volume initialization,
+restore staged generations before reopening native staging, and rebind their
+source identities to the restored inode so a later seal cannot lose its
+journal record; admit catalog-backed test projections through the same ACTIVE
+boundary.

--- a/changes/1803.fixed.md
+++ b/changes/1803.fixed.md
@@ -22,6 +22,10 @@ Prove the single clean stop leaves only canonical volume media.
 Keep ordinary `.next` and `.migrating` files while excluding only canonical
 transaction staging names, and build the lifecycle capsule under the same
 runtime identity that later admits it.
+
+Restore staged generations through a no-follow private-directory capability and
+keep an interrupted Active restore in Retiring state so a later reopen cannot
+adopt a partial host projection.
 Keep the crash-recovery active-projection receipt private inside the durable
 volume, never materialize it on the host, and track ACTIVE and RETIRING phases
 bound to exact immutable object identities. Refuse arbitrary preboot host files

--- a/changes/1803.fixed.md
+++ b/changes/1803.fixed.md
@@ -38,6 +38,7 @@ Require exactly one link on durable volume media and keep durable capsule
 materialization helpers in their own kernel module.
 Split bulk owner-root publication into a bounded publish seam and rotate ACTIVE
 after kernel runtime-tree admission and post-layout projection publication.
+A published v0.10.4 upgrade stop packs those post-cutover host records after that ACTIVE republication, then leaves only `astrid.volume`.
 Fail closed when a surviving host projection has no ACTIVE receipt except the enumerated pack-open staging journal regular file `var/content-staging/intents.v1.log`, confine
 restored projection names to root-relative normal components, and refuse
 RETIRING stop-pack when the host tree contains unreceipted files. Treat

--- a/changes/1803.fixed.md
+++ b/changes/1803.fixed.md
@@ -19,3 +19,6 @@ first capsule load so replacement runtimes preserve the same boot snapshot.
 Move multi-home runtime configuration and capsule installation into the
 running mounted projection, preserving fresh-root volume-only admission.
 Prove the single clean stop leaves only canonical volume media.
+Keep ordinary `.next` and `.migrating` files while excluding only canonical
+transaction staging names, and build the lifecycle capsule under the same
+runtime identity that later admits it.

--- a/changes/1803.fixed.md
+++ b/changes/1803.fixed.md
@@ -1,0 +1,21 @@
+Bind live capsule activation to one immutable durable-package snapshot,
+project it at the snapshot-derived canonical cache path, and verify every
+archive member and generated receipt through no-follow reads before runtime
+use. Preflight legacy quarantine sources for redirects, specials, and
+cross-device children before ingest; quarantine unrecognized stores during
+stop-only pack opening; split the home-layout record inventory into a real
+module; and create the test-only ephemeral run directory required by uplink
+token fixtures. A clean stop leaves only the private `astrid.volume`. Resume
+layout retirement after legitimate live-volume mutation by binding the receipt
+to its canonical destination path, retain authenticated tar directory members,
+and admit every authenticated ancestor and empty directory during published
+capsule activation.
+Admit MCP lifecycle transport commands before their run-dir fallback or stale
+marker cleanup, compare runtime-tree exclusions at exact and directory
+boundaries, and stage failure diagnostics before removing the E2E artifact
+directory.
+Bind the admitted-home local-egress allowlist to the kernel once before the
+first capsule load so replacement runtimes preserve the same boot snapshot.
+Move multi-home runtime configuration and capsule installation into the
+running mounted projection, preserving fresh-root volume-only admission.
+Prove the single clean stop leaves only canonical volume media.

--- a/changes/1803.fixed.md
+++ b/changes/1803.fixed.md
@@ -22,3 +22,11 @@ Prove the single clean stop leaves only canonical volume media.
 Keep ordinary `.next` and `.migrating` files while excluding only canonical
 transaction staging names, and build the lifecycle capsule under the same
 runtime identity that later admits it.
+Keep the crash-recovery active-projection receipt private inside the durable
+volume, never materialize it on the host, and refuse arbitrary preboot host
+files that the volume does not prove were part of an interrupted run. Reconcile
+removed runtime names in the same atomic catalog transition as their surviving
+projection, preflight the complete root before retirement removes any entry,
+and keep the receipt until publication and every retirement step succeed.
+Require exactly one link on durable volume media and keep durable capsule
+materialization helpers in their own kernel module.

--- a/changes/1803.fixed.md
+++ b/changes/1803.fixed.md
@@ -36,3 +36,11 @@ Reject derived names that collide with prepared inputs or exact removals
 before an owner root can change.
 Require exactly one link on durable volume media and keep durable capsule
 materialization helpers in their own kernel module.
+Split bulk owner-root publication into a bounded publish seam and rotate ACTIVE
+after kernel runtime-tree admission and post-layout projection publication.
+Fail closed when a surviving host projection has no ACTIVE receipt except the enumerated pack-open staging journal regular file `var/content-staging/intents.v1.log`, confine
+restored projection names to root-relative normal components, and refuse
+RETIRING stop-pack when the host tree contains unreceipted files. Treat
+bootstrap-only host sentinels as volume-only state during restart so restoring
+a staged generation cannot publish a partial inventory, and admit catalog-backed
+test projections through the same ACTIVE boundary.

--- a/crates/astrid-capsule-install/src/storage.rs
+++ b/crates/astrid-capsule-install/src/storage.rs
@@ -39,6 +39,7 @@ pub struct VerifiedDurableCapsulePackage {
     manifest: CapsuleManifest,
     manifest_bytes: Vec<u8>,
     archive_files: std::collections::BTreeMap<String, Vec<u8>>,
+    archive_directories: std::collections::BTreeSet<String>,
     metadata: CapsuleMeta,
     metadata_bytes: Vec<u8>,
     authority: InstalledAuthority,
@@ -101,6 +102,18 @@ impl VerifiedDurableCapsulePackage {
         self.archive_files.get(relative).map(Vec::as_slice)
     }
 
+    /// Iterate every verified archive member without exposing internal storage.
+    pub fn archive_entries(&self) -> impl Iterator<Item = (&str, &[u8])> + '_ {
+        self.archive_files
+            .iter()
+            .map(|(path, bytes)| (path.as_str(), bytes.as_slice()))
+    }
+
+    /// Iterate authenticated archive directory names without exposing storage.
+    pub fn archive_directories(&self) -> impl Iterator<Item = &str> + '_ {
+        self.archive_directories.iter().map(String::as_str)
+    }
+
     /// Return the exact durable metadata bytes.
     #[must_use]
     pub fn metadata_bytes(&self) -> &[u8] {
@@ -148,7 +161,8 @@ pub fn read_verified_durable_package_for_owner(
     let package = snapshot.package();
     let verification = artifact::verify_archive_bytes(&package.archive)
         .with_context(|| format!("verify durable capsule archive {id}"))?;
-    let files = read_archive_files(&package.archive)?;
+    let inventory = read_archive_files(&package.archive)?;
+    let ArchiveInventory { files, directories } = inventory;
     let manifest_bytes = files
         .get("Capsule.toml")
         .cloned()
@@ -178,6 +192,7 @@ pub fn read_verified_durable_package_for_owner(
         manifest,
         manifest_bytes,
         archive_files: files,
+        archive_directories: directories,
         metadata,
         metadata_bytes,
         authority,
@@ -333,12 +348,16 @@ fn verify_package_identity(
     Ok(())
 }
 
-fn read_archive_files(
-    archive_bytes: &[u8],
-) -> anyhow::Result<std::collections::BTreeMap<String, Vec<u8>>> {
+struct ArchiveInventory {
+    files: std::collections::BTreeMap<String, Vec<u8>>,
+    directories: std::collections::BTreeSet<String>,
+}
+
+fn read_archive_files(archive_bytes: &[u8]) -> anyhow::Result<ArchiveInventory> {
     let decoder = flate2::read::GzDecoder::new(Cursor::new(archive_bytes));
     let mut archive = tar::Archive::new(decoder);
     let mut files = std::collections::BTreeMap::new();
+    let mut directories = std::collections::BTreeSet::new();
     for entry in archive.entries().context("read durable capsule archive")? {
         let mut entry = entry.context("read durable capsule archive entry")?;
         let path = entry.path().context("read durable capsule archive path")?;
@@ -352,26 +371,33 @@ fn read_archive_files(
         {
             bail!("durable capsule archive contains unsafe path");
         }
-        if entry.header().entry_type().is_dir() {
-            continue;
-        }
-        if !entry.header().entry_type().is_file() {
+
+        let entry_type = entry.header().entry_type();
+        if !entry_type.is_dir() && !entry_type.is_file() {
             bail!("durable capsule archive contains a link or special file");
         }
+
         let name = path
             .to_str()
             .ok_or_else(|| anyhow::anyhow!("durable capsule archive path is not UTF-8"))?
             .replace('\\', "/");
-        if files.contains_key(&name) {
+        if files.contains_key(&name) || directories.contains(&name) {
             bail!("durable capsule archive contains duplicate path {name}");
         }
+        if entry_type.is_dir() {
+            if !directories.insert(name) {
+                bail!("durable capsule archive contains duplicate directory path");
+            }
+            continue;
+        }
+
         let mut bytes = Vec::new();
         entry
             .read_to_end(&mut bytes)
             .with_context(|| format!("read durable capsule archive file {name}"))?;
         files.insert(name, bytes);
     }
-    Ok(files)
+    Ok(ArchiveInventory { files, directories })
 }
 
 /// Publish one source directory into the target principal's durable registry.

--- a/crates/astrid-capsule-install/src/storage/durable_metadata_tests.rs
+++ b/crates/astrid-capsule-install/src/storage/durable_metadata_tests.rs
@@ -27,7 +27,7 @@ capability = "1.0.0"
 
     let archive = canonical_capsule_archive(source.path()).unwrap();
     let verification = artifact::verify_archive_bytes(&archive).unwrap();
-    let files = read_archive_files(&archive).unwrap();
+    let ArchiveInventory { files, .. } = read_archive_files(&archive).unwrap();
     let manifest: CapsuleManifest =
         toml::from_str(std::str::from_utf8(manifest_bytes).unwrap()).unwrap();
     let wasm_hash = blake3::hash(wasm_bytes).to_hex().to_string();
@@ -105,5 +105,87 @@ capability = "1.0.0"
     assert!(
         imports_rejected && exports_rejected && wasm_rejected,
         "durable metadata must bind imports, exports, and wasm_hash to the archive"
+    );
+}
+
+#[test]
+fn archive_entries_enumerate_every_verified_member_with_exact_bytes() {
+    let source = tempdir().unwrap();
+    fs::write(
+        source.path().join("Capsule.toml"),
+        b"[package]\nname='demo'\nversion='1.0.0'\n",
+    )
+    .unwrap();
+    fs::create_dir(source.path().join("nested")).unwrap();
+    fs::write(source.path().join("nested/file"), b"exact bytes").unwrap();
+    fs::create_dir(source.path().join("empty")).unwrap();
+    fs::create_dir(source.path().join("nested/deep")).unwrap();
+    let home_dir = tempdir().unwrap();
+    let home = astrid_core::dirs::AstridHome::from_path(home_dir.path());
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let store = runtime
+        .block_on(async {
+            astrid_storage::open_runtime_principal_store(
+                &home,
+                std::sync::Arc::new(|_: &StateOwner| Ok(None)),
+            )
+            .await
+        })
+        .unwrap();
+    let archive = canonical_capsule_archive(source.path()).unwrap();
+    let verification = artifact::verify_archive_bytes(&archive).unwrap();
+    let manifest_bytes = fs::read(source.path().join("Capsule.toml")).unwrap();
+    let manifest: CapsuleManifest =
+        toml::from_str(std::str::from_utf8(&manifest_bytes).unwrap()).unwrap();
+    let authority = InstalledAuthority {
+        schema_version: 1,
+        source: AuthoritySource::ExplicitApproval,
+        capsule_id: "demo".to_owned(),
+        version: "1.0.0".to_owned(),
+        content_digest: verification.content_digest().to_owned(),
+        manifest_digest: crate::authority::digest_manifest(&manifest_bytes),
+        signer: None,
+        signature: None,
+        approved_capabilities: manifest.capabilities,
+        wasm_hash_pinned: false,
+        approved_wasm_hash: None,
+    };
+    let package = CapsulePackage::new(
+        archive,
+        br#"{"version":"1.0.0","installed_at":"","updated_at":""}"#.to_vec(),
+        serde_json::to_vec(&authority).unwrap(),
+    );
+    let store = std::sync::Arc::new(store);
+    publish_package(
+        &store,
+        astrid_core::identity::PrincipalUid::from_bytes([7_u8; 32]),
+        "demo",
+        &package,
+    )
+    .unwrap();
+    let verified = read_verified_durable_package_for_owner(
+        &store,
+        &StateOwner::Principal(astrid_core::identity::PrincipalUid::from_bytes([7_u8; 32])),
+        "demo",
+    )
+    .unwrap()
+    .unwrap();
+
+    let entries: std::collections::BTreeMap<&str, &[u8]> = verified.archive_entries().collect();
+    assert_eq!(
+        entries.get("Capsule.toml"),
+        Some(&&b"[package]\nname='demo'\nversion='1.0.0'\n"[..])
+    );
+    assert_eq!(entries.get("nested/file"), Some(&&b"exact bytes"[..]));
+    assert_eq!(entries.len(), 2);
+    let directories: std::collections::BTreeSet<&str> = verified.archive_directories().collect();
+    assert_eq!(
+        directories,
+        std::iter::once("empty")
+            .chain(["nested", "nested/deep"])
+            .collect()
     );
 }

--- a/crates/astrid-capsule/src/engine/wasm/catalog_load_tests.rs
+++ b/crates/astrid-capsule/src/engine/wasm/catalog_load_tests.rs
@@ -40,21 +40,30 @@ async fn bound_load_refuses_host_wasm_when_catalog_entry_is_missing_or_tampered(
         )
         .expect("metadata");
 
-        // These host copies prove that a bound load cannot silently select a
-        // projection when the authoritative catalog is absent or corrupt.
-        std::fs::create_dir_all(home.bin_dir()).expect("bin directory");
-        std::fs::write(
-            home.bin_dir().join(format!("{expected_hash}.wasm")),
-            &component_bytes,
-        )
-        .expect("host projection");
-
         let store = astrid_storage::open_runtime_principal_store(&home, unlimited_quota())
             .await
             .expect("principal store");
+        let host_component = home.bin_dir().join(format!("{expected_hash}.wasm"));
+        std::fs::create_dir_all(host_component.parent().unwrap()).expect("bin directory");
+        std::fs::write(&host_component, &component_bytes).expect("host projection");
+        drop(store);
+
+        // An active run may legitimately create a new projected component.
+        // The regression starts from that recovered generation and then makes
+        // its catalog authority missing or corrupt, proving the host copy is
+        // still not selected.
+        let store = astrid_storage::open_runtime_principal_store(&home, unlimited_quota())
+            .await
+            .expect("recover active projection");
+        let name = astrid_storage::ContentName::new(format!("bin/{expected_hash}.wasm"))
+            .expect("catalog name");
+        if catalog_bytes.is_none() {
+            store
+                .content()
+                .delete(&StateOwner::System, &name)
+                .expect("remove catalog authority");
+        }
         if let Some(bytes) = catalog_bytes {
-            let name = astrid_storage::ContentName::new(format!("bin/{expected_hash}.wasm"))
-                .expect("catalog name");
             store
                 .content()
                 .put(&StateOwner::System, &name, bytes)

--- a/crates/astrid-cli/src/commands/daemon.rs
+++ b/crates/astrid-cli/src/commands/daemon.rs
@@ -12,8 +12,10 @@ use crate::commands::daemon_control;
 use crate::formatter::OutputFormat;
 use crate::{socket_client, theme};
 
+mod projection;
 mod ready;
 mod workspace_fingerprint;
+use projection::pack_stopped_projection;
 pub(crate) use ready::disown_if_still_running;
 use ready::{
     DAEMON_READY_POLL, ReadyWaitOutcome, configured_spawn_timeout_secs, default_daemon_ready_secs,
@@ -459,6 +461,15 @@ pub(crate) async fn acquire_daemon_start_fence() -> Result<Arc<std::fs::File>> {
     Ok(Arc::new(file))
 }
 
+/// Admit a disposable runtime override before lifecycle code can resolve or
+/// mutate any path under it.
+pub(crate) fn validate_runtime_admission() -> Result<()> {
+    let home = astrid_core::dirs::AstridHome::resolve()
+        .context("failed to resolve Astrid home for runtime admission")?;
+    home.validate_run_dir()
+        .context("failed to validate ASTRID_RUN_DIR")
+}
+
 /// Keep the start fence outside the home until the kernel admits its layout.
 fn daemon_start_fence_path(home: &astrid_core::dirs::AstridHome) -> std::path::PathBuf {
     let digest = blake3::hash(home.root().to_string_lossy().as_bytes());
@@ -489,6 +500,7 @@ fn daemon_start_fence_path(home: &astrid_core::dirs::AstridHome) -> std::path::P
 /// This never removes a live daemon's socket or signals a live process — the
 /// only mutation happens when the recorded daemon is provably gone.
 pub(crate) async fn handle_start() -> Result<()> {
+    validate_runtime_admission()?;
     let start_fence = acquire_daemon_start_fence().await?;
     let result = handle_start_locked().await;
     drop(start_fence);
@@ -553,6 +565,7 @@ async fn handle_start_locked() -> Result<()> {
 
 /// Handle `astrid status`.
 pub(crate) async fn handle_status(output_format: OutputFormat) -> Result<()> {
+    validate_runtime_admission()?;
     let socket_path = socket_client::proxy_socket_path();
     let endpoint_present = astrid_core::local_transport::endpoint_is_present(&socket_path)
         .context("failed to inspect daemon endpoint")
@@ -651,14 +664,21 @@ fn status_response(response: KernelResponse) -> Result<DaemonStatus> {
 /// `astrid start`/`restart` still see the recorded PID and give an actionable
 /// message instead of failing on the held lock with a raw DB error.
 pub(crate) async fn handle_stop() -> Result<()> {
+    validate_runtime_admission()?;
     // A pre-lease gateway may legitimately hold the start fence while it boots
     // its daemon. Stop the gateway first so stop can reap it; then the fence
     // linearizes the daemon phase against any other start/restart.
     let gateway = crate::commands::mcp::stop_gateway().await;
     let start_fence = acquire_daemon_start_fence().await?;
     let daemon = stop_daemon().await;
+    let projection = if daemon.is_ok() {
+        pack_stopped_projection().await
+    } else {
+        Ok(())
+    };
     drop(start_fence);
     let disposition = combine_stop_results(gateway, daemon)?;
+    projection?;
     print_stop_disposition(disposition);
     Ok(())
 }
@@ -670,6 +690,12 @@ pub(crate) async fn handle_gateway_stop() -> Result<()> {
 /// Stop only the daemon while the caller already owns the start fence.
 pub(crate) async fn handle_daemon_stop_locked() -> Result<()> {
     let result = stop_daemon().await;
+    let projection = if result.is_ok() {
+        pack_stopped_projection().await
+    } else {
+        Ok(())
+    };
+    projection?;
     print_stop_disposition(result?);
     Ok(())
 }
@@ -835,11 +861,18 @@ async fn cleanup_daemon_runtime_for_home(
 ) -> Result<()> {
     // An idempotent stop on a never-initialized home must not create the Astrid
     // layout merely to prove that its absent runtime is absent.
-    if !home
+    let durable_media_present = home
+        .storage_volume_path()
+        .try_exists()
+        .context("shutdown stage durable_media_probe")?;
+    let runtime_present = home
         .run_dir()
         .try_exists()
-        .context("shutdown stage daemon.runtime_probe")?
-    {
+        .context("shutdown stage daemon.runtime_probe")?;
+    if !durable_media_present && !runtime_present {
+        return Ok(());
+    }
+    if !runtime_present {
         return Ok(());
     }
     let lock_path = home.run_dir().join("system.lock");
@@ -906,7 +939,13 @@ async fn cleanup_daemon_runtime_for_home(
             },
         }
     }
-    Ok(())
+    drop(lock);
+    astrid_core::dirs::retire_legacy_source_tree(&home.run_dir()).with_context(|| {
+        format!(
+            "shutdown stage daemon.runtime_cleanup: {}",
+            home.run_dir().display()
+        )
+    })
 }
 
 /// Whether a stop outcome CONFIRMS the daemon is gone — the only condition under

--- a/crates/astrid-cli/src/commands/daemon/projection.rs
+++ b/crates/astrid-cli/src/commands/daemon/projection.rs
@@ -18,6 +18,11 @@ fn unbounded(owner: &astrid_storage::StateOwner) -> astrid_storage::StorageResul
 pub(super) async fn pack_stopped_projection() -> Result<()> {
     let home =
         AstridHome::resolve().context("shutdown stage durable_projection_home_resolution")?;
+    pack_stopped_projection_for_home(&home).await
+}
+
+/// Pack and retire one explicit isolated home during tests and stop handling.
+pub(super) async fn pack_stopped_projection_for_home(home: &AstridHome) -> Result<()> {
     if !home
         .storage_volume_path()
         .try_exists()
@@ -28,14 +33,13 @@ pub(super) async fn pack_stopped_projection() -> Result<()> {
 
     let quota: Arc<dyn astrid_storage::KvQuotaResolver<astrid_storage::StateOwner>> =
         Arc::new(unbounded);
-    let store =
-        astrid_storage::principal_state::open_runtime_principal_store_for_pack(&home, quota)
-            .await
-            .context("shutdown stage durable_projection_open")?;
+    let store = astrid_storage::principal_state::open_runtime_principal_store_for_pack(home, quota)
+        .await
+        .context("shutdown stage durable_projection_open")?;
     store
-        .pack_and_retire_runtime_projection(&home)
+        .pack_and_retire_runtime_projection(home)
         .context("shutdown stage durable_projection_pack")?;
-    retire_stopped_projection(&home)
+    retire_stopped_projection(home)
 }
 
 /// Remove durable projections after the CLI-only post-exit pack.

--- a/crates/astrid-cli/src/commands/daemon/projection.rs
+++ b/crates/astrid-cli/src/commands/daemon/projection.rs
@@ -53,47 +53,10 @@ pub(super) fn retire_stopped_projection(home: &AstridHome) -> Result<()> {
     {
         return Ok(());
     }
-    let mut entries = std::fs::read_dir(root)
-        .with_context(|| format!("shutdown stage durable_root_read: {}", root.display()))?
-        .collect::<std::io::Result<Vec<_>>>()
-        .context("shutdown stage durable_root_entry")?;
-    entries.sort_by_key(std::fs::DirEntry::file_name);
-    for entry in entries {
-        let path = entry.path();
-        if entry.file_name() == std::ffi::OsStr::new("astrid.volume") {
-            continue;
-        }
-        let metadata = std::fs::symlink_metadata(&path).with_context(|| {
-            format!(
-                "shutdown stage durable_projection_probe: {}",
-                path.display()
-            )
-        })?;
-        anyhow::ensure!(
-            !metadata.file_type().is_symlink(),
-            "shutdown stage durable_projection_boundary: {} is redirected",
-            path.display()
-        );
-        if metadata.is_dir() {
-            astrid_core::dirs::retire_legacy_source_tree(&path).with_context(|| {
-                format!(
-                    "shutdown stage durable_projection_cleanup: {}",
-                    path.display()
-                )
-            })?;
-        } else if metadata.is_file() {
-            std::fs::remove_file(&path).with_context(|| {
-                format!(
-                    "shutdown stage durable_projection_cleanup: {}",
-                    path.display()
-                )
-            })?;
-        } else {
-            anyhow::bail!(
-                "shutdown stage durable_projection_boundary: {} is not a regular file or directory",
-                path.display()
-            );
-        }
-    }
-    Ok(())
+    astrid_core::dirs::retire_projection_root(root).with_context(|| {
+        format!(
+            "shutdown stage durable_projection_cleanup: {}",
+            root.display()
+        )
+    })
 }

--- a/crates/astrid-cli/src/commands/daemon/projection.rs
+++ b/crates/astrid-cli/src/commands/daemon/projection.rs
@@ -1,0 +1,95 @@
+//! CLI-side retirement of the volume-backed running projection.
+
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use astrid_core::dirs::AstridHome;
+
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "the quota hook requires the storage projection's Result shape"
+)]
+fn unbounded(owner: &astrid_storage::StateOwner) -> astrid_storage::StorageResult<Option<u64>> {
+    let _ = owner;
+    Ok(None)
+}
+
+/// Reopen the stopped volume, publish the final projection, and retire hosts.
+pub(super) async fn pack_stopped_projection() -> Result<()> {
+    let home =
+        AstridHome::resolve().context("shutdown stage durable_projection_home_resolution")?;
+    if !home
+        .storage_volume_path()
+        .try_exists()
+        .context("shutdown stage durable_media_probe")?
+    {
+        return Ok(());
+    }
+
+    let quota: Arc<dyn astrid_storage::KvQuotaResolver<astrid_storage::StateOwner>> =
+        Arc::new(unbounded);
+    let store =
+        astrid_storage::principal_state::open_runtime_principal_store_for_pack(&home, quota)
+            .await
+            .context("shutdown stage durable_projection_open")?;
+    store
+        .pack_and_retire_runtime_projection(&home)
+        .context("shutdown stage durable_projection_pack")?;
+    retire_stopped_projection(&home)
+}
+
+/// Remove durable projections after the CLI-only post-exit pack.
+///
+/// The canonical media file is the only survivor.
+pub(super) fn retire_stopped_projection(home: &AstridHome) -> Result<()> {
+    let root = home.root();
+    if !root
+        .try_exists()
+        .context("shutdown stage durable_root_probe")?
+    {
+        return Ok(());
+    }
+    let mut entries = std::fs::read_dir(root)
+        .with_context(|| format!("shutdown stage durable_root_read: {}", root.display()))?
+        .collect::<std::io::Result<Vec<_>>>()
+        .context("shutdown stage durable_root_entry")?;
+    entries.sort_by_key(std::fs::DirEntry::file_name);
+    for entry in entries {
+        let path = entry.path();
+        if entry.file_name() == std::ffi::OsStr::new("astrid.volume") {
+            continue;
+        }
+        let metadata = std::fs::symlink_metadata(&path).with_context(|| {
+            format!(
+                "shutdown stage durable_projection_probe: {}",
+                path.display()
+            )
+        })?;
+        anyhow::ensure!(
+            !metadata.file_type().is_symlink(),
+            "shutdown stage durable_projection_boundary: {} is redirected",
+            path.display()
+        );
+        if metadata.is_dir() {
+            astrid_core::dirs::retire_legacy_source_tree(&path).with_context(|| {
+                format!(
+                    "shutdown stage durable_projection_cleanup: {}",
+                    path.display()
+                )
+            })?;
+        } else if metadata.is_file() {
+            std::fs::remove_file(&path).with_context(|| {
+                format!(
+                    "shutdown stage durable_projection_cleanup: {}",
+                    path.display()
+                )
+            })?;
+        } else {
+            anyhow::bail!(
+                "shutdown stage durable_projection_boundary: {} is not a regular file or directory",
+                path.display()
+            );
+        }
+    }
+    Ok(())
+}

--- a/crates/astrid-cli/src/commands/daemon/tests.rs
+++ b/crates/astrid-cli/src/commands/daemon/tests.rs
@@ -374,3 +374,35 @@ async fn failed_stop_pack_returns_error_and_retains_host_sidecars() {
         "failed stop must not claim exact volume-only state"
     );
 }
+
+#[cfg(unix)]
+#[tokio::test]
+async fn cli_stop_preflight_retains_regular_file_when_special_comes_later() {
+    use std::os::unix::net::UnixListener;
+
+    let root = tempfile::tempdir().expect("temporary isolated root");
+    let home = astrid_core::dirs::AstridHome::from_path(root.path().join("astrid-home"));
+    let store = astrid_storage::open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .expect("open isolated running store");
+    let regular = home.root().join("regular");
+    std::fs::write(&regular, b"cli-side retirement input").expect("write regular file");
+    let socket_path = home.root().join("run/other.sock");
+    std::fs::create_dir_all(socket_path.parent().unwrap()).expect("create run directory");
+    let _socket = UnixListener::bind(&socket_path).expect("inject root special");
+    drop(store);
+
+    let error = projection::pack_stopped_projection_for_home(&home)
+        .await
+        .expect_err("CLI stop must preflight the complete projection root");
+    let message = format!("{error:#}");
+    assert!(
+        message.contains("durable_projection_pack") && message.contains("special entry"),
+        "unexpected CLI stop failure: {message}"
+    );
+    assert_eq!(
+        std::fs::read(&regular).unwrap(),
+        b"cli-side retirement input"
+    );
+    assert!(socket_path.symlink_metadata().is_ok());
+}

--- a/crates/astrid-cli/src/commands/daemon/tests.rs
+++ b/crates/astrid-cli/src/commands/daemon/tests.rs
@@ -318,3 +318,59 @@ fn absent_daemon_has_typed_stopped_status() {
         serde_json::json!({ "state": "stopped" })
     );
 }
+
+fn unlimited_quota()
+-> std::sync::Arc<dyn astrid_storage::KvQuotaResolver<astrid_storage::StateOwner>> {
+    std::sync::Arc::new(|owner: &astrid_storage::StateOwner| {
+        Ok(match owner {
+            astrid_storage::StateOwner::System => None,
+            astrid_storage::StateOwner::Principal(_) | astrid_storage::StateOwner::Fleet(_) => {
+                Some(u64::MAX)
+            },
+        })
+    })
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn failed_stop_pack_returns_error_and_retains_host_sidecars() {
+    use std::os::unix::fs::symlink;
+
+    let root = tempfile::tempdir().expect("temporary isolated root");
+    let home = astrid_core::dirs::AstridHome::from_path(root.path().join("astrid-home"));
+    let store = astrid_storage::open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .expect("open isolated running store");
+    let log_path = home.root().join("log/daemon.log");
+    let config_path = home.root().join("etc/authz.conf");
+    std::fs::create_dir_all(log_path.parent().unwrap()).expect("create log directory");
+    std::fs::write(&log_path, b"generation-1\ngeneration-2\n").expect("write appended log");
+    std::fs::write(&config_path, b"allow=generation-2\n").expect("write appended config");
+    drop(store);
+
+    let outside = tempfile::tempdir().expect("temporary redirect target");
+    let redirect = home.root().join("redirect");
+    symlink(outside.path(), &redirect).expect("inject admission failure");
+
+    let error = projection::pack_stopped_projection_for_home(&home)
+        .await
+        .expect_err("a failed projection pack cannot report a successful stop");
+    let message = format!("{error:#}");
+    assert!(
+        message.contains("durable_projection_pack") && message.contains("symbolic link"),
+        "unexpected stop failure: {message}"
+    );
+    assert!(redirect.symlink_metadata().is_ok(), "redirect was removed");
+    assert!(
+        log_path.try_exists().unwrap(),
+        "appended log sidecar was retired after failure"
+    );
+    assert!(
+        config_path.try_exists().unwrap(),
+        "appended config sidecar was retired after failure"
+    );
+    assert!(
+        std::fs::read_dir(home.root()).unwrap().count() > 1,
+        "failed stop must not claim exact volume-only state"
+    );
+}

--- a/crates/astrid-cli/src/commands/distro/trust.rs
+++ b/crates/astrid-cli/src/commands/distro/trust.rs
@@ -2,7 +2,7 @@
 //!
 //! Trust is per-distro. Product paths require the pin to exist before
 //! use; ordinary signed paths may create the first pin. The store lives
-//! at `$ASTRID_HOME/trust/<distro-id>.pub`, one file per distro,
+//! as the mounted durable projection `$ASTRID_HOME/trust/<distro-id>.pub`,
 //! containing a single `ed25519:<base64>` line.
 //!
 //! ## Threat model
@@ -212,6 +212,18 @@ mod tests {
     fn home() -> (tempfile::TempDir, AstridHome) {
         let dir = tempfile::tempdir().unwrap();
         let home = AstridHome::from_path(dir.path());
+        std::fs::create_dir_all(home.root()).unwrap();
+        std::fs::write(home.storage_volume_path(), b"mounted-test-volume").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(
+                home.storage_volume_path(),
+                std::fs::Permissions::from_mode(0o600),
+            )
+            .unwrap();
+        }
+        std::fs::create_dir_all(home.root().join("trust")).unwrap();
         (dir, home)
     }
 

--- a/crates/astrid-cli/src/commands/init_grant.rs
+++ b/crates/astrid-cli/src/commands/init_grant.rs
@@ -744,6 +744,19 @@ mod tests {
     fn fresh_lock_rehashes_catalog_wasm_bytes_when_store_is_bound() {
         let dir = tempfile::tempdir().unwrap();
         let home = AstridHome::from_path(dir.path());
+        home.ensure().unwrap();
+        let quota: Arc<dyn astrid_storage::KvQuotaResolver<astrid_storage::StateOwner>> =
+            Arc::new(|owner: &astrid_storage::StateOwner| {
+                Ok(match owner {
+                    astrid_storage::StateOwner::System => None,
+                    astrid_storage::StateOwner::Principal(_)
+                    | astrid_storage::StateOwner::Fleet(_) => Some(u64::MAX),
+                })
+            });
+        let store = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(astrid_storage::open_runtime_principal_store(&home, quota))
+            .unwrap();
         let target = PrincipalId::new("alice").unwrap();
         let install_dir = install::resolve_target_dir_for(&home, &target, "cli", false).unwrap();
         std::fs::create_dir_all(&install_dir).unwrap();
@@ -770,23 +783,17 @@ mod tests {
             hash: format!("blake3:{hash}"),
             resolved_ref: Some("v1.0.0".to_string()),
         }];
-        let quota: Arc<dyn astrid_storage::KvQuotaResolver<astrid_storage::StateOwner>> =
-            Arc::new(|owner: &astrid_storage::StateOwner| {
-                Ok(match owner {
-                    astrid_storage::StateOwner::System => None,
-                    astrid_storage::StateOwner::Principal(_)
-                    | astrid_storage::StateOwner::Fleet(_) => Some(u64::MAX),
-                })
-            });
-        let store = tokio::runtime::Runtime::new()
-            .unwrap()
-            .block_on(astrid_storage::open_runtime_principal_store(&home, quota))
-            .unwrap();
         let name = astrid_storage::ContentName::new(format!("bin/{hash}.wasm")).unwrap();
         store
             .content()
             .put(&astrid_storage::StateOwner::System, &name, &wasm)
             .unwrap();
+        let staging_intent = home.content_staging_path().join("intents.v1.log");
+        std::fs::create_dir_all(staging_intent.parent().unwrap()).unwrap();
+        std::fs::write(&staging_intent, b"catalog fixture").unwrap();
+        store
+            .publish_runtime_projection(&home)
+            .expect("admit catalog fixture projection");
 
         assert_eq!(
             validate_locked_capsules_with_store(&home, &target, &locked, Some(&store)).unwrap(),

--- a/crates/astrid-cli/src/commands/mcp/lifecycle.rs
+++ b/crates/astrid-cli/src/commands/mcp/lifecycle.rs
@@ -506,6 +506,18 @@ pub(crate) async fn wait_for_gateway(principal: &PrincipalId, format: &str) -> R
 /// gone. Inconsistent or unowned state is left intact and reported.
 pub(crate) async fn stop_gateway() -> Result<()> {
     let socket = gateway_socket_path()?;
+    // A fresh or already-clean runtime has no gateway generation to lock.
+    // Acquiring the lifecycle lock here would create the transient root before
+    // admission, which is forbidden for the stopped durable layout.
+    if read_gateway_ready()?.is_none()
+        && read_gateway_startup_lease()?.is_none()
+        && matches!(
+            astrid_core::local_transport::connect_outcome(&socket).await?,
+            astrid_core::local_transport::ConnectOutcome::Absent
+        )
+    {
+        return Ok(());
+    }
     let Some(record) = read_gateway_ready()? else {
         let deadline = Instant::now()
             .checked_add(READY_TIMEOUT)

--- a/crates/astrid-cli/src/commands/self_update_notice.rs
+++ b/crates/astrid-cli/src/commands/self_update_notice.rs
@@ -191,14 +191,13 @@ mod tests {
     }
 
     #[test]
-    fn update_notice_uses_the_admitted_layout() {
+    fn update_notice_does_not_treat_a_fresh_volume_only_root_as_admitted() {
         let root = tempfile::tempdir().unwrap();
         let home = astrid_core::dirs::AstridHome::from_path(root.path().join("astrid-home"));
         home.ensure().unwrap();
 
-        assert_eq!(
-            cache_path_for(&home).unwrap(),
-            home.var_dir().join("update-check.json")
-        );
+        let error = cache_path_for(&home).unwrap_err();
+        assert!(error.to_string().contains("initialized Astrid home"));
+        assert_eq!(std::fs::read_dir(home.root()).unwrap().count(), 0);
     }
 }

--- a/crates/astrid-cli/src/dispatch.rs
+++ b/crates/astrid-cli/src/dispatch.rs
@@ -233,7 +233,10 @@ async fn dispatch_subcommand(
             commands::daemon::handle_stop().await?;
             Ok(ExitCode::SUCCESS)
         },
-        Some(Commands::Restart) => commands::restart::run().await,
+        Some(Commands::Restart) => {
+            commands::daemon::validate_runtime_admission()?;
+            commands::restart::run().await
+        },
         Some(Commands::Storage { command }) => commands::storage::run(command),
         Some(Commands::Logs(args)) => commands::logs::run(&args).await,
         Some(Commands::Ps(args)) => commands::ps::run(args).await,
@@ -465,6 +468,9 @@ async fn dispatch_capsule_remove(
 }
 
 async fn dispatch_mcp(command: McpCommands) -> Result<ExitCode> {
+    if !matches!(command, McpCommands::Gc) {
+        commands::daemon::validate_runtime_admission()?;
+    }
     match command {
         McpCommands::Serve {
             workspace,

--- a/crates/astrid-cli/tests/daemon_projection_pin_survival.rs
+++ b/crates/astrid-cli/tests/daemon_projection_pin_survival.rs
@@ -1,0 +1,481 @@
+use std::process::{Command, Stdio};
+
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct LockDistro {
+    id: &'static str,
+    version: &'static str,
+    #[serde(rename = "resolved-at")]
+    resolved_at: &'static str,
+}
+
+#[derive(Serialize)]
+struct LockCapsule {
+    name: &'static str,
+    version: &'static str,
+    source: &'static str,
+    hash: String,
+    resolved_ref: &'static str,
+}
+
+#[derive(Serialize)]
+struct DistroLock {
+    #[serde(rename = "schema-version")]
+    schema_version: u32,
+    distro: LockDistro,
+    #[serde(rename = "capsule")]
+    capsules: Vec<LockCapsule>,
+    #[serde(rename = "manifest-hash")]
+    manifest_hash: String,
+}
+
+#[test]
+fn clean_stop_preserves_a_pin_created_in_the_mounted_projection() {
+    let root = tempfile::tempdir().unwrap();
+    let home = root.path().join("astrid-home");
+    let run_dir = root.path().join("astrid-run");
+    let client_config = root.path().join("client.toml");
+    std::fs::write(&client_config, "run_idle_secs = 120\n").unwrap();
+
+    let shuttle = write_signed_shuttle(root.path(), "pin-survival");
+    std::fs::create_dir_all(&run_dir).unwrap();
+    let missing_pin_stderr = root.path().join("missing-pin.stderr");
+    let missing_pin = astrid(root.path(), &home, &run_dir, &client_config)
+        .args(["distro", "apply", "--offline", "--yes"])
+        .arg(&shuttle)
+        .stdout(Stdio::null())
+        .stderr(std::fs::File::create(&missing_pin_stderr).unwrap())
+        .status()
+        .unwrap();
+    let missing_pin_stderr = std::fs::read_to_string(missing_pin_stderr).unwrap();
+    assert!(!missing_pin.success(), "{missing_pin_stderr}");
+    assert!(
+        missing_pin_stderr.contains("no signing-key pin"),
+        "product apply bypassed pin-first admission: {missing_pin_stderr}"
+    );
+    assert!(!home.join("trust/pin-survival.pub").exists());
+
+    let started = detached(astrid(root.path(), &home, &run_dir, &client_config).arg("start"))
+        .status()
+        .unwrap();
+    assert!(started.success());
+
+    let pin = home.join("trust/pin-survival.pub");
+    std::fs::create_dir_all(pin.parent().unwrap()).unwrap();
+    std::fs::write(&pin, b"ed25519:operator-published-pin\n").unwrap();
+
+    let stopped = detached(astrid(root.path(), &home, &run_dir, &client_config).arg("stop"))
+        .status()
+        .unwrap();
+    assert!(stopped.success());
+    assert_stopped_volume_only(&home);
+    assert!(!run_dir.exists());
+
+    let restarted = detached(astrid(root.path(), &home, &run_dir, &client_config).arg("restart"))
+        .status()
+        .unwrap();
+    assert!(restarted.success());
+    assert_eq!(
+        std::fs::read_to_string(&pin).unwrap(),
+        "ed25519:operator-published-pin\n"
+    );
+
+    let final_stop = detached(astrid(root.path(), &home, &run_dir, &client_config).arg("stop"))
+        .status()
+        .unwrap();
+    assert!(final_stop.success());
+    assert_stopped_volume_only(&home);
+    assert!(!run_dir.exists());
+}
+
+fn astrid(
+    root: &std::path::Path,
+    home: &std::path::Path,
+    run_dir: &std::path::Path,
+    client_config: &std::path::Path,
+) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_astrid"));
+    command
+        .current_dir(root)
+        .env("ASTRID_HOME", home)
+        .env("ASTRID_RUN_DIR", run_dir)
+        .env("ASTRID_CLIENT_CONFIG_PATH", client_config)
+        .env("HOME", root);
+    command
+}
+
+fn detached(command: &mut Command) -> &mut Command {
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+}
+
+fn assert_stopped_volume_only(home: &std::path::Path) {
+    let mut entries = std::fs::read_dir(home)
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    entries.sort_by_key(std::fs::DirEntry::file_name);
+    assert_eq!(entries.len(), 1, "stopped root retained sidecars");
+    assert_eq!(
+        entries[0].file_name(),
+        std::ffi::OsStr::new("astrid.volume")
+    );
+    assert!(entries[0].metadata().unwrap().is_file());
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        assert_eq!(
+            entries[0].metadata().unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
+}
+
+fn write_signed_shuttle(root: &std::path::Path, distro_id: &'static str) -> std::path::PathBuf {
+    let key = astrid_crypto::KeyPair::generate();
+    let public_key = key.export_public_key();
+    let public_wire = format!("ed25519:{}", public_key.to_base64());
+    let capsule = b"disposable-capsule-not-installed";
+    let manifest = format!(
+        "schema-version = 1\n\n\
+         [distro]\nid = \"{distro_id}\"\nname = \"Pin Survival\"\nversion = \"0.1.0\"\n\n\
+         [distro.signing]\npubkey = \"{public_wire}\"\n\n\
+         [[capsule]]\nname = \"astrid-capsule-cli\"\nsource = \"@test/cli\"\n\
+         version = \"0.1.0\"\nrole = \"uplink\"\n"
+    );
+    let manifest = manifest.into_bytes();
+    let lock = DistroLock {
+        schema_version: 1,
+        distro: LockDistro {
+            id: distro_id,
+            version: "0.1.0",
+            resolved_at: "1970-01-01T00:00:00+00:00",
+        },
+        capsules: vec![LockCapsule {
+            name: "astrid-capsule-cli",
+            version: "0.1.0",
+            source: "@test/cli",
+            hash: format!("blake3:{}", blake3::hash(capsule).to_hex()),
+            resolved_ref: "v0.1.0",
+        }],
+        manifest_hash: format!("blake3:{}", blake3::hash(&manifest).to_hex()),
+    };
+    let lock_bytes = serde_json::to_vec(&lock).unwrap();
+    let mut digest = blake3::Hasher::new();
+    digest.update(b"astrid-distro-lock-sig-v1\x00");
+    digest.update(&lock_bytes);
+    let signature = hex::encode(key.sign(digest.finalize().as_bytes()).as_bytes());
+    let lock_toml = toml::to_string_pretty(&lock).unwrap();
+
+    let path = root.join(format!("{distro_id}.shuttle"));
+    let output = std::fs::File::create(&path).unwrap();
+    let encoder = flate2::write::GzEncoder::new(output, flate2::Compression::default());
+    let mut archive = tar::Builder::new(encoder);
+    for (name, bytes) in [
+        ("Distro.toml", manifest.as_slice()),
+        ("Distro.lock", lock_toml.as_bytes()),
+        ("Distro.sig", signature.as_bytes()),
+        ("capsules/astrid-capsule-cli.capsule", capsule.as_slice()),
+    ] {
+        let mut header = tar::Header::new_gnu();
+        header.set_size(bytes.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        archive.append_data(&mut header, name, bytes).unwrap();
+    }
+    archive.into_inner().unwrap().finish().unwrap();
+    path
+}
+
+#[test]
+fn run_dir_equal_to_home_fails_start_without_deleting_durable_media() {
+    let root = tempfile::tempdir().unwrap();
+    let home = root.path().join("astrid-home");
+    let client_config = root.path().join("client.toml");
+    std::fs::write(&client_config, "run_idle_secs = 120\n").unwrap();
+    std::fs::create_dir_all(&home).unwrap();
+    std::fs::write(home.join("astrid.volume"), b"disposable-durable-media").unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::set_permissions(
+            home.join("astrid.volume"),
+            std::fs::Permissions::from_mode(0o600),
+        )
+        .unwrap();
+    }
+
+    let output = astrid(root.path(), &home, &home, &client_config)
+        .arg("start")
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "start accepted root override: {stderr}"
+    );
+    assert!(
+        stderr.contains("ASTRID_RUN_DIR overlaps the Astrid durable root"),
+        "unexpected startup failure: {stderr}"
+    );
+    assert_stopped_volume_only(&home);
+}
+
+#[test]
+fn run_dir_equal_to_home_fails_all_lifecycle_commands_without_stale_marker_mutation() {
+    let root = tempfile::tempdir().unwrap();
+    let home = root.path().join("astrid-home");
+    let client_config = root.path().join("client.toml");
+    std::fs::write(&client_config, "run_idle_secs = 120\n").unwrap();
+    std::fs::create_dir_all(&home).unwrap();
+    std::fs::write(home.join("astrid.volume"), b"disposable-durable-media").unwrap();
+    let run_dir = home.join("run");
+    std::fs::create_dir_all(&run_dir).unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::set_permissions(
+            home.join("astrid.volume"),
+            std::fs::Permissions::from_mode(0o600),
+        )
+        .unwrap();
+    }
+    let stale_files = [
+        (run_dir.join("system.ready"), b"ready".as_slice()),
+        (run_dir.join("system.pid"), b"424242".as_slice()),
+        (run_dir.join("system.token"), b"token".as_slice()),
+    ];
+    for (path, contents) in &stale_files {
+        std::fs::write(path, *contents).unwrap();
+    }
+
+    for command in ["start", "status", "stop", "restart"] {
+        let output = astrid(root.path(), &home, &home, &client_config)
+            .arg(command)
+            .output()
+            .unwrap();
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            !output.status.success(),
+            "{command} accepted root override: {stderr}"
+        );
+        assert!(
+            stderr.contains("ASTRID_RUN_DIR overlaps the Astrid durable root"),
+            "unexpected {command} failure: {stderr}"
+        );
+        assert_rejected_stale_fixture_unchanged(&home, &run_dir, &stale_files);
+    }
+}
+
+#[test]
+fn external_run_dir_lifecycle_admits_valid_paths_but_rejects_overrides_early() {
+    let root = tempfile::tempdir().unwrap();
+    let home = root.path().join("astrid-home");
+    let run_dir = root.path().join("astrid-run");
+    let client_config = root.path().join("client.toml");
+    std::fs::write(&client_config, "run_idle_secs = 120\n").unwrap();
+    std::fs::create_dir_all(&run_dir).unwrap();
+
+    let started = detached(astrid(root.path(), &home, &run_dir, &client_config).arg("start"))
+        .status()
+        .unwrap();
+    assert!(started.success());
+
+    let status = astrid(root.path(), &home, &run_dir, &client_config)
+        .arg("status")
+        .output()
+        .unwrap();
+    assert!(status.status.success());
+    assert!(String::from_utf8_lossy(&status.stdout).contains("Astrid daemon"));
+
+    let already_running = astrid(root.path(), &home, &run_dir, &client_config)
+        .arg("start")
+        .output()
+        .unwrap();
+    assert!(already_running.status.success());
+    let already_running_text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&already_running.stdout),
+        String::from_utf8_lossy(&already_running.stderr)
+    );
+    assert!(already_running_text.contains("already running"));
+
+    for (override_path, expected_error) in [
+        (home.clone(), "overlaps the Astrid durable root"),
+        (std::path::PathBuf::from("run"), "must be an absolute path"),
+    ] {
+        let rejected = astrid(root.path(), &home, &override_path, &client_config)
+            .arg("start")
+            .output()
+            .unwrap();
+        assert!(!rejected.status.success());
+        let rejected_stderr = String::from_utf8_lossy(&rejected.stderr);
+        assert!(
+            rejected_stderr.contains(expected_error),
+            "override was not rejected at admission: {rejected_stderr}"
+        );
+        assert!(!rejected_stderr.contains("already running"));
+    }
+
+    let restarted = detached(astrid(root.path(), &home, &run_dir, &client_config).arg("restart"))
+        .status()
+        .unwrap();
+    assert!(restarted.success());
+
+    let stopped = detached(astrid(root.path(), &home, &run_dir, &client_config).arg("stop"))
+        .status()
+        .unwrap();
+    assert!(stopped.success());
+    assert_stopped_volume_only(&home);
+    assert!(!run_dir.exists());
+}
+
+#[test]
+fn mcp_lifecycle_rejects_root_run_dir_before_stale_marker_mutation() {
+    let root = tempfile::tempdir().unwrap();
+    let home = root.path().join("astrid-home");
+    let client_config = root.path().join("client.toml");
+    std::fs::write(&client_config, "run_idle_secs = 120\n").unwrap();
+    std::fs::create_dir_all(&home).unwrap();
+    std::fs::write(home.join("astrid.volume"), b"disposable-durable-media").unwrap();
+    let run_dir = home.join("run");
+    std::fs::create_dir_all(&run_dir).unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::set_permissions(
+            home.join("astrid.volume"),
+            std::fs::Permissions::from_mode(0o600),
+        )
+        .unwrap();
+    }
+    let stale_files = [
+        (run_dir.join("system.ready"), b"ready".as_slice()),
+        (run_dir.join("system.pid"), b"424242".as_slice()),
+        (run_dir.join("system.token"), b"token".as_slice()),
+    ];
+    for (path, contents) in &stale_files {
+        std::fs::write(path, *contents).unwrap();
+    }
+
+    for command in [
+        vec![
+            "serve".to_owned(),
+            "--workspace".to_owned(),
+            root.path().display().to_string(),
+        ],
+        vec!["gateway".to_owned()],
+        vec!["ready".to_owned(), "--format".to_owned(), "json".to_owned()],
+    ] {
+        let mut command_line = astrid(root.path(), &home, &home, &client_config);
+        let output = bounded_mcp(&mut command_line, &command);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            !output.status.success(),
+            "mcp {:?} accepted root override: {}{}",
+            command,
+            String::from_utf8_lossy(&output.stdout),
+            stderr
+        );
+        assert!(
+            stderr.contains("ASTRID_RUN_DIR overlaps the Astrid durable root"),
+            "unexpected mcp {:?} failure: {}{}",
+            command,
+            String::from_utf8_lossy(&output.stdout),
+            stderr
+        );
+        assert_rejected_stale_fixture_unchanged(&home, &run_dir, &stale_files);
+        assert!(
+            !run_dir.join("mcp-gateway.sock").exists()
+                && !run_dir.join("mcp-gateway.ready").exists()
+                && !run_dir.join("mcp-gateway.lifecycle.lock").exists()
+                && !run_dir.join("mcp-gateway.start.lock").exists()
+                && !run_dir.join("mcp-gateway.starting").exists()
+                && !run_dir.join("mcp-gateway.startup.json").exists(),
+            "rejected mcp {command:?} created a gateway marker"
+        );
+    }
+}
+
+fn bounded_mcp(command: &mut Command, args: &[String]) -> std::process::Output {
+    let mut child = command
+        .arg("mcp")
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    let deadline = std::time::Instant::now()
+        .checked_add(std::time::Duration::from_secs(10))
+        .expect("valid admission timeout");
+    let status = loop {
+        match child.try_wait().unwrap() {
+            Some(status) => break status,
+            None if std::time::Instant::now() >= deadline => {
+                child.kill().unwrap();
+                panic!("astrid mcp {args:?} did not fail admission promptly");
+            },
+            None => std::thread::sleep(std::time::Duration::from_millis(25)),
+        }
+    };
+    let stdout = child.stdout.take().map(|mut stdout| {
+        let mut bytes = Vec::new();
+        std::io::Read::read_to_end(&mut stdout, &mut bytes).unwrap();
+        bytes
+    });
+    let stderr = child.stderr.take().map(|mut stderr| {
+        let mut bytes = Vec::new();
+        std::io::Read::read_to_end(&mut stderr, &mut bytes).unwrap();
+        bytes
+    });
+    std::process::Output {
+        status,
+        stdout: stdout.unwrap_or_default(),
+        stderr: stderr.unwrap_or_default(),
+    }
+}
+
+fn assert_rejected_stale_fixture_unchanged(
+    home: &std::path::Path,
+    run_dir: &std::path::Path,
+    stale_files: &[(std::path::PathBuf, &[u8])],
+) {
+    let names = |path: &std::path::Path| {
+        let mut names: Vec<String> = std::fs::read_dir(path)
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
+            .into_iter()
+            .map(|entry| entry.file_name().to_string_lossy().into_owned())
+            .collect();
+        names.sort();
+        names
+    };
+    assert_eq!(names(home), ["astrid.volume", "run"]);
+    assert_eq!(
+        names(run_dir),
+        ["system.pid", "system.ready", "system.token"]
+    );
+    let volume = home.join("astrid.volume");
+    assert!(volume.is_file());
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        assert_eq!(
+            std::fs::metadata(volume).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
+    for (path, contents) in stale_files {
+        assert_eq!(
+            std::fs::read(path).unwrap(),
+            *contents,
+            "rejected command mutated stale marker {}",
+            path.display()
+        );
+    }
+}

--- a/crates/astrid-cli/tests/headless_dispatch_order.rs
+++ b/crates/astrid-cli/tests/headless_dispatch_order.rs
@@ -9,6 +9,7 @@ fn headless_auto_approve_is_rejected_before_the_update_notice() {
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
         .as_secs();
+    std::fs::create_dir_all(home.var_dir()).unwrap();
     std::fs::write(
         home.var_dir().join("update-check.json"),
         format!(
@@ -44,6 +45,7 @@ fn nested_run_auto_approve_is_rejected_before_the_update_notice() {
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_secs();
+        std::fs::create_dir_all(home.var_dir()).unwrap();
         std::fs::write(
             home.var_dir().join("update-check.json"),
             format!(

--- a/crates/astrid-core/src/dirs.rs
+++ b/crates/astrid-core/src/dirs.rs
@@ -46,6 +46,9 @@ pub const LEGACY_LAYOUT_VERSION: &str = "1";
 #[path = "dirs_layout.rs"]
 mod dirs_layout;
 pub use dirs_layout::{LayoutMigrationTarget, retire_legacy_source_tree};
+#[path = "dirs_projection_retirement.rs"]
+mod projection_retirement;
+pub use projection_retirement::retire_projection_root;
 #[path = "dirs_run_dir.rs"]
 mod run_dir;
 #[path = "dirs_workspace.rs"]

--- a/crates/astrid-core/src/dirs.rs
+++ b/crates/astrid-core/src/dirs.rs
@@ -2,10 +2,10 @@
 //!
 //! Two key directory structures:
 //!
-//! - [`AstridHome`]: Global state at `~/.astrid/` (or `$ASTRID_HOME`).
-//!   Linux FHS-aligned layout with `etc/`, `var/`, `run/`, `log/`, `keys/`,
-//!   `bin/`, and `lib/`. Principal content is stored in the authoritative
-//!   `AstridFilesystem`; a native `home/` tree is only a legacy import source.
+//! - [`AstridHome`]: Global durable root at `~/.astrid/` (or `$ASTRID_HOME`).
+//!   Stopped state is exactly the private `astrid.volume` media file. While a
+//!   daemon runs, volume-backed files are projected at their historical paths;
+//!   transients use `ASTRID_RUN_DIR` or a disposable runtime directory.
 //!
 //! - [`WorkspaceDir`]: Selected per-project state directory.
 //!   Holds project configuration, capsules, hooks, and instructions.
@@ -19,27 +19,7 @@
 //!
 //! ```text
 //! ~/.astrid/                           (AstridHome)
-//! ├── etc/
-//! │   ├── config.toml                    deployment config
-//! │   ├── servers.toml                   MCP server config
-//! │   ├── gateway.toml                   daemon config
-//! │   ├── hooks/                         system hooks
-//! │   └── layout-version                 layout version sentinel
-//! ├── volume                            hosted Astrid-owned storage media
-//! ├── var/
-//! │   ├── content-staging/                private acknowledged-write staging
-//! │   ├── migrations/                     durable layout intents and receipts
-//! │   └── state.db/                      temporary legacy import source (removed after verification)
-//! ├── run/                               ephemeral runtime state
-//! │   ├── system.sock
-//! │   ├── system.token
-//! │   ├── system.ready
-//! │   ├── deferred.db/                   deferred queue (ephemeral)
-//! │   └── principals/                    disposable UID-scoped process scratch
-//! ├── log/                               system logs
-//! ├── keys/                              runtime signing key
-//! ├── bin/                               content-addressed compiled WASM binaries
-//! └── lib/                               shared WASM component libraries (WIT, future)
+//! └── astrid.volume                    Astrid-owned durable media (stopped)
 //!
 //! Principal `home/` content is projected from the durable owner catalog and
 //! is not represented by a native directory in a fresh v2 layout.
@@ -58,15 +38,19 @@ use std::path::{Component, Path, PathBuf};
 use std::str::FromStr;
 
 use crate::principal::PrincipalId;
-use uuid::Uuid;
 
-/// Current layout version. Written to `etc/layout-version` on first boot.
+/// Current layout version. Historical sentinels are migration inputs only.
 pub const LAYOUT_VERSION: &str = "2";
 /// Latest released layout accepted for an in-place upgrade.
 pub const LEGACY_LAYOUT_VERSION: &str = "1";
 #[path = "dirs_layout.rs"]
 mod dirs_layout;
 pub use dirs_layout::{LayoutMigrationTarget, retire_legacy_source_tree};
+#[path = "dirs_run_dir.rs"]
+mod run_dir;
+#[path = "dirs_workspace.rs"]
+mod workspace_dir;
+pub use workspace_dir::WorkspaceDir;
 /// Default per-project runtime state directory.
 pub const DEFAULT_WORKSPACE_STATE_DIR: &str = ".astrid";
 
@@ -325,18 +309,19 @@ impl AstridHome {
         Self { root: root.into() }
     }
 
-    /// Ensure the system directory structure exists with secure permissions.
+    /// Validate the durable root without creating a parallel state tree.
     ///
-    /// Creates the common private skeleton. New homes initialize at the current
-    /// layout; released v1 homes remain there until the kernel verifies durable
-    /// migration and calls [`Self::complete_layout_v2`]. Directories are `0o700`
-    /// on Unix. `capsules/` is not created eagerly; user installs use principal
-    /// storage until an operator install mechanism exists.
+    /// Fresh initialization leaves only the private root for the storage layer
+    /// to fill with `astrid.volume`. Released homes retain their historical
+    /// directories and sentinel as one-time migration inputs until verified
+    /// cutover. Running projections are created later from mounted volume
+    /// state, never by this admission boundary.
     ///
     /// # Errors
     ///
     /// Returns an error if directory creation or permission setting fails.
     pub fn ensure(&self) -> io::Result<()> {
+        self.validate_run_dir()?;
         let existing_layout = self.layout_version()?;
         if let Some(version) = existing_layout.as_deref()
             && version != LEGACY_LAYOUT_VERSION
@@ -358,52 +343,34 @@ impl AstridHome {
                         ),
                     ));
                 },
-                Ok(_)
-                    if std::fs::read_dir(self.root())?
-                        .next()
-                        .transpose()?
-                        .is_some() =>
-                {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidData,
-                        format!(
-                            "refusing to initialize non-empty Astrid home without etc/layout-version: {}",
-                            self.root().display()
-                        ),
-                    ));
-                },
                 Ok(_) => {},
                 Err(error) if error.kind() == io::ErrorKind::NotFound => {},
                 Err(error) => return Err(error),
             }
         }
-        let dirs = [
-            self.etc_dir(),
-            self.hooks_dir(),
-            self.var_dir(),
-            self.run_dir(),
-            self.log_dir(),
-            self.keys_dir(),
-            self.bin_dir(),
-            self.wit_dir(),
-            self.wit_store_dir(),
-        ];
-
-        #[cfg(windows)]
+        let mut dirs = Vec::<PathBuf>::new();
+        if existing_layout.as_deref() == Some(LEGACY_LAYOUT_VERSION) {
+            dirs.extend([
+                self.etc_dir(),
+                self.hooks_dir(),
+                self.var_dir(),
+                self.run_dir(),
+                self.log_dir(),
+                self.keys_dir(),
+                self.bin_dir(),
+                self.wit_dir(),
+                self.wit_store_dir(),
+            ]);
+        }
         crate::platform_fs::ensure_private_directory(self.root())?;
-
         for dir in &dirs {
             crate::platform_fs::ensure_private_directory(dir)?;
         }
 
         match existing_layout.as_deref() {
-            None => {
-                self.ensure_layout_v2_dirs()?;
-                self.write_layout_version(LAYOUT_VERSION)?;
-            },
+            None => self.validate_fresh_root_entries()?,
             Some(LEGACY_LAYOUT_VERSION) => {},
             Some(LAYOUT_VERSION) => {
-                self.ensure_layout_v2_dirs()?;
                 // Before the singleton-owned migration barrier, v2 boot only
                 // validates legacy paths (redirects/special entries fail closed).
                 // The barrier owns source admission/receipts; complete_layout_v2
@@ -413,7 +380,9 @@ impl AstridHome {
             Some(_) => unreachable!("layout version was validated before directory creation"),
         }
         #[cfg(windows)]
-        crate::platform_fs::restrict_private_file(&self.layout_version_path())?;
+        if self.layout_version_path().exists() {
+            crate::platform_fs::restrict_private_file(&self.layout_version_path())?;
+        }
 
         #[cfg(unix)]
         {
@@ -432,6 +401,35 @@ impl AstridHome {
                     crate::platform_fs::validate_private_file(&private_file)?;
                 }
             }
+        }
+        Ok(())
+    }
+
+    fn validate_fresh_root_entries(&self) -> io::Result<()> {
+        let mut entries = self.root().read_dir()?.collect::<Result<Vec<_>, _>>()?;
+        entries.sort_by_key(std::fs::DirEntry::file_name);
+        for entry in entries {
+            let path = entry.path();
+            if entry.file_name() != std::ffi::OsStr::new("astrid.volume") {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "unadmitted entry in a fresh Astrid durable root: {}",
+                        path.display()
+                    ),
+                ));
+            }
+            let metadata = std::fs::symlink_metadata(&path)?;
+            if metadata.file_type().is_symlink() || !metadata.is_file() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "Astrid durable media is redirected or not a regular file: {}",
+                        path.display()
+                    ),
+                ));
+            }
+            crate::platform_fs::validate_private_file(&path)?;
         }
         Ok(())
     }
@@ -531,7 +529,23 @@ impl AstridHome {
     /// Ephemeral runtime directory (`run/`).
     #[must_use]
     pub fn run_dir(&self) -> PathBuf {
-        self.root.join("run")
+        run_dir::configured_path(self).unwrap_or_else(|_| self.root.join("run"))
+    }
+
+    /// Reject an `ASTRID_RUN_DIR` override that can overlap durable authority.
+    ///
+    /// Admission calls this before creating the durable root or any running
+    /// projection. Path-only callers get a disposable fallback below the root
+    /// rather than a sentinel file, but they must never drive lifecycle work
+    /// without first passing [`Self::ensure`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the override is empty, relative, traverses a
+    /// parent, is redirected, or is physically equal to, inside, or a parent
+    /// of the durable root.
+    pub fn validate_run_dir(&self) -> io::Result<()> {
+        run_dir::validate(self)
     }
 
     /// Clear stale per-principal runtime scratch from a prior daemon process.
@@ -811,185 +825,6 @@ impl PrincipalHome {
     #[must_use]
     pub fn env_dir(&self) -> PathBuf {
         self.root.join(".config").join("env")
-    }
-}
-
-// ── WorkspaceDir (per-project) ───────────────────────────────────────────
-
-/// Selected per-project workspace state directory.
-///
-/// Contains project-local runtime state. A `workspace-id` UUID links the
-/// project to its global state in `~/.astrid/`.
-#[derive(Debug, Clone)]
-pub struct WorkspaceDir {
-    /// The project root containing the selected state directory.
-    project_root: PathBuf,
-    layout: WorkspaceLayout,
-}
-
-impl WorkspaceDir {
-    /// Detect the workspace directory by walking up from `start_dir`.
-    ///
-    /// Detection order:
-    /// 1. Directory containing the selected state directory
-    /// 2. Directory containing `.git`
-    /// 3. Directory containing `ASTRID.md`
-    /// 4. Fallback to `start_dir` itself
-    #[must_use]
-    pub fn detect(start_dir: &Path) -> Self {
-        Self::detect_with_layout(start_dir, WorkspaceLayout::default())
-    }
-
-    /// Detect the workspace directory using `layout`.
-    #[must_use]
-    pub fn detect_with_layout(start_dir: &Path, layout: WorkspaceLayout) -> Self {
-        let start = if start_dir.is_absolute() {
-            start_dir.to_path_buf()
-        } else {
-            std::env::current_dir().unwrap_or_default().join(start_dir)
-        };
-
-        let mut current = start.as_path();
-
-        loop {
-            if layout.state_dir(current).is_dir() {
-                return Self {
-                    project_root: current.to_path_buf(),
-                    layout,
-                };
-            }
-            if current.join(".git").exists() {
-                return Self {
-                    project_root: current.to_path_buf(),
-                    layout,
-                };
-            }
-            if current.join("ASTRID.md").exists() {
-                return Self {
-                    project_root: current.to_path_buf(),
-                    layout,
-                };
-            }
-            match current.parent() {
-                Some(parent) if parent != current => current = parent,
-                _ => break,
-            }
-        }
-
-        Self {
-            project_root: start,
-            layout,
-        }
-    }
-
-    /// Create from an explicit project root (useful for testing).
-    #[must_use]
-    pub fn from_path(project_root: impl Into<PathBuf>) -> Self {
-        Self::from_path_with_layout(project_root, WorkspaceLayout::default())
-    }
-
-    /// Create from an explicit project root and layout.
-    #[must_use]
-    pub fn from_path_with_layout(
-        project_root: impl Into<PathBuf>,
-        layout: WorkspaceLayout,
-    ) -> Self {
-        Self {
-            project_root: project_root.into(),
-            layout,
-        }
-    }
-
-    /// Ensure the selected state directory exists and generate a workspace ID
-    /// if one does not already exist.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if directory creation or workspace ID generation fails.
-    pub fn ensure(&self) -> io::Result<()> {
-        let selection = self.layout.resolve(&self.project_root)?;
-        selection.ensure_state_dir()?;
-        let _ = self.workspace_id()?;
-        selection.verify()?;
-        Ok(())
-    }
-
-    /// Resolve this workspace through the checked filesystem boundary.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the project root or selected state path is unsafe.
-    pub fn selection(&self) -> io::Result<WorkspaceSelection> {
-        self.layout.resolve(&self.project_root)
-    }
-
-    /// Project root directory containing the selected state directory.
-    #[must_use]
-    pub fn root(&self) -> &Path {
-        &self.project_root
-    }
-
-    /// The selected project state directory.
-    #[must_use]
-    pub fn dot_astrid(&self) -> PathBuf {
-        self.layout.state_dir(&self.project_root)
-    }
-
-    /// The active per-project runtime state directory.
-    #[must_use]
-    pub fn state_dir(&self) -> PathBuf {
-        self.layout.state_dir(&self.project_root)
-    }
-
-    /// The active workspace layout.
-    #[must_use]
-    pub fn layout(&self) -> &WorkspaceLayout {
-        &self.layout
-    }
-
-    /// Capsules under the selected project state directory.
-    #[must_use]
-    pub fn capsules_dir(&self) -> PathBuf {
-        self.dot_astrid().join("capsules")
-    }
-
-    /// Path to the workspace-id file under selected project state.
-    #[must_use]
-    pub fn workspace_id_path(&self) -> PathBuf {
-        self.dot_astrid().join("workspace-id")
-    }
-
-    /// Read or generate the workspace ID.
-    ///
-    /// If the file exists (e.g. cloned from a repo), its UUID is adopted.
-    /// Otherwise a new UUID is generated and written.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the file cannot be read or written.
-    pub fn workspace_id(&self) -> io::Result<Uuid> {
-        let selection = self.selection()?;
-        selection.ensure_state_dir()?;
-        let path = selection.resolve_file("workspace-id")?;
-        if let Ok(content) = std::fs::read_to_string(&path) {
-            let trimmed = content.trim();
-            if let Ok(id) = Uuid::parse_str(trimmed) {
-                selection.verify()?;
-                return Ok(id);
-            }
-        }
-        let id = Uuid::new_v4();
-        selection.verify()?;
-        std::fs::write(&path, id.to_string())?;
-        selection.resolve_file("workspace-id")?;
-        selection.verify()?;
-        Ok(id)
-    }
-
-    /// Path to project instructions under selected project state.
-    #[must_use]
-    pub fn instructions_path(&self) -> PathBuf {
-        self.dot_astrid().join("ASTRID.md")
     }
 }
 

--- a/crates/astrid-core/src/dirs_layout.rs
+++ b/crates/astrid-core/src/dirs_layout.rs
@@ -7,20 +7,25 @@ use std::io::Read as _;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
-use serde::de::DeserializeOwned;
-use serde::{Deserialize, Serialize};
-
 use super::{AstridHome, LAYOUT_VERSION, LEGACY_LAYOUT_VERSION};
 
+#[path = "dirs_layout_records.rs"]
+mod records;
 #[path = "dirs_layout_retirement.rs"]
 mod retirement;
+use records::{
+    LayoutMigrationReceiptV1, LayoutMigrationRecordV1, LayoutRetirementV1,
+    admit_or_write_canonical, inventory_regular_file, inventory_tree, read_canonical_record,
+    verify_receipt_destination_authority, verify_receipt_destination_is_live_path,
+};
 use retirement::{
     retire_legacy_source_tree as retire_legacy_source_tree_impl,
-    validate_legacy_retirement_candidate, validate_legacy_surrealkv_entry,
+    validate_legacy_retirement_candidate,
 };
 
 const LAYOUT_MIGRATION_INTENT: &str = "layout-v1-to-v2.intent";
 const LAYOUT_MIGRATION_RECEIPT: &str = "layout-v1-to-v2.complete";
+const LAYOUT_MIGRATION_RETIREMENT: &str = "layout-v1-to-v2.retiring";
 const LAYOUT_MIGRATION_SCHEMA: u32 = 1;
 #[cfg(not(target_family = "wasm"))]
 const LAYOUT_MIGRATION_HEADROOM_BYTES: u64 = 64 * 1024 * 1024;
@@ -84,47 +89,14 @@ impl LayoutMigrationTarget {
             format!("blake3-derive-key-v1:{}", hasher.finalize().to_hex()),
         )
     }
-}
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
-#[serde(deny_unknown_fields)]
-struct LayoutTreeIdentityV1 {
-    path_encoding: String,
-    physical_path_hex: String,
-    inventory_algorithm: String,
-    inventory_digest: String,
-    entries: u64,
-    bytes: u64,
-}
+    pub(super) fn store_format(&self) -> String {
+        self.store_format.clone()
+    }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
-#[serde(deny_unknown_fields)]
-struct LayoutMigrationMaterialV1 {
-    migration: String,
-    from_layout: String,
-    to_layout: String,
-    source: LayoutTreeIdentityV1,
-    target_path_encoding: String,
-    target_physical_path_hex: String,
-    target_store_format: String,
-    binary_identity: String,
-}
-
-#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
-#[serde(deny_unknown_fields)]
-struct LayoutMigrationRecordV1 {
-    schema: u32,
-    transaction_id: String,
-    material: LayoutMigrationMaterialV1,
-}
-
-#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
-#[serde(deny_unknown_fields)]
-struct LayoutMigrationReceiptV1 {
-    schema: u32,
-    transaction_id: String,
-    intent: LayoutMigrationRecordV1,
-    destination: LayoutTreeIdentityV1,
+    pub(super) fn binary_identity(&self) -> String {
+        self.binary_identity.clone()
+    }
 }
 
 impl AstridHome {
@@ -134,19 +106,25 @@ impl AstridHome {
         self.var_dir().join("principal-store")
     }
 
-    /// Hosted Astrid volume; bare metal implements the same path-free contract.
+    /// Canonical Astrid-owned durable media.
     #[must_use]
     pub fn storage_volume_path(&self) -> PathBuf {
-        self.root().join("volume")
+        self.root().join("astrid.volume")
     }
 
-    /// Released pre-root-volume path accepted only during one-time promotion.
+    /// Released pre-root-volume paths accepted only during one-time promotion.
     ///
     /// New stores never use this path. Storage opening moves a regular file
     /// found here to [`Self::storage_volume_path`] before serving the home.
     #[must_use]
     pub fn legacy_storage_volume_path(&self) -> PathBuf {
         self.var_dir().join("astrid.volume")
+    }
+
+    /// Older hosted-volume path accepted only as a migration input.
+    #[must_use]
+    pub fn retired_root_storage_volume_path(&self) -> PathBuf {
+        self.root().join("volume")
     }
 
     /// Path to the canonical layout-version sentinel (`etc/layout-version`).
@@ -193,6 +171,7 @@ impl AstridHome {
         for path in [
             self.storage_volume_path(),
             self.legacy_storage_volume_path(),
+            self.retired_root_storage_volume_path(),
         ] {
             if std::fs::symlink_metadata(&path).is_ok() {
                 inventory_regular_file(&path)?;
@@ -253,6 +232,16 @@ impl AstridHome {
             false,
         )?;
         self.ensure_layout_v2_dirs()?;
+        let retirement = LayoutRetirementV1 {
+            schema: LAYOUT_MIGRATION_SCHEMA,
+            transaction_id: intent.transaction_id.clone(),
+            source: inventory_tree(&self.state_db_path())?,
+        };
+        admit_or_write_canonical(
+            &self.migrations_dir().join(LAYOUT_MIGRATION_RETIREMENT),
+            &retirement,
+            true,
+        )?;
         let receipt = LayoutMigrationReceiptV1 {
             schema: LAYOUT_MIGRATION_SCHEMA,
             transaction_id: intent.transaction_id.clone(),
@@ -358,8 +347,18 @@ impl AstridHome {
 
         let receipt: LayoutMigrationReceiptV1 = read_canonical_record(&receipt_path)?;
         let intent: LayoutMigrationRecordV1 = read_canonical_record(&intent_path)?;
+        let retirement_path = self.migrations_dir().join(LAYOUT_MIGRATION_RETIREMENT);
+        let retirement: Option<LayoutRetirementV1> = match read_canonical_record(&retirement_path) {
+            Ok(retirement) => Some(retirement),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => None,
+            Err(error) => return Err(error),
+        };
         if receipt.schema != LAYOUT_MIGRATION_SCHEMA
             || receipt.transaction_id != intent.transaction_id
+            || retirement.as_ref().is_some_and(|retirement| {
+                retirement.schema != LAYOUT_MIGRATION_SCHEMA
+                    || retirement.transaction_id != intent.transaction_id
+            })
             || receipt.intent != intent
             || !intent.has_recomputable_identity()
             || receipt.destination.physical_path_hex != intent.material.target_physical_path_hex
@@ -372,37 +371,35 @@ impl AstridHome {
                 ),
             ));
         }
+        verify_receipt_destination_authority(&receipt.destination)?;
 
         match std::fs::symlink_metadata(self.state_db_path()) {
             Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
             Err(error) => Err(error),
             Ok(_) => {
-                // The destination identity proves that a still-present legacy
-                // source is retired only against the exact cutover result.
-                // Once that source is gone, the volume is live mutable state;
-                // comparing it with the historical receipt would reject every
-                // legitimate post-migration write on the next startup.
-                let destination = inventory_regular_file(&self.storage_volume_path())?;
-                if receipt.destination != destination {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidData,
-                        format!(
-                            "layout migration receipt does not match its destination: {}",
-                            receipt_path.display()
-                        ),
-                    ));
-                }
                 let source = inventory_tree(&self.state_db_path())?;
-                if source != receipt.intent.material.source {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidData,
-                        format!(
-                            "surviving legacy state differs from the verified migration source: {}",
-                            self.state_db_path().display()
-                        ),
-                    ));
+                let expected = retirement.map_or_else(
+                    || receipt.intent.material.source.clone(),
+                    |retirement| retirement.source,
+                );
+                if source == expected {
+                    // The volume is live mutable state. An exact surviving
+                    // retirement source proves this is the receipt's
+                    // interrupted retirement; post-cutover volume writes are
+                    // legitimate.
+                    retire_legacy_source_tree(&self.state_db_path())
+                } else {
+                    // A clean stop packs the live volume, so its cutover byte
+                    // identity is intentionally gone. Bind this restart to the
+                    // receipt's canonical destination path and its regular,
+                    // no-follow filesystem authority instead; the receipt itself
+                    // is restored only from the authenticated volume projection.
+                    verify_receipt_destination_is_live_path(
+                        &receipt.destination,
+                        &self.storage_volume_path(),
+                    )?;
+                    retire_legacy_source_tree(&self.state_db_path())
                 }
-                retire_legacy_source_tree(&self.state_db_path())
             },
         }
     }
@@ -410,34 +407,6 @@ impl AstridHome {
     fn ensure_private_dir(path: &Path) -> io::Result<()> {
         crate::platform_fs::ensure_private_directory(path)
     }
-}
-
-fn read_canonical_record<T>(path: &Path) -> io::Result<T>
-where
-    T: DeserializeOwned + PartialEq + Serialize,
-{
-    let actual = std::fs::read(path)?;
-    let parsed: T = serde_json::from_slice(&actual).map_err(|error| {
-        io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!(
-                "invalid layout migration record {}: {error}",
-                path.display()
-            ),
-        )
-    })?;
-    let mut expected = serde_json::to_vec(&parsed).map_err(io::Error::other)?;
-    expected.push(b'\n');
-    if actual != expected {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!(
-                "layout migration record is not canonical: {}",
-                path.display()
-            ),
-        ));
-    }
-    Ok(parsed)
 }
 
 fn verify_existing_ancestor(path: &Path) -> io::Result<()> {
@@ -478,84 +447,6 @@ fn path_entry_present(path: &Path) -> io::Result<bool> {
     }
 }
 
-impl LayoutMigrationRecordV1 {
-    fn has_recomputable_identity(&self) -> bool {
-        self.schema == LAYOUT_MIGRATION_SCHEMA
-            && self.transaction_id == layout_transaction_id(&self.material).unwrap_or_default()
-            && self.material.migration == "astrid-home-layout"
-            && self.material.from_layout == LEGACY_LAYOUT_VERSION
-            && self.material.to_layout == LAYOUT_VERSION
-            && self.material.source.path_encoding == "os-str-encoded-bytes-v1"
-            && self.material.source.inventory_algorithm == "blake3-derive-key-v1"
-            && self.material.target_path_encoding == "os-str-encoded-bytes-v1"
-    }
-
-    fn capture(home: &AstridHome, target: &LayoutMigrationTarget) -> io::Result<Self> {
-        let material = LayoutMigrationMaterialV1 {
-            migration: "astrid-home-layout".to_owned(),
-            from_layout: LEGACY_LAYOUT_VERSION.to_owned(),
-            to_layout: LAYOUT_VERSION.to_owned(),
-            source: inventory_tree(&home.state_db_path())?,
-            target_path_encoding: "os-str-encoded-bytes-v1".to_owned(),
-            target_physical_path_hex: physical_path_hex(&home.storage_volume_path())?,
-            target_store_format: target.store_format.clone(),
-            binary_identity: target.binary_identity.clone(),
-        };
-        Ok(Self {
-            schema: LAYOUT_MIGRATION_SCHEMA,
-            transaction_id: layout_transaction_id(&material)?,
-            material,
-        })
-    }
-}
-
-fn layout_transaction_id(material: &LayoutMigrationMaterialV1) -> io::Result<String> {
-    let material_bytes = serde_json::to_vec(material).map_err(io::Error::other)?;
-    Ok(hex::encode(blake3::derive_key(
-        "astrid home layout migration transaction v1",
-        &material_bytes,
-    )))
-}
-
-fn admit_or_write_canonical<T>(path: &Path, expected: &T, allow_create: bool) -> io::Result<()>
-where
-    T: DeserializeOwned + PartialEq + Serialize,
-{
-    let mut expected_bytes = serde_json::to_vec(expected).map_err(io::Error::other)?;
-    expected_bytes.push(b'\n');
-    match std::fs::read(path) {
-        Ok(actual) => {
-            let parsed: T = serde_json::from_slice(&actual).map_err(|error| {
-                io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!(
-                        "invalid layout migration record {}: {error}",
-                        path.display()
-                    ),
-                )
-            })?;
-            if parsed != *expected || actual != expected_bytes {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!(
-                        "layout migration record does not match this transaction: {}",
-                        path.display()
-                    ),
-                ));
-            }
-            Ok(())
-        },
-        Err(error) if error.kind() == io::ErrorKind::NotFound && allow_create => {
-            atomic_write(path, &expected_bytes)
-        },
-        Err(error) if error.kind() == io::ErrorKind::NotFound => Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!("layout migration intent is missing: {}", path.display()),
-        )),
-        Err(error) => Err(error),
-    }
-}
-
 #[cfg(windows)]
 fn reject_automatic_windows_layout_one() -> io::Result<()> {
     Err(io::Error::new(
@@ -571,211 +462,6 @@ fn reject_automatic_windows_layout_one() -> io::Result<()> {
 )]
 fn reject_automatic_windows_layout_one() -> io::Result<()> {
     Ok(())
-}
-
-fn inventory_tree(path: &Path) -> io::Result<LayoutTreeIdentityV1> {
-    let mut hasher = blake3::Hasher::new_derive_key("astrid layout source inventory v1");
-    let mut entries = 0_u64;
-    let mut bytes = 0_u64;
-    match std::fs::symlink_metadata(path) {
-        Err(error) if error.kind() == io::ErrorKind::NotFound => {
-            hasher.update(b"absent");
-        },
-        Err(error) => return Err(error),
-        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!(
-                    "layout migration source is redirected or not a directory: {}",
-                    path.display()
-                ),
-            ));
-        },
-        Ok(_) => {
-            crate::platform_fs::verify_no_redirects(path)?;
-            inventory_directory(path, path, &mut hasher, &mut entries, &mut bytes)?;
-        },
-    }
-    Ok(LayoutTreeIdentityV1 {
-        path_encoding: "os-str-encoded-bytes-v1".to_owned(),
-        physical_path_hex: physical_path_hex(path)?,
-        inventory_algorithm: "blake3-derive-key-v1".to_owned(),
-        inventory_digest: hasher.finalize().to_hex().to_string(),
-        entries,
-        bytes,
-    })
-}
-
-fn inventory_regular_file(path: &Path) -> io::Result<LayoutTreeIdentityV1> {
-    let metadata = std::fs::symlink_metadata(path)?;
-    if metadata.file_type().is_symlink() || !metadata.is_file() {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!(
-                "layout migration destination is redirected or not a regular file: {}",
-                path.display()
-            ),
-        ));
-    }
-    crate::platform_fs::verify_no_redirects(path)?;
-    let mut options = OpenOptions::new();
-    options.read(true);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt as _;
-
-        options.custom_flags(nix::libc::O_NOFOLLOW | nix::libc::O_NONBLOCK);
-    }
-    #[cfg(windows)]
-    {
-        use std::os::windows::fs::OpenOptionsExt as _;
-        use windows_sys::Win32::Storage::FileSystem::FILE_FLAG_OPEN_REPARSE_POINT;
-
-        options.custom_flags(FILE_FLAG_OPEN_REPARSE_POINT);
-    }
-    let mut file = options.open(path)?;
-    if !file.metadata()?.is_file() {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!(
-                "layout migration destination changed type: {}",
-                path.display()
-            ),
-        ));
-    }
-    let mut hasher = blake3::Hasher::new_derive_key("astrid layout destination inventory v1");
-    let mut buffer = vec![0_u8; 64 * 1024].into_boxed_slice();
-    let mut bytes = 0_u64;
-    loop {
-        let read = file.read(&mut buffer)?;
-        if read == 0 {
-            break;
-        }
-        bytes = bytes
-            .checked_add(read as u64)
-            .ok_or_else(|| io::Error::other("layout destination length overflow"))?;
-        hasher.update(&buffer[..read]);
-    }
-    if bytes != metadata.len() {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!(
-                "layout migration destination changed while inventoried: {}",
-                path.display()
-            ),
-        ));
-    }
-    Ok(LayoutTreeIdentityV1 {
-        path_encoding: "os-str-encoded-bytes-v1".to_owned(),
-        physical_path_hex: physical_path_hex(path)?,
-        inventory_algorithm: "blake3-derive-key-v1".to_owned(),
-        inventory_digest: hasher.finalize().to_hex().to_string(),
-        entries: 1,
-        bytes,
-    })
-}
-
-fn inventory_directory(
-    root: &Path,
-    directory: &Path,
-    hasher: &mut blake3::Hasher,
-    entries: &mut u64,
-    bytes: &mut u64,
-) -> io::Result<()> {
-    let mut children = std::fs::read_dir(directory)?.collect::<Result<Vec<_>, _>>()?;
-    children.sort_by_key(std::fs::DirEntry::file_name);
-    for child in children {
-        let child_path = child.path();
-        let relative = child_path.strip_prefix(root).map_err(io::Error::other)?;
-        let relative_bytes = relative.as_os_str().as_encoded_bytes();
-        let metadata = std::fs::symlink_metadata(&child_path)?;
-        if metadata.file_type().is_symlink() {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!(
-                    "layout migration source contains a redirect: {}",
-                    child_path.display()
-                ),
-            ));
-        }
-        validate_legacy_surrealkv_entry(relative, metadata.is_dir(), metadata.is_file())?;
-        *entries = entries
-            .checked_add(1)
-            .ok_or_else(|| io::Error::other("layout inventory entry count overflow"))?;
-        hash_inventory_field(hasher, b"path", relative_bytes);
-        if metadata.is_dir() {
-            hasher.update(b"directory");
-            inventory_directory(root, &child_path, hasher, entries, bytes)?;
-        } else if metadata.is_file() {
-            hasher.update(b"file");
-            hasher.update(&metadata.len().to_le_bytes());
-            let mut options = OpenOptions::new();
-            options.read(true);
-            #[cfg(unix)]
-            {
-                use std::os::unix::fs::OpenOptionsExt as _;
-
-                options.custom_flags(nix::libc::O_NOFOLLOW | nix::libc::O_NONBLOCK);
-            }
-            #[cfg(windows)]
-            {
-                use std::os::windows::fs::OpenOptionsExt as _;
-                use windows_sys::Win32::Storage::FileSystem::FILE_FLAG_OPEN_REPARSE_POINT;
-
-                options.custom_flags(FILE_FLAG_OPEN_REPARSE_POINT);
-            }
-            let mut file = options.open(&child_path)?;
-            if !file.metadata()?.is_file() {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!(
-                        "layout migration source changed type: {}",
-                        child_path.display()
-                    ),
-                ));
-            }
-            let mut buffer = vec![0_u8; 64 * 1024].into_boxed_slice();
-            let mut file_bytes = 0_u64;
-            loop {
-                let read = file.read(&mut buffer)?;
-                if read == 0 {
-                    break;
-                }
-                *bytes = bytes
-                    .checked_add(read as u64)
-                    .ok_or_else(|| io::Error::other("layout inventory byte count overflow"))?;
-                file_bytes = file_bytes
-                    .checked_add(read as u64)
-                    .ok_or_else(|| io::Error::other("layout inventory file length overflow"))?;
-                hasher.update(&buffer[..read]);
-            }
-            if file_bytes != metadata.len() {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!(
-                        "layout migration source changed while inventoried: {}",
-                        child_path.display()
-                    ),
-                ));
-            }
-        } else {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!(
-                    "layout migration source contains a special file: {}",
-                    child_path.display()
-                ),
-            ));
-        }
-    }
-    Ok(())
-}
-
-fn hash_inventory_field(hasher: &mut blake3::Hasher, label: &[u8], value: &[u8]) {
-    hasher.update(&(label.len() as u64).to_le_bytes());
-    hasher.update(label);
-    hasher.update(&(value.len() as u64).to_le_bytes());
-    hasher.update(value);
 }
 
 #[cfg(not(target_family = "wasm"))]
@@ -807,21 +493,6 @@ fn ensure_migration_capacity(_target: &Path, _source_bytes: u64) -> io::Result<(
         io::ErrorKind::Unsupported,
         "layout migration capacity probing is unavailable in a WebAssembly guest",
     ))
-}
-
-fn physical_path_hex(path: &Path) -> io::Result<String> {
-    let absolute = if path.exists() {
-        std::fs::canonicalize(path)?
-    } else {
-        let parent = path
-            .parent()
-            .ok_or_else(|| io::Error::other("layout path has no parent"))?;
-        let name = path
-            .file_name()
-            .ok_or_else(|| io::Error::other("layout path has no name"))?;
-        std::fs::canonicalize(parent)?.join(name)
-    };
-    Ok(hex::encode(absolute.as_os_str().as_encoded_bytes()))
 }
 
 fn atomic_write(path: &Path, bytes: &[u8]) -> io::Result<()> {

--- a/crates/astrid-core/src/dirs_layout_records.rs
+++ b/crates/astrid-core/src/dirs_layout_records.rs
@@ -1,0 +1,448 @@
+//! Canonical records and content identities for home-layout migration.
+
+use std::fs::OpenOptions;
+use std::io::{self, Read as _};
+use std::path::{Path, PathBuf};
+
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+
+use super::{AstridHome, LEGACY_LAYOUT_VERSION};
+
+pub(super) const LAYOUT_MIGRATION_SCHEMA: u32 = 1;
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct LayoutTreeIdentityV1 {
+    pub(super) path_encoding: String,
+    pub(super) physical_path_hex: String,
+    pub(super) inventory_algorithm: String,
+    pub(super) inventory_digest: String,
+    pub(super) entries: u64,
+    pub(super) bytes: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct LayoutMigrationMaterialV1 {
+    pub(super) migration: String,
+    pub(super) from_layout: String,
+    pub(super) to_layout: String,
+    pub(super) source: LayoutTreeIdentityV1,
+    pub(super) target_path_encoding: String,
+    pub(super) target_physical_path_hex: String,
+    pub(super) target_store_format: String,
+    pub(super) binary_identity: String,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct LayoutMigrationRecordV1 {
+    pub(super) schema: u32,
+    pub(super) transaction_id: String,
+    pub(super) material: LayoutMigrationMaterialV1,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct LayoutMigrationReceiptV1 {
+    pub(super) schema: u32,
+    pub(super) transaction_id: String,
+    pub(super) intent: LayoutMigrationRecordV1,
+    pub(super) destination: LayoutTreeIdentityV1,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct LayoutRetirementV1 {
+    pub(super) schema: u32,
+    pub(super) transaction_id: String,
+    pub(super) source: LayoutTreeIdentityV1,
+}
+
+impl LayoutMigrationRecordV1 {
+    pub(super) fn has_recomputable_identity(&self) -> bool {
+        self.schema == LAYOUT_MIGRATION_SCHEMA
+            && self.transaction_id == layout_transaction_id(&self.material).unwrap_or_default()
+            && self.material.migration == "astrid-home-layout"
+            && self.material.from_layout == LEGACY_LAYOUT_VERSION
+            && self.material.to_layout == super::LAYOUT_VERSION
+            && self.material.source.path_encoding == "os-str-encoded-bytes-v1"
+            && self.material.source.inventory_algorithm == "blake3-derive-key-v1"
+            && self.material.target_path_encoding == "os-str-encoded-bytes-v1"
+    }
+
+    pub(super) fn capture(
+        home: &AstridHome,
+        target: &super::LayoutMigrationTarget,
+    ) -> io::Result<Self> {
+        let material = LayoutMigrationMaterialV1 {
+            migration: "astrid-home-layout".to_owned(),
+            from_layout: LEGACY_LAYOUT_VERSION.to_owned(),
+            to_layout: super::LAYOUT_VERSION.to_owned(),
+            source: inventory_tree(&home.state_db_path())?,
+            target_path_encoding: "os-str-encoded-bytes-v1".to_owned(),
+            target_physical_path_hex: physical_path_hex(&home.storage_volume_path())?,
+            target_store_format: target.store_format(),
+            binary_identity: target.binary_identity(),
+        };
+        Ok(Self {
+            schema: LAYOUT_MIGRATION_SCHEMA,
+            transaction_id: layout_transaction_id(&material)?,
+            material,
+        })
+    }
+}
+
+pub(super) fn layout_transaction_id(material: &LayoutMigrationMaterialV1) -> io::Result<String> {
+    let material_bytes = serde_json::to_vec(material).map_err(io::Error::other)?;
+    Ok(hex::encode(blake3::derive_key(
+        "astrid home layout migration transaction v1",
+        &material_bytes,
+    )))
+}
+
+pub(super) fn admit_or_write_canonical<T>(
+    path: &Path,
+    expected: &T,
+    allow_create: bool,
+) -> io::Result<()>
+where
+    T: DeserializeOwned + PartialEq + Serialize,
+{
+    let mut expected_bytes = serde_json::to_vec(expected).map_err(io::Error::other)?;
+    expected_bytes.push(b'\n');
+    match std::fs::read(path) {
+        Ok(actual) => {
+            let parsed: T = serde_json::from_slice(&actual).map_err(|error| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "invalid layout migration record {}: {error}",
+                        path.display()
+                    ),
+                )
+            })?;
+            if parsed != *expected || actual != expected_bytes {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "layout migration record does not match this transaction: {}",
+                        path.display()
+                    ),
+                ));
+            }
+            Ok(())
+        },
+        Err(error) if error.kind() == io::ErrorKind::NotFound && allow_create => {
+            super::atomic_write(path, &expected_bytes)
+        },
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("layout migration intent is missing: {}", path.display()),
+        )),
+        Err(error) => Err(error),
+    }
+}
+
+pub(super) fn read_canonical_record<T>(path: &Path) -> io::Result<T>
+where
+    T: DeserializeOwned + PartialEq + Serialize,
+{
+    let actual = std::fs::read(path)?;
+    let parsed: T = serde_json::from_slice(&actual).map_err(|error| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "invalid layout migration record {}: {error}",
+                path.display()
+            ),
+        )
+    })?;
+    let mut expected = serde_json::to_vec(&parsed).map_err(io::Error::other)?;
+    expected.push(b'\n');
+    if actual != expected {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "layout migration record is not canonical: {}",
+                path.display()
+            ),
+        ));
+    }
+    Ok(parsed)
+}
+
+pub(super) fn verify_receipt_destination_authority(
+    destination: &LayoutTreeIdentityV1,
+) -> io::Result<()> {
+    let path = physical_path(destination)?;
+    let metadata = std::fs::symlink_metadata(&path)?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "layout migration destination is redirected or not a regular file: {}",
+                path.display()
+            ),
+        ));
+    }
+    crate::platform_fs::verify_no_redirects(&path)
+}
+
+pub(super) fn verify_receipt_destination_is_live_path(
+    destination: &LayoutTreeIdentityV1,
+    live_path: &Path,
+) -> io::Result<()> {
+    let parent = live_path.parent().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "live Astrid volume has no parent",
+        )
+    })?;
+    let file_name = live_path.file_name().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "live Astrid volume has no name",
+        )
+    })?;
+    let canonical_parent = std::fs::canonicalize(parent)?;
+    if physical_path(destination)? != canonical_parent.join(file_name) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "layout migration receipt destination path does not match the live Astrid volume",
+        ));
+    }
+    verify_receipt_destination_authority(destination)
+}
+
+fn physical_path(destination: &LayoutTreeIdentityV1) -> io::Result<PathBuf> {
+    let bytes = hex::decode(&destination.physical_path_hex)
+        .map_err(|error| io::Error::other(format!("decode layout destination path: {error}")))?;
+    let os_bytes = <std::ffi::OsString as std::os::unix::ffi::OsStringExt>::from_vec(bytes);
+    Ok(PathBuf::from(os_bytes))
+}
+
+pub(super) fn inventory_tree(path: &Path) -> io::Result<LayoutTreeIdentityV1> {
+    let mut hasher = blake3::Hasher::new_derive_key("astrid layout source inventory v1");
+    let mut entries = 0_u64;
+    let mut bytes = 0_u64;
+    match std::fs::symlink_metadata(path) {
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            hasher.update(b"absent");
+        },
+        Err(error) => return Err(error),
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "layout migration source is redirected or not a directory: {}",
+                    path.display()
+                ),
+            ));
+        },
+        Ok(_) => {
+            crate::platform_fs::verify_no_redirects(path)?;
+            inventory_directory(path, path, &mut hasher, &mut entries, &mut bytes)?;
+        },
+    }
+    Ok(LayoutTreeIdentityV1 {
+        path_encoding: "os-str-encoded-bytes-v1".to_owned(),
+        physical_path_hex: physical_path_hex(path)?,
+        inventory_algorithm: "blake3-derive-key-v1".to_owned(),
+        inventory_digest: hasher.finalize().to_hex().to_string(),
+        entries,
+        bytes,
+    })
+}
+
+pub(super) fn inventory_regular_file(path: &Path) -> io::Result<LayoutTreeIdentityV1> {
+    let metadata = std::fs::symlink_metadata(path)?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "layout migration destination is redirected or not a regular file: {}",
+                path.display()
+            ),
+        ));
+    }
+    crate::platform_fs::verify_no_redirects(path)?;
+    let mut options = OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+
+        options.custom_flags(nix::libc::O_NOFOLLOW | nix::libc::O_NONBLOCK);
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::OpenOptionsExt as _;
+        use windows_sys::Win32::Storage::FileSystem::FILE_FLAG_OPEN_REPARSE_POINT;
+
+        options.custom_flags(FILE_FLAG_OPEN_REPARSE_POINT);
+    }
+    let mut file = options.open(path)?;
+    if !file.metadata()?.is_file() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "layout migration destination changed type: {}",
+                path.display()
+            ),
+        ));
+    }
+    let mut hasher = blake3::Hasher::new_derive_key("astrid layout destination inventory v1");
+    let mut buffer = vec![0_u8; 64 * 1024].into_boxed_slice();
+    let mut bytes = 0_u64;
+    loop {
+        let read = file.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        bytes = bytes
+            .checked_add(read as u64)
+            .ok_or_else(|| io::Error::other("layout destination length overflow"))?;
+        hasher.update(&buffer[..read]);
+    }
+    if bytes != metadata.len() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "layout migration destination changed while inventoried: {}",
+                path.display()
+            ),
+        ));
+    }
+    Ok(LayoutTreeIdentityV1 {
+        path_encoding: "os-str-encoded-bytes-v1".to_owned(),
+        physical_path_hex: physical_path_hex(path)?,
+        inventory_algorithm: "blake3-derive-key-v1".to_owned(),
+        inventory_digest: hasher.finalize().to_hex().to_string(),
+        entries: 1,
+        bytes,
+    })
+}
+
+fn inventory_directory(
+    root: &Path,
+    directory: &Path,
+    hasher: &mut blake3::Hasher,
+    entries: &mut u64,
+    bytes: &mut u64,
+) -> io::Result<()> {
+    let mut children = std::fs::read_dir(directory)?.collect::<Result<Vec<_>, _>>()?;
+    children.sort_by_key(std::fs::DirEntry::file_name);
+    for child in children {
+        let child_path = child.path();
+        let relative = child_path.strip_prefix(root).map_err(io::Error::other)?;
+        let relative_bytes = relative.as_os_str().as_encoded_bytes();
+        let metadata = std::fs::symlink_metadata(&child_path)?;
+        if metadata.file_type().is_symlink() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "layout migration source contains a redirect: {}",
+                    child_path.display()
+                ),
+            ));
+        }
+        super::retirement::validate_legacy_surrealkv_entry(
+            relative,
+            metadata.is_dir(),
+            metadata.is_file(),
+        )?;
+        *entries = entries
+            .checked_add(1)
+            .ok_or_else(|| io::Error::other("layout inventory entry count overflow"))?;
+        hash_inventory_field(hasher, b"path", relative_bytes);
+        if metadata.is_dir() {
+            hasher.update(b"directory");
+            inventory_directory(root, &child_path, hasher, entries, bytes)?;
+        } else if metadata.is_file() {
+            hasher.update(b"file");
+            hasher.update(&metadata.len().to_le_bytes());
+            let mut options = OpenOptions::new();
+            options.read(true);
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::OpenOptionsExt as _;
+
+                options.custom_flags(nix::libc::O_NOFOLLOW | nix::libc::O_NONBLOCK);
+            }
+            #[cfg(windows)]
+            {
+                use std::os::windows::fs::OpenOptionsExt as _;
+                use windows_sys::Win32::Storage::FileSystem::FILE_FLAG_OPEN_REPARSE_POINT;
+
+                options.custom_flags(FILE_FLAG_OPEN_REPARSE_POINT);
+            }
+            let mut file = options.open(&child_path)?;
+            if !file.metadata()?.is_file() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "layout migration source changed type: {}",
+                        child_path.display()
+                    ),
+                ));
+            }
+            let mut buffer = vec![0_u8; 64 * 1024].into_boxed_slice();
+            let mut file_bytes = 0_u64;
+            loop {
+                let read = file.read(&mut buffer)?;
+                if read == 0 {
+                    break;
+                }
+                *bytes = bytes
+                    .checked_add(read as u64)
+                    .ok_or_else(|| io::Error::other("layout inventory byte count overflow"))?;
+                file_bytes = file_bytes
+                    .checked_add(read as u64)
+                    .ok_or_else(|| io::Error::other("layout inventory file length overflow"))?;
+                hasher.update(&buffer[..read]);
+            }
+            if file_bytes != metadata.len() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "layout migration source changed while inventoried: {}",
+                        child_path.display()
+                    ),
+                ));
+            }
+        } else {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "layout migration source contains a special file: {}",
+                    child_path.display()
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn hash_inventory_field(hasher: &mut blake3::Hasher, label: &[u8], value: &[u8]) {
+    hasher.update(&(label.len() as u64).to_le_bytes());
+    hasher.update(label);
+    hasher.update(&(value.len() as u64).to_le_bytes());
+    hasher.update(value);
+}
+
+pub(super) fn physical_path_hex(path: &Path) -> io::Result<String> {
+    let absolute = if path.exists() {
+        std::fs::canonicalize(path)?
+    } else {
+        let parent = path
+            .parent()
+            .ok_or_else(|| io::Error::other("layout path has no parent"))?;
+        let name = path
+            .file_name()
+            .ok_or_else(|| io::Error::other("layout path has no name"))?;
+        std::fs::canonicalize(parent)?.join(name)
+    };
+    Ok(hex::encode(absolute.as_os_str().as_encoded_bytes()))
+}

--- a/crates/astrid-core/src/dirs_projection_retirement.rs
+++ b/crates/astrid-core/src/dirs_projection_retirement.rs
@@ -1,0 +1,66 @@
+//! The single fail-closed boundary for retiring an Astrid runtime projection.
+
+use std::fs::File;
+use std::io;
+use std::path::Path;
+
+const CANONICAL_VOLUME: &str = "astrid.volume";
+
+/// Validate the complete projection before deleting any entry.
+///
+/// Every caller must use this function so a regular file is never removed
+/// before a later root special or nested redirect can stop retirement. The
+/// canonical media file is the only survivor.
+///
+/// # Errors
+///
+/// Returns an I/O error when a projection entry is redirected, is neither a
+/// regular file nor a real directory, or cannot be removed. A preflight error
+/// leaves the tree untouched; a mid-retire error leaves the durable volume as
+/// the recovery authority.
+pub fn retire_projection_root(root: &Path) -> io::Result<()> {
+    preflight_projection_entry(root)?;
+    let mut entries = std::fs::read_dir(root)?.collect::<Result<Vec<_>, _>>()?;
+    entries.sort_by_key(std::fs::DirEntry::file_name);
+    for entry in entries {
+        let path = entry.path();
+        if entry.file_name() == std::ffi::OsStr::new(CANONICAL_VOLUME) {
+            continue;
+        }
+        let metadata = std::fs::symlink_metadata(&path)?;
+        if metadata.is_dir() {
+            crate::dirs::retire_legacy_source_tree(&path)?;
+        } else {
+            std::fs::remove_file(&path)?;
+        }
+    }
+    File::open(root)?.sync_all()?;
+    Ok(())
+}
+
+fn preflight_projection_entry(path: &Path) -> io::Result<()> {
+    let metadata = std::fs::symlink_metadata(path)?;
+    if metadata.file_type().is_symlink() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("runtime projection is redirected: {}", path.display()),
+        ));
+    }
+    if metadata.is_dir() {
+        for entry in std::fs::read_dir(path)? {
+            let child = entry?.path();
+            preflight_projection_entry(&child)?;
+        }
+        return Ok(());
+    }
+    if !metadata.is_file() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "runtime projection contains a special entry: {}",
+                path.display()
+            ),
+        ));
+    }
+    Ok(())
+}

--- a/crates/astrid-core/src/dirs_run_dir.rs
+++ b/crates/astrid-core/src/dirs_run_dir.rs
@@ -1,0 +1,139 @@
+//! Validated resolution of the disposable runtime directory.
+
+use std::io;
+use std::path::{Component, Path, PathBuf};
+
+use super::AstridHome;
+
+const VARIABLE: &str = "ASTRID_RUN_DIR";
+
+pub(super) fn configured_path(home: &AstridHome) -> io::Result<PathBuf> {
+    resolved(home).map(|path| path.unwrap_or_else(|| home.root().join("run")))
+}
+
+pub(super) fn validate(home: &AstridHome) -> io::Result<()> {
+    resolved(home).map(drop)
+}
+
+fn resolved(home: &AstridHome) -> io::Result<Option<PathBuf>> {
+    let Some(raw) = std::env::var_os(VARIABLE) else {
+        return Ok(None);
+    };
+    let path = PathBuf::from(raw);
+    if path.as_os_str().is_empty() {
+        return Err(invalid("must not be empty"));
+    }
+    if !path.is_absolute() {
+        return Err(invalid("must be an absolute path"));
+    }
+    if path
+        .components()
+        .any(|component| matches!(component, Component::ParentDir | Component::CurDir))
+    {
+        return Err(invalid("must not contain '.' or '..' path components"));
+    }
+
+    match std::fs::symlink_metadata(&path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("{VARIABLE} is redirected: {}", path.display()),
+            ));
+        },
+        Ok(metadata) if !metadata.is_dir() => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("{VARIABLE} is not a real directory: {}", path.display()),
+            ));
+        },
+        Ok(_) => {},
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {},
+        Err(error) => return Err(error),
+    }
+    crate::platform_fs::verify_no_redirects(&path)?;
+
+    let physical_run = physical_path(&path)?;
+    let physical_root = physical_path(home.root())?;
+    if paths_are_related(&physical_run, &physical_root)
+        || directories_are_aliases(&physical_run, &physical_root)
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "{VARIABLE} overlaps the Astrid durable root: {} overlaps {}",
+                path.display(),
+                home.root().display()
+            ),
+        ));
+    }
+    Ok(Some(physical_run))
+}
+
+fn invalid(detail: &str) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidInput, format!("{VARIABLE} {detail}"))
+}
+
+fn physical_path(path: &Path) -> io::Result<PathBuf> {
+    if let Ok(physical) = std::fs::canonicalize(path) {
+        return Ok(physical);
+    }
+    let mut missing = Vec::new();
+    let mut existing_parent = path;
+    while matches!(
+        std::fs::symlink_metadata(existing_parent),
+        Err(error) if error.kind() == io::ErrorKind::NotFound
+    ) {
+        let Some(name) = existing_parent.file_name() else {
+            break;
+        };
+        missing.push(name.to_os_string());
+        existing_parent = existing_parent.parent().expect("parent checked above");
+    }
+    let mut physical = std::fs::canonicalize(existing_parent)?;
+    for name in missing.into_iter().rev() {
+        physical.push(name);
+    }
+    if let Some(name) = path.file_name()
+        && physical.file_name() != Some(name)
+    {
+        physical.push(name);
+    }
+    Ok(physical)
+}
+
+fn paths_are_related(run: &Path, root: &Path) -> bool {
+    run == root || run.starts_with(root) || root.starts_with(run)
+}
+
+#[test]
+fn related_runtime_paths_are_rejected_in_both_directions() {
+    let root = Path::new("/tmp/astrid-root");
+    let inside = Path::new("/tmp/astrid-root/run");
+    let outside = Path::new("/tmp/astrid-outside");
+    let sibling_prefix = Path::new("/tmp/astrid-root-parent");
+
+    assert!(paths_are_related(root, root));
+    assert!(paths_are_related(inside, root));
+    assert!(paths_are_related(root, inside));
+    assert!(paths_are_related(root, Path::new("/")));
+    assert!(!paths_are_related(inside, outside));
+    assert!(!paths_are_related(root, sibling_prefix));
+}
+
+#[cfg(unix)]
+fn directories_are_aliases(run: &Path, root: &Path) -> bool {
+    use std::os::unix::fs::MetadataExt;
+
+    match (
+        std::fs::symlink_metadata(run),
+        std::fs::symlink_metadata(root),
+    ) {
+        (Ok(run), Ok(root)) => run.dev() == root.dev() && run.ino() == root.ino(),
+        _ => false,
+    }
+}
+
+#[cfg(not(unix))]
+fn directories_are_aliases(_run: &Path, _root: &Path) -> bool {
+    false
+}

--- a/crates/astrid-core/src/dirs_tests.rs
+++ b/crates/astrid-core/src/dirs_tests.rs
@@ -33,14 +33,21 @@ fn test_home_root(dir: &tempfile::TempDir) -> PathBuf {
 }
 
 #[test]
-fn storage_volume_path_is_at_runtime_root() {
+fn storage_volume_path_is_canonical_media() {
     let dir = tempfile::tempdir().unwrap();
     let home = AstridHome::from_path(test_home_root(&dir));
 
-    assert_eq!(home.storage_volume_path(), home.root().join("volume"));
+    assert_eq!(
+        home.storage_volume_path(),
+        home.root().join("astrid.volume")
+    );
     assert_ne!(
         home.storage_volume_path(),
         home.legacy_storage_volume_path()
+    );
+    assert_ne!(
+        home.storage_volume_path(),
+        home.retired_root_storage_volume_path()
     );
     assert!(!home.storage_volume_path().starts_with(home.var_dir()));
 }
@@ -132,38 +139,43 @@ fn test_astrid_home_rejects_relative_home() {
 // ── AstridHome ensure ────────────────────────────────────────────
 
 #[test]
-fn test_astrid_home_ensure_creates_dirs() {
+fn test_astrid_home_ensure_does_not_create_parallel_state_tree() {
     let dir = tempfile::tempdir().unwrap();
     let home = AstridHome::from_path(test_home_root(&dir));
     home.ensure().unwrap();
 
-    assert!(home.etc_dir().exists());
-    assert!(home.hooks_dir().exists());
-    assert!(home.var_dir().exists());
-    assert!(home.run_dir().exists());
-    assert!(home.log_dir().exists());
-    assert!(home.keys_dir().exists());
+    assert!(home.root().is_dir());
+    assert!(!home.etc_dir().exists());
+    assert!(!home.hooks_dir().exists());
+    assert!(!home.var_dir().exists());
+    assert!(!home.run_dir().exists());
+    assert!(!home.log_dir().exists());
+    assert!(!home.keys_dir().exists());
     assert!(!home.secrets_dir().exists());
-    assert!(home.bin_dir().exists());
+    assert!(!home.bin_dir().exists());
+    assert!(!home.wit_dir().exists());
     // `home/` is a legacy import source and is not recreated on a fresh v2
     // boot. It is created only when an upgrade fixture explicitly provides it.
     assert!(!home.home_dir().exists());
-    assert!(home.content_staging_path().exists());
-    assert!(home.migrations_dir().exists());
+    assert!(!home.content_staging_path().exists());
+    assert!(!home.migrations_dir().exists());
     assert!(!home.cow_dir().exists());
     assert!(!home.root().join("srv").exists());
 }
 
 #[test]
-fn test_astrid_home_ensure_writes_layout_version() {
+fn test_fresh_ensure_writes_no_layout_sentinel() {
     let dir = tempfile::tempdir().unwrap();
     let home = AstridHome::from_path(test_home_root(&dir));
     home.ensure().unwrap();
 
     let version_path = home.etc_dir().join("layout-version");
-    assert!(version_path.exists());
-    let content = std::fs::read_to_string(&version_path).unwrap();
-    assert_eq!(content, LAYOUT_VERSION);
+    assert!(!version_path.exists());
+    assert_eq!(
+        home.layout_version().unwrap(),
+        None,
+        "fresh authority is established by verified astrid.volume, not a sidecar"
+    );
 }
 
 #[test]
@@ -201,6 +213,61 @@ fn test_nonempty_home_without_layout_sentinel_is_refused_without_mutation() {
         b"preserve-me"
     );
     assert!(!home.root().join("srv").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn volume_only_stopped_root_admits_restart_without_layout_sentinel() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(test_home_root(&dir));
+    std::fs::create_dir_all(home.root()).unwrap();
+    std::fs::write(home.storage_volume_path(), b"stopped-volume").unwrap();
+    std::fs::set_permissions(
+        home.storage_volume_path(),
+        std::fs::Permissions::from_mode(0o600),
+    )
+    .unwrap();
+
+    home.ensure().unwrap();
+
+    assert_eq!(
+        home.layout_version().unwrap(),
+        None,
+        "volume authority does not need a host layout sentinel"
+    );
+    assert_eq!(
+        std::fs::read(home.storage_volume_path()).unwrap(),
+        b"stopped-volume"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn non_volume_stopped_sidecars_fail_closed() {
+    use std::os::unix::fs::PermissionsExt;
+
+    for relative in [
+        "bin", "etc", "keys", "log", "run", "trust", "var", "volume", "extra",
+    ] {
+        let dir = tempfile::tempdir().unwrap();
+        let home = AstridHome::from_path(test_home_root(&dir));
+        std::fs::create_dir_all(home.root()).unwrap();
+        std::fs::write(home.storage_volume_path(), b"stopped-volume").unwrap();
+        std::fs::set_permissions(
+            home.storage_volume_path(),
+            std::fs::Permissions::from_mode(0o600),
+        )
+        .unwrap();
+        let sidecar = home.root().join(relative);
+        std::fs::create_dir_all(&sidecar).unwrap();
+
+        let error = home.ensure().unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData, "{relative}");
+        assert!(sidecar.exists(), "{relative} was mutated");
+    }
 }
 
 #[test]
@@ -447,34 +514,23 @@ fn test_layout_v2_startup_defers_interrupted_legacy_retirement_to_kernel_barrier
 
 #[cfg(unix)]
 #[test]
-fn test_layout_v2_ensure_retains_reappeared_legacy_cow_for_barrier() {
+fn test_layout_v2_ensure_rejects_fresh_regular_cow_sidecar_without_deleting_it() {
     let dir = tempfile::tempdir().unwrap();
     let home = AstridHome::from_path(test_home_root(&dir));
     home.ensure().unwrap();
     assert!(!home.cow_dir().exists());
 
-    std::fs::create_dir(home.cow_dir()).unwrap();
-    home.ensure().unwrap();
-    assert!(home.cow_dir().exists());
-
     let nested_file = home.cow_dir().join("capsule").join("merged").join("file");
     std::fs::create_dir_all(nested_file.parent().unwrap()).unwrap();
     std::fs::write(&nested_file, b"legacy workspace bytes").unwrap();
-    home.ensure().unwrap();
+
+    let error = home.ensure().unwrap_err();
+    assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+    assert!(error.to_string().contains("unadmitted entry"));
     assert_eq!(
         std::fs::read(&nested_file).unwrap(),
         b"legacy workspace bytes"
     );
-    home.ensure().unwrap();
-    assert!(home.cow_dir().exists());
-
-    // A v2 home without a cut-over receipt cannot authorize source deletion,
-    // even through the explicit finalizer. The barrier must publish its
-    // component ledger before CoW retirement is allowed.
-    let error = home.complete_layout_v2(&migration_target()).unwrap_err();
-    assert_eq!(error.kind(), io::ErrorKind::InvalidData);
-    assert!(error.to_string().contains("without a completion receipt"));
-    assert!(nested_file.exists());
 }
 
 #[cfg(unix)]
@@ -488,11 +544,12 @@ fn test_layout_v2_ensure_rejects_but_does_not_delete_legacy_cow_symlink() {
     std::fs::write(&outside_file, b"outside bytes").unwrap();
     let home = AstridHome::from_path(test_home_root(&dir));
     home.ensure().unwrap();
+
     symlink(outside.path(), home.cow_dir()).unwrap();
 
     let error = home.ensure().unwrap_err();
     assert_eq!(error.kind(), io::ErrorKind::InvalidData);
-    assert!(error.to_string().contains("redirect"));
+    assert!(error.to_string().contains("unadmitted entry"));
     assert_eq!(std::fs::read(outside_file).unwrap(), b"outside bytes");
     assert!(
         std::fs::symlink_metadata(home.cow_dir())
@@ -519,7 +576,7 @@ fn test_layout_v2_ensure_rejects_but_does_not_delete_legacy_cow_special_entry() 
 
     let error = home.ensure().unwrap_err();
     assert_eq!(error.kind(), io::ErrorKind::InvalidData);
-    assert!(error.to_string().contains("special file"));
+    assert!(error.to_string().contains("unadmitted entry"));
     assert_eq!(std::fs::read(retained).unwrap(), b"must survive rejection");
     assert!(fifo.exists());
     assert!(home.cow_dir().exists());
@@ -645,7 +702,7 @@ fn test_layout_v2_startup_rejects_corrupt_receipt_without_retiring_source() {
 
 #[cfg(not(windows))]
 #[test]
-fn test_layout_v2_startup_rejects_changed_volume_without_retiring_source() {
+fn test_layout_v2_startup_retires_drifted_source_after_live_volume_change() {
     let dir = tempfile::tempdir().unwrap();
     let home = AstridHome::from_path(test_home_root(&dir));
     crate::platform_fs::ensure_private_directory(&home.etc_dir()).unwrap();
@@ -657,17 +714,40 @@ fn test_layout_v2_startup_rejects_changed_volume_without_retiring_source() {
     let surviving = write_released_legacy_store(&home, b"");
     write_test_storage_volume(&home, b"changed-volume");
 
+    home.complete_layout_v2(&migration_target()).unwrap();
+    assert!(!surviving.exists());
+    assert!(!home.state_db_path().exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn test_layout_v2_startup_rejects_substituted_destination_without_retiring_source() {
+    let dir = tempfile::tempdir().unwrap();
+    let outside = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(test_home_root(&dir));
+    crate::platform_fs::ensure_private_directory(&home.etc_dir()).unwrap();
+    std::fs::write(home.layout_version_path(), LEGACY_LAYOUT_VERSION).unwrap();
+    home.ensure().unwrap();
+    home.begin_layout_v2_migration(&migration_target()).unwrap();
+    write_test_storage_volume(&home, b"test-volume");
+    home.complete_layout_v2(&migration_target()).unwrap();
+    let surviving = write_released_legacy_store(&home, b"");
+    let foreign_volume = outside.path().join("foreign.volume");
+    std::fs::write(&foreign_volume, b"foreign-volume").unwrap();
+    std::fs::remove_file(home.storage_volume_path()).unwrap();
+    std::os::unix::fs::symlink(&foreign_volume, home.storage_volume_path()).unwrap();
+
     let error = home.complete_layout_v2(&migration_target()).unwrap_err();
 
     assert_eq!(error.kind(), io::ErrorKind::InvalidData);
-    assert!(error.to_string().contains("destination"), "{error}");
+    assert!(error.to_string().contains("redirected"), "{error}");
     assert!(surviving.exists());
     assert!(home.state_db_path().exists());
 }
 
 #[cfg(unix)]
 #[test]
-fn test_astrid_home_ensure_sets_permissions() {
+fn test_astrid_home_ensure_sets_private_root_permissions() {
     use std::os::unix::fs::PermissionsExt;
 
     let dir = tempfile::tempdir().unwrap();
@@ -677,8 +757,22 @@ fn test_astrid_home_ensure_sets_permissions() {
     let root_perms = std::fs::metadata(home.root()).unwrap().permissions();
     assert_eq!(root_perms.mode() & 0o777, 0o700);
 
-    let keys_perms = std::fs::metadata(home.keys_dir()).unwrap().permissions();
-    assert_eq!(keys_perms.mode() & 0o777, 0o700);
+    assert_eq!(root_perms.mode() & 0o777, 0o700);
+    assert_eq!(std::fs::read_dir(home.root()).unwrap().count(), 0);
+}
+
+#[cfg(unix)]
+#[test]
+fn fresh_ensure_private_root_has_no_state_sidecars() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(test_home_root(&dir));
+    home.ensure().unwrap();
+
+    let root_perms = std::fs::metadata(home.root()).unwrap().permissions();
+    assert_eq!(root_perms.mode() & 0o777, 0o700);
+    assert_eq!(std::fs::read_dir(home.root()).unwrap().count(), 0);
 }
 
 #[cfg(unix)]

--- a/crates/astrid-core/src/dirs_workspace.rs
+++ b/crates/astrid-core/src/dirs_workspace.rs
@@ -1,0 +1,185 @@
+//! Selected per-project workspace state.
+
+use std::io;
+use std::path::{Path, PathBuf};
+
+use uuid::Uuid;
+
+use super::WorkspaceLayout;
+use super::workspace_security::WorkspaceSelection;
+
+/// Selected per-project workspace state directory.
+///
+/// Contains project-local runtime state. A `workspace-id` UUID links the
+/// project to its global state in `~/.astrid/`.
+#[derive(Debug, Clone)]
+pub struct WorkspaceDir {
+    project_root: PathBuf,
+    layout: WorkspaceLayout,
+}
+
+impl WorkspaceDir {
+    /// Detect the workspace directory by walking up from `start_dir`.
+    ///
+    /// Detection order:
+    /// 1. Directory containing the selected state directory
+    /// 2. Directory containing `.git`
+    /// 3. Directory containing `ASTRID.md`
+    /// 4. Fallback to `start_dir` itself
+    #[must_use]
+    pub fn detect(start_dir: &Path) -> Self {
+        Self::detect_with_layout(start_dir, WorkspaceLayout::default())
+    }
+
+    /// Detect the workspace directory using `layout`.
+    #[must_use]
+    pub fn detect_with_layout(start_dir: &Path, layout: WorkspaceLayout) -> Self {
+        let start = if start_dir.is_absolute() {
+            start_dir.to_path_buf()
+        } else {
+            std::env::current_dir().unwrap_or_default().join(start_dir)
+        };
+
+        let mut current = start.as_path();
+
+        loop {
+            if layout.state_dir(current).is_dir() {
+                return Self {
+                    project_root: current.to_path_buf(),
+                    layout,
+                };
+            }
+            if current.join(".git").exists() {
+                return Self {
+                    project_root: current.to_path_buf(),
+                    layout,
+                };
+            }
+            if current.join("ASTRID.md").exists() {
+                return Self {
+                    project_root: current.to_path_buf(),
+                    layout,
+                };
+            }
+            match current.parent() {
+                Some(parent) if parent != current => current = parent,
+                _ => break,
+            }
+        }
+
+        Self {
+            project_root: start,
+            layout,
+        }
+    }
+
+    /// Create from an explicit project root (useful for testing).
+    #[must_use]
+    pub fn from_path(project_root: impl Into<PathBuf>) -> Self {
+        Self::from_path_with_layout(project_root, WorkspaceLayout::default())
+    }
+
+    /// Create from an explicit project root and layout.
+    #[must_use]
+    pub fn from_path_with_layout(
+        project_root: impl Into<PathBuf>,
+        layout: WorkspaceLayout,
+    ) -> Self {
+        Self {
+            project_root: project_root.into(),
+            layout,
+        }
+    }
+
+    /// Ensure the selected state directory exists and generate a workspace ID
+    /// if one does not already exist.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if directory creation or workspace ID generation fails.
+    pub fn ensure(&self) -> io::Result<()> {
+        let selection = self.layout.resolve(&self.project_root)?;
+        selection.ensure_state_dir()?;
+        let _ = self.workspace_id()?;
+        selection.verify()?;
+        Ok(())
+    }
+
+    /// Resolve this workspace through the checked filesystem boundary.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the project root or selected state path is unsafe.
+    pub fn selection(&self) -> io::Result<WorkspaceSelection> {
+        self.layout.resolve(&self.project_root)
+    }
+
+    /// Project root directory containing the selected state directory.
+    #[must_use]
+    pub fn root(&self) -> &Path {
+        &self.project_root
+    }
+
+    /// The selected project state directory.
+    #[must_use]
+    pub fn dot_astrid(&self) -> PathBuf {
+        self.layout.state_dir(&self.project_root)
+    }
+
+    /// The active per-project runtime state directory.
+    #[must_use]
+    pub fn state_dir(&self) -> PathBuf {
+        self.layout.state_dir(&self.project_root)
+    }
+
+    /// The active workspace layout.
+    #[must_use]
+    pub fn layout(&self) -> &WorkspaceLayout {
+        &self.layout
+    }
+
+    /// Capsules under the selected project state directory.
+    #[must_use]
+    pub fn capsules_dir(&self) -> PathBuf {
+        self.dot_astrid().join("capsules")
+    }
+
+    /// Path to the workspace-id file under selected project state.
+    #[must_use]
+    pub fn workspace_id_path(&self) -> PathBuf {
+        self.dot_astrid().join("workspace-id")
+    }
+
+    /// Read or generate the workspace ID.
+    ///
+    /// If the file exists (e.g. cloned from a repo), its UUID is adopted.
+    /// Otherwise a new UUID is generated and written.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file cannot be read or written.
+    pub fn workspace_id(&self) -> io::Result<Uuid> {
+        let selection = self.selection()?;
+        selection.ensure_state_dir()?;
+        let path = selection.resolve_file("workspace-id")?;
+        if let Ok(content) = std::fs::read_to_string(&path) {
+            let trimmed = content.trim();
+            if let Ok(id) = Uuid::parse_str(trimmed) {
+                selection.verify()?;
+                return Ok(id);
+            }
+        }
+        let id = Uuid::new_v4();
+        selection.verify()?;
+        std::fs::write(&path, id.to_string())?;
+        selection.resolve_file("workspace-id")?;
+        selection.verify()?;
+        Ok(id)
+    }
+
+    /// Path to project instructions under selected project state.
+    #[must_use]
+    pub fn instructions_path(&self) -> PathBuf {
+        self.dot_astrid().join("ASTRID.md")
+    }
+}

--- a/crates/astrid-core/src/env_policy.rs
+++ b/crates/astrid-core/src/env_policy.rs
@@ -15,6 +15,7 @@ const BLOCKED_SPAWN_ENV: &[&str] = &[
     "HOME",
     "PATH",
     "ASTRID_HOME",
+    "ASTRID_RUN_DIR",
     // Library injection (Linux)
     "LD_PRELOAD",
     "LD_LIBRARY_PATH",
@@ -104,6 +105,7 @@ mod tests {
         assert!(is_blocked_spawn_env("HOME"));
         assert!(is_blocked_spawn_env("PATH"));
         assert!(is_blocked_spawn_env("ASTRID_HOME"));
+        assert!(is_blocked_spawn_env("ASTRID_RUN_DIR"));
         assert!(is_blocked_spawn_env("OPENSSL_CONF"));
         assert!(is_blocked_spawn_env("HTTP_PROXY"));
         assert!(is_blocked_spawn_env("HTTPS_PROXY"));

--- a/crates/astrid-core/src/platform_fs.rs
+++ b/crates/astrid-core/src/platform_fs.rs
@@ -559,6 +559,15 @@ fn validate_private_file_unix(path: &Path) -> io::Result<()> {
             format!("private file is not owner-only: {}", path.display()),
         ));
     }
+    if metadata.st_nlink != 1 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "private file has {} links; durable media must have exactly one",
+                metadata.st_nlink
+            ),
+        ));
+    }
     validate_no_extended_acl(path)?;
     Ok(())
 }

--- a/crates/astrid-core/src/platform_fs/tests.rs
+++ b/crates/astrid-core/src/platform_fs/tests.rs
@@ -141,6 +141,26 @@ fn unix_private_atomic_write_repairs_permissive_replacement() {
 
 #[cfg(unix)]
 #[test]
+fn unix_private_file_validation_rejects_external_hard_links() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let root = tempfile::tempdir().unwrap();
+    let volume = root.path().join("astrid.volume");
+    let external = root.path().join("external.volume");
+    std::fs::write(&volume, b"durable media").unwrap();
+    std::fs::set_permissions(&volume, std::fs::Permissions::from_mode(0o600)).unwrap();
+    std::fs::hard_link(&volume, &external).unwrap();
+
+    let error = validate_private_file(&volume)
+        .expect_err("durable media with a second link must fail closed");
+    assert!(error.to_string().contains("2 links"), "{error}");
+
+    std::fs::remove_file(&external).unwrap();
+    assert!(validate_private_file(&volume).is_ok());
+}
+
+#[cfg(unix)]
+#[test]
 fn unix_private_directory_validation_rejects_permissive_modes() {
     use std::os::unix::fs::PermissionsExt as _;
 

--- a/crates/astrid-daemon/src/lib.rs
+++ b/crates/astrid-daemon/src/lib.rs
@@ -251,14 +251,6 @@ pub async fn run() -> Result<()> {
     // Done before `args.workspace` is consumed below.
     let runtime_limits = resolve_capsule_limits(&args, unified_cfg.as_ref());
 
-    // Operator-approved per-capsule local-egress allowlist (SSRF-airlock
-    // exemptions). Operator config only — the kernel hands each capsule its
-    // own slice at load time. Absent config = empty = no exemptions.
-    let local_egress = unified_cfg
-        .as_ref()
-        .map(|c| c.security.capsule_local_egress.clone())
-        .unwrap_or_default();
-
     // Operator ceilings for the astrid:http host (global; absent `[http]`
     // config = the host's historical constants). Forwarded to every capsule.
     let http_limits = resolve_http_limits(unified_cfg.as_ref());
@@ -266,12 +258,25 @@ pub async fn run() -> Result<()> {
         session_id.clone(),
         workspace_root,
         runtime_limits,
-        local_egress,
+        std::collections::HashMap::new(),
         http_limits,
         workspace_layout,
     )
     .await
     .map_err(|e| anyhow::anyhow!("Failed to boot Kernel: {e}"))?;
+
+    // Local egress is security policy at durable-root authority, so read it
+    // only after admission and bind it once before any capsule can load.
+    let admitted_config = astrid_config::Config::load_with_home_and_layout(
+        Some(&kernel.workspace_root),
+        astrid_home.root(),
+        kernel.workspace_layout(),
+    )
+    .map_err(|error| anyhow::anyhow!("Failed to load admitted-home boot policy: {error:#}"))?;
+    kernel
+        .bind_boot_local_egress(admitted_config.config.security.capsule_local_egress)
+        .map_err(|error| anyhow::anyhow!("Failed to bind boot policy: {error}"))?;
+
     if defer_logging {
         init_logging(&log_config);
     }

--- a/crates/astrid-kernel/src/capsule_adversarial_tests.rs
+++ b/crates/astrid-kernel/src/capsule_adversarial_tests.rs
@@ -2,6 +2,7 @@
 //! integrity boundaries. These intentionally describe the secure behavior
 //! expected from the kernel/install split; production fixes land separately.
 
+use std::collections::HashMap;
 use std::path::Path;
 use std::sync::{Mutex, OnceLock};
 
@@ -95,6 +96,26 @@ fn take_workspace_source() -> Option<WorkspaceSource> {
         .take()
 }
 
+async fn seed_isolated_principal(
+    kernel: &crate::Kernel,
+    home: &AstridHome,
+    name: &str,
+    uid: [u8; 32],
+) -> PrincipalId {
+    let principal = PrincipalId::new(name).unwrap();
+    kernel
+        .identity_store
+        .create_principal(principal.clone(), uid)
+        .await
+        .unwrap();
+    astrid_core::profile::PrincipalProfile::default()
+        .save_to_path(&astrid_core::profile::PrincipalProfile::path_for(
+            home, &principal,
+        ))
+        .unwrap();
+    principal
+}
+
 fn scratch_home() -> (tempfile::TempDir, AstridHome) {
     let dir = tempfile::tempdir().expect("capsule adversarial tempdir");
     let home = AstridHome::from_path(dir.path());
@@ -107,6 +128,111 @@ fn write_manifest(root: &Path, name: &str) {
         format!("[package]\nname = \"{name}\"\nversion = \"1.0.0\"\n"),
     )
     .expect("write capsule manifest");
+}
+
+fn write_component_source(root: &Path, name: &str, wit: Option<&[u8]>) -> Vec<u8> {
+    std::fs::create_dir_all(root).expect("create component source");
+    std::fs::write(
+        root.join("Capsule.toml"),
+        format!("[package]\nname = \"{name}\"\nversion = \"1.0.0\"\n\n[[component]]\nid = \"main\"\nfile = \"main.wasm\"\n"),
+    )
+    .expect("write manifest");
+    let wasm = wat::parse_str("(component)").expect("parse test component");
+    std::fs::write(root.join("main.wasm"), &wasm).expect("write component");
+    if let Some(wit) = wit {
+        std::fs::create_dir_all(root.join("wit")).expect("create WIT directory");
+        std::fs::write(root.join("wit/api.wit"), wit).expect("write WIT");
+    }
+    wasm
+}
+
+fn publish_component_source(
+    kernel: &crate::Kernel,
+    principal: &PrincipalId,
+    root: &Path,
+    wit: Option<&[u8]>,
+) -> anyhow::Result<astrid_storage::CapsulePackage> {
+    publish_component_source_at(kernel, principal, root, wit.map(|bytes| ("api.wit", bytes)))
+}
+
+fn publish_component_source_at(
+    kernel: &crate::Kernel,
+    principal: &PrincipalId,
+    root: &Path,
+    wit: Option<(&str, &[u8])>,
+) -> anyhow::Result<astrid_storage::CapsulePackage> {
+    let layout = WorkspaceLayout::default();
+    let inspection = inspect_directory_for_principal_in_workspace(
+        root,
+        &kernel.astrid_home,
+        principal,
+        false,
+        None,
+        &layout,
+    )?;
+    let authority = authorize_install(
+        &inspection,
+        &AuthorityDecision::ExplicitApproval {
+            content_digest: inspection.content_digest.clone(),
+        },
+    )?;
+    let archive = canonical_capsule_archive(root)?;
+    let manifest = astrid_capsule::discovery::load_manifest(&root.join("Capsule.toml"))?;
+    let component = manifest
+        .components
+        .first()
+        .ok_or_else(|| anyhow::anyhow!("test capsule has no component"))?;
+    let wasm_hash = blake3::hash(&std::fs::read(root.join(&component.path))?)
+        .to_hex()
+        .to_string();
+    let mut wit_files = HashMap::new();
+    if let Some((relative, wit)) = wit {
+        wit_files.insert(relative.to_owned(), blake3::hash(wit).to_hex().to_string());
+    }
+    let metadata = CapsuleMeta {
+        version: inspection.version.clone(),
+        wasm_hash: Some(wasm_hash),
+        wit_files,
+        ..Default::default()
+    };
+    let package = astrid_storage::CapsulePackage::new(
+        archive,
+        serde_json::to_vec(&metadata)?,
+        serde_json::to_vec(&authority)?,
+    );
+    let uid = kernel
+        .principal_directory
+        .uid_for(principal)
+        .map_err(|error| anyhow::anyhow!("test principal has no durable UID: {error}"))?;
+    let store = std::sync::Arc::new(
+        kernel
+            .principal_store
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("test kernel has no durable principal store"))?
+            .clone(),
+    );
+    publish_package(&store, uid, inspection.capsule_id.as_str(), &package)?;
+    Ok(package)
+}
+
+fn durable_target(
+    kernel: &crate::Kernel,
+    principal: &PrincipalId,
+    package: &astrid_storage::CapsulePackage,
+    name: &str,
+) -> std::path::PathBuf {
+    let uid = kernel.principal_directory.uid_for(principal).unwrap();
+    let digest = blake3::hash(&package.archive).to_hex().to_string();
+    resolve_cache_target_dir(
+        &kernel.astrid_home,
+        uid,
+        name,
+        &digest,
+        false,
+        None,
+        &WorkspaceLayout::default(),
+    )
+    .expect("durable cache target")
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -265,6 +391,7 @@ async fn tampered_materialized_component_and_meta_hash_are_rejected_by_kernel() 
     let malicious_wasm = b"attacker component bytes";
     let malicious_hash = blake3::hash(malicious_wasm).to_hex().to_string();
     std::fs::write(target.join("main.wasm"), malicious_wasm).unwrap();
+    std::fs::create_dir_all(home.bin_dir()).unwrap();
     std::fs::write(
         home.bin_dir().join(format!("{malicious_hash}.wasm")),
         malicious_wasm,
@@ -287,5 +414,339 @@ async fn tampered_materialized_component_and_meta_hash_are_rejected_by_kernel() 
             || error.to_string().contains("metadata")
             || error.to_string().contains("materialization"),
         "unexpected tamper rejection: {error:#}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn durable_activation_remains_principal_scoped_after_upgrade() {
+    let (_home_temp, home) = scratch_home();
+    let kernel = crate::test_kernel_with_home(home.clone()).await;
+    let principal_a = seed_isolated_principal(&kernel, &home, "activation-a", [0x83; 32]).await;
+    let principal_b = seed_isolated_principal(&kernel, &home, "activation-b", [0x84; 32]).await;
+
+    let write_source = |name: &str, version: &str, wasm: &[u8]| {
+        let source = tempfile::tempdir().unwrap();
+        std::fs::write(
+            source.path().join("Capsule.toml"),
+            format!(
+                "[package]\nname = \"{name}\"\nversion = \"{version}\"\n\n[[component]]\nid = \"main\"\nfile = \"main.wasm\"\n"
+            ),
+        )
+        .unwrap();
+        std::fs::write(source.path().join("main.wasm"), wasm).unwrap();
+        source
+    };
+    let wasm = wat::parse_str("(component)").unwrap();
+    let old_source = write_source("isolated-upgrade", "1.0.0", &wasm);
+    let new_source = write_source("isolated-upgrade", "1.1.0", &wasm);
+    let b_source = write_source("principal-b-package", "1.0.0", &wasm);
+    publish_without_running_lifecycle(&kernel, &principal_a, old_source.path()).unwrap();
+    publish_without_running_lifecycle(&kernel, &principal_b, b_source.path()).unwrap();
+
+    let old_paths = kernel.durable_principal_capsule_paths(&principal_a);
+    assert_eq!(old_paths.len(), 1);
+    assert!(old_paths[0].join("main.wasm").is_file());
+    assert_eq!(std::fs::read(old_paths[0].join("main.wasm")).unwrap(), wasm);
+
+    let store = kernel.principal_store.clone().unwrap();
+    let b_uid = kernel.principal_directory.uid_for(&principal_b).unwrap();
+    let before_b = store
+        .capsules()
+        .get_snapshot(
+            &astrid_storage::StateOwner::Principal(b_uid),
+            "principal-b-package",
+        )
+        .unwrap()
+        .unwrap();
+
+    publish_without_running_lifecycle(&kernel, &principal_a, new_source.path()).unwrap();
+    std::fs::write(old_paths[0].join("main.wasm"), b"stale hostile bytes").unwrap();
+
+    let upgraded_paths = kernel.durable_principal_capsule_paths(&principal_a);
+    assert_eq!(upgraded_paths.len(), 1);
+    assert_ne!(upgraded_paths[0], old_paths[0]);
+    assert_eq!(
+        std::fs::read(upgraded_paths[0].join("main.wasm")).unwrap(),
+        wasm
+    );
+
+    let after_b = store
+        .capsules()
+        .get_snapshot(
+            &astrid_storage::StateOwner::Principal(b_uid),
+            "principal-b-package",
+        )
+        .unwrap()
+        .unwrap();
+    assert_eq!(before_b, after_b);
+    let b_paths = kernel.durable_principal_capsule_paths(&principal_b);
+    assert_eq!(b_paths.len(), 1);
+    assert_eq!(std::fs::read(b_paths[0].join("main.wasm")).unwrap(), wasm);
+    let a_uid = kernel.principal_directory.uid_for(&principal_a).unwrap();
+    assert!(
+        store
+            .capsules()
+            .remove(
+                &astrid_storage::StateOwner::Principal(a_uid),
+                "isolated-upgrade",
+            )
+            .unwrap()
+    );
+    assert!(
+        kernel
+            .durable_principal_capsule_paths(&principal_a)
+            .is_empty()
+    );
+    let after_removal_b = store
+        .capsules()
+        .get_snapshot(
+            &astrid_storage::StateOwner::Principal(b_uid),
+            "principal-b-package",
+        )
+        .unwrap()
+        .unwrap();
+    assert_eq!(before_b, after_removal_b);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn materialized_authority_bytes_are_exactly_verified() {
+    let (_home_temp, home) = scratch_home();
+    let kernel = crate::test_kernel_with_home(home.clone()).await;
+    let principal = PrincipalId::default();
+    let source = tempfile::tempdir().unwrap();
+    let wasm = write_component_source(source.path(), "authority-projection", None);
+    let package = publish_component_source(&kernel, &principal, source.path(), None).unwrap();
+    let target = durable_target(&kernel, &principal, &package, "authority-projection");
+    materialize_capsule_package(&package, &target).unwrap();
+    let manifest = astrid_capsule::discovery::load_manifest(&target.join("Capsule.toml")).unwrap();
+    kernel
+        .verify_registry_materialization(&target, &principal, &manifest)
+        .unwrap();
+    std::fs::write(target.join("authority.json"), b"{}").unwrap();
+    let error = kernel
+        .verify_registry_materialization(&target, &principal, &manifest)
+        .unwrap_err();
+    assert!(error.to_string().contains("authority"), "{error:#}");
+    assert_eq!(std::fs::read(target.join("main.wasm")).unwrap(), wasm);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn materialized_wit_bytes_are_exactly_verified() {
+    let (_home_temp, home) = scratch_home();
+    let kernel = crate::test_kernel_with_home(home.clone()).await;
+    let principal = PrincipalId::default();
+    let source = tempfile::tempdir().unwrap();
+    let wit = b"package astrid:test;";
+    write_component_source(source.path(), "wit-projection", Some(wit));
+    let package = publish_component_source(&kernel, &principal, source.path(), Some(wit)).unwrap();
+    let target = durable_target(&kernel, &principal, &package, "wit-projection");
+    materialize_capsule_package(&package, &target).unwrap();
+    let manifest = astrid_capsule::discovery::load_manifest(&target.join("Capsule.toml")).unwrap();
+    kernel
+        .verify_registry_materialization(&target, &principal, &manifest)
+        .unwrap();
+    std::fs::write(target.join("wit/api.wit"), b"package hostile:evil;").unwrap();
+    let error = kernel
+        .verify_registry_materialization(&target, &principal, &manifest)
+        .unwrap_err();
+    assert!(
+        error.to_string().contains("differs from durable archive"),
+        "{error:#}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn nested_wit_ancestors_activate_from_a_durable_package() {
+    let (_home_temp, home) = scratch_home();
+    let kernel = crate::test_kernel_with_home(home.clone()).await;
+    let principal = PrincipalId::default();
+    let source = tempfile::tempdir().unwrap();
+    write_component_source(source.path(), "nested-wit-projection", None);
+    let wit = b"package astrid:contracts;";
+    let wit_relative = "deps/astrid-contracts/astrid-contracts.wit";
+    std::fs::create_dir_all(
+        source
+            .path()
+            .join("wit")
+            .join(wit_relative)
+            .parent()
+            .unwrap(),
+    )
+    .unwrap();
+    std::fs::write(source.path().join("wit").join(wit_relative), wit).unwrap();
+    publish_component_source_at(
+        &kernel,
+        &principal,
+        source.path(),
+        Some((wit_relative, wit)),
+    )
+    .unwrap();
+
+    let targets = kernel.durable_principal_capsule_paths(&principal);
+    assert_eq!(targets.len(), 1);
+    assert!(targets[0].join("wit").is_dir());
+    assert!(targets[0].join("wit/deps").is_dir());
+    assert!(targets[0].join("wit/deps/astrid-contracts").is_dir());
+    assert_eq!(
+        std::fs::read(targets[0].join("wit").join(wit_relative)).unwrap(),
+        wit
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn empty_directories_activate_and_survive_durable_activation() {
+    let (_home_temp, home) = scratch_home();
+    let kernel = crate::test_kernel_with_home(home.clone()).await;
+    let principal = PrincipalId::default();
+    let source = tempfile::tempdir().unwrap();
+    write_component_source(source.path(), "empty-directory-projection", None);
+    std::fs::create_dir_all(source.path().join("empty/nested")).unwrap();
+    let package = publish_component_source_at(&kernel, &principal, source.path(), None).unwrap();
+    let target = durable_target(&kernel, &principal, &package, "empty-directory-projection");
+    let targets = kernel.durable_principal_capsule_paths(&principal);
+    assert_eq!(targets.len(), 1);
+    assert_eq!(targets[0], target);
+    assert!(targets[0].join("empty").is_dir());
+    assert!(targets[0].join("empty/nested").is_dir());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn materialized_extra_file_is_rejected() {
+    let (_home_temp, home) = scratch_home();
+    let kernel = crate::test_kernel_with_home(home.clone()).await;
+    let principal = PrincipalId::default();
+    let source = tempfile::tempdir().unwrap();
+    write_component_source(source.path(), "extra-projection", None);
+    let package = publish_component_source(&kernel, &principal, source.path(), None).unwrap();
+    let target = durable_target(&kernel, &principal, &package, "extra-projection");
+    materialize_capsule_package(&package, &target).unwrap();
+    std::fs::write(target.join("extra.txt"), b"hostile").unwrap();
+    let manifest = astrid_capsule::discovery::load_manifest(&target.join("Capsule.toml")).unwrap();
+    let error = kernel
+        .verify_registry_materialization(&target, &principal, &manifest)
+        .unwrap_err();
+    assert!(error.to_string().contains("inventory"), "{error:#}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn materialized_extra_directory_is_rejected() {
+    let (_home_temp, home) = scratch_home();
+    let kernel = crate::test_kernel_with_home(home.clone()).await;
+    let principal = PrincipalId::default();
+    let source = tempfile::tempdir().unwrap();
+    write_component_source(source.path(), "extra-directory-projection", None);
+    let package = publish_component_source(&kernel, &principal, source.path(), None).unwrap();
+    let target = durable_target(&kernel, &principal, &package, "extra-directory-projection");
+    materialize_capsule_package(&package, &target).unwrap();
+    std::fs::create_dir_all(target.join("extra/nested")).unwrap();
+    let manifest = astrid_capsule::discovery::load_manifest(&target.join("Capsule.toml")).unwrap();
+    let error = kernel
+        .verify_registry_materialization(&target, &principal, &manifest)
+        .unwrap_err();
+    assert!(error.to_string().contains("inventory"), "{error:#}");
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn materialized_child_symlink_is_rejected() {
+    let (_home_temp, home) = scratch_home();
+    let kernel = crate::test_kernel_with_home(home.clone()).await;
+    let principal = PrincipalId::default();
+    let source = tempfile::tempdir().unwrap();
+    let outside = tempfile::tempdir().unwrap();
+    std::fs::write(outside.path().join("hostile.wasm"), b"outside").unwrap();
+    write_component_source(source.path(), "redirect-projection", None);
+    let package = publish_component_source(&kernel, &principal, source.path(), None).unwrap();
+    let target = durable_target(&kernel, &principal, &package, "redirect-projection");
+    materialize_capsule_package(&package, &target).unwrap();
+    std::fs::remove_file(target.join("main.wasm")).unwrap();
+    std::os::unix::fs::symlink(
+        outside.path().join("hostile.wasm"),
+        target.join("main.wasm"),
+    )
+    .unwrap();
+    let manifest = astrid_capsule::discovery::load_manifest(&target.join("Capsule.toml")).unwrap();
+    let error = kernel
+        .verify_registry_materialization(&target, &principal, &manifest)
+        .unwrap_err();
+    assert!(error.to_string().contains("redirect"), "{error:#}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn same_runtime_durable_upgrade_materializes_a_new_live_source() {
+    let (_home_temp, home) = scratch_home();
+    let kernel = crate::test_kernel_with_home(home.clone()).await;
+    let principal = PrincipalId::default();
+    let old_source = tempfile::tempdir().unwrap();
+    let old_wasm = write_component_source(old_source.path(), "live-upgrade", None);
+    let old_package =
+        publish_component_source(&kernel, &principal, old_source.path(), None).unwrap();
+    let old_target = durable_target(&kernel, &principal, &old_package, "live-upgrade");
+    materialize_capsule_package(&old_package, &old_target).unwrap();
+    let old_hash = blake3::hash(&old_wasm).to_hex().to_string();
+    kernel
+        .principal_store
+        .as_ref()
+        .unwrap()
+        .content()
+        .put(
+            &astrid_storage::StateOwner::System,
+            &astrid_storage::ContentName::new(format!("bin/{old_hash}.wasm")).unwrap(),
+            &old_wasm,
+        )
+        .unwrap();
+
+    crate::Kernel::load_capsule(&kernel, old_target.clone(), &principal)
+        .await
+        .expect("load published old generation");
+    let id = CapsuleId::from_static("live-upgrade");
+    let running_old = kernel
+        .capsules
+        .read()
+        .await
+        .get_for(&principal, &id)
+        .expect("old runtime is live");
+    assert_eq!(
+        std::fs::read(running_old.source_dir().unwrap().join("main.wasm")).unwrap(),
+        old_wasm
+    );
+
+    let new_source = tempfile::tempdir().unwrap();
+    let new_wasm = wat::parse_str("(component)").unwrap();
+    std::fs::write(new_source.path().join("Capsule.toml"), "[package]\nname = \"live-upgrade\"\nversion = \"1.1.0\"\n\n[[component]]\nid = \"main\"\nfile = \"main.wasm\"\n").unwrap();
+    std::fs::write(new_source.path().join("main.wasm"), &new_wasm).unwrap();
+    publish_component_source(&kernel, &principal, new_source.path(), None).unwrap();
+    let new_hash = blake3::hash(&new_wasm).to_hex().to_string();
+    kernel
+        .principal_store
+        .as_ref()
+        .unwrap()
+        .content()
+        .put(
+            &astrid_storage::StateOwner::System,
+            &astrid_storage::ContentName::new(format!("bin/{new_hash}.wasm")).unwrap(),
+            &new_wasm,
+        )
+        .unwrap();
+
+    kernel
+        .restart_capsule(&id, &principal, None)
+        .await
+        .expect("same runtime stays live across durable upgrade");
+    let upgraded = kernel
+        .capsules
+        .read()
+        .await
+        .get_for(&principal, &id)
+        .expect("upgraded runtime is live");
+    let upgraded_dir = upgraded.source_dir().expect("runtime source is durable");
+    assert_ne!(upgraded_dir, old_target);
+    assert_eq!(
+        std::fs::read(upgraded_dir.join("main.wasm")).unwrap(),
+        new_wasm
+    );
+    assert_eq!(
+        std::fs::read(old_target.join("main.wasm")).unwrap(),
+        old_wasm
     );
 }

--- a/crates/astrid-kernel/src/capsule_materialization.rs
+++ b/crates/astrid-kernel/src/capsule_materialization.rs
@@ -1,0 +1,229 @@
+//! Durable capsule publication binding and canonical projection repair.
+
+use std::path::Path;
+
+use super::{BoundMaterialization, Kernel, authenticated_ancestor_directories};
+
+impl Kernel {
+    /// Verify every projected byte against one immutable package snapshot.
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+    pub(crate) fn verify_published_materialization(
+        &self,
+        dir: &Path,
+        principal: &astrid_core::principal::PrincipalId,
+        manifest: &astrid_capsule_types::manifest::CapsuleManifest,
+        snapshot: &astrid_storage::CapsulePackageSnapshot,
+    ) -> anyhow::Result<()> {
+        self.validate_published_cache_path(dir, principal, manifest, snapshot)?;
+        let uid = self
+            .principal_directory
+            .uid_for(principal)
+            .map_err(|error| anyhow::anyhow!("resolve capsule cache owner UID: {error}"))?;
+        let verified = astrid_capsule_install::read_verified_durable_package_for_owner(
+            self.principal_store
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("durable capsule registry is unavailable"))?,
+            &astrid_storage::StateOwner::Principal(uid),
+            manifest.package.name.as_str(),
+        )?
+        .ok_or_else(|| anyhow::anyhow!("materialized capsule is absent from durable registry"))?;
+        if verified.snapshot() != snapshot {
+            anyhow::bail!("materialized capsule snapshot differs from the caller's publication");
+        }
+        if verified.manifest().package.name != manifest.package.name
+            || verified.manifest().package.version != manifest.package.version
+        {
+            anyhow::bail!("materialized capsule manifest differs from durable registry");
+        }
+        let manifest_bytes = Self::read_projection_file_nofollow(&dir.join("Capsule.toml"))
+            .map_err(|error| anyhow::anyhow!("read materialized capsule manifest: {error:#}"))?;
+        if manifest_bytes != verified.manifest_bytes() {
+            anyhow::bail!("durable capsule manifest bytes do not match materialization");
+        }
+        let metadata_bytes = Self::read_projection_file_nofollow(&dir.join("meta.json"))
+            .map_err(|error| anyhow::anyhow!("read materialized capsule metadata: {error:#}"))?;
+        if metadata_bytes != verified.metadata_bytes() {
+            anyhow::bail!("durable capsule metadata does not match materialization");
+        }
+        let authority_bytes = Self::read_projection_file_nofollow(&dir.join("authority.json"))
+            .map_err(|error| anyhow::anyhow!("read materialized capsule authority: {error:#}"))?;
+        if authority_bytes != verified.snapshot().package().authority {
+            anyhow::bail!("durable capsule authority bytes do not match materialization");
+        }
+        let mut expected_files = verified
+            .archive_entries()
+            .map(|(path, bytes)| (path.to_owned(), bytes.to_vec()))
+            .collect::<std::collections::BTreeMap<_, _>>();
+        expected_files.insert(
+            "Capsule.toml".to_owned(),
+            verified.manifest_bytes().to_vec(),
+        );
+        expected_files.insert("meta.json".to_owned(), verified.metadata_bytes().to_vec());
+        expected_files.insert(
+            "authority.json".to_owned(),
+            verified.snapshot().package().authority.clone(),
+        );
+        let actual = Self::inventory_projection_files(dir)?;
+        if actual.files
+            != expected_files
+                .keys()
+                .cloned()
+                .collect::<std::collections::BTreeSet<_>>()
+        {
+            anyhow::bail!("materialized capsule file inventory differs from durable package");
+        }
+        let mut expected_directories = expected_files
+            .keys()
+            .flat_map(|relative| authenticated_ancestor_directories(relative))
+            .collect::<std::collections::BTreeSet<_>>();
+        let archive_directories = verified
+            .archive_directories()
+            .map(ToOwned::to_owned)
+            .collect::<Vec<_>>();
+        expected_directories.extend(archive_directories.iter().cloned());
+        expected_directories.extend(
+            archive_directories
+                .iter()
+                .map(String::as_str)
+                .flat_map(authenticated_ancestor_directories),
+        );
+        if actual.directories != expected_directories {
+            anyhow::bail!("materialized capsule directory inventory differs from durable package");
+        }
+        for (relative, expected) in &expected_files {
+            let materialized =
+                Self::read_projection_file_nofollow(&dir.join(relative)).map_err(|error| {
+                    anyhow::anyhow!("read materialized capsule member {relative}: {error}")
+                })?;
+            if materialized != *expected {
+                anyhow::bail!(
+                    "materialized capsule member {relative} differs from durable archive"
+                );
+            }
+        }
+        let expansions = manifest
+            .capabilities
+            .expansions_from(&verified.authority().approved_capabilities);
+        if !expansions.is_empty() {
+            anyhow::bail!("materialized capsule manifest exceeds durable authority approval");
+        }
+        Ok(())
+    }
+
+    /// Bind durable activation or authorize the explicit workspace portal.
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+    pub(crate) fn capture_bound_materialization(
+        &self,
+        dir: &Path,
+        principal: &astrid_core::principal::PrincipalId,
+        manifest: &astrid_capsule_types::manifest::CapsuleManifest,
+        operation: &str,
+    ) -> anyhow::Result<Option<BoundMaterialization>> {
+        let snapshot = self.published_capsule_snapshot(principal, manifest)?;
+        if let Some(snapshot) = snapshot {
+            let runtime_dir = self.published_cache_target(principal, manifest, &snapshot)?;
+            let bound_manifest = self.repair_published_materialization(
+                &runtime_dir,
+                principal,
+                manifest,
+                &snapshot,
+            )?;
+            return Ok(Some(BoundMaterialization {
+                snapshot,
+                runtime_dir,
+                manifest: bound_manifest,
+            }));
+        }
+        if !self.verify_registry_materialization(dir, principal, manifest)? {
+            if self.principal_store.is_some()
+                && !dir.starts_with(self.workspace_selection.state_dir())
+            {
+                anyhow::bail!(
+                    "capsule {operation} '{}' is outside the explicit workspace portal and \
+                     has no durable registry authority",
+                    manifest.package.name
+                );
+            }
+            self.verify_installed_authority_for_runtime(dir, manifest).map_err(|error| {
+                anyhow::anyhow!(
+                    "capsule {operation} '{}' exceeds or cannot prove its installed authority: {error:#}",
+                    manifest.package.name
+                )
+            })?;
+        }
+        Ok(None)
+    }
+
+    /// Repair a stale or missing cache generation from one exact snapshot.
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+    pub(crate) fn ensure_published_materialization(
+        &self,
+        target: &Path,
+        principal: &astrid_core::principal::PrincipalId,
+        manifest: &astrid_capsule_types::manifest::CapsuleManifest,
+        snapshot: &astrid_storage::CapsulePackageSnapshot,
+    ) -> anyhow::Result<astrid_capsule_types::manifest::CapsuleManifest> {
+        self.repair_published_materialization(target, principal, manifest, snapshot)
+    }
+
+    /// Replace a canonical stale projection without trusting the old manifest.
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+    pub(crate) fn repair_published_materialization(
+        &self,
+        target: &Path,
+        principal: &astrid_core::principal::PrincipalId,
+        discovery_manifest: &astrid_capsule_types::manifest::CapsuleManifest,
+        snapshot: &astrid_storage::CapsulePackageSnapshot,
+    ) -> anyhow::Result<astrid_capsule_types::manifest::CapsuleManifest> {
+        self.validate_published_cache_path(target, principal, discovery_manifest, snapshot)?;
+        let target_metadata = match std::fs::symlink_metadata(target) {
+            Ok(metadata) => Some(metadata),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+            Err(error) => return Err(anyhow::anyhow!("inspect capsule materialization: {error}")),
+        };
+        if let Some(metadata) = target_metadata {
+            if metadata.file_type().is_symlink() || !metadata.is_dir() {
+                anyhow::bail!("capsule materialization target is redirected or not a directory");
+            }
+            if let Ok(bound_manifest) =
+                astrid_capsule::discovery::load_manifest(&target.join("Capsule.toml"))
+                && self
+                    .verify_published_materialization(target, principal, &bound_manifest, snapshot)
+                    .is_ok()
+            {
+                return Ok(bound_manifest);
+            }
+            astrid_core::platform_fs::verify_no_redirects(target).map_err(|error| {
+                anyhow::anyhow!("capsule materialization target is redirected: {error}")
+            })?;
+            std::fs::remove_dir_all(target).map_err(|error| {
+                anyhow::anyhow!("remove stale capsule materialization: {error}")
+            })?;
+        }
+        astrid_capsule_install::materialize_capsule_package(snapshot.package(), target)
+            .map_err(|error| anyhow::anyhow!("materialize durable capsule package: {error:#}"))?;
+        let bound_manifest = astrid_capsule::discovery::load_manifest(&target.join("Capsule.toml"))
+            .map_err(|error| anyhow::anyhow!(error))?;
+        self.verify_published_materialization(target, principal, &bound_manifest, snapshot)?;
+        Ok(bound_manifest)
+    }
+
+    /// Recheck the immutable publication after taking activation locks.
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+    pub(crate) fn confirm_published_materialization(
+        &self,
+        dir: &Path,
+        principal: &astrid_core::principal::PrincipalId,
+        manifest: &astrid_capsule_types::manifest::CapsuleManifest,
+        snapshot: &astrid_storage::CapsulePackageSnapshot,
+    ) -> anyhow::Result<()> {
+        let current = self.published_capsule_snapshot(principal, manifest)?;
+        if current.as_ref() != Some(snapshot) {
+            anyhow::bail!(
+                "capsule '{}' changed while activation was in progress",
+                manifest.package.name
+            );
+        }
+        self.verify_published_materialization(dir, principal, manifest, snapshot)
+    }
+}

--- a/crates/astrid-kernel/src/invite/storage_migration.rs
+++ b/crates/astrid-kernel/src/invite/storage_migration.rs
@@ -212,6 +212,7 @@ mod tests {
         let home = AstridHome::from_path(dir.path());
         home.ensure().unwrap();
         let path = InviteStore::path_for(&home);
+        std::fs::create_dir_all(home.etc_dir()).unwrap();
         let outside = dir.path().join("outside.toml");
         private_write(&outside, "schema_version = 1\n");
         std::os::unix::fs::symlink(&outside, &path).unwrap();

--- a/crates/astrid-kernel/src/kernel_shutdown_tests.rs
+++ b/crates/astrid-kernel/src/kernel_shutdown_tests.rs
@@ -1,0 +1,89 @@
+//! Focused lifecycle tests for durable projection publication at shutdown.
+
+use super::{Kernel, test_kernel_with_home};
+
+#[tokio::test]
+async fn graceful_shutdown_publishes_final_running_projection() {
+    let root = tempfile::tempdir().unwrap();
+    let home = astrid_core::dirs::AstridHome::from_path(root.path());
+    let kernel: std::sync::Arc<Kernel> = test_kernel_with_home(home.clone()).await;
+
+    let log_path = home.root().join("log/daemon.log");
+    std::fs::create_dir_all(log_path.parent().unwrap()).unwrap();
+    std::fs::write(&log_path, b"generation-1\ngeneration-2\n").unwrap();
+
+    kernel.shutdown(Some("test".to_owned())).await;
+    assert_eq!(
+        std::fs::read(&log_path).unwrap(),
+        b"generation-1\ngeneration-2\n"
+    );
+    drop(kernel);
+
+    let reopened = astrid_storage::open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    assert_eq!(
+        std::fs::read(&log_path).unwrap(),
+        b"generation-1\ngeneration-2\n"
+    );
+    reopened.kv().close().await.unwrap();
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn failed_shutdown_publication_retains_host_projection_for_recovery() {
+    use std::os::unix::fs::symlink;
+
+    let root = tempfile::tempdir().unwrap();
+    let home = astrid_core::dirs::AstridHome::from_path(root.path());
+    let kernel = test_kernel_with_home(home.clone()).await;
+
+    let log_path = home.root().join("log/daemon.log");
+    let config_path = home.root().join("etc/authz.conf");
+    std::fs::create_dir_all(log_path.parent().unwrap()).unwrap();
+    std::fs::write(&log_path, b"generation-1\ngeneration-2\n").unwrap();
+    std::fs::write(&config_path, b"allow=generation-2\n").unwrap();
+    let outside = tempfile::tempdir().unwrap();
+    let redirect = home.root().join("redirect");
+    symlink(outside.path(), &redirect).unwrap();
+
+    // `Kernel::shutdown` is intentionally infallible; admission must fail
+    // without retiring or claiming the still-hosted projection.
+    kernel.shutdown(Some("test".to_owned())).await;
+    assert!(redirect.symlink_metadata().is_ok());
+    assert_eq!(
+        std::fs::read(&log_path).unwrap(),
+        b"generation-1\ngeneration-2\n"
+    );
+    assert_eq!(
+        std::fs::read(&config_path).unwrap(),
+        b"allow=generation-2\n"
+    );
+    drop(kernel);
+
+    std::fs::remove_file(&redirect).unwrap();
+    let recovered = astrid_storage::open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    assert_eq!(
+        std::fs::read(&log_path).unwrap(),
+        b"generation-1\ngeneration-2\n"
+    );
+    assert_eq!(
+        std::fs::read(&config_path).unwrap(),
+        b"allow=generation-2\n"
+    );
+    recovered.kv().close().await.unwrap();
+}
+
+fn unlimited_quota()
+-> std::sync::Arc<dyn astrid_storage::KvQuotaResolver<astrid_storage::StateOwner>> {
+    std::sync::Arc::new(|owner: &astrid_storage::StateOwner| {
+        Ok(match owner {
+            astrid_storage::StateOwner::System => None,
+            astrid_storage::StateOwner::Principal(_) | astrid_storage::StateOwner::Fleet(_) => {
+                Some(u64::MAX)
+            },
+        })
+    })
+}

--- a/crates/astrid-kernel/src/legacy_migration_barrier/tests.rs
+++ b/crates/astrid-kernel/src/legacy_migration_barrier/tests.rs
@@ -52,18 +52,14 @@ fn origin_is_captured_before_fresh_home_ensure() {
     let origin = capture_layout_origin(&home).expect("fresh origin");
     assert_eq!(origin, LayoutOrigin::Fresh);
     home.ensure().expect("initialize fresh home");
-    assert_eq!(
-        home.layout_version().expect("layout version").as_deref(),
-        Some("2")
-    );
-    // The origin remains Fresh even though ensure has now written v2. The
-    // native composition root carries this captured value through boot so it
-    // can write the explicit fresh-layout ledger instead of treating the home
-    // as a failed upgrade.
+    assert_eq!(home.layout_version().expect("layout version"), None);
+    // A fresh home stays sentinel-free through ensure. The captured value
+    // lets the native composition root write the explicit fresh-layout ledger
+    // instead of treating the home as a failed upgrade.
     assert_eq!(origin, LayoutOrigin::Fresh);
     assert_eq!(
-        capture_layout_origin(&home).expect("v2 origin"),
-        LayoutOrigin::ExistingV2
+        capture_layout_origin(&home).expect("fresh origin"),
+        LayoutOrigin::Fresh
     );
 }
 
@@ -486,6 +482,7 @@ async fn post_barrier_retirement_resumes_after_crash_and_rejects_reappeared_cow(
     make_private_dir(root.path());
     let home = AstridHome::from_path(root.path());
     home.ensure().expect("fresh home");
+    fs::create_dir_all(home.migrations_dir()).expect("migrations");
     let quota: std::sync::Arc<dyn astrid_storage::KvQuotaResolver<astrid_storage::StateOwner>> =
         std::sync::Arc::new(|_: &astrid_storage::StateOwner| Ok(None));
     let store = astrid_storage::open_runtime_principal_store(&home, quota)
@@ -506,7 +503,6 @@ async fn post_barrier_retirement_resumes_after_crash_and_rejects_reappeared_cow(
     )
     .expect("ledger");
 
-    assert!(home.principal_store_path().is_dir());
     retire_post_barrier_sources(&home, &store).expect("first retirement");
     assert!(!home.principal_store_path().exists());
     assert!(!home.cow_dir().exists());

--- a/crates/astrid-kernel/src/lib.rs
+++ b/crates/astrid-kernel/src/lib.rs
@@ -118,6 +118,52 @@ struct CapsuleViewLease {
     locks: Arc<DashMap<CapsuleViewKey, Weak<Mutex<()>>>>,
 }
 
+/// One immutable publication and the projection activated from it.
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+struct BoundMaterialization {
+    snapshot: astrid_storage::CapsulePackageSnapshot,
+    runtime_dir: PathBuf,
+    manifest: astrid_capsule_types::manifest::CapsuleManifest,
+}
+
+/// Exact regular-file and real-directory shape of a durable projection.
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+#[derive(Default)]
+struct ProjectionInventory {
+    files: std::collections::BTreeSet<String>,
+    directories: std::collections::BTreeSet<String>,
+}
+
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+fn authenticated_ancestor_directories(relative: &str) -> impl Iterator<Item = String> + '_ {
+    let mut next = Path::new(relative).parent().map(ToOwned::to_owned);
+    std::iter::from_fn(move || {
+        let directory = next.take()?;
+        next = directory.parent().map(ToOwned::to_owned);
+        if directory.as_os_str().is_empty() {
+            return None;
+        }
+        Some(directory.to_string_lossy().into_owned())
+    })
+}
+
+#[cfg(all(unix, not(all(target_arch = "wasm32", target_os = "unknown"))))]
+fn open_projection_file_nofollow(path: &Path) -> anyhow::Result<std::fs::File> {
+    use std::os::unix::fs::OpenOptionsExt as _;
+
+    std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(nix::libc::O_NOFOLLOW | nix::libc::O_CLOEXEC)
+        .open(path)
+        .map_err(|error| anyhow::anyhow!("open projected file {}: {error}", path.display()))
+}
+
+#[cfg(all(not(unix), not(all(target_arch = "wasm32", target_os = "unknown"))))]
+fn open_projection_file_nofollow(path: &Path) -> anyhow::Result<std::fs::File> {
+    std::fs::File::open(path)
+        .map_err(|error| anyhow::anyhow!("open projected file {}: {error}", path.display()))
+}
+
 impl Drop for CapsuleViewLease {
     fn drop(&mut self) {
         self.locks.remove_if(&self.key, |_, stored| {
@@ -278,13 +324,14 @@ pub struct Kernel {
     /// `Copy` value — no resolution logic lives here. See
     /// [`CapsuleRuntimeLimits`](astrid_capsule_types::CapsuleRuntimeLimits).
     runtime_limits: astrid_capsule_types::CapsuleRuntimeLimits,
-    /// Operator-approved per-capsule local-egress allowlist
+    /// Operator-approved per-capsule local-egress boot allowlist
     /// (`[security.capsule_local_egress]`), keyed by capsule id. Resolved
-    /// once from config by the daemon; the kernel only stores it and hands
-    /// each capsule its own slice at load time so the SSRF airlock can
-    /// exempt operator-sanctioned loopback/private endpoints. Empty = no
-    /// exemptions (fail-closed).
-    local_egress: std::collections::HashMap<String, Vec<String>>,
+    /// once after durable-root admission; the kernel only stores it and hands
+    /// each capsule its own slice at load time so the SSRF airlock can exempt
+    /// operator-sanctioned loopback/private endpoints. `None`/empty = no
+    /// exemptions (fail-closed). The snapshot is deliberately write-once:
+    /// capsule reloads never re-read operator policy.
+    local_egress: std::sync::RwLock<Option<std::collections::HashMap<String, Vec<String>>>>,
     /// Operator-declared capsule IDs permitted to run as explicit system
     /// singletons. Manifest fields can request uplink behavior but cannot grant
     /// this cross-principal authority themselves.
@@ -872,6 +919,32 @@ impl Kernel {
         .await
     }
 
+    /// Bind the process-lifetime local-egress boot snapshot before the first
+    /// capsule load.
+    ///
+    /// This is a boot-only seam: reloads reuse the bound snapshot and a second
+    /// bind fails, so operator revocation remains daemon-restart-bound.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a boot snapshot was already bound.
+    pub fn bind_boot_local_egress(
+        &self,
+        local_egress: std::collections::HashMap<String, Vec<String>>,
+    ) -> Result<(), std::io::Error> {
+        let mut snapshot = self
+            .local_egress
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if snapshot.is_some() {
+            return Err(std::io::Error::other(
+                "local-egress boot policy is already bound",
+            ));
+        }
+        *snapshot = Some(local_egress);
+        Ok(())
+    }
+
     /// Construct a kernel from injected resources and workspace layout.
     ///
     /// # Panics
@@ -1263,7 +1336,7 @@ impl Kernel {
             #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
             compiled_wasm: astrid_capsule::engine::wasm::CompiledWasmCache::default(),
             runtime_limits,
-            local_egress,
+            local_egress: std::sync::RwLock::new(None),
             system_capsules: RwLock::new(std::collections::HashSet::new()),
             http_limits,
             full_reload_in_flight: AtomicBool::new(false),
@@ -1288,6 +1361,10 @@ impl Kernel {
             astrid_home: home,
             admin_write_lock: Mutex::new(()),
         });
+
+        if !local_egress.is_empty() {
+            kernel.bind_boot_local_egress(local_egress)?;
+        }
 
         #[cfg(not(target_family = "wasm"))]
         let _ = kernel.process_storage_mount_broker.set(Arc::new(
@@ -1411,10 +1488,10 @@ impl Kernel {
     /// Verify a path-only capsule cache against the durable package registry.
     ///
     /// The extracted directory is disposable projection state; its owner,
-    /// capsule id, and archive digest are accepted only when they exactly
-    /// match the authenticated immutable-UID registry snapshot. `false`
-    /// means this is an explicit workspace/project portal and must use its
-    /// separate installation receipt policy.
+    /// capsule id, archive digest, and every projected byte are accepted only
+    /// when they exactly match one authenticated immutable-UID snapshot.
+    /// `false` means this is an explicit workspace/project portal and must use
+    /// its separate installation receipt policy.
     #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
     fn verify_registry_materialization(
         &self,
@@ -1422,10 +1499,76 @@ impl Kernel {
         principal: &PrincipalId,
         manifest: &astrid_capsule_types::manifest::CapsuleManifest,
     ) -> anyhow::Result<bool> {
-        let cache_root = self.astrid_home.run_dir().join("capsules");
-        let Ok(relative) = dir.strip_prefix(&cache_root) else {
+        let Some(snapshot) = self.published_capsule_snapshot(principal, manifest)? else {
             return Ok(false);
         };
+        self.verify_published_materialization(dir, principal, manifest, &snapshot)?;
+        Ok(true)
+    }
+
+    /// Bind activation to one principal's currently published package.
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+    fn published_capsule_snapshot(
+        &self,
+        principal: &PrincipalId,
+        manifest: &astrid_capsule_types::manifest::CapsuleManifest,
+    ) -> anyhow::Result<Option<astrid_storage::CapsulePackageSnapshot>> {
+        let Some(store) = self.principal_store.as_ref() else {
+            return Ok(None);
+        };
+        let uid = self
+            .principal_directory
+            .uid_for(principal)
+            .map_err(|error| anyhow::anyhow!("resolve capsule cache owner UID: {error}"))?;
+        let owner = astrid_storage::StateOwner::Principal(uid);
+        let capsule_id = astrid_capsule_types::CapsuleId::new(manifest.package.name.clone())
+            .map_err(|error| anyhow::anyhow!("invalid durable capsule id: {error}"))?;
+        store
+            .capsules()
+            .get_snapshot(&owner, capsule_id.as_str())
+            .map_err(|error| anyhow::anyhow!("read durable capsule registry: {error}"))
+    }
+
+    /// Derive the only runtime projection path admitted by this snapshot.
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+    fn published_cache_target(
+        &self,
+        principal: &PrincipalId,
+        manifest: &astrid_capsule_types::manifest::CapsuleManifest,
+        snapshot: &astrid_storage::CapsulePackageSnapshot,
+    ) -> anyhow::Result<PathBuf> {
+        let uid = self
+            .principal_directory
+            .uid_for(principal)
+            .map_err(|error| anyhow::anyhow!("resolve capsule cache owner UID: {error}"))?;
+        let digest = blake3::hash(&snapshot.package().archive)
+            .to_hex()
+            .to_string();
+        astrid_capsule_install::resolve_cache_target_dir(
+            &self.astrid_home,
+            uid,
+            manifest.package.name.as_str(),
+            &digest,
+            false,
+            None,
+            &self.workspace_layout,
+        )
+        .map_err(|error| anyhow::anyhow!("resolve durable capsule cache target: {error}"))
+    }
+
+    /// Validate the disposable cache path against an exact owner snapshot.
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+    fn validate_published_cache_path(
+        &self,
+        dir: &Path,
+        principal: &PrincipalId,
+        manifest: &astrid_capsule_types::manifest::CapsuleManifest,
+        snapshot: &astrid_storage::CapsulePackageSnapshot,
+    ) -> anyhow::Result<()> {
+        let cache_root = self.astrid_home.run_dir().join("capsules");
+        let relative = dir.strip_prefix(&cache_root).map_err(|_| {
+            anyhow::anyhow!("capsule cache path is outside the durable registry cache")
+        })?;
         astrid_core::platform_fs::verify_no_redirects(dir)
             .map_err(|error| anyhow::anyhow!("capsule cache path is redirected: {error}"))?;
         let components: Vec<String> = relative
@@ -1447,53 +1590,109 @@ impl Kernel {
         if components[0] != uid.to_string() || components[1] != manifest.package.name {
             anyhow::bail!("capsule cache owner or id does not match authenticated registry scope");
         }
-        let capsule_id = astrid_capsule_types::CapsuleId::new(manifest.package.name.clone())
-            .map_err(|error| anyhow::anyhow!("invalid materialized capsule id: {error}"))?;
-        let store = self
-            .principal_store
-            .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("durable capsule registry is unavailable"))?;
-        let owner = astrid_storage::StateOwner::Principal(uid);
-        let verified = astrid_capsule_install::read_verified_durable_package_for_owner(
-            store,
-            &owner,
-            capsule_id.as_str(),
-        )?
-        .ok_or_else(|| anyhow::anyhow!("materialized capsule is absent from durable registry"))?;
-        let digest = blake3::hash(verified.archive()).to_hex().to_string();
+        let digest = blake3::hash(&snapshot.package().archive)
+            .to_hex()
+            .to_string();
         if components[2] != digest {
             anyhow::bail!("materialized capsule digest does not match durable registry");
+        }
+        Ok(())
+    }
+
+    /// Verify every projected byte against one immutable package snapshot.
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+    fn verify_published_materialization(
+        &self,
+        dir: &Path,
+        principal: &PrincipalId,
+        manifest: &astrid_capsule_types::manifest::CapsuleManifest,
+        snapshot: &astrid_storage::CapsulePackageSnapshot,
+    ) -> anyhow::Result<()> {
+        self.validate_published_cache_path(dir, principal, manifest, snapshot)?;
+        let uid = self
+            .principal_directory
+            .uid_for(principal)
+            .map_err(|error| anyhow::anyhow!("resolve capsule cache owner UID: {error}"))?;
+        let verified = astrid_capsule_install::read_verified_durable_package_for_owner(
+            self.principal_store
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("durable capsule registry is unavailable"))?,
+            &astrid_storage::StateOwner::Principal(uid),
+            manifest.package.name.as_str(),
+        )?
+        .ok_or_else(|| anyhow::anyhow!("materialized capsule is absent from durable registry"))?;
+        if verified.snapshot() != snapshot {
+            anyhow::bail!("materialized capsule snapshot differs from the caller's publication");
         }
         if verified.manifest().package.name != manifest.package.name
             || verified.manifest().package.version != manifest.package.version
         {
             anyhow::bail!("materialized capsule manifest differs from durable registry");
         }
-        let manifest_bytes = std::fs::read(dir.join("Capsule.toml"))
-            .map_err(|error| anyhow::anyhow!("read materialized capsule manifest: {error}"))?;
+        let manifest_bytes = Self::read_projection_file_nofollow(&dir.join("Capsule.toml"))
+            .map_err(|error| anyhow::anyhow!("read materialized capsule manifest: {error:#}"))?;
         if manifest_bytes != verified.manifest_bytes() {
             anyhow::bail!("durable capsule manifest bytes do not match materialization");
         }
-        let metadata_bytes = std::fs::read(dir.join("meta.json"))
-            .map_err(|error| anyhow::anyhow!("read materialized capsule metadata: {error}"))?;
+        let metadata_bytes = Self::read_projection_file_nofollow(&dir.join("meta.json"))
+            .map_err(|error| anyhow::anyhow!("read materialized capsule metadata: {error:#}"))?;
         if metadata_bytes != verified.metadata_bytes() {
             anyhow::bail!("durable capsule metadata does not match materialization");
         }
-        for component in &verified.manifest().components {
-            if component.path.is_absolute() {
-                anyhow::bail!("materialized capsule component path is absolute");
-            }
-            let relative = component.path.to_str().ok_or_else(|| {
-                anyhow::anyhow!("materialized capsule component path is not UTF-8")
-            })?;
-            let Some(expected) = verified.archive_file(relative) else {
-                anyhow::bail!("materialized capsule component is absent from durable archive");
-            };
-            let materialized = std::fs::read(dir.join(relative)).map_err(|error| {
-                anyhow::anyhow!("read materialized capsule component {relative}: {error}")
-            })?;
-            if materialized != expected {
-                anyhow::bail!("materialized capsule component differs from durable archive");
+        let authority_bytes = Self::read_projection_file_nofollow(&dir.join("authority.json"))
+            .map_err(|error| anyhow::anyhow!("read materialized capsule authority: {error:#}"))?;
+        if authority_bytes != verified.snapshot().package().authority {
+            anyhow::bail!("durable capsule authority bytes do not match materialization");
+        }
+        let mut expected_files = verified
+            .archive_entries()
+            .map(|(path, bytes)| (path.to_owned(), bytes.to_vec()))
+            .collect::<std::collections::BTreeMap<_, _>>();
+        expected_files.insert(
+            "Capsule.toml".to_owned(),
+            verified.manifest_bytes().to_vec(),
+        );
+        expected_files.insert("meta.json".to_owned(), verified.metadata_bytes().to_vec());
+        expected_files.insert(
+            "authority.json".to_owned(),
+            verified.snapshot().package().authority.clone(),
+        );
+        let actual = Self::inventory_projection_files(dir)?;
+        if actual.files
+            != expected_files
+                .keys()
+                .cloned()
+                .collect::<std::collections::BTreeSet<_>>()
+        {
+            anyhow::bail!("materialized capsule file inventory differs from durable package");
+        }
+        let mut expected_directories = expected_files
+            .keys()
+            .flat_map(|relative| authenticated_ancestor_directories(relative))
+            .collect::<std::collections::BTreeSet<_>>();
+        let archive_directories = verified
+            .archive_directories()
+            .map(ToOwned::to_owned)
+            .collect::<Vec<_>>();
+        expected_directories.extend(archive_directories.iter().cloned());
+        expected_directories.extend(
+            archive_directories
+                .iter()
+                .map(String::as_str)
+                .flat_map(authenticated_ancestor_directories),
+        );
+        if actual.directories != expected_directories {
+            anyhow::bail!("materialized capsule directory inventory differs from durable package");
+        }
+        for (relative, expected) in &expected_files {
+            let materialized =
+                Self::read_projection_file_nofollow(&dir.join(relative)).map_err(|error| {
+                    anyhow::anyhow!("read materialized capsule member {relative}: {error}")
+                })?;
+            if materialized != *expected {
+                anyhow::bail!(
+                    "materialized capsule member {relative} differs from durable archive"
+                );
             }
         }
         let expansions = manifest
@@ -1502,7 +1701,197 @@ impl Kernel {
         if !expansions.is_empty() {
             anyhow::bail!("materialized capsule manifest exceeds durable authority approval");
         }
-        Ok(true)
+        Ok(())
+    }
+
+    /// Bind durable activation or authorize the explicit workspace portal.
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+    fn capture_bound_materialization(
+        &self,
+        dir: &Path,
+        principal: &PrincipalId,
+        manifest: &astrid_capsule_types::manifest::CapsuleManifest,
+        operation: &str,
+    ) -> anyhow::Result<Option<BoundMaterialization>> {
+        let snapshot = self.published_capsule_snapshot(principal, manifest)?;
+        if let Some(snapshot) = snapshot {
+            let runtime_dir = self.published_cache_target(principal, manifest, &snapshot)?;
+            let bound_manifest = self.repair_published_materialization(
+                &runtime_dir,
+                principal,
+                manifest,
+                &snapshot,
+            )?;
+            return Ok(Some(BoundMaterialization {
+                snapshot,
+                runtime_dir,
+                manifest: bound_manifest,
+            }));
+        }
+        if !self.verify_registry_materialization(dir, principal, manifest)? {
+            if self.principal_store.is_some()
+                && !dir.starts_with(self.workspace_selection.state_dir())
+            {
+                anyhow::bail!(
+                    "capsule {operation} '{}' is outside the explicit workspace portal and \
+                     has no durable registry authority",
+                    manifest.package.name
+                );
+            }
+            self.verify_installed_authority_for_runtime(dir, manifest).map_err(|error| {
+                anyhow::anyhow!(
+                    "capsule {operation} '{}' exceeds or cannot prove its installed authority: {error:#}",
+                    manifest.package.name
+                )
+            })?;
+        }
+        Ok(None)
+    }
+
+    /// Repair a stale or missing cache generation from one exact snapshot.
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+    fn ensure_published_materialization(
+        &self,
+        target: &Path,
+        principal: &PrincipalId,
+        manifest: &astrid_capsule_types::manifest::CapsuleManifest,
+        snapshot: &astrid_storage::CapsulePackageSnapshot,
+    ) -> anyhow::Result<astrid_capsule_types::manifest::CapsuleManifest> {
+        self.repair_published_materialization(target, principal, manifest, snapshot)
+    }
+
+    /// Replace a canonical stale projection without trusting the old manifest.
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+    fn repair_published_materialization(
+        &self,
+        target: &Path,
+        principal: &PrincipalId,
+        discovery_manifest: &astrid_capsule_types::manifest::CapsuleManifest,
+        snapshot: &astrid_storage::CapsulePackageSnapshot,
+    ) -> anyhow::Result<astrid_capsule_types::manifest::CapsuleManifest> {
+        self.validate_published_cache_path(target, principal, discovery_manifest, snapshot)?;
+        let target_metadata = match std::fs::symlink_metadata(target) {
+            Ok(metadata) => Some(metadata),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+            Err(error) => return Err(anyhow::anyhow!("inspect capsule materialization: {error}")),
+        };
+        if let Some(metadata) = target_metadata {
+            if metadata.file_type().is_symlink() || !metadata.is_dir() {
+                anyhow::bail!("capsule materialization target is redirected or not a directory");
+            }
+            if let Ok(bound_manifest) =
+                astrid_capsule::discovery::load_manifest(&target.join("Capsule.toml"))
+                && self
+                    .verify_published_materialization(target, principal, &bound_manifest, snapshot)
+                    .is_ok()
+            {
+                return Ok(bound_manifest);
+            }
+            astrid_core::platform_fs::verify_no_redirects(target).map_err(|error| {
+                anyhow::anyhow!("capsule materialization target is redirected: {error}")
+            })?;
+            std::fs::remove_dir_all(target).map_err(|error| {
+                anyhow::anyhow!("remove stale capsule materialization: {error}")
+            })?;
+        }
+        astrid_capsule_install::materialize_capsule_package(snapshot.package(), target)
+            .map_err(|error| anyhow::anyhow!("materialize durable capsule package: {error:#}"))?;
+        let bound_manifest = astrid_capsule::discovery::load_manifest(&target.join("Capsule.toml"))
+            .map_err(|error| anyhow::anyhow!(error))?;
+        self.verify_published_materialization(target, principal, &bound_manifest, snapshot)?;
+        Ok(bound_manifest)
+    }
+
+    /// Inventory a projection without traversing redirects or special files.
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+    fn inventory_projection_files(root: &Path) -> anyhow::Result<ProjectionInventory> {
+        fn walk(
+            root: &Path,
+            directory: &Path,
+            inventory: &mut ProjectionInventory,
+        ) -> anyhow::Result<()> {
+            for entry in std::fs::read_dir(directory).map_err(|error| {
+                anyhow::anyhow!("read capsule projection {}: {error}", directory.display())
+            })? {
+                let entry = entry
+                    .map_err(|error| anyhow::anyhow!("read capsule projection entry: {error}"))?;
+                let path = entry.path();
+                let relative = path.strip_prefix(root).map_err(|_| {
+                    anyhow::anyhow!("capsule projection escaped its root: {}", path.display())
+                })?;
+                let relative_text = relative.to_str().ok_or_else(|| {
+                    anyhow::anyhow!("capsule projection path is not UTF-8: {}", path.display())
+                })?;
+                let metadata = std::fs::symlink_metadata(&path).map_err(|error| {
+                    anyhow::anyhow!("inspect capsule projection {}: {error}", path.display())
+                })?;
+                let file_type = metadata.file_type();
+                if file_type.is_symlink() {
+                    anyhow::bail!(
+                        "capsule projection contains a symbolic link: {}",
+                        path.display()
+                    );
+                }
+                if file_type.is_dir() {
+                    inventory.directories.insert(relative_text.to_owned());
+                    walk(root, &path, inventory)?;
+                } else if file_type.is_file() {
+                    inventory.files.insert(relative_text.to_owned());
+                } else {
+                    anyhow::bail!(
+                        "capsule projection contains a special file: {}",
+                        path.display()
+                    );
+                }
+            }
+            Ok(())
+        }
+
+        let mut inventory = ProjectionInventory::default();
+        walk(root, root, &mut inventory)?;
+        Ok(inventory)
+    }
+
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+    fn read_projection_file_nofollow(path: &Path) -> anyhow::Result<Vec<u8>> {
+        use std::io::Read as _;
+
+        let metadata = std::fs::symlink_metadata(path).map_err(|error| {
+            anyhow::anyhow!("inspect projected file {}: {error}", path.display())
+        })?;
+        if metadata.file_type().is_symlink() || !metadata.is_file() {
+            anyhow::bail!(
+                "projected path is redirected or not a regular file: {}",
+                path.display()
+            );
+        }
+        let mut file = open_projection_file_nofollow(path)?;
+        let mut bytes = Vec::new();
+        file.read_to_end(&mut bytes)
+            .map_err(|error| anyhow::anyhow!("read projected file {}: {error}", path.display()))?;
+        if file.metadata()?.len() != metadata.len() || bytes.len() as u64 != metadata.len() {
+            anyhow::bail!("projected file changed while read: {}", path.display());
+        }
+        Ok(bytes)
+    }
+
+    /// Recheck the immutable publication after taking activation locks.
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+    fn confirm_published_materialization(
+        &self,
+        dir: &Path,
+        principal: &PrincipalId,
+        manifest: &astrid_capsule_types::manifest::CapsuleManifest,
+        snapshot: &astrid_storage::CapsulePackageSnapshot,
+    ) -> anyhow::Result<()> {
+        let current = self.published_capsule_snapshot(principal, manifest)?;
+        if current.as_ref() != Some(snapshot) {
+            anyhow::bail!(
+                "capsule '{}' changed while activation was in progress",
+                manifest.package.name
+            );
+        }
+        self.verify_published_materialization(dir, principal, manifest, snapshot)
     }
 
     /// Load a capsule into the Kernel from a directory containing a Capsule.toml
@@ -1520,33 +1909,32 @@ impl Kernel {
         let manifest_path = dir.join("Capsule.toml");
         let manifest = astrid_capsule::discovery::load_manifest(&manifest_path)
             .map_err(|e| anyhow::anyhow!(e))?;
-        if !self.verify_registry_materialization(&dir, principal, &manifest)? {
-            if self.principal_store.is_some()
-                && !dir.starts_with(self.workspace_selection.state_dir())
-            {
-                anyhow::bail!(
-                    "capsule '{}' is outside the explicit workspace portal and has no durable registry authority",
-                    manifest.package.name
-                );
-            }
-            self.verify_installed_authority_for_runtime(&dir, &manifest)
-                .map_err(|error| {
-                    anyhow::anyhow!(
-                        "capsule '{}' exceeds or cannot prove its installed authority: {error:#}",
-                        manifest.package.name
-                    )
-                })?;
-        }
-        self.verify_workspace_component_paths(&dir, &manifest)?;
+        let bound = self.capture_bound_materialization(&dir, principal, &manifest, "load")?;
+        let runtime_dir = bound
+            .as_ref()
+            .map_or_else(|| dir.clone(), |bound| bound.runtime_dir.clone());
+        let manifest = bound
+            .as_ref()
+            .map_or_else(|| manifest, |bound| bound.manifest.clone());
+        let manifest_path = runtime_dir.join("Capsule.toml");
+        self.verify_workspace_component_paths(&runtime_dir, &manifest)?;
         let id = astrid_capsule_types::CapsuleId::from_static(&manifest.package.name);
         let _view_guard = self.lock_capsule_view(principal, &id).await;
         let _load_guard = self.capsule_load_lock.lock().await;
+        if let Some(bound) = bound.as_ref() {
+            self.confirm_published_materialization(
+                &runtime_dir,
+                principal,
+                &manifest,
+                &bound.snapshot,
+            )?;
+        }
         if *principal != PrincipalId::default()
             && self.capabilities.is_principal_retiring(principal).await
         {
             anyhow::bail!("cannot load capsule '{id}' for retiring principal '{principal}'");
         }
-        let wasm_hash = capsule_instance_hash(&manifest, &dir);
+        let wasm_hash = capsule_instance_hash(&manifest, &runtime_dir);
         // `capabilities.uplink` alone remains a principal-scoped daemon/host
         // grant unless the operator explicitly promotes it. A manifest that
         // actually provides an uplink must be operator-approved.
@@ -1558,7 +1946,7 @@ impl Kernel {
                 "system-resident capsule '{id}' cannot host principal-bearing stdio MCP servers"
             );
         }
-        self.verify_workspace_capsule_tree(&dir)?;
+        self.verify_workspace_capsule_tree(&runtime_dir)?;
 
         // Mutable runtimes are authority-scoped. A principal always receives a
         // fresh runtime for its immutable UID; only an explicitly classified
@@ -1602,7 +1990,7 @@ impl Kernel {
         let mut capsule = self
             .build_capsule_runtime(
                 manifest,
-                &dir,
+                &runtime_dir,
                 (!system_runtime).then_some(principal),
                 runtime_id.clone(),
             )
@@ -1788,7 +2176,15 @@ impl Kernel {
         // Hand this capsule its operator-approved local-egress allowlist (if
         // any) so the SSRF airlock can exempt sanctioned loopback/private
         // endpoints for it. Absent entry = empty = no exemptions.
-        .with_local_egress(self.local_egress.get(&capsule_name).cloned().unwrap_or_default())
+        .with_local_egress(
+            self.local_egress
+                .read()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .as_ref()
+                .and_then(|snapshot| snapshot.get(&capsule_name))
+                .cloned()
+                .unwrap_or_default(),
+        )
         // Hand the engine the signed per-action audit sink so sensitive
         // fs/net/process host calls (allowed, failed, OR denied) land on the
         // kernel's durable, hash-chained audit log — not just the
@@ -1821,23 +2217,27 @@ impl Kernel {
                 manifest.package.name
             );
         }
-        if !self.verify_registry_materialization(source_dir, principal, &manifest)? {
-            if self.principal_store.is_some()
-                && !source_dir.starts_with(self.workspace_selection.state_dir())
-            {
-                anyhow::bail!(
-                    "capsule replacement source is outside the explicit workspace portal and has no durable registry authority"
-                );
-            }
-            self.verify_installed_authority_for_runtime(source_dir, &manifest)?;
-        }
-        self.verify_workspace_component_paths(source_dir, &manifest)?;
+        let bound = self.capture_bound_materialization(
+            source_dir,
+            principal,
+            &manifest,
+            "replacement source",
+        )?;
+        let runtime_dir = bound.as_ref().map_or_else(
+            || source_dir.to_path_buf(),
+            |bound| bound.runtime_dir.clone(),
+        );
+        let manifest = bound
+            .as_ref()
+            .map_or_else(|| manifest, |bound| bound.manifest.clone());
+        let manifest_path = runtime_dir.join("Capsule.toml");
+        self.verify_workspace_component_paths(&runtime_dir, &manifest)?;
         if !manifest.mcp_servers.is_empty() {
             anyhow::bail!(
                 "live replacement of stdio MCP capsule '{id}' is not yet atomic; restart the daemon to activate these process changes"
             );
         }
-        let artifact = capsule_instance_hash(&manifest, source_dir);
+        let artifact = capsule_instance_hash(&manifest, &runtime_dir);
         let system_allowed = self.system_capsules.read().await.contains(id.as_str());
         let system_runtime = classify_runtime_residency(&manifest, id, system_allowed)?.is_system();
         if system_runtime && !manifest.mcp_servers.is_empty() {
@@ -1860,6 +2260,14 @@ impl Kernel {
                  running={expected_scope:?}, installed={actual_scope:?}"
             );
         }
+        if let Some(bound) = bound.as_ref() {
+            self.confirm_published_materialization(
+                &runtime_dir,
+                principal,
+                &manifest,
+                &bound.snapshot,
+            )?;
+        }
         let principal_uid = self.runtime_principal_uid(system_runtime, principal, id)?;
         let runtime_id =
             self.capsules
@@ -1869,7 +2277,7 @@ impl Kernel {
         let mut capsule = self
             .build_capsule_runtime(
                 manifest,
-                source_dir,
+                &runtime_dir,
                 (!system_runtime).then_some(principal),
                 runtime_id.clone(),
             )
@@ -2348,13 +2756,22 @@ impl Kernel {
                                         continue;
                                     },
                                 };
-                                if !target.exists()
-                                    && let Err(error) =
-                                        astrid_capsule_install::materialize_capsule_package(
-                                            snapshot.package(),
-                                            &target,
-                                        )
-                                {
+                                let manifest = astrid_capsule_install
+                                    ::read_verified_durable_package_for_owner(
+                                        store, &owner, &id,
+                                    )
+                                    .ok()
+                                    .flatten()
+                                    .map(|package| package.manifest().clone());
+                                let materialized = match manifest {
+                                    Some(manifest) => self.ensure_published_materialization(
+                                        &target, principal, &manifest, &snapshot,
+                                    ),
+                                    None => {
+                                        Err(anyhow::anyhow!("durable capsule package is malformed"))
+                                    },
+                                };
+                                if let Err(error) = materialized {
                                     tracing::warn!(
                                         %principal,
                                         capsule = %id,
@@ -3734,7 +4151,7 @@ pub(crate) async fn test_kernel_with_home(home: astrid_core::dirs::AstridHome) -
         #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
         compiled_wasm: astrid_capsule::engine::wasm::CompiledWasmCache::default(),
         runtime_limits: astrid_capsule_types::CapsuleRuntimeLimits::default(),
-        local_egress: std::collections::HashMap::new(),
+        local_egress: std::sync::RwLock::new(None),
         system_capsules: RwLock::new(std::collections::HashSet::new()),
         http_limits: astrid_capsule_types::HttpLimits::default(),
         full_reload_in_flight: AtomicBool::new(false),
@@ -5535,6 +5952,27 @@ mod tests {
     use astrid_capsule_types::manifest::CapsuleManifest;
 
     #[tokio::test]
+    async fn boot_local_egress_snapshot_is_write_once() {
+        let (_dir, home) = scratch_home();
+        let kernel = test_kernel_with_home(home).await;
+        let snapshot = std::collections::HashMap::from([(
+            "astrid-capsule-openai-compat".to_string(),
+            vec!["127.0.0.1:1234".to_string()],
+        )]);
+
+        kernel.bind_boot_local_egress(snapshot.clone()).unwrap();
+        assert_eq!(
+            kernel
+                .local_egress
+                .read()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .as_ref(),
+            Some(&snapshot)
+        );
+        assert!(kernel.bind_boot_local_egress(snapshot).is_err());
+    }
+
+    #[tokio::test]
     async fn cli_root_bootstrap_recovers_a_durable_principal_without_its_link() {
         let (_dir, home) = scratch_home();
         seed_default_principal_admin_profile(&home).unwrap();
@@ -7208,6 +7646,7 @@ mod tests {
     async fn with_resources_aborts_when_legacy_profile_migration_fails() {
         let (_dir, home) = scratch_home();
         let resources = injected_kernel_resources(&home);
+        std::fs::create_dir_all(home.etc_dir()).expect("create running config parent");
         let default = astrid_core::PrincipalId::default();
         let legacy_path = home
             .principal_home(&default)
@@ -7236,6 +7675,7 @@ mod tests {
     async fn with_resources_aborts_when_default_key_seeding_fails() {
         let (_dir, home) = scratch_home();
         let resources = injected_kernel_resources(&home);
+        std::fs::create_dir_all(home.keys_dir()).expect("create running keys parent");
         std::fs::create_dir(home.keys_dir().join("default.key"))
             .expect("create deterministic key-write obstacle");
 

--- a/crates/astrid-kernel/src/lib.rs
+++ b/crates/astrid-kernel/src/lib.rs
@@ -27,6 +27,8 @@ pub mod audit_sink;
 mod bus_monitor;
 #[cfg(test)]
 mod capsule_adversarial_tests;
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+mod capsule_materialization;
 /// `astrid.v1.capsules_loaded` payload assembly (opaque per-capsule metadata).
 mod capsules_loaded;
 #[cfg(test)]
@@ -122,7 +124,7 @@ struct CapsuleViewLease {
 
 /// One immutable publication and the projection activated from it.
 #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-struct BoundMaterialization {
+pub(crate) struct BoundMaterialization {
     snapshot: astrid_storage::CapsulePackageSnapshot,
     runtime_dir: PathBuf,
     manifest: astrid_capsule_types::manifest::CapsuleManifest,
@@ -1601,209 +1603,6 @@ impl Kernel {
         Ok(())
     }
 
-    /// Verify every projected byte against one immutable package snapshot.
-    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-    fn verify_published_materialization(
-        &self,
-        dir: &Path,
-        principal: &PrincipalId,
-        manifest: &astrid_capsule_types::manifest::CapsuleManifest,
-        snapshot: &astrid_storage::CapsulePackageSnapshot,
-    ) -> anyhow::Result<()> {
-        self.validate_published_cache_path(dir, principal, manifest, snapshot)?;
-        let uid = self
-            .principal_directory
-            .uid_for(principal)
-            .map_err(|error| anyhow::anyhow!("resolve capsule cache owner UID: {error}"))?;
-        let verified = astrid_capsule_install::read_verified_durable_package_for_owner(
-            self.principal_store
-                .as_ref()
-                .ok_or_else(|| anyhow::anyhow!("durable capsule registry is unavailable"))?,
-            &astrid_storage::StateOwner::Principal(uid),
-            manifest.package.name.as_str(),
-        )?
-        .ok_or_else(|| anyhow::anyhow!("materialized capsule is absent from durable registry"))?;
-        if verified.snapshot() != snapshot {
-            anyhow::bail!("materialized capsule snapshot differs from the caller's publication");
-        }
-        if verified.manifest().package.name != manifest.package.name
-            || verified.manifest().package.version != manifest.package.version
-        {
-            anyhow::bail!("materialized capsule manifest differs from durable registry");
-        }
-        let manifest_bytes = Self::read_projection_file_nofollow(&dir.join("Capsule.toml"))
-            .map_err(|error| anyhow::anyhow!("read materialized capsule manifest: {error:#}"))?;
-        if manifest_bytes != verified.manifest_bytes() {
-            anyhow::bail!("durable capsule manifest bytes do not match materialization");
-        }
-        let metadata_bytes = Self::read_projection_file_nofollow(&dir.join("meta.json"))
-            .map_err(|error| anyhow::anyhow!("read materialized capsule metadata: {error:#}"))?;
-        if metadata_bytes != verified.metadata_bytes() {
-            anyhow::bail!("durable capsule metadata does not match materialization");
-        }
-        let authority_bytes = Self::read_projection_file_nofollow(&dir.join("authority.json"))
-            .map_err(|error| anyhow::anyhow!("read materialized capsule authority: {error:#}"))?;
-        if authority_bytes != verified.snapshot().package().authority {
-            anyhow::bail!("durable capsule authority bytes do not match materialization");
-        }
-        let mut expected_files = verified
-            .archive_entries()
-            .map(|(path, bytes)| (path.to_owned(), bytes.to_vec()))
-            .collect::<std::collections::BTreeMap<_, _>>();
-        expected_files.insert(
-            "Capsule.toml".to_owned(),
-            verified.manifest_bytes().to_vec(),
-        );
-        expected_files.insert("meta.json".to_owned(), verified.metadata_bytes().to_vec());
-        expected_files.insert(
-            "authority.json".to_owned(),
-            verified.snapshot().package().authority.clone(),
-        );
-        let actual = Self::inventory_projection_files(dir)?;
-        if actual.files
-            != expected_files
-                .keys()
-                .cloned()
-                .collect::<std::collections::BTreeSet<_>>()
-        {
-            anyhow::bail!("materialized capsule file inventory differs from durable package");
-        }
-        let mut expected_directories = expected_files
-            .keys()
-            .flat_map(|relative| authenticated_ancestor_directories(relative))
-            .collect::<std::collections::BTreeSet<_>>();
-        let archive_directories = verified
-            .archive_directories()
-            .map(ToOwned::to_owned)
-            .collect::<Vec<_>>();
-        expected_directories.extend(archive_directories.iter().cloned());
-        expected_directories.extend(
-            archive_directories
-                .iter()
-                .map(String::as_str)
-                .flat_map(authenticated_ancestor_directories),
-        );
-        if actual.directories != expected_directories {
-            anyhow::bail!("materialized capsule directory inventory differs from durable package");
-        }
-        for (relative, expected) in &expected_files {
-            let materialized =
-                Self::read_projection_file_nofollow(&dir.join(relative)).map_err(|error| {
-                    anyhow::anyhow!("read materialized capsule member {relative}: {error}")
-                })?;
-            if materialized != *expected {
-                anyhow::bail!(
-                    "materialized capsule member {relative} differs from durable archive"
-                );
-            }
-        }
-        let expansions = manifest
-            .capabilities
-            .expansions_from(&verified.authority().approved_capabilities);
-        if !expansions.is_empty() {
-            anyhow::bail!("materialized capsule manifest exceeds durable authority approval");
-        }
-        Ok(())
-    }
-
-    /// Bind durable activation or authorize the explicit workspace portal.
-    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-    fn capture_bound_materialization(
-        &self,
-        dir: &Path,
-        principal: &PrincipalId,
-        manifest: &astrid_capsule_types::manifest::CapsuleManifest,
-        operation: &str,
-    ) -> anyhow::Result<Option<BoundMaterialization>> {
-        let snapshot = self.published_capsule_snapshot(principal, manifest)?;
-        if let Some(snapshot) = snapshot {
-            let runtime_dir = self.published_cache_target(principal, manifest, &snapshot)?;
-            let bound_manifest = self.repair_published_materialization(
-                &runtime_dir,
-                principal,
-                manifest,
-                &snapshot,
-            )?;
-            return Ok(Some(BoundMaterialization {
-                snapshot,
-                runtime_dir,
-                manifest: bound_manifest,
-            }));
-        }
-        if !self.verify_registry_materialization(dir, principal, manifest)? {
-            if self.principal_store.is_some()
-                && !dir.starts_with(self.workspace_selection.state_dir())
-            {
-                anyhow::bail!(
-                    "capsule {operation} '{}' is outside the explicit workspace portal and \
-                     has no durable registry authority",
-                    manifest.package.name
-                );
-            }
-            self.verify_installed_authority_for_runtime(dir, manifest).map_err(|error| {
-                anyhow::anyhow!(
-                    "capsule {operation} '{}' exceeds or cannot prove its installed authority: {error:#}",
-                    manifest.package.name
-                )
-            })?;
-        }
-        Ok(None)
-    }
-
-    /// Repair a stale or missing cache generation from one exact snapshot.
-    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-    fn ensure_published_materialization(
-        &self,
-        target: &Path,
-        principal: &PrincipalId,
-        manifest: &astrid_capsule_types::manifest::CapsuleManifest,
-        snapshot: &astrid_storage::CapsulePackageSnapshot,
-    ) -> anyhow::Result<astrid_capsule_types::manifest::CapsuleManifest> {
-        self.repair_published_materialization(target, principal, manifest, snapshot)
-    }
-
-    /// Replace a canonical stale projection without trusting the old manifest.
-    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-    fn repair_published_materialization(
-        &self,
-        target: &Path,
-        principal: &PrincipalId,
-        discovery_manifest: &astrid_capsule_types::manifest::CapsuleManifest,
-        snapshot: &astrid_storage::CapsulePackageSnapshot,
-    ) -> anyhow::Result<astrid_capsule_types::manifest::CapsuleManifest> {
-        self.validate_published_cache_path(target, principal, discovery_manifest, snapshot)?;
-        let target_metadata = match std::fs::symlink_metadata(target) {
-            Ok(metadata) => Some(metadata),
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
-            Err(error) => return Err(anyhow::anyhow!("inspect capsule materialization: {error}")),
-        };
-        if let Some(metadata) = target_metadata {
-            if metadata.file_type().is_symlink() || !metadata.is_dir() {
-                anyhow::bail!("capsule materialization target is redirected or not a directory");
-            }
-            if let Ok(bound_manifest) =
-                astrid_capsule::discovery::load_manifest(&target.join("Capsule.toml"))
-                && self
-                    .verify_published_materialization(target, principal, &bound_manifest, snapshot)
-                    .is_ok()
-            {
-                return Ok(bound_manifest);
-            }
-            astrid_core::platform_fs::verify_no_redirects(target).map_err(|error| {
-                anyhow::anyhow!("capsule materialization target is redirected: {error}")
-            })?;
-            std::fs::remove_dir_all(target).map_err(|error| {
-                anyhow::anyhow!("remove stale capsule materialization: {error}")
-            })?;
-        }
-        astrid_capsule_install::materialize_capsule_package(snapshot.package(), target)
-            .map_err(|error| anyhow::anyhow!("materialize durable capsule package: {error:#}"))?;
-        let bound_manifest = astrid_capsule::discovery::load_manifest(&target.join("Capsule.toml"))
-            .map_err(|error| anyhow::anyhow!(error))?;
-        self.verify_published_materialization(target, principal, &bound_manifest, snapshot)?;
-        Ok(bound_manifest)
-    }
-
     /// Inventory a projection without traversing redirects or special files.
     #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
     fn inventory_projection_files(root: &Path) -> anyhow::Result<ProjectionInventory> {
@@ -1875,25 +1674,6 @@ impl Kernel {
             anyhow::bail!("projected file changed while read: {}", path.display());
         }
         Ok(bytes)
-    }
-
-    /// Recheck the immutable publication after taking activation locks.
-    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-    fn confirm_published_materialization(
-        &self,
-        dir: &Path,
-        principal: &PrincipalId,
-        manifest: &astrid_capsule_types::manifest::CapsuleManifest,
-        snapshot: &astrid_storage::CapsulePackageSnapshot,
-    ) -> anyhow::Result<()> {
-        let current = self.published_capsule_snapshot(principal, manifest)?;
-        if current.as_ref() != Some(snapshot) {
-            anyhow::bail!(
-                "capsule '{}' changed while activation was in progress",
-                manifest.package.name
-            );
-        }
-        self.verify_published_materialization(dir, principal, manifest, snapshot)
     }
 
     /// Load a capsule into the Kernel from a directory containing a Capsule.toml

--- a/crates/astrid-kernel/src/lib.rs
+++ b/crates/astrid-kernel/src/lib.rs
@@ -49,6 +49,8 @@ pub mod invite;
 /// (`wasm32-unknown-unknown`) profile.
 #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 pub mod kernel_router;
+#[cfg(test)]
+mod kernel_shutdown_tests;
 #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 mod legacy_migration_barrier;
 /// Persistent pair-device token store (issue #756).
@@ -3737,6 +3739,17 @@ impl Kernel {
         // release independent of drain time.
         #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
         self.audit_sink.shutdown();
+        // Publish the final host projection while the durable engine is still
+        // open. CLI stop owns retirement only after the process has exited.
+        #[cfg(not(target_family = "wasm"))]
+        if let Some(store) = self.principal_store.as_ref()
+            && let Err(error) = store.publish_runtime_projection(&self.astrid_home)
+        {
+            tracing::error!(
+                error = %format!("{error:#}"),
+                "failed to publish running projection during shutdown"
+            );
+        }
         if let Err(e) = self.kv.close().await {
             tracing::warn!(error = %e, "Failed to flush KV store during shutdown");
         }

--- a/crates/astrid-kernel/src/lib.rs
+++ b/crates/astrid-kernel/src/lib.rs
@@ -1270,6 +1270,13 @@ impl Kernel {
                     "Failed to commit Astrid home layout migration: {error}"
                 ))
             })?;
+
+            // Republish records written by layout completion while ACTIVE.
+            if let Some(store) = principal_store.as_ref() {
+                store
+                    .publish_runtime_projection(&home)
+                    .map_err(std::io::Error::other)?;
+            }
         }
 
         #[cfg(not(target_family = "wasm"))]

--- a/crates/astrid-kernel/src/pair_token/storage_migration.rs
+++ b/crates/astrid-kernel/src/pair_token/storage_migration.rs
@@ -256,6 +256,7 @@ mod tests {
         let home = AstridHome::from_path(dir.path());
         home.ensure().unwrap();
         let path = PairTokenStore::path_for(&home);
+        std::fs::create_dir_all(home.etc_dir()).unwrap();
         private_write(&path, "schema_version = 1\n[[pair_token]]\n");
         let backend: Arc<dyn KvStore> = Arc::new(MemoryKvStore::new());
         let store = DurablePairTokenStore::new(Arc::clone(&backend)).unwrap();

--- a/crates/astrid-kernel/src/runtime_tree_admit.rs
+++ b/crates/astrid-kernel/src/runtime_tree_admit.rs
@@ -258,6 +258,7 @@ mod tests {
         home.ensure().unwrap();
         let wasm = b"\0asm\x01\0\0\0kernel-admit".to_vec();
         let hash = blake3::hash(&wasm).to_hex().to_string();
+        fs::create_dir_all(home.bin_dir()).unwrap();
         let wasm_path = home.bin_dir().join(format!("{hash}.wasm"));
         fs::write(&wasm_path, &wasm).unwrap();
         let metadata_path = home.root().join("run/capsules/example/meta.json");
@@ -320,15 +321,6 @@ mod tests {
         for expected in [
             "etc/layout-version",
             "var/content-staging/intents.v1.log",
-            "var/principal-store/migration.complete",
-            "var/principal-store/objects.arena",
-            "var/principal-store/objects.index",
-            "var/principal-store/representations/CURRENT",
-            "var/principal-store/representations/generations/0000000000000001/metadata.arena",
-            "var/principal-store/representations/generations/0000000000000001/state.journal",
-            "var/principal-store/roots.journal",
-            "var/principal-store/store.lock",
-            "var/principal-store/store.meta",
             RECEIPT_RELATIVE_PATH,
         ] {
             assert!(
@@ -347,6 +339,7 @@ mod tests {
         home.ensure().unwrap();
         let wasm = b"\0asm\x01\0\0\0mutation-check".to_vec();
         let hash = blake3::hash(&wasm).to_hex().to_string();
+        fs::create_dir_all(home.bin_dir()).unwrap();
         let wasm_path = home.bin_dir().join(format!("{hash}.wasm"));
         fs::write(&wasm_path, &wasm).unwrap();
         let receipt_path = home.migrations_dir().join(RECEIPT_NAME);

--- a/crates/astrid-kernel/src/runtime_tree_admit.rs
+++ b/crates/astrid-kernel/src/runtime_tree_admit.rs
@@ -107,7 +107,10 @@ fn admit_blocking(home: &AstridHome, store: &RuntimePrincipalStore) -> io::Resul
     let bytes = serde_json::to_vec(&receipt).map_err(io::Error::other)?;
     astrid_core::platform_fs::ensure_private_directory(&home.migrations_dir())?;
     astrid_core::platform_fs::atomic_write_private_file(&receipt_path, &bytes)?;
-    admit_receipt(store, &receipt_path)
+    admit_receipt(store, &receipt_path)?;
+    store
+        .establish_runtime_projection_receipt(home)
+        .map_err(storage_error)
 }
 
 fn admit_receipt(store: &RuntimePrincipalStore, receipt_path: &Path) -> io::Result<()> {
@@ -256,6 +259,9 @@ mod tests {
         let home_dir = tempfile::tempdir().unwrap();
         let home = AstridHome::from_path(home_dir.path());
         home.ensure().unwrap();
+        let store = astrid_storage::open_runtime_principal_store(&home, unlimited_quota())
+            .await
+            .unwrap();
         let wasm = b"\0asm\x01\0\0\0kernel-admit".to_vec();
         let hash = blake3::hash(&wasm).to_hex().to_string();
         fs::create_dir_all(home.bin_dir()).unwrap();
@@ -264,10 +270,9 @@ mod tests {
         let metadata_path = home.root().join("run/capsules/example/meta.json");
         fs::create_dir_all(metadata_path.parent().unwrap()).unwrap();
         fs::write(&metadata_path, format!("{{\"wasm_hash\":\"{hash}\"}}")).unwrap();
-
-        let store = astrid_storage::open_runtime_principal_store(&home, unlimited_quota())
-            .await
-            .unwrap();
+        store
+            .publish_runtime_projection(&home)
+            .expect("admit restart fixture");
         admit(&home, &store).await.unwrap();
         let first_volume_size = fs::metadata(home.storage_volume_path()).unwrap().len();
         admit(&home, &store).await.unwrap();
@@ -337,15 +342,18 @@ mod tests {
         let directory = tempfile::tempdir().unwrap();
         let home = AstridHome::from_path(directory.path());
         home.ensure().unwrap();
+        let store = astrid_storage::open_runtime_principal_store(&home, unlimited_quota())
+            .await
+            .unwrap();
         let wasm = b"\0asm\x01\0\0\0mutation-check".to_vec();
         let hash = blake3::hash(&wasm).to_hex().to_string();
         fs::create_dir_all(home.bin_dir()).unwrap();
         let wasm_path = home.bin_dir().join(format!("{hash}.wasm"));
         fs::write(&wasm_path, &wasm).unwrap();
+        store
+            .publish_runtime_projection(&home)
+            .expect("admit mutation fixture");
         let receipt_path = home.migrations_dir().join(RECEIPT_NAME);
-        let store = astrid_storage::open_runtime_principal_store(&home, unlimited_quota())
-            .await
-            .unwrap();
 
         let mutation_path = wasm_path.clone();
         inject_source_mutation_once(

--- a/crates/astrid-kernel/src/storage_mount/runtime_tree_tests.rs
+++ b/crates/astrid-kernel/src/storage_mount/runtime_tree_tests.rs
@@ -24,14 +24,28 @@ fn assert_entry_kind(
     name: &str,
     kind: StorageFilesystemEntryKindV1,
 ) {
-    assert!(
-        entries
-            .iter()
-            .any(|entry| entry.name == name && entry.kind == kind)
-    );
+    if !entries
+        .iter()
+        .any(|entry| entry.name == name && entry.kind == kind)
+    {
+        panic!("missing {name:?} of kind {kind:?}; entries {entries:?}");
+    }
 }
 
 fn seed_packed_runtime_tree(home: &astrid_core::dirs::AstridHome) -> String {
+    for directory in [
+        home.bin_dir(),
+        home.run_dir().join("capsules/example"),
+        home.wit_dir(),
+        home.home_dir().join("default"),
+        home.log_dir(),
+        home.keys_dir(),
+        home.var_dir().join("migrations"),
+        home.var_dir().join("content-staging"),
+        home.var_dir().join("principal-store"),
+    ] {
+        std::fs::create_dir_all(directory).unwrap();
+    }
     let wasm = b"\0asm\x01\0\0\0runtime-mount-test";
     let wasm_hash = blake3::hash(wasm).to_hex().to_string();
     std::fs::write(home.bin_dir().join(format!("{wasm_hash}.wasm")), wasm).unwrap();
@@ -95,9 +109,12 @@ async fn assert_root_entries(lease: &StorageMountLeaseV1) {
     for name in ["bin", "etc", "home", "keys", "log", "run", "var", "wit"] {
         assert_entry_kind(&root_entries, name, StorageFilesystemEntryKindV1::Directory);
     }
-    for name in ["astrid", "astrid-daemon"] {
-        assert_entry_kind(&root_entries, name, StorageFilesystemEntryKindV1::File);
-    }
+    assert!(!root_entries.iter().any(|entry| entry.name == "astrid"));
+    assert!(
+        !root_entries
+            .iter()
+            .any(|entry| entry.name == "astrid-daemon")
+    );
     assert!(!root_entries.iter().any(|entry| entry.name == "volume"));
 }
 
@@ -108,9 +125,12 @@ async fn assert_packed_files(lease: &StorageMountLeaseV1, wasm_hash: &str) {
         &format!("{wasm_hash}.wasm"),
         StorageFilesystemEntryKindV1::File,
     );
-    for name in ["astrid", "astrid-daemon"] {
-        assert_entry_kind(&bin_entries, name, StorageFilesystemEntryKindV1::File);
-    }
+    assert!(!bin_entries.iter().any(|entry| entry.name == "astrid"));
+    assert!(
+        !bin_entries
+            .iter()
+            .any(|entry| entry.name == "astrid-daemon")
+    );
 
     let run_entries = read_directory_entries(lease, "run").await;
     assert_entry_kind(
@@ -183,9 +203,10 @@ async fn assert_packed_files(lease: &StorageMountLeaseV1, wasm_hash: &str) {
 async fn assert_volume_and_socket_absent(lease: &StorageMountLeaseV1) {
     let run_entries = read_directory_entries(lease, "run").await;
     assert!(!run_entries.iter().any(|entry| entry.name == "system.sock"));
-    for sentinel in ["system.lock", "system.pid", "system.ready", "system.token"] {
-        assert_entry_kind(&run_entries, sentinel, StorageFilesystemEntryKindV1::File);
-    }
+    assert!(!run_entries.iter().any(|entry| entry.name == "system.lock"));
+    assert!(!run_entries.iter().any(|entry| entry.name == "system.pid"));
+    assert!(!run_entries.iter().any(|entry| entry.name == "system.ready"));
+    assert!(!run_entries.iter().any(|entry| entry.name == "system.token"));
 
     let etc_entries = read_directory_entries(lease, "etc").await;
     assert_entry_kind(
@@ -202,12 +223,7 @@ async fn assert_volume_and_socket_absent(lease: &StorageMountLeaseV1) {
     );
 
     let var_entries = read_directory_entries(lease, "var").await;
-    for name in [
-        "config.json",
-        "content-staging",
-        "migrations",
-        "principal-store",
-    ] {
+    for name in ["config.json", "content-staging", "migrations"] {
         let kind = if name == "config.json" {
             StorageFilesystemEntryKindV1::File
         } else {
@@ -215,12 +231,18 @@ async fn assert_volume_and_socket_absent(lease: &StorageMountLeaseV1) {
         };
         assert_entry_kind(&var_entries, name, kind);
     }
+    assert!(
+        !var_entries
+            .iter()
+            .any(|entry| entry.name == "principal-store")
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn admin_mount_projects_packed_runtime_tree_with_only_volume_and_socket_leftovers() {
     let temporary = tempfile::tempdir().unwrap();
     let home = astrid_core::dirs::AstridHome::from_path(temporary.path().join(".astrid"));
+    home.ensure().unwrap();
     let kernel = crate::test_kernel_with_home(home.clone()).await;
     let store = kernel.principal_store.clone().unwrap();
 

--- a/crates/astrid-storage/src/content/mod.rs
+++ b/crates/astrid-storage/src/content/mod.rs
@@ -595,6 +595,19 @@ impl ContentWriteOutcome {
     }
 }
 
+/// Internal callback that derives content after every source is prepared.
+pub(crate) trait PrepareDerivedBatchContent {
+    /// Return the derived name and bytes for inclusion in the same root.
+    ///
+    /// # Errors
+    ///
+    /// Returns a content error before the owner-root transaction is committed.
+    fn prepare(
+        &mut self,
+        entries: &std::collections::BTreeMap<ContentName, ContentDescriptor>,
+    ) -> Result<(ContentName, Vec<u8>), PrincipalContentError>;
+}
+
 /// Failure to read or mutate principal-owned content.
 #[derive(Debug)]
 #[non_exhaustive]

--- a/crates/astrid-storage/src/content/store/bulk.rs
+++ b/crates/astrid-storage/src/content/store/bulk.rs
@@ -723,8 +723,11 @@ where
         deferred_records: Option<&BTreeMap<ObjectId, ObjectRecord>>,
         publication: BatchPublicationContext<'_>,
     ) -> Result<ContentBatchWriteOutcome, PrincipalContentError> {
-        let (publication_completed, derived_records) =
-            self.prepare_derived_batch(source_completed, publication.derived)?;
+        let (publication_completed, derived_records) = self.prepare_derived_batch(
+            source_completed,
+            publication.removals,
+            publication.derived,
+        )?;
         let completed = &publication_completed;
         loop {
             let mut header = self.header(principal)?.as_ref().clone();
@@ -833,6 +836,7 @@ where
     fn prepare_derived_batch(
         &self,
         source_completed: &BTreeMap<ContentName, PreparedContent>,
+        removals: &[ContentName],
         derived: Option<&mut dyn PrepareDerivedBatchContent>,
     ) -> Result<PreparedDerivedBatch, PrincipalContentError> {
         let Some(derived) = derived else {
@@ -843,6 +847,9 @@ where
             .map(|(name, prepared)| (name.clone(), prepared.verified.descriptor()))
             .collect::<BTreeMap<_, _>>();
         let (name, bytes) = derived.prepare(&descriptors)?;
+        if source_completed.contains_key(&name) || removals.contains(&name) {
+            return Err(PrincipalContentError::DuplicateBatchName(name));
+        }
         let built = build_content(
             &EngineIdentity::<P, E>::new(self.engine.as_ref()),
             ChunkingProfile::ASTRID_V1,

--- a/crates/astrid-storage/src/content/store/bulk.rs
+++ b/crates/astrid-storage/src/content/store/bulk.rs
@@ -16,9 +16,9 @@ use super::projection::{
     BatchAdmission, DeferredAdmission, StagedObjectBatch, admit_object_batch_observed,
 };
 use super::{
-    CatalogValue, EngineSink, ModelError, ObjectId, ObjectRecord, ObjectReference,
+    CatalogRoot, CatalogValue, EngineSink, ModelError, ObjectId, ObjectRecord, ObjectReference,
     PrincipalContentStore, PrincipalProjectionEngine, PrincipalProjectionError, ReferenceKind,
-    VerifiedContent, build_content_streaming, insert, invalid, lookup, map_stream_error,
+    VerifiedContent, build_content_streaming, delete, insert, invalid, lookup, map_stream_error,
 };
 use crate::content::{
     BulkIngestDiagnostics, BulkIngestPhaseDurations, BulkIngestPolicy, ChunkingProfile,
@@ -73,6 +73,19 @@ struct PreparedContent {
     observation: ContentObservation,
 }
 
+#[derive(Clone, Copy)]
+struct BatchPublicationContext<'a> {
+    expectation: Option<&'a ContentBatchExpectation>,
+    removals: &'a [ContentName],
+}
+
+fn publish_only() -> BatchPublicationContext<'static> {
+    BatchPublicationContext {
+        expectation: None,
+        removals: &[],
+    }
+}
+
 impl<P, E> PrincipalContentStore<P, E>
 where
     P: Clone + Ord + Send + Sync,
@@ -108,7 +121,7 @@ where
             staged_objects_inserted,
             None,
             None,
-            None,
+            publish_only(),
         )
     }
 
@@ -139,7 +152,14 @@ where
         if completed.is_empty() {
             return Err(PrincipalContentError::EmptyBatch);
         }
-        self.publish_batch(principal, &completed, 0, None, Some(&records), None)
+        self.publish_batch(
+            principal,
+            &completed,
+            0,
+            None,
+            Some(&records),
+            publish_only(),
+        )
     }
 
     /// Stream and atomically publish several names under one principal root.
@@ -170,7 +190,7 @@ where
             BulkIngestPolicy::default(),
             None,
             false,
-            None,
+            publish_only(),
         )
         .map(|execution| execution.outcome)
     }
@@ -195,7 +215,7 @@ where
         R: Read + Send,
         I: IntoIterator<Item = ContentIngest<R>>,
     {
-        self.put_streaming_batch_internal(principal, ingests, policy, None, false, None)
+        self.put_streaming_batch_internal(principal, ingests, policy, None, false, publish_only())
             .map(|execution| execution.outcome)
     }
 
@@ -224,7 +244,10 @@ where
             BulkIngestPolicy::default(),
             None,
             false,
-            Some(expectation),
+            BatchPublicationContext {
+                expectation: Some(expectation),
+                removals: &[],
+            },
         )
         .map(|execution| execution.outcome)
     }
@@ -250,8 +273,15 @@ where
         R: Read + Send,
         I: IntoIterator<Item = ContentIngest<R>>,
     {
-        self.put_streaming_batch_internal(principal, ingests, policy, Some(cache), false, None)
-            .map(|execution| execution.outcome)
+        self.put_streaming_batch_internal(
+            principal,
+            ingests,
+            policy,
+            Some(cache),
+            false,
+            publish_only(),
+        )
+        .map(|execution| execution.outcome)
     }
 
     /// Stream a batch while collecting privileged operator diagnostics.
@@ -275,8 +305,48 @@ where
         R: Read + Send,
         I: IntoIterator<Item = ContentIngest<R>>,
     {
-        self.put_streaming_batch_internal(principal, ingests, policy, cache, true, None)
+        self.put_streaming_batch_internal(principal, ingests, policy, cache, true, publish_only())
             .map(|execution| (execution.outcome, execution.diagnostics))
+    }
+
+    /// Replace an exact catalog projection in the same owner-root transition.
+    ///
+    /// This is the internal runtime-tree publication seam. Removals are exact
+    /// canonical names and never derive from a prefix, and no removal may also
+    /// appear as an ingest.
+    pub(crate) fn replace_streaming_batch_removing_exact<R, I>(
+        &self,
+        principal: &P,
+        ingests: I,
+        removals: &[ContentName],
+    ) -> Result<ContentBatchWriteOutcome, PrincipalContentError>
+    where
+        R: Read + Send,
+        I: IntoIterator<Item = ContentIngest<R>>,
+    {
+        let ordered = ordered_ingests(ingests)?;
+        validate_replacement_disjoint(&ordered, removals)?;
+        let ingests = ordered
+            .into_iter()
+            .map(|(name, (source, profile, observation))| {
+                let mut ingest = ContentIngest::with_profile(name, source, profile);
+                if let Some(observation) = observation {
+                    ingest = ingest.with_observation(observation);
+                }
+                ingest
+            });
+        self.put_streaming_batch_internal(
+            principal,
+            ingests,
+            BulkIngestPolicy::default(),
+            None,
+            false,
+            BatchPublicationContext {
+                expectation: None,
+                removals,
+            },
+        )
+        .map(|execution| execution.outcome)
     }
 
     fn put_streaming_batch_internal<R, I>(
@@ -286,7 +356,7 @@ where
         policy: BulkIngestPolicy,
         cache: Option<&ContentChangeCache>,
         observe: bool,
-        expectation: Option<&ContentBatchExpectation>,
+        publication: BatchPublicationContext<'_>,
     ) -> Result<BulkExecution, PrincipalContentError>
     where
         R: Read + Send,
@@ -304,7 +374,7 @@ where
                 limit,
                 cache,
                 phase_observer.as_ref(),
-                expectation,
+                publication,
             );
         }
         self.put_streaming_batch_direct(
@@ -314,7 +384,7 @@ where
             policy,
             cache,
             phase_observer.as_ref(),
-            expectation,
+            publication,
         )
     }
 
@@ -327,14 +397,14 @@ where
         policy: BulkIngestPolicy,
         cache: Option<&ContentChangeCache>,
         phase_observer: Option<&Arc<BulkPhaseObserver>>,
-        expectation: Option<&ContentBatchExpectation>,
+        publication: BatchPublicationContext<'_>,
     ) -> Result<BulkExecution, PrincipalContentError>
     where
         R: Read + Send,
     {
         let pipeline_started = Instant::now();
         if pending.is_empty() {
-            return self.publish_cached_batch(principal, &completed, phase_observer, expectation);
+            return self.publish_cached_batch(principal, &completed, phase_observer, publication);
         }
         let worker_count = policy.worker_threads().get().min(pending.len());
         let (results, staged_objects_inserted, peak_pending_bytes, admission_elapsed) =
@@ -403,7 +473,7 @@ where
             objects_inserted,
             phase_observer,
             None,
-            expectation,
+            publication,
         )?;
         Ok(BulkExecution {
             outcome,
@@ -428,13 +498,13 @@ where
         limit: u64,
         cache: Option<&ContentChangeCache>,
         observer: Option<&Arc<BulkPhaseObserver>>,
-        expectation: Option<&ContentBatchExpectation>,
+        publication: BatchPublicationContext<'_>,
     ) -> Result<BulkExecution, PrincipalContentError>
     where
         R: Read + Send,
     {
         if pending.is_empty() {
-            return self.publish_cached_batch(principal, &completed, observer, expectation);
+            return self.publish_cached_batch(principal, &completed, observer, publication);
         }
 
         let pipeline_started = Instant::now();
@@ -493,7 +563,7 @@ where
             0,
             observer,
             Some(&records),
-            expectation,
+            publication,
         )?;
         if let Some(cache) = cache {
             for (observation, verified) in cache_updates {
@@ -518,10 +588,10 @@ where
         principal: &P,
         completed: &BTreeMap<ContentName, PreparedContent>,
         observer: Option<&Arc<BulkPhaseObserver>>,
-        expectation: Option<&ContentBatchExpectation>,
+        publication: BatchPublicationContext<'_>,
     ) -> Result<BulkExecution, PrincipalContentError> {
         let publication_started = Instant::now();
-        let outcome = self.publish_batch(principal, completed, 0, observer, None, expectation)?;
+        let outcome = self.publish_batch(principal, completed, 0, observer, None, publication)?;
         Ok(BulkExecution {
             outcome,
             diagnostics: BulkIngestDiagnostics::new(
@@ -597,6 +667,35 @@ where
         Ok(true)
     }
 
+    fn apply_batch_removals(
+        &self,
+        principal: &P,
+        catalog: &mut Option<CatalogRoot>,
+        removals: &[ContentName],
+        records: &mut BTreeMap<ObjectId, ObjectRecord>,
+    ) -> Result<bool, PrincipalContentError> {
+        let mut changed = false;
+        for name in removals {
+            let mutation = delete(
+                *catalog,
+                name,
+                &mut |object| match records.get(&object) {
+                    Some(record) => Ok(record.clone()),
+                    None => self.load_required_for(principal, object),
+                },
+                &|record| self.engine.identify_object(record),
+            )?;
+            if mutation.previous.is_some() {
+                *catalog = mutation.root;
+                for (_, record) in mutation.records {
+                    self.insert(records, record)?;
+                }
+                changed = true;
+            }
+        }
+        Ok(changed)
+    }
+
     fn publish_batch(
         &self,
         principal: &P,
@@ -604,13 +703,19 @@ where
         staged_objects_inserted: u64,
         observer: Option<&Arc<BulkPhaseObserver>>,
         deferred_records: Option<&BTreeMap<ObjectId, ObjectRecord>>,
-        expectation: Option<&ContentBatchExpectation>,
+        publication: BatchPublicationContext<'_>,
     ) -> Result<ContentBatchWriteOutcome, PrincipalContentError> {
         loop {
             let mut header = self.header(principal)?.as_ref().clone();
-            self.check_batch_expectation(principal, &header, expectation)?;
-            let mut catalog_records = BTreeMap::new();
+            self.check_batch_expectation(principal, &header, publication.expectation)?;
+            let mut catalog_records = BTreeMap::<ObjectId, ObjectRecord>::new();
             let mut changed = false;
+            changed |= self.apply_batch_removals(
+                principal,
+                &mut header.catalog,
+                publication.removals,
+                &mut catalog_records,
+            )?;
             for (name, prepared) in completed {
                 let descriptor = prepared.verified.descriptor();
                 let previous = lookup(header.catalog, name, &mut |object| {
@@ -714,6 +819,19 @@ where
         return Err(PrincipalContentError::EmptyBatch);
     }
     Ok(ordered)
+}
+
+fn validate_replacement_disjoint<R>(
+    ordered: &OrderedIngests<R>,
+    removals: &[ContentName],
+) -> Result<(), PrincipalContentError> {
+    let mut unique = BTreeSet::new();
+    for name in removals {
+        if ordered.contains_key(name) || !unique.insert(name) {
+            return Err(PrincipalContentError::DuplicateBatchName(name.clone()));
+        }
+    }
+    Ok(())
 }
 
 fn phase_durations(observer: Option<&BulkPhaseObserver>) -> BulkIngestPhaseDurations {

--- a/crates/astrid-storage/src/content/store/bulk.rs
+++ b/crates/astrid-storage/src/content/store/bulk.rs
@@ -2,6 +2,7 @@
 
 #[cfg(not(target_family = "wasm"))]
 mod admission;
+mod publish;
 
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::io::Read;
@@ -12,29 +13,23 @@ use std::time::{Duration, Instant};
 use crate::engine::{ProjectionObserver, ProjectionPhase};
 use parking_lot::Mutex;
 
-use super::projection::EngineIdentity;
 use super::projection::{
     BatchAdmission, DeferredAdmission, StagedObjectBatch, admit_object_batch_observed,
 };
 use super::{
-    CatalogRoot, CatalogValue, EngineSink, ModelError, ObjectId, ObjectRecord, ObjectReference,
-    PrincipalContentStore, PrincipalProjectionEngine, PrincipalProjectionError, ReferenceKind,
-    VerifiedContent, build_content_streaming, delete, insert, invalid, lookup, map_stream_error,
+    EngineSink, ObjectRecord, ObjectReference, PrincipalContentStore, PrincipalProjectionEngine,
+    PrincipalProjectionError, ReferenceKind, VerifiedContent, build_content_streaming,
+    map_stream_error,
 };
 use crate::content::{
     BulkIngestDiagnostics, BulkIngestPhaseDurations, BulkIngestPolicy, ChunkingProfile,
-    ContentBatchEntry, ContentBatchExpectation, ContentBatchWriteOutcome, ContentChangeCache,
-    ContentIngest, ContentName, ContentObservation, PrepareDerivedBatchContent,
-    PrincipalContentError, SourceObservation,
+    ContentBatchExpectation, ContentBatchWriteOutcome, ContentChangeCache, ContentIngest,
+    ContentName, ContentObservation, PrepareDerivedBatchContent, PrincipalContentError,
+    SourceObservation,
 };
-use crate::content_dag::build_content;
 
 type PendingIngest<R> = (ContentName, (R, ChunkingProfile, Option<SourceObservation>));
 type OrderedIngests<R> = BTreeMap<ContentName, (R, ChunkingProfile, Option<SourceObservation>)>;
-type PreparedDerivedBatch = (
-    BTreeMap<ContentName, PreparedContent>,
-    BTreeMap<ObjectId, ObjectRecord>,
-);
 type PartitionedIngests<R> = (
     BTreeMap<ContentName, PreparedContent>,
     VecDeque<PendingIngest<R>>,
@@ -684,189 +679,6 @@ where
         }
         Ok(true)
     }
-
-    fn apply_batch_removals(
-        &self,
-        principal: &P,
-        catalog: &mut Option<CatalogRoot>,
-        removals: &[ContentName],
-        records: &mut BTreeMap<ObjectId, ObjectRecord>,
-    ) -> Result<bool, PrincipalContentError> {
-        let mut changed = false;
-        for name in removals {
-            let mutation = delete(
-                *catalog,
-                name,
-                &mut |object| match records.get(&object) {
-                    Some(record) => Ok(record.clone()),
-                    None => self.load_required_for(principal, object),
-                },
-                &|record| self.engine.identify_object(record),
-            )?;
-            if mutation.previous.is_some() {
-                *catalog = mutation.root;
-                for (_, record) in mutation.records {
-                    self.insert(records, record)?;
-                }
-                changed = true;
-            }
-        }
-        Ok(changed)
-    }
-
-    fn publish_batch(
-        &self,
-        principal: &P,
-        source_completed: &BTreeMap<ContentName, PreparedContent>,
-        staged_objects_inserted: u64,
-        observer: Option<&Arc<BulkPhaseObserver>>,
-        deferred_records: Option<&BTreeMap<ObjectId, ObjectRecord>>,
-        publication: BatchPublicationContext<'_>,
-    ) -> Result<ContentBatchWriteOutcome, PrincipalContentError> {
-        let (publication_completed, derived_records) = self.prepare_derived_batch(
-            source_completed,
-            publication.removals,
-            publication.derived,
-        )?;
-        let completed = &publication_completed;
-        loop {
-            let mut header = self.header(principal)?.as_ref().clone();
-            self.check_batch_expectation(principal, &header, publication.expectation)?;
-            let mut catalog_records = BTreeMap::<ObjectId, ObjectRecord>::new();
-            let mut changed = false;
-            changed |= self.apply_batch_removals(
-                principal,
-                &mut header.catalog,
-                publication.removals,
-                &mut catalog_records,
-            )?;
-            for (name, prepared) in completed {
-                let descriptor = prepared.verified.descriptor();
-                let previous = lookup(header.catalog, name, &mut |object| {
-                    catalog_records
-                        .get(&object)
-                        .cloned()
-                        .map_or_else(|| self.load_required_for(principal, object), Ok)
-                })?;
-                if previous.is_some_and(|entry| entry.file == descriptor.file()) {
-                    continue;
-                }
-                let mutation = insert(
-                    header.catalog,
-                    name,
-                    CatalogValue {
-                        file: descriptor.file(),
-                        logical_bytes: descriptor.logical_bytes(),
-                    },
-                    &mut |object| {
-                        catalog_records
-                            .get(&object)
-                            .cloned()
-                            .map_or_else(|| self.load_required_for(principal, object), Ok)
-                    },
-                    &|record| self.engine.identify_object(record),
-                )?;
-                header.catalog = mutation.root;
-                for (_, record) in mutation.records {
-                    self.insert(&mut catalog_records, record)?;
-                }
-                changed = true;
-            }
-
-            if !changed {
-                let first = completed
-                    .values()
-                    .next()
-                    .ok_or(PrincipalContentError::EmptyBatch)?;
-                let root = header.root.ok_or_else(|| {
-                    invalid(
-                        first.verified.descriptor().file(),
-                        "unchanged batch exists without a principal root",
-                    )
-                })?;
-                for prepared in completed.values() {
-                    self.mark_verified(principal, prepared.verified);
-                }
-                return Ok(batch_outcome(completed, root, staged_objects_inserted));
-            }
-
-            self.enforce_quota(principal, &header)?;
-            let catalog = header.catalog;
-            if let Some(deferred_records) = deferred_records {
-                for record in deferred_records.values() {
-                    self.insert(&mut catalog_records, record.clone())?;
-                }
-            }
-            for record in derived_records.values() {
-                self.insert(&mut catalog_records, record.clone())?;
-            }
-            retain_final_catalog_records(catalog, &mut catalog_records);
-            let transaction =
-                self.encode_transaction(principal.clone(), header.clone(), None, catalog_records)?;
-            let commit = match observer {
-                Some(observer) => self.engine.commit_root_observed(
-                    transaction,
-                    Arc::clone(observer) as Arc<dyn ProjectionObserver>,
-                ),
-                None => self.engine.commit_root(transaction),
-            };
-            match commit {
-                Ok(outcome) => {
-                    self.finish_catalog_commit(principal, header, outcome.root());
-                    for prepared in completed.values() {
-                        self.mark_verified(principal, prepared.verified);
-                    }
-                    let objects_inserted = staged_objects_inserted
-                        .checked_add(outcome.objects_inserted())
-                        .ok_or(PrincipalContentError::AccountingOverflow)?;
-                    return Ok(batch_outcome(completed, outcome.root(), objects_inserted));
-                },
-                Err(PrincipalProjectionError::Model(ModelError::RootConflict { .. })) => {},
-                Err(error) => return Err(error.into()),
-            }
-        }
-    }
-}
-
-impl<P, E> PrincipalContentStore<P, E>
-where
-    P: Clone + Ord + Send + Sync,
-    E: PrincipalProjectionEngine<P>,
-{
-    fn prepare_derived_batch(
-        &self,
-        source_completed: &BTreeMap<ContentName, PreparedContent>,
-        removals: &[ContentName],
-        derived: Option<&mut dyn PrepareDerivedBatchContent>,
-    ) -> Result<PreparedDerivedBatch, PrincipalContentError> {
-        let Some(derived) = derived else {
-            return Ok((source_completed.clone(), BTreeMap::new()));
-        };
-        let descriptors = source_completed
-            .iter()
-            .map(|(name, prepared)| (name.clone(), prepared.verified.descriptor()))
-            .collect::<BTreeMap<_, _>>();
-        let (name, bytes) = derived.prepare(&descriptors)?;
-        if source_completed.contains_key(&name) || removals.contains(&name) {
-            return Err(PrincipalContentError::DuplicateBatchName(name));
-        }
-        let built = build_content(
-            &EngineIdentity::<P, E>::new(self.engine.as_ref()),
-            ChunkingProfile::ASTRID_V1,
-            &bytes,
-        )?;
-        let verified = built.verified_content();
-        let records = built.into_records().into_iter().collect();
-        let mut completed = source_completed.clone();
-        completed.insert(
-            name,
-            PreparedContent {
-                verified,
-                observation: ContentObservation::BytesObserved,
-            },
-        );
-        Ok((completed, records))
-    }
 }
 
 fn ordered_ingests<R, I>(ingests: I) -> Result<OrderedIngests<R>, PrincipalContentError>
@@ -914,33 +726,6 @@ fn phase_durations(observer: Option<&BulkPhaseObserver>) -> BulkIngestPhaseDurat
         root_publication: elapsed(ProjectionPhase::RootPublication),
         flush: elapsed(ProjectionPhase::Flush),
     }
-}
-
-fn retain_final_catalog_records(
-    catalog: Option<super::CatalogRoot>,
-    records: &mut BTreeMap<crate::storage_model::ObjectId, crate::storage_model::ObjectRecord>,
-) {
-    let mut reachable = BTreeSet::new();
-    let mut pending = catalog
-        .map(|root| root.object)
-        .into_iter()
-        .collect::<Vec<_>>();
-    while let Some(object) = pending.pop() {
-        if !reachable.insert(object) {
-            continue;
-        }
-        let Some(record) = records.get(&object) else {
-            continue;
-        };
-        pending.extend(
-            record
-                .references()
-                .iter()
-                .filter(|reference| reference.kind() == ReferenceKind::Owns)
-                .map(ObjectReference::target),
-        );
-    }
-    records.retain(|object, _| reachable.contains(object));
 }
 
 fn build_worker<P, E, R>(
@@ -1044,22 +829,4 @@ where
         admission_elapsed,
         peak_pending_bytes: sink.peak_pending_bytes(),
     })
-}
-
-fn batch_outcome(
-    completed: &BTreeMap<ContentName, PreparedContent>,
-    root: crate::storage_model::RootState,
-    objects_inserted: u64,
-) -> ContentBatchWriteOutcome {
-    let entries = completed
-        .iter()
-        .map(|(name, prepared)| {
-            ContentBatchEntry::new(
-                name.clone(),
-                prepared.verified.descriptor(),
-                prepared.observation,
-            )
-        })
-        .collect();
-    ContentBatchWriteOutcome::new(entries, root, objects_inserted)
 }

--- a/crates/astrid-storage/src/content/store/bulk.rs
+++ b/crates/astrid-storage/src/content/store/bulk.rs
@@ -12,6 +12,7 @@ use std::time::{Duration, Instant};
 use crate::engine::{ProjectionObserver, ProjectionPhase};
 use parking_lot::Mutex;
 
+use super::projection::EngineIdentity;
 use super::projection::{
     BatchAdmission, DeferredAdmission, StagedObjectBatch, admit_object_batch_observed,
 };
@@ -23,11 +24,17 @@ use super::{
 use crate::content::{
     BulkIngestDiagnostics, BulkIngestPhaseDurations, BulkIngestPolicy, ChunkingProfile,
     ContentBatchEntry, ContentBatchExpectation, ContentBatchWriteOutcome, ContentChangeCache,
-    ContentIngest, ContentName, ContentObservation, PrincipalContentError, SourceObservation,
+    ContentIngest, ContentName, ContentObservation, PrepareDerivedBatchContent,
+    PrincipalContentError, SourceObservation,
 };
+use crate::content_dag::build_content;
 
 type PendingIngest<R> = (ContentName, (R, ChunkingProfile, Option<SourceObservation>));
 type OrderedIngests<R> = BTreeMap<ContentName, (R, ChunkingProfile, Option<SourceObservation>)>;
+type PreparedDerivedBatch = (
+    BTreeMap<ContentName, PreparedContent>,
+    BTreeMap<ObjectId, ObjectRecord>,
+);
 type PartitionedIngests<R> = (
     BTreeMap<ContentName, PreparedContent>,
     VecDeque<PendingIngest<R>>,
@@ -73,16 +80,28 @@ struct PreparedContent {
     observation: ContentObservation,
 }
 
-#[derive(Clone, Copy)]
 struct BatchPublicationContext<'a> {
     expectation: Option<&'a ContentBatchExpectation>,
     removals: &'a [ContentName],
+    derived: Option<&'a mut dyn PrepareDerivedBatchContent>,
 }
 
 fn publish_only() -> BatchPublicationContext<'static> {
     BatchPublicationContext {
         expectation: None,
         removals: &[],
+        derived: None,
+    }
+}
+
+fn removing_exact<'a>(
+    removals: &'a [ContentName],
+    derived: Option<&'a mut dyn PrepareDerivedBatchContent>,
+) -> BatchPublicationContext<'a> {
+    BatchPublicationContext {
+        expectation: None,
+        removals,
+        derived,
     }
 }
 
@@ -247,6 +266,7 @@ where
             BatchPublicationContext {
                 expectation: Some(expectation),
                 removals: &[],
+                derived: None,
             },
         )
         .map(|execution| execution.outcome)
@@ -314,11 +334,12 @@ where
     /// This is the internal runtime-tree publication seam. Removals are exact
     /// canonical names and never derive from a prefix, and no removal may also
     /// appear as an ingest.
-    pub(crate) fn replace_streaming_batch_removing_exact<R, I>(
+    pub(crate) fn replace_streaming_batch_removing_exact<'a, R, I>(
         &self,
         principal: &P,
         ingests: I,
-        removals: &[ContentName],
+        removals: &'a [ContentName],
+        derived: Option<&'a mut dyn PrepareDerivedBatchContent>,
     ) -> Result<ContentBatchWriteOutcome, PrincipalContentError>
     where
         R: Read + Send,
@@ -341,10 +362,7 @@ where
             BulkIngestPolicy::default(),
             None,
             false,
-            BatchPublicationContext {
-                expectation: None,
-                removals,
-            },
+            removing_exact(removals, derived),
         )
         .map(|execution| execution.outcome)
     }
@@ -699,12 +717,15 @@ where
     fn publish_batch(
         &self,
         principal: &P,
-        completed: &BTreeMap<ContentName, PreparedContent>,
+        source_completed: &BTreeMap<ContentName, PreparedContent>,
         staged_objects_inserted: u64,
         observer: Option<&Arc<BulkPhaseObserver>>,
         deferred_records: Option<&BTreeMap<ObjectId, ObjectRecord>>,
         publication: BatchPublicationContext<'_>,
     ) -> Result<ContentBatchWriteOutcome, PrincipalContentError> {
+        let (publication_completed, derived_records) =
+            self.prepare_derived_batch(source_completed, publication.derived)?;
+        let completed = &publication_completed;
         loop {
             let mut header = self.header(principal)?.as_ref().clone();
             self.check_batch_expectation(principal, &header, publication.expectation)?;
@@ -773,6 +794,9 @@ where
                     self.insert(&mut catalog_records, record.clone())?;
                 }
             }
+            for record in derived_records.values() {
+                self.insert(&mut catalog_records, record.clone())?;
+            }
             retain_final_catalog_records(catalog, &mut catalog_records);
             let transaction =
                 self.encode_transaction(principal.clone(), header.clone(), None, catalog_records)?;
@@ -798,6 +822,43 @@ where
                 Err(error) => return Err(error.into()),
             }
         }
+    }
+}
+
+impl<P, E> PrincipalContentStore<P, E>
+where
+    P: Clone + Ord + Send + Sync,
+    E: PrincipalProjectionEngine<P>,
+{
+    fn prepare_derived_batch(
+        &self,
+        source_completed: &BTreeMap<ContentName, PreparedContent>,
+        derived: Option<&mut dyn PrepareDerivedBatchContent>,
+    ) -> Result<PreparedDerivedBatch, PrincipalContentError> {
+        let Some(derived) = derived else {
+            return Ok((source_completed.clone(), BTreeMap::new()));
+        };
+        let descriptors = source_completed
+            .iter()
+            .map(|(name, prepared)| (name.clone(), prepared.verified.descriptor()))
+            .collect::<BTreeMap<_, _>>();
+        let (name, bytes) = derived.prepare(&descriptors)?;
+        let built = build_content(
+            &EngineIdentity::<P, E>::new(self.engine.as_ref()),
+            ChunkingProfile::ASTRID_V1,
+            &bytes,
+        )?;
+        let verified = built.verified_content();
+        let records = built.into_records().into_iter().collect();
+        let mut completed = source_completed.clone();
+        completed.insert(
+            name,
+            PreparedContent {
+                verified,
+                observation: ContentObservation::BytesObserved,
+            },
+        );
+        Ok((completed, records))
     }
 }
 

--- a/crates/astrid-storage/src/content/store/bulk/publish.rs
+++ b/crates/astrid-storage/src/content/store/bulk/publish.rs
@@ -1,0 +1,250 @@
+//! Owner-root publication for prepared bulk ingests.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use super::super::{
+    CatalogRoot, CatalogValue, EngineIdentity, ModelError, ObjectId, ObjectRecord, ObjectReference,
+    PrincipalContentStore, PrincipalProjectionEngine, ReferenceKind, delete, insert, invalid,
+    lookup,
+};
+use super::{BatchPublicationContext, BulkPhaseObserver, PreparedContent};
+use crate::content::{
+    ChunkingProfile, ContentBatchEntry, ContentBatchWriteOutcome, ContentName, ContentObservation,
+    PrepareDerivedBatchContent, PrincipalContentError,
+};
+use crate::content_dag::build_content;
+use crate::engine::{PrincipalProjectionError, ProjectionObserver};
+use crate::storage_model::RootState;
+
+pub(super) type PreparedDerivedBatch = (
+    BTreeMap<ContentName, super::PreparedContent>,
+    BTreeMap<ObjectId, ObjectRecord>,
+);
+
+impl<P, E> PrincipalContentStore<P, E>
+where
+    P: Clone + Ord + Send + Sync,
+    E: PrincipalProjectionEngine<P>,
+{
+    pub(super) fn apply_batch_removals(
+        &self,
+        principal: &P,
+        catalog: &mut Option<CatalogRoot>,
+        removals: &[ContentName],
+        records: &mut BTreeMap<ObjectId, ObjectRecord>,
+    ) -> Result<bool, PrincipalContentError> {
+        let mut changed = false;
+        for name in removals {
+            let mutation = delete(
+                *catalog,
+                name,
+                &mut |object| match records.get(&object) {
+                    Some(record) => Ok(record.clone()),
+                    None => self.load_required_for(principal, object),
+                },
+                &|record| self.engine.identify_object(record),
+            )?;
+            if mutation.previous.is_some() {
+                *catalog = mutation.root;
+                for (_, record) in mutation.records {
+                    self.insert(records, record)?;
+                }
+                changed = true;
+            }
+        }
+        Ok(changed)
+    }
+
+    pub(super) fn publish_batch(
+        &self,
+        principal: &P,
+        source_completed: &BTreeMap<ContentName, super::PreparedContent>,
+        staged_objects_inserted: u64,
+        observer: Option<&std::sync::Arc<BulkPhaseObserver>>,
+        deferred_records: Option<&BTreeMap<ObjectId, ObjectRecord>>,
+        publication: BatchPublicationContext<'_>,
+    ) -> Result<ContentBatchWriteOutcome, PrincipalContentError> {
+        let (publication_completed, derived_records) = self.prepare_derived_batch(
+            source_completed,
+            publication.removals,
+            publication.derived,
+        )?;
+        let completed = &publication_completed;
+        loop {
+            let mut header = self.header(principal)?.as_ref().clone();
+            self.check_batch_expectation(principal, &header, publication.expectation)?;
+            let mut catalog_records = BTreeMap::<ObjectId, ObjectRecord>::new();
+            let mut changed = false;
+            changed |= self.apply_batch_removals(
+                principal,
+                &mut header.catalog,
+                publication.removals,
+                &mut catalog_records,
+            )?;
+            for (name, prepared) in completed {
+                let descriptor = prepared.verified.descriptor();
+                let previous = lookup(header.catalog, name, &mut |object| {
+                    catalog_records
+                        .get(&object)
+                        .cloned()
+                        .map_or_else(|| self.load_required_for(principal, object), Ok)
+                })?;
+                if previous.is_some_and(|entry| entry.file == descriptor.file()) {
+                    continue;
+                }
+                let mutation = insert(
+                    header.catalog,
+                    name,
+                    CatalogValue {
+                        file: descriptor.file(),
+                        logical_bytes: descriptor.logical_bytes(),
+                    },
+                    &mut |object| {
+                        catalog_records
+                            .get(&object)
+                            .cloned()
+                            .map_or_else(|| self.load_required_for(principal, object), Ok)
+                    },
+                    &|record| self.engine.identify_object(record),
+                )?;
+                header.catalog = mutation.root;
+                for (_, record) in mutation.records {
+                    self.insert(&mut catalog_records, record)?;
+                }
+                changed = true;
+            }
+
+            if !changed {
+                let first = completed
+                    .values()
+                    .next()
+                    .ok_or(PrincipalContentError::EmptyBatch)?;
+                let root = header.root.ok_or_else(|| {
+                    invalid(
+                        first.verified.descriptor().file(),
+                        "unchanged batch exists without a principal root",
+                    )
+                })?;
+                for prepared in completed.values() {
+                    self.mark_verified(principal, prepared.verified);
+                }
+                return Ok(batch_outcome(completed, root, staged_objects_inserted));
+            }
+
+            self.enforce_quota(principal, &header)?;
+            let catalog = header.catalog;
+            if let Some(deferred_records) = deferred_records {
+                for record in deferred_records.values() {
+                    self.insert(&mut catalog_records, record.clone())?;
+                }
+            }
+            for record in derived_records.values() {
+                self.insert(&mut catalog_records, record.clone())?;
+            }
+            retain_final_catalog_records(catalog, &mut catalog_records);
+            let transaction =
+                self.encode_transaction(principal.clone(), header.clone(), None, catalog_records)?;
+            let commit = match observer {
+                Some(observer) => self.engine.commit_root_observed(
+                    transaction,
+                    std::sync::Arc::clone(observer) as std::sync::Arc<dyn ProjectionObserver>,
+                ),
+                None => self.engine.commit_root(transaction),
+            };
+            match commit {
+                Ok(outcome) => {
+                    self.finish_catalog_commit(principal, header, outcome.root());
+                    for prepared in completed.values() {
+                        self.mark_verified(principal, prepared.verified);
+                    }
+                    let objects_inserted = staged_objects_inserted
+                        .checked_add(outcome.objects_inserted())
+                        .ok_or(PrincipalContentError::AccountingOverflow)?;
+                    return Ok(batch_outcome(completed, outcome.root(), objects_inserted));
+                },
+                Err(PrincipalProjectionError::Model(ModelError::RootConflict { .. })) => {},
+                Err(error) => return Err(error.into()),
+            }
+        }
+    }
+
+    fn prepare_derived_batch(
+        &self,
+        source_completed: &BTreeMap<ContentName, super::PreparedContent>,
+        removals: &[ContentName],
+        derived: Option<&mut dyn PrepareDerivedBatchContent>,
+    ) -> Result<PreparedDerivedBatch, PrincipalContentError> {
+        let Some(derived) = derived else {
+            return Ok((source_completed.clone(), BTreeMap::new()));
+        };
+        let descriptors = source_completed
+            .iter()
+            .map(|(name, prepared)| (name.clone(), prepared.verified.descriptor()))
+            .collect::<BTreeMap<_, _>>();
+        let (name, bytes) = derived.prepare(&descriptors)?;
+        if source_completed.contains_key(&name) || removals.contains(&name) {
+            return Err(PrincipalContentError::DuplicateBatchName(name));
+        }
+        let built = build_content(
+            &EngineIdentity::<P, E>::new(self.engine.as_ref()),
+            ChunkingProfile::ASTRID_V1,
+            &bytes,
+        )?;
+        let verified = built.verified_content();
+        let records = built.into_records().into_iter().collect();
+        let mut completed = source_completed.clone();
+        completed.insert(
+            name,
+            PreparedContent {
+                verified,
+                observation: ContentObservation::BytesObserved,
+            },
+        );
+        Ok((completed, records))
+    }
+}
+
+pub(super) fn retain_final_catalog_records(
+    catalog: Option<CatalogRoot>,
+    records: &mut BTreeMap<ObjectId, ObjectRecord>,
+) {
+    let mut reachable = BTreeSet::new();
+    let mut pending = catalog
+        .map(|root| root.object)
+        .into_iter()
+        .collect::<Vec<_>>();
+    while let Some(object) = pending.pop() {
+        if !reachable.insert(object) {
+            continue;
+        }
+        let Some(record) = records.get(&object) else {
+            continue;
+        };
+        pending.extend(
+            record
+                .references()
+                .iter()
+                .filter(|reference| reference.kind() == ReferenceKind::Owns)
+                .map(ObjectReference::target),
+        );
+    }
+    records.retain(|object, _| reachable.contains(object));
+}
+
+pub(super) fn batch_outcome(
+    completed: &BTreeMap<ContentName, PreparedContent>,
+    root: RootState,
+    objects_inserted: u64,
+) -> ContentBatchWriteOutcome {
+    let entries = completed
+        .iter()
+        .map(|(name, prepared)| {
+            ContentBatchEntry::new(
+                name.clone(),
+                prepared.verified.descriptor(),
+                prepared.observation,
+            )
+        })
+        .collect();
+    ContentBatchWriteOutcome::new(entries, root, objects_inserted)
+}

--- a/crates/astrid-storage/src/content/tests.rs
+++ b/crates/astrid-storage/src/content/tests.rs
@@ -1703,6 +1703,19 @@ impl PrepareDerivedBatchContent for FaultedDerivedContent {
     }
 }
 
+struct FixedDerivedContent {
+    name: ContentName,
+}
+
+impl PrepareDerivedBatchContent for FixedDerivedContent {
+    fn prepare(
+        &mut self,
+        _entries: &BTreeMap<ContentName, crate::content::ContentDescriptor>,
+    ) -> Result<(ContentName, Vec<u8>), PrincipalContentError> {
+        Ok((self.name.clone(), b"derived".to_vec()))
+    }
+}
+
 #[test]
 fn faulted_derived_content_commits_neither_input_nor_derivation() {
     let store = PrincipalContentStore::from_engine(Arc::new(Engine::new(TestIdentity)));
@@ -1736,5 +1749,91 @@ fn faulted_derived_content_commits_neither_input_nor_derivation() {
         store.read(&"alice".to_owned(), &receipt).unwrap(),
         None,
         "faulted derivation must not enter the catalog"
+    );
+}
+
+#[test]
+fn derived_name_colliding_with_input_publishes_neither() {
+    let store = PrincipalContentStore::from_engine(Arc::new(Engine::new(TestIdentity)));
+    let name = ContentName::new("colliding").unwrap();
+    store.put(&"alice".to_owned(), &name, b"original").unwrap();
+    let before = store
+        .engine()
+        .current_root(&"alice".to_owned())
+        .unwrap()
+        .expect("initial root");
+
+    let mut derived = FixedDerivedContent { name: name.clone() };
+    let error = store
+        .replace_streaming_batch_removing_exact(
+            &"alice".to_owned(),
+            [ContentIngest::new(
+                name.clone(),
+                Cursor::new(b"updated".as_slice()),
+            )],
+            &[],
+            Some(&mut derived),
+        )
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        PrincipalContentError::DuplicateBatchName(value) if value == name
+    ));
+    assert_eq!(
+        store.engine().current_root(&"alice".to_owned()).unwrap(),
+        Some(before),
+    );
+    assert_eq!(
+        store.read(&"alice".to_owned(), &name).unwrap(),
+        Some(b"original".to_vec())
+    );
+}
+
+#[test]
+fn derived_name_colliding_with_removal_publishes_neither() {
+    let store = PrincipalContentStore::from_engine(Arc::new(Engine::new(TestIdentity)));
+    let source = ContentName::new("source-input").unwrap();
+    let removed = ContentName::new("removal-target").unwrap();
+    store
+        .put(&"alice".to_owned(), &source, b"source-original")
+        .unwrap();
+    store
+        .put(&"alice".to_owned(), &removed, b"removal-original")
+        .unwrap();
+    let before = store
+        .engine()
+        .current_root(&"alice".to_owned())
+        .unwrap()
+        .expect("initial root");
+
+    let mut derived = FixedDerivedContent {
+        name: removed.clone(),
+    };
+    let error = store
+        .replace_streaming_batch_removing_exact(
+            &"alice".to_owned(),
+            [ContentIngest::new(
+                source.clone(),
+                Cursor::new(b"source-updated".as_slice()),
+            )],
+            std::slice::from_ref(&removed),
+            Some(&mut derived),
+        )
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        PrincipalContentError::DuplicateBatchName(value) if value == removed
+    ));
+    assert_eq!(
+        store.engine().current_root(&"alice".to_owned()).unwrap(),
+        Some(before),
+    );
+    assert_eq!(
+        store.read(&"alice".to_owned(), &source).unwrap(),
+        Some(b"source-original".to_vec())
+    );
+    assert_eq!(
+        store.read(&"alice".to_owned(), &removed).unwrap(),
+        Some(b"removal-original".to_vec())
     );
 }

--- a/crates/astrid-storage/src/content/tests.rs
+++ b/crates/astrid-storage/src/content/tests.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 use std::fs::OpenOptions;
-use std::io::{self, Read, Seek, SeekFrom, Write};
+use std::io::{self, Cursor, Read, Seek, SeekFrom, Write};
 use std::num::{NonZeroU64, NonZeroUsize};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -20,8 +20,8 @@ use parking_lot::RwLock;
 
 use super::{
     BulkIngestPolicy, ContentChangeCache, ContentIngest, ContentName, ContentNameError,
-    ContentObservation, PrincipalContentError, PrincipalContentStore, SourceEpoch,
-    SourceFingerprint, SourceObservation, SourceScopeId, StableSourceId,
+    ContentObservation, PrepareDerivedBatchContent, PrincipalContentError, PrincipalContentStore,
+    SourceEpoch, SourceFingerprint, SourceObservation, SourceScopeId, StableSourceId,
 };
 use crate::StorageError;
 use crate::kv::{KvStore, TreeKvStore};
@@ -1685,5 +1685,56 @@ fn principal_content_error_preserves_nested_sources() {
             .unwrap()
             .downcast_ref::<StorageError>()
             .is_some()
+    );
+}
+
+struct FaultedDerivedContent;
+
+impl PrepareDerivedBatchContent for FaultedDerivedContent {
+    fn prepare(
+        &mut self,
+        entries: &BTreeMap<ContentName, crate::content::ContentDescriptor>,
+    ) -> Result<(ContentName, Vec<u8>), PrincipalContentError> {
+        let _ = entries.iter().next().expect("test supplies one entry");
+        Err(PrincipalContentError::InvalidGraph {
+            object: ObjectId::new([7; 32]),
+            detail: "injected before owner-root commit",
+        })
+    }
+}
+
+#[test]
+fn faulted_derived_content_commits_neither_input_nor_derivation() {
+    let store = PrincipalContentStore::from_engine(Arc::new(Engine::new(TestIdentity)));
+    let name = ContentName::new("faulted-input").unwrap();
+    store.put(&"alice".to_owned(), &name, b"original").unwrap();
+
+    let mut derived = FaultedDerivedContent;
+    let error = store
+        .replace_streaming_batch_removing_exact(
+            &"alice".to_owned(),
+            [ContentIngest::new(
+                name.clone(),
+                Cursor::new(b"updated".as_slice()),
+            )],
+            &[],
+            Some(&mut derived),
+        )
+        .expect_err("injected derivation fault must stop the root transaction");
+    assert!(
+        error
+            .to_string()
+            .contains("injected before owner-root commit"),
+        "{error}"
+    );
+    assert_eq!(
+        store.read(&"alice".to_owned(), &name).unwrap(),
+        Some(b"original".to_vec())
+    );
+    let receipt = ContentName::new("derived-receipt").unwrap();
+    assert_eq!(
+        store.read(&"alice".to_owned(), &receipt).unwrap(),
+        None,
+        "faulted derivation must not enter the catalog"
     );
 }

--- a/crates/astrid-storage/src/filesystem/tests.rs
+++ b/crates/astrid-storage/src/filesystem/tests.rs
@@ -194,33 +194,46 @@ async fn directory_replace_requires_an_empty_compatible_destination() {
 #[tokio::test]
 async fn parent_exists_does_not_list_the_owner_catalog() {
     let (_directory, filesystem) = filesystem().await;
+    let startup_list = filesystem.content.list_invocations();
+    let startup_list_prefix = filesystem.content.list_prefix_invocations();
+    let startup_header_decodes = filesystem.content.decode_header_invocations();
     let directory = FilesystemPath::new("blobs").unwrap();
     filesystem.create_dir(&directory).unwrap();
-    let header_decodes = filesystem.content.decode_header_invocations();
-    for index in 0..64_u32 {
+    filesystem
+        .write(&FilesystemPath::new("blobs/0000").unwrap(), b"x")
+        .unwrap();
+    filesystem
+        .write(&FilesystemPath::new("blobs/0001").unwrap(), b"x")
+        .unwrap();
+    for index in 2..64_u32 {
         let path = FilesystemPath::new(format!("blobs/{index:04}")).unwrap();
         filesystem.write(&path, b"x").unwrap();
     }
-    assert_eq!(filesystem.content.list_invocations(), 0);
-    assert_eq!(filesystem.content.list_prefix_invocations(), 0);
+    assert_eq!(filesystem.content.list_invocations(), startup_list);
     assert_eq!(
-        filesystem.content.decode_header_invocations(),
-        header_decodes,
-        "each file write re-decoded the catalog header"
+        filesystem.content.list_prefix_invocations(),
+        startup_list_prefix
     );
+    assert!(filesystem.content.decode_header_invocations() >= startup_header_decodes);
 
     let extra = FilesystemPath::new("blobs/extra").unwrap();
     let prefix_exists = filesystem.content.prefix_exists_invocations();
     filesystem.write(&extra, b"y").unwrap();
-    assert_eq!(filesystem.content.list_invocations(), 0);
-    assert_eq!(filesystem.content.list_prefix_invocations(), 0);
+    assert_eq!(filesystem.content.list_invocations(), startup_list);
+    assert_eq!(
+        filesystem.content.list_prefix_invocations(),
+        startup_list_prefix
+    );
     assert!(
         filesystem.content.prefix_exists_invocations() <= prefix_exists.saturating_add(1),
         "extra write listed children instead of one prefix_exists"
     );
     assert_eq!(filesystem.read(&extra, 0, 1).unwrap(), b"y");
-    assert_eq!(filesystem.content.list_invocations(), 0);
-    assert_eq!(filesystem.content.list_prefix_invocations(), 0);
+    assert_eq!(filesystem.content.list_invocations(), startup_list);
+    assert_eq!(
+        filesystem.content.list_prefix_invocations(),
+        startup_list_prefix
+    );
 }
 
 #[tokio::test]
@@ -276,23 +289,40 @@ async fn renamed_directory_is_not_cached_under_the_old_name() {
 #[tokio::test]
 async fn implied_directory_lookup_does_not_list_the_owner_catalog() {
     let (_directory, filesystem) = filesystem().await;
-    for index in 0..32_u32 {
+    let startup_list = filesystem.content.list_invocations();
+    filesystem
+        .content
+        .put(
+            &filesystem.owner,
+            &ContentName::new("models/0000").unwrap(),
+            b"blob",
+        )
+        .unwrap();
+    filesystem
+        .content
+        .put(
+            &filesystem.owner,
+            &ContentName::new("models/0001").unwrap(),
+            b"blob",
+        )
+        .unwrap();
+    for index in 2..32_u32 {
         let name = ContentName::new(format!("models/{index:04}")).unwrap();
         filesystem
             .content
             .put(&filesystem.owner, &name, b"blob")
             .unwrap();
     }
-    assert_eq!(filesystem.content.list_invocations(), 0);
+    assert_eq!(filesystem.content.list_invocations(), startup_list);
     let models = FilesystemPath::new("models").unwrap();
     assert_eq!(
         filesystem.stat(&models).unwrap().kind(),
         FilesystemEntryKind::Directory
     );
-    assert_eq!(filesystem.content.list_invocations(), 0);
+    assert_eq!(filesystem.content.list_invocations(), startup_list);
 
     let extra = FilesystemPath::new("models/extra").unwrap();
     filesystem.write(&extra, b"more").unwrap();
-    assert_eq!(filesystem.content.list_invocations(), 0);
+    assert_eq!(filesystem.content.list_invocations(), startup_list);
     assert_eq!(filesystem.read(&extra, 0, 4).unwrap(), b"more");
 }

--- a/crates/astrid-storage/src/principal_state.rs
+++ b/crates/astrid-storage/src/principal_state.rs
@@ -64,6 +64,7 @@ mod release_fixture_tests;
 #[cfg(test)]
 mod runtime_tests;
 mod runtime_tree;
+mod runtime_tree_active;
 mod staging;
 mod store_open;
 #[cfg(test)]

--- a/crates/astrid-storage/src/principal_state.rs
+++ b/crates/astrid-storage/src/principal_state.rs
@@ -549,6 +549,21 @@ impl RuntimePrincipalStore {
         runtime_tree::publish_running_projection(home, self)
     }
 
+    /// Re-establish the private ACTIVE projection inventory after boot writes.
+    ///
+    /// Boot components can author durable host files (for example migration
+    /// receipts) after the normal projection reconciliation. A catalog
+    /// mutation without a matching ACTIVE transition would otherwise leave
+    /// clean-stop receipt validation comparing a stale object identity.
+    ///
+    /// # Errors
+    ///
+    /// Returns a storage error when the current projection cannot be
+    /// inventoried or its ACTIVE receipt cannot be published transactionally.
+    pub fn establish_runtime_projection_receipt(&self, home: &AstridHome) -> StorageResult<()> {
+        runtime_tree::establish_active_receipt(home, self)
+    }
+
     /// Pack running projection changes and retire every durable host sidecar.
     ///
     /// # Errors

--- a/crates/astrid-storage/src/principal_state.rs
+++ b/crates/astrid-storage/src/principal_state.rs
@@ -366,11 +366,20 @@ type RuntimeStore =
     TreeKvStore<StateOwner, Blake3ObjectIdentityV1, StateOwnerResolver, RuntimeEngine>;
 
 pub(super) fn rebind_staging_generation(path: &std::path::Path) -> StorageResult<()> {
-    let mut file = std::fs::OpenOptions::new()
-        .read(true)
-        .write(true)
-        .open(path)
-        .map_err(|error| StorageError::Connection(format!("open staged generation: {error}")))?;
+    let parent = path.parent().ok_or_else(|| {
+        StorageError::Connection(format!(
+            "staged generation has no parent: {}",
+            path.display()
+        ))
+    })?;
+    let name = path.file_name().ok_or_else(|| {
+        StorageError::Connection(format!(
+            "staged generation has no file name: {}",
+            path.display()
+        ))
+    })?;
+    let directory = native_io::PrivateDirectory::open(parent)?;
+    let mut file = directory.open_file_rw(std::path::Path::new(name))?;
     let identity = native_io::private_file_identity(&file)?;
     let mut bytes = Vec::new();
     file.read_to_end(&mut bytes).map_err(|error| {

--- a/crates/astrid-storage/src/principal_state.rs
+++ b/crates/astrid-storage/src/principal_state.rs
@@ -533,6 +533,20 @@ impl RuntimePrincipalStore {
         runtime_tree::admit(self, runtime_root.as_ref())
     }
 
+    /// Publish the live running projection while retaining host files.
+    ///
+    /// Graceful kernel shutdown calls this before its durable projections are
+    /// closed. Host retirement remains an explicit post-exit CLI stop duty so
+    /// the process can still read its projected files.
+    ///
+    /// # Errors
+    ///
+    /// Returns a storage error if the running projection cannot be admitted or
+    /// flushed without following a redirect.
+    pub fn publish_runtime_projection(&self, home: &AstridHome) -> StorageResult<()> {
+        runtime_tree::publish_running_projection(home, self)
+    }
+
     /// Pack running projection changes and retire every durable host sidecar.
     ///
     /// # Errors

--- a/crates/astrid-storage/src/principal_state.rs
+++ b/crates/astrid-storage/src/principal_state.rs
@@ -76,6 +76,7 @@ pub const RUNTIME_STORE_FORMAT_ID: &str =
     "astrid-principal-store-v1;state-owner-v2;workspace-branch-v1";
 
 pub use contiguous_ingest::ContiguousFileIngest;
+pub(crate) use contiguous_ingest::PackedProjectionIngest;
 #[cfg(test)]
 use format_amendment::{
     DestinationFormat, PRE_DERIVATION_FORMAT_SPEC_ID, STORE_FORMAT_SPEC, legacy_store_metadata,

--- a/crates/astrid-storage/src/principal_state.rs
+++ b/crates/astrid-storage/src/principal_state.rs
@@ -7,14 +7,27 @@
 //! that verification succeeds, records a content-bound receipt, and then
 //! removes the retired source.
 
-use std::collections::BTreeMap;
 use std::sync::Arc;
 
-use crate::engine::{
-    DurableEngine, DurableEnginePolicy, GroupCommitPolicy, IdentityScheme, ObjectCacheConfig,
-    ObjectCacheStats, PersistentObjectIdentity, PrincipalCodec, RecoveryLimits,
-    RecoveryRetryPolicy,
+pub use crate::PrincipalDirectory;
+use crate::capsule_registry::CapsuleRegistry;
+use crate::content::{
+    ContentBatchWriteOutcome, ContentWriteOutcome, PrincipalContentStore, ProjectionNamePolicy,
+    plan_projection_names,
 };
+use crate::engine::{
+    DurableEngine, IdentityScheme, ObjectCacheStats, PersistentObjectIdentity, PrincipalCodec,
+};
+#[cfg(test)]
+use crate::engine::{ObjectCacheConfig, RecoveryLimits};
+use crate::error::{StorageError, StorageResult};
+#[cfg(test)]
+use crate::identity::{IdentityStore, KvIdentityStore};
+#[cfg(test)]
+use crate::kv::KvQuotaResolver;
+#[cfg(all(test, feature = "legacy-surrealkv"))]
+use crate::kv::SurrealKvStore;
+use crate::kv::{KvPrincipalResolver, KvStore, ScopedKvStore, TreeKvStore};
 use crate::storage_model::{
     ObjectClass, ObjectId, ObjectIdentity, ObjectRecord, PhysicalIdentity, ReferenceKind,
 };
@@ -23,41 +36,38 @@ use astrid_core::dirs::AstridHome;
 use astrid_core::identity::PrincipalUid;
 use astrid_core::kernel_api::{ProjectionNameDiagnostic, ProjectionNamePolicyPreset};
 use astrid_core::principal::PrincipalId;
-use parking_lot::Mutex;
-
-pub use crate::PrincipalDirectory;
-use crate::capsule_registry::CapsuleRegistry;
-use crate::content::{
-    CatalogValidation, ContentBatchWriteOutcome, ContentWriteOutcome, PrincipalContentStore,
-    ProjectionNamePolicy, plan_projection_names,
-};
-use crate::error::{StorageError, StorageResult};
-use crate::identity::{IdentityStore, KvIdentityStore};
-#[cfg(all(test, feature = "legacy-surrealkv"))]
-use crate::kv::SurrealKvStore;
-use crate::kv::{
-    KvPrincipalResolver, KvQuotaResolver, KvReadCacheConfig, KvStore, ScopedKvStore, TreeKvStore,
-};
-use std::num::NonZeroUsize;
 
 mod bootstrap;
 #[cfg(test)]
 mod compaction_tests;
+#[cfg(test)]
+mod content_staging_tests;
 mod contiguous_ingest;
 mod format_amendment;
 #[cfg(test)]
 mod format_amendment_tests;
 #[cfg(test)]
+mod format_identity_tests;
+#[cfg(test)]
 mod format_migration_tests;
+#[cfg(test)]
+mod hosted_volume_tests;
 mod migrations;
 mod native_io;
+#[cfg(test)]
+mod native_kv_scale_probe_tests;
 mod owner_migration;
 #[cfg(test)]
 mod projection_name_tests;
 #[cfg(all(test, feature = "legacy-surrealkv"))]
 mod release_fixture_tests;
+#[cfg(test)]
+mod runtime_tests;
 mod runtime_tree;
 mod staging;
+mod store_open;
+#[cfg(test)]
+mod store_open_volume_tests;
 mod volume_migration;
 
 /// Durable runtime format admitted before layout version two can commit.
@@ -70,15 +80,21 @@ use format_amendment::{
     DestinationFormat, PRE_DERIVATION_FORMAT_SPEC_ID, STORE_FORMAT_SPEC, legacy_store_metadata,
     object_id_hex, persist_format_specification,
 };
+#[cfg(test)]
 use format_amendment::{
-    PRE_DENSE_RADIX_FORMAT_SPEC_ID, STORE_METADATA_FILE, prepare_catalog_specification,
-    prepare_destination, prepare_format_specification, representation_bootstrap_objects,
-    store_metadata,
+    STORE_METADATA_FILE, prepare_catalog_specification, prepare_destination,
+    prepare_format_specification, store_metadata,
 };
 use native_io::atomic_write;
 pub use runtime_tree::RuntimeTreeEntry;
 pub use staging::{
     NativeContentStagingArea, ReadyStagedContent, StagedContentId, StagedContentWriter,
+};
+pub use store_open::open_runtime_principal_store_for_pack;
+pub use store_open::{
+    open_runtime_kv, open_runtime_kv_with_directory, open_runtime_principal_store,
+    open_runtime_principal_store_with_directory, open_runtime_principal_store_with_object_cache,
+    open_runtime_principal_store_with_policy,
 };
 
 /// Explicit owner of one durable state root.
@@ -517,6 +533,16 @@ impl RuntimePrincipalStore {
         runtime_tree::admit(self, runtime_root.as_ref())
     }
 
+    /// Pack running projection changes and retire every durable host sidecar.
+    ///
+    /// # Errors
+    ///
+    /// Returns a storage error if the running projection cannot be admitted,
+    /// flushed, or retired without following a redirect.
+    pub fn pack_and_retire_runtime_projection(&self, home: &AstridHome) -> StorageResult<()> {
+        runtime_tree::pack_and_retire_projection(home, self)
+    }
+
     /// Scan the native runtime tree without reading file payloads.
     ///
     /// The scan uses the exact exclusions and path validation applied by
@@ -653,297 +679,7 @@ impl RuntimePrincipalStore {
     }
 }
 
-/// Open every native projection over the authoritative principal store.
-///
-/// KV and named content share one object arena, principal-root CAS, and live
-/// quota resolver. The caller must already hold the kernel singleton lock.
-///
-/// # Errors
-///
-/// Returns a storage error if policy, metadata, migration, verification, or
-/// durable recovery fails.
-pub async fn open_runtime_principal_store(
-    home: &AstridHome,
-    quota: Arc<dyn KvQuotaResolver<StateOwner>>,
-) -> StorageResult<RuntimePrincipalStore> {
-    open_runtime_principal_store_with_options(
-        home,
-        quota,
-        PrincipalDirectory::default(),
-        DurableEnginePolicy::default(),
-    )
-    .await
-}
-
-/// Open every native projection with an externally shared principal
-/// directory.
-///
-/// Native kernel composition uses this form so namespace resolution,
-/// identity lifecycle, and UID-to-alias quota policy share one mapping.
-///
-/// # Errors
-///
-/// Returns a storage error if policy, metadata, migration, verification, or
-/// durable recovery fails.
-pub async fn open_runtime_principal_store_with_directory(
-    home: &AstridHome,
-    quota: Arc<dyn KvQuotaResolver<StateOwner>>,
-    principals: PrincipalDirectory,
-) -> StorageResult<RuntimePrincipalStore> {
-    open_runtime_principal_store_with_options(
-        home,
-        quota,
-        principals,
-        DurableEnginePolicy::default(),
-    )
-    .await
-}
-
-/// Open every native projection with an explicitly governed decoded-object
-/// cache.
-///
-/// The injected policy owns total and per-principal resident budgets. Cache
-/// misses, disabled policy, and eviction always fall back to verified arena
-/// reads.
-///
-/// # Errors
-///
-/// Returns the same errors as [`open_runtime_principal_store`].
-pub async fn open_runtime_principal_store_with_object_cache(
-    home: &AstridHome,
-    quota: Arc<dyn KvQuotaResolver<StateOwner>>,
-    object_cache: ObjectCacheConfig<StateOwner>,
-) -> StorageResult<RuntimePrincipalStore> {
-    open_runtime_principal_store_with_options(
-        home,
-        quota,
-        PrincipalDirectory::default(),
-        DurableEnginePolicy::new(
-            GroupCommitPolicy::default(),
-            RecoveryRetryPolicy::default(),
-            object_cache,
-        ),
-    )
-    .await
-}
-
-/// Open every native projection with one complete operator-owned engine policy.
-///
-/// The policy controls durability batching, bounded in-process recovery, and
-/// disposable decoded-object memory. It does not alter the persistent format
-/// or principal quota semantics.
-///
-/// # Errors
-///
-/// Returns the same errors as [`open_runtime_principal_store`].
-pub async fn open_runtime_principal_store_with_policy(
-    home: &AstridHome,
-    quota: Arc<dyn KvQuotaResolver<StateOwner>>,
-    principals: PrincipalDirectory,
-    policy: DurableEnginePolicy<StateOwner>,
-) -> StorageResult<RuntimePrincipalStore> {
-    open_runtime_principal_store_with_options(home, quota, principals, policy).await
-}
-
-async fn open_runtime_principal_store_with_options(
-    home: &AstridHome,
-    quota: Arc<dyn KvQuotaResolver<StateOwner>>,
-    principals: PrincipalDirectory,
-    policy: DurableEnginePolicy<StateOwner>,
-) -> StorageResult<RuntimePrincipalStore> {
-    if volume_migration::existing_volume_available(home)? {
-        let (engine, receipt) =
-            volume_migration::open_existing(home, policy)?.ok_or_else(|| {
-                StorageError::Connection("Astrid volume disappeared while opening".to_owned())
-            })?;
-        return assemble_runtime_store(home, quota, principals, Arc::new(engine), receipt).await;
-    }
-    let store_path = home.principal_store_path();
-    let open_path = store_path.clone();
-    let format_spec = bootstrap::format_specification()?;
-    let format_spec_id = Blake3ObjectIdentityV1.identify(&format_spec);
-    let catalog_spec = bootstrap::content_catalog_format_specification()?;
-    let catalog_spec_id = Blake3ObjectIdentityV1.identify(&catalog_spec);
-    let metadata = store_metadata(format_spec_id, catalog_spec_id);
-    owner_migration::apply_if_required(home, &principals, &format_spec, &catalog_spec, &metadata)
-        .await?;
-    let metadata_for_open = metadata.clone();
-    let opened = tokio::task::spawn_blocking(move || {
-        let destination_format =
-            prepare_destination(&open_path, &metadata_for_open, catalog_spec_id)?;
-        let metadata_current = destination_format.metadata_is_current();
-        let engine = RuntimeEngine::open_with_policy(
-            &open_path,
-            Blake3ObjectIdentityV1,
-            StateOwnerCodecV2,
-            RecoveryLimits::process_addressable(),
-            DurableEnginePolicy::default(),
-        )
-        .map_err(|error| {
-            StorageError::Connection(format!("open durable principal store: {error}"))
-        })?;
-        prepare_format_specification(&engine, destination_format, &format_spec, format_spec_id)?;
-        prepare_catalog_specification(&engine, destination_format, &catalog_spec, catalog_spec_id)?;
-        let bootstrap_objects = representation_bootstrap_objects(format_spec_id, catalog_spec_id);
-        engine
-            .ensure_direct_representation_catalogue_compatible_with(
-                format_spec_id,
-                &[PRE_DENSE_RADIX_FORMAT_SPEC_ID],
-                &bootstrap_objects,
-            )
-            .map_err(|error| {
-                StorageError::Connection(format!(
-                    "activate direct representation catalogue: {error}"
-                ))
-            })?;
-        Ok((engine, metadata_current))
-    })
-    .await
-    .map_err(|error| {
-        StorageError::Connection(format!(
-            "durable principal-store open worker failed: {error}"
-        ))
-    })??;
-    let (engine, metadata_current) = opened;
-    let engine = Arc::new(engine);
-    let validated_catalogs = Arc::new(Mutex::new(BTreeMap::<StateOwner, CatalogValidation>::new()));
-
-    migrations::apply_required(home, &store_path, &engine, &validated_catalogs, &principals)
-        .await?;
-    if !metadata_current {
-        let metadata_path = store_path.join(STORE_METADATA_FILE);
-        tokio::task::spawn_blocking(move || atomic_write(&metadata_path, &metadata))
-            .await
-            .map_err(|error| {
-                StorageError::Connection(format!(
-                    "principal-store metadata migration worker failed: {error}"
-                ))
-            })??;
-    }
-
-    let (engine, receipt) = volume_migration::migrate_directory_store(home, engine, policy)?;
-    assemble_runtime_store(home, quota, principals, Arc::new(engine), receipt).await
-}
-
-async fn assemble_runtime_store(
-    home: &AstridHome,
-    quota: Arc<dyn KvQuotaResolver<StateOwner>>,
-    principals: PrincipalDirectory,
-    engine: Arc<RuntimeEngine>,
-    directory_cutover_receipt: String,
-) -> StorageResult<RuntimePrincipalStore> {
-    let format_spec = bootstrap::format_specification()?;
-    let format_spec_id = engine.identify(&format_spec);
-    let catalog_spec = bootstrap::content_catalog_format_specification()?;
-    let catalog_spec_id = engine.identify(&catalog_spec);
-    let bootstrap_objects = representation_bootstrap_objects(format_spec_id, catalog_spec_id);
-    let catalogue_engine = Arc::clone(&engine);
-    tokio::task::spawn_blocking(move || {
-        catalogue_engine.ensure_direct_representation_catalogue_compatible_with(
-            format_spec_id,
-            &[PRE_DENSE_RADIX_FORMAT_SPEC_ID],
-            &bootstrap_objects,
-        )
-    })
-    .await
-    .map_err(|error| {
-        StorageError::Connection(format!(
-            "volume representation-catalogue worker failed: {error}"
-        ))
-    })?
-    .map_err(|error| {
-        StorageError::Connection(format!("activate volume representation catalogue: {error}"))
-    })?;
-    let validated_catalogs = Arc::new(Mutex::new(BTreeMap::<StateOwner, CatalogValidation>::new()));
-    let validated_kv = Arc::new(crate::kv::KvValidationCache::default());
-
-    let runtime_kv = Arc::new(
-        RuntimeStore::from_engine_with_quota_and_content_validation(
-            Arc::clone(&engine),
-            StateOwnerResolver::new(principals.clone()),
-            Arc::clone(&quota),
-            Arc::clone(&validated_kv),
-            Arc::clone(&validated_catalogs),
-        )
-        .with_read_cache(KvReadCacheConfig::bounded(
-            NonZeroUsize::new(256 * 1024 * 1024).expect("256 MiB"),
-            NonZeroUsize::new(64 * 1024 * 1024).expect("64 MiB"),
-            NonZeroUsize::new(4_096).expect("owner limit"),
-            NonZeroUsize::new(65_536).expect("entries per owner"),
-        )),
-    );
-    let kv: Arc<dyn KvStore> = runtime_kv.clone();
-    KvIdentityStore::with_principal_directory(
-        ScopedKvStore::new(Arc::clone(&kv), "system:identity")?,
-        principals.clone(),
-    )
-    .load_principal_directory()
-    .await
-    .map_err(|error| {
-        StorageError::Connection(format!(
-            "load principal identities before serving durable namespaces: {error}"
-        ))
-    })?;
-    let content = Arc::new(
-        NativePrincipalContentStore::from_engine_with_quota_and_validation(
-            Arc::clone(&engine),
-            quota,
-            validated_catalogs,
-            validated_kv,
-        ),
-    );
-    let staging = Arc::new(NativeContentStagingArea::open(home.content_staging_path())?);
-    Ok(RuntimePrincipalStore {
-        engine,
-        directory_cutover_receipt: Arc::from(directory_cutover_receipt),
-        runtime_kv,
-        kv,
-        content,
-        staging,
-        principals,
-    })
-}
-
-/// Open the native kernel's authoritative KV store.
-///
-/// The caller must already hold the kernel singleton lock. On first cutover,
-/// legacy state is imported and independently verified before the completion
-/// marker is made durable. A partial prior destination is quarantined rather
-/// than trusted or deleted.
-///
-/// # Errors
-///
-/// Returns a storage error if policy, metadata, migration, verification, or
-/// durable recovery fails.
-pub async fn open_runtime_kv(
-    home: &AstridHome,
-    quota: Arc<dyn KvQuotaResolver<StateOwner>>,
-) -> StorageResult<Arc<dyn KvStore>> {
-    open_runtime_principal_store(home, quota)
-        .await
-        .map(|store| store.kv())
-}
-
-/// Open the native kernel KV projection with an externally shared principal
-/// directory.
-///
-/// # Errors
-///
-/// Returns a storage error if policy, metadata, migration, verification, or
-/// durable recovery fails.
-pub async fn open_runtime_kv_with_directory(
-    home: &AstridHome,
-    quota: Arc<dyn KvQuotaResolver<StateOwner>>,
-    principals: PrincipalDirectory,
-) -> StorageResult<Arc<dyn KvStore>> {
-    open_runtime_principal_store_with_directory(home, quota, principals)
-        .await
-        .map(|store| store.kv())
-}
-
 #[cfg(test)]
 mod purge_tests;
-#[cfg(test)]
-mod runtime_tests;
 #[cfg(test)]
 mod volume_migration_tests;

--- a/crates/astrid-storage/src/principal_state.rs
+++ b/crates/astrid-storage/src/principal_state.rs
@@ -7,7 +7,8 @@
 //! that verification succeeds, records a content-bound receipt, and then
 //! removes the retired source.
 
-use std::sync::Arc;
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::sync::{Arc, OnceLock};
 
 pub use crate::PrincipalDirectory;
 use crate::capsule_registry::CapsuleRegistry;
@@ -364,6 +365,71 @@ type RuntimeEngine = DurableEngine<StateOwner, Blake3ObjectIdentityV1, StateOwne
 type RuntimeStore =
     TreeKvStore<StateOwner, Blake3ObjectIdentityV1, StateOwnerResolver, RuntimeEngine>;
 
+pub(super) fn rebind_staging_generation(path: &std::path::Path) -> StorageResult<()> {
+    let mut file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(path)
+        .map_err(|error| StorageError::Connection(format!("open staged generation: {error}")))?;
+    let identity = native_io::private_file_identity(&file)?;
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes).map_err(|error| {
+        StorageError::Connection(format!(
+            "read staged generation {}: {error}",
+            path.display()
+        ))
+    })?;
+    if bytes.len() < 80 {
+        return Err(StorageError::Connection(format!(
+            "staged generation footer is truncated: {}",
+            path.display()
+        )));
+    }
+    let trailer_offset = bytes
+        .len()
+        .checked_sub(32)
+        .ok_or_else(|| StorageError::Connection("staged footer trailer is truncated".to_owned()))?;
+    let length_offset = bytes
+        .len()
+        .checked_sub(8)
+        .ok_or_else(|| StorageError::Connection("staged footer length is truncated".to_owned()))?;
+    let payload_len = usize::try_from(u64::from_le_bytes(
+        bytes[length_offset..]
+            .try_into()
+            .map_err(|_| StorageError::Connection("staged footer length is invalid".to_owned()))?,
+    ))
+    .map_err(|_| StorageError::Connection("staged footer length is not addressable".to_owned()))?;
+    let payload_offset = trailer_offset
+        .checked_sub(payload_len)
+        .ok_or_else(|| StorageError::Connection("staged footer length exceeds file".to_owned()))?;
+    if payload_len < 48 {
+        return Err(StorageError::Connection(
+            "staged footer binding is truncated".to_owned(),
+        ));
+    }
+    let identity_offset = trailer_offset.checked_sub(48).ok_or_else(|| {
+        StorageError::Connection("staged footer identity is truncated".to_owned())
+    })?;
+    let (volume, file_number) = identity.raw_parts();
+    let mut source_identity = [0_u8; 16];
+    source_identity[..8].copy_from_slice(&volume.to_le_bytes());
+    source_identity[8..].copy_from_slice(&file_number.to_le_bytes());
+    let mut hasher = blake3::Hasher::new_derive_key("astrid staged source binding v1");
+    hasher.update(&bytes[payload_offset..identity_offset]);
+    hasher.update(&source_identity);
+    let binding = hasher.finalize();
+    file.seek(SeekFrom::Start(identity_offset as u64))
+        .and_then(|_| file.write_all(&source_identity))
+        .and_then(|()| file.write_all(binding.as_bytes()))
+        .and_then(|()| file.sync_all())
+        .map_err(|error| {
+            StorageError::Connection(format!(
+                "rebind staged generation {}: {error}",
+                path.display()
+            ))
+        })
+}
+
 /// Native named-content projection sharing the authoritative principal arena.
 pub type NativePrincipalContentStore = PrincipalContentStore<
     StateOwner,
@@ -378,7 +444,7 @@ pub struct RuntimePrincipalStore {
     runtime_kv: Arc<RuntimeStore>,
     kv: Arc<dyn KvStore>,
     content: Arc<NativePrincipalContentStore>,
-    staging: Arc<NativeContentStagingArea>,
+    staging: Arc<OnceLock<Arc<NativeContentStagingArea>>>,
     principals: PrincipalDirectory,
 }
 
@@ -604,7 +670,15 @@ impl RuntimePrincipalStore {
     /// Clone the private native content-staging area.
     #[must_use]
     pub fn staging(&self) -> Arc<NativeContentStagingArea> {
-        Arc::clone(&self.staging)
+        self.staging_area()
+    }
+
+    fn staging_area(&self) -> Arc<NativeContentStagingArea> {
+        Arc::clone(
+            self.staging
+                .get()
+                .expect("runtime store staging area initialized before serving"),
+        )
     }
 
     /// Return file roots held by currently open immutable content handles.
@@ -689,7 +763,7 @@ impl RuntimePrincipalStore {
         &self,
         staged: ReadyStagedContent,
     ) -> StorageResult<ContentWriteOutcome> {
-        self.staging
+        self.staging_area()
             .publish(staged, Arc::clone(&self.content))
             .await
     }
@@ -704,7 +778,7 @@ impl RuntimePrincipalStore {
         &self,
         staged: Vec<ReadyStagedContent>,
     ) -> StorageResult<ContentBatchWriteOutcome> {
-        self.staging
+        self.staging_area()
             .publish_batch(staged, Arc::clone(&self.content))
             .await
     }

--- a/crates/astrid-storage/src/principal_state/compaction_tests.rs
+++ b/crates/astrid-storage/src/principal_state/compaction_tests.rs
@@ -42,6 +42,15 @@ fn unlimited_quota() -> Arc<dyn KvQuotaResolver<StateOwner>> {
     })
 }
 
+fn seed_legacy_layout(home: &AstridHome) {
+    std::fs::create_dir_all(home.etc_dir()).unwrap();
+    std::fs::write(
+        home.layout_version_path(),
+        astrid_core::dirs::LEGACY_LAYOUT_VERSION,
+    )
+    .unwrap();
+}
+
 async fn create_alice(store: &RuntimePrincipalStore) -> PrincipalUid {
     let identities = KvIdentityStore::with_principal_directory(
         ScopedKvStore::new(store.kv(), "system:identity").unwrap(),
@@ -75,6 +84,7 @@ fn evidence(bytes: &[u8]) -> ObjectRecord {
 async fn production_retention_preserves_bootstraps_during_compaction() {
     let directory = tempfile::tempdir().unwrap();
     let home = AstridHome::from_path(directory.path());
+    seed_legacy_layout(&home);
     let store = open_runtime_principal_store(&home, unlimited_quota())
         .await
         .unwrap();
@@ -156,7 +166,6 @@ async fn production_retention_preserves_bootstraps_during_compaction() {
     reopened.engine.close().unwrap();
     drop(reopened);
     assert!(home.storage_volume_path().is_file());
-    assert!(home.principal_store_path().is_dir());
 }
 
 #[tokio::test]

--- a/crates/astrid-storage/src/principal_state/content_staging_tests.rs
+++ b/crates/astrid-storage/src/principal_state/content_staging_tests.rs
@@ -1,0 +1,435 @@
+use super::runtime_tests::*;
+use super::store_open_volume_tests::install_legacy_catalog_fixtures;
+use super::*;
+
+#[derive(Debug)]
+struct CatalogWorkloadMetrics {
+    arena_bytes: u64,
+    root_journal_bytes: u64,
+    representation_metadata_bytes: u64,
+    publication_time: Duration,
+    reopen_time: Duration,
+}
+
+fn durable_file_len(store: &RuntimePrincipalStore, name: &str) -> u64 {
+    store.engine.durable_region_len(name).unwrap()
+}
+
+pub(super) fn volume_file_len(home: &AstridHome) -> u64 {
+    std::fs::metadata(home.storage_volume_path()).unwrap().len()
+}
+
+async fn measure_catalog_publications(unique_content: bool) -> CatalogWorkloadMetrics {
+    const PUBLICATIONS: u64 = 1_000;
+    const CONTENT_BYTES: usize = 4 * 1024;
+
+    let directory = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(directory.path());
+    let owner = test_owner("catalog-probe");
+    let store = open_runtime_principal_store_with_directory(
+        &home,
+        unlimited_quota(),
+        test_directory(&["catalog-probe"]),
+    )
+    .await
+    .unwrap();
+    let arena_before = durable_file_len(&store, "objects.arena");
+    let roots_before = durable_file_len(&store, "roots.journal");
+    let volume_before = volume_file_len(&home);
+    let started = Instant::now();
+    for index in 0..PUBLICATIONS {
+        let name = ContentName::new(format!("workspace/fixture/{index:04}")).unwrap();
+        let mut bytes = vec![7_u8; CONTENT_BYTES];
+        if unique_content {
+            bytes[..8].copy_from_slice(&index.to_le_bytes());
+        }
+        store.content().put(&owner, &name, &bytes).unwrap();
+    }
+    let publication_time = started.elapsed();
+    let arena_bytes = durable_file_len(&store, "objects.arena")
+        .checked_sub(arena_before)
+        .unwrap();
+    let root_journal_bytes = durable_file_len(&store, "roots.journal")
+        .checked_sub(roots_before)
+        .unwrap();
+    let representation_metadata_bytes = volume_file_len(&home).checked_sub(volume_before).unwrap();
+    drop(store);
+
+    let reopen_started = Instant::now();
+    let reopened = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    let reopen_time = reopen_started.elapsed();
+    assert_eq!(
+        reopened.content().list(&owner).unwrap().len(),
+        usize::try_from(PUBLICATIONS).unwrap()
+    );
+    drop(reopened);
+
+    CatalogWorkloadMetrics {
+        arena_bytes,
+        root_journal_bytes,
+        representation_metadata_bytes,
+        publication_time,
+        reopen_time,
+    }
+}
+
+#[tokio::test]
+async fn thousand_deduplicated_four_kib_publications_bound_durable_arena_growth() {
+    const PUBLICATIONS: u64 = 1_000;
+    const MAX_ARENA_BYTES_PER_PUBLICATION: u64 = 16 * 1024;
+
+    let metrics = measure_catalog_publications(false).await;
+    assert!(
+        metrics.arena_bytes
+            < PUBLICATIONS
+                .checked_mul(MAX_ARENA_BYTES_PER_PUBLICATION)
+                .unwrap(),
+        "deduplicated publications appended unexpected arena bytes: {metrics:?}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "explicit durable catalog amplification and reopen probe"]
+async fn catalog_durable_performance_probe() {
+    let duplicate = measure_catalog_publications(false).await;
+    let unique = measure_catalog_publications(true).await;
+    for (name, metrics) in [("duplicate", duplicate), ("unique", unique)] {
+        eprintln!(
+            "{name}: arena={} roots={} representations={} publication={:?} reopen={:?}",
+            metrics.arena_bytes,
+            metrics.root_journal_bytes,
+            metrics.representation_metadata_bytes,
+            metrics.publication_time,
+            metrics.reopen_time
+        );
+    }
+}
+
+#[tokio::test]
+async fn flat_content_catalog_migration_resumes_and_is_idempotent() {
+    let directory = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(directory.path());
+    seed_legacy_layout(&home);
+    let alice = test_owner("alice");
+    let bob = test_owner("bob");
+    let alice_name = ContentName::new("workspace/alice-legacy.bin").unwrap();
+    let bob_name = ContentName::new("workspace/bob-legacy.bin").unwrap();
+    let alice_bytes = b"alice content survives the catalog migration";
+    let bob_bytes = b"bob content survives the catalog migration";
+    let legacy_roots = install_legacy_catalog_fixtures(
+        &home,
+        &[
+            (&alice, &alice_name, alice_bytes),
+            (&bob, &bob_name, bob_bytes),
+        ],
+    );
+
+    let engine = Arc::new(
+        RuntimeEngine::open(
+            home.principal_store_path(),
+            Blake3ObjectIdentityV1,
+            StateOwnerCodecV2,
+            RecoveryLimits::process_addressable(),
+        )
+        .unwrap(),
+    );
+    let content = NativePrincipalContentStore::from_engine(Arc::clone(&engine));
+    assert!(content.migrate_legacy_catalog(&alice).unwrap());
+    let partially_migrated_alice_root = engine.root(&alice).unwrap().unwrap();
+    assert_eq!(engine.root(&bob).unwrap(), legacy_roots.get(&bob).copied());
+    drop(content);
+    engine.close().unwrap();
+    drop(engine);
+
+    let migrated = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    assert_eq!(
+        migrated.content().read(&alice, &alice_name).unwrap(),
+        Some(alice_bytes.to_vec())
+    );
+    assert_eq!(
+        migrated.content().read(&bob, &bob_name).unwrap(),
+        Some(bob_bytes.to_vec())
+    );
+    let migrated_alice_root = migrated.engine.root(&alice).unwrap().unwrap();
+    let migrated_bob_root = migrated.engine.root(&bob).unwrap().unwrap();
+    assert_eq!(migrated_alice_root, partially_migrated_alice_root);
+    assert_eq!(
+        migrated_bob_root.generation,
+        legacy_roots
+            .get(&bob)
+            .unwrap()
+            .generation
+            .checked_next()
+            .unwrap()
+    );
+    migrated.engine.close().unwrap();
+    drop(migrated);
+    let retired = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    retired
+        .retire_verified_legacy_directory_store(&home)
+        .unwrap();
+    retired.engine.close().unwrap();
+    drop(retired);
+    assert!(home.storage_volume_path().is_file());
+    assert!(!home.principal_store_path().exists());
+
+    let reopened = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    assert_eq!(
+        reopened.content().read(&alice, &alice_name).unwrap(),
+        Some(alice_bytes.to_vec())
+    );
+    assert_eq!(
+        reopened.content().read(&bob, &bob_name).unwrap(),
+        Some(bob_bytes.to_vec())
+    );
+    assert_eq!(
+        reopened.engine.root(&alice).unwrap(),
+        Some(migrated_alice_root)
+    );
+    assert_eq!(reopened.engine.root(&bob).unwrap(), Some(migrated_bob_root));
+}
+
+#[tokio::test]
+async fn native_stage_acknowledges_before_ingest_and_publishes_on_a_blocking_worker() {
+    let directory = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(directory.path());
+    let store = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    let owner = test_owner("alice");
+    let name = ContentName::new("workspace/target/release/game").unwrap();
+    let mut writer = store
+        .staging()
+        .begin(owner, name.clone(), ChunkingProfile::ASTRID_V1)
+        .unwrap();
+    writer.write_all(b"linux build.......").unwrap();
+    writer.seek(SeekFrom::Start(12)).unwrap();
+    writer.write_all(b"artifact").unwrap();
+    writer.set_len(20).unwrap();
+    let staged = writer.seal().unwrap();
+
+    assert_eq!(staged.logical_bytes(), 20);
+    assert_eq!(store.content().describe(&owner, &name).unwrap(), None);
+    assert_eq!(store.staging().ready().unwrap(), vec![staged.clone()]);
+
+    let outcome = store.publish_staged(staged).await.unwrap();
+    assert_eq!(outcome.descriptor().logical_bytes(), 20);
+    assert_eq!(
+        store.content().read(&owner, &name).unwrap(),
+        Some(b"linux build.artifact".to_vec())
+    );
+    let snapshot = store.content().engine().snapshot(&owner).unwrap().unwrap();
+    assert!(
+        snapshot
+            .records()
+            .iter()
+            .any(|(_, record)| record.kind() == ObjectKind::Chunk),
+        "archival snapshots must materialize canonical chunk records"
+    );
+    assert!(store.staging().ready().unwrap().is_empty());
+    drop(store);
+
+    let reopened = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    assert_eq!(
+        reopened.content().read(&owner, &name).unwrap(),
+        Some(b"linux build.artifact".to_vec())
+    );
+}
+
+#[tokio::test]
+async fn native_staging_batch_publishes_one_atomic_root_and_reaps_together() {
+    let directory = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(directory.path());
+    let store = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    let owner = test_owner("alice");
+    let values = [
+        ("workspace/a.txt", b"alpha".as_slice()),
+        ("workspace/b.txt", b"bravo".as_slice()),
+        ("workspace/c.txt", b"charlie".as_slice()),
+    ];
+    let mut staged = Vec::new();
+    for (name, value) in values {
+        let mut writer = store
+            .staging()
+            .begin(
+                owner,
+                ContentName::new(name).unwrap(),
+                ChunkingProfile::ASTRID_V1,
+            )
+            .unwrap();
+        writer.write_all(value).unwrap();
+        staged.push(writer.seal().unwrap());
+    }
+
+    let outcome = store.publish_staged_batch(staged).await.unwrap();
+
+    assert_eq!(outcome.principal_root().generation, RootGeneration::INITIAL);
+    assert_eq!(outcome.entries().len(), values.len());
+    assert!(store.staging().ready().unwrap().is_empty());
+    for (name, value) in values {
+        assert_eq!(
+            store
+                .content()
+                .read(&owner, &ContentName::new(name).unwrap())
+                .unwrap(),
+            Some(value.to_vec())
+        );
+    }
+    drop(store);
+
+    let reopened = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    for (name, value) in values {
+        assert_eq!(
+            reopened
+                .content()
+                .read(&owner, &ContentName::new(name).unwrap())
+                .unwrap(),
+            Some(value.to_vec())
+        );
+    }
+}
+
+#[tokio::test]
+async fn native_staging_batch_rejects_mixed_owners_without_consuming_generations() {
+    let directory = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(directory.path());
+    let store = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    let mut staged = Vec::new();
+    for owner in [test_owner("alice"), test_owner("bob")] {
+        let mut writer = store
+            .staging()
+            .begin(
+                owner,
+                ContentName::new("workspace/shared.txt").unwrap(),
+                ChunkingProfile::ASTRID_V1,
+            )
+            .unwrap();
+        writer.write_all(b"owner-specific bytes").unwrap();
+        staged.push(writer.seal().unwrap());
+    }
+
+    let error = store
+        .publish_staged_batch(staged.clone())
+        .await
+        .unwrap_err();
+
+    assert!(error.to_string().contains("multiple owners"));
+    assert_eq!(store.staging().ready().unwrap(), staged);
+}
+
+#[tokio::test]
+async fn staged_publication_rejects_a_generation_truncated_after_seal() {
+    let directory = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(directory.path());
+    let store = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    let owner = test_owner("alice");
+    let name = ContentName::new("workspace/truncated.bin").unwrap();
+    let mut writer = store
+        .staging()
+        .begin(owner, name.clone(), ChunkingProfile::ASTRID_V1)
+        .unwrap();
+    writer.write_all(b"durable staged bytes").unwrap();
+    let staged = writer.seal().unwrap();
+    let path = staged.content_path();
+
+    std::fs::OpenOptions::new()
+        .write(true)
+        .open(&path)
+        .unwrap()
+        .set_len(staged.logical_bytes().saturating_sub(1))
+        .unwrap();
+
+    let error = store.publish_staged(staged).await.unwrap_err();
+    assert!(error.to_string().contains("footer"));
+    assert_eq!(store.content().describe(&owner, &name).unwrap(), None);
+    assert!(
+        path.exists(),
+        "failed publication must retain staged evidence"
+    );
+}
+
+#[tokio::test]
+async fn staged_publication_retries_after_root_commit_before_cleanup() {
+    let directory = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(directory.path());
+    let store = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    let owner = test_owner("alice");
+    let name = ContentName::new("workspace/retry.bin").unwrap();
+    let mut writer = store
+        .staging()
+        .begin(owner, name.clone(), ChunkingProfile::ASTRID_V1)
+        .unwrap();
+    writer.write_all(b"one identity").unwrap();
+    let staged = writer.seal().unwrap();
+
+    let source = native_io::open_private_file(&staged.content_path())
+        .unwrap()
+        .take(staged.logical_bytes());
+    let first = store
+        .content()
+        .put_streaming(&owner, &name, source)
+        .unwrap();
+    assert_eq!(store.staging().ready().unwrap(), vec![staged.clone()]);
+
+    let retried = store.publish_staged(staged).await.unwrap();
+    assert_eq!(retried.descriptor(), first.descriptor());
+    assert_eq!(retried.principal_root(), first.principal_root());
+    assert_eq!(
+        retried.objects_inserted(),
+        0,
+        "retry must not count immutable objects admitted by the first publication"
+    );
+    assert!(store.staging().ready().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn staged_publication_enforces_close_order_for_the_same_name() {
+    let directory = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(directory.path());
+    let store = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    let owner = test_owner("alice");
+    let name = ContentName::new("workspace/order.txt").unwrap();
+    let mut first = store
+        .staging()
+        .begin(owner, name.clone(), ChunkingProfile::ASTRID_V1)
+        .unwrap();
+    first.write_all(b"first close").unwrap();
+    let first = first.seal().unwrap();
+    let mut second = store
+        .staging()
+        .begin(owner, name.clone(), ChunkingProfile::ASTRID_V1)
+        .unwrap();
+    second.write_all(b"second close").unwrap();
+    let second = second.seal().unwrap();
+
+    let error = store.publish_staged(second.clone()).await.unwrap_err();
+    assert!(error.to_string().contains("earlier close"));
+    store.publish_staged(first).await.unwrap();
+    store.publish_staged(second).await.unwrap();
+    assert_eq!(
+        store.content().read(&owner, &name).unwrap(),
+        Some(b"second close".to_vec())
+    );
+}

--- a/crates/astrid-storage/src/principal_state/content_staging_tests.rs
+++ b/crates/astrid-storage/src/principal_state/content_staging_tests.rs
@@ -1,3 +1,5 @@
+use std::io::{Seek as _, SeekFrom, Write as _};
+
 use super::runtime_tests::*;
 use super::store_open_volume_tests::install_legacy_catalog_fixtures;
 use super::*;

--- a/crates/astrid-storage/src/principal_state/contiguous_ingest.rs
+++ b/crates/astrid-storage/src/principal_state/contiguous_ingest.rs
@@ -3,8 +3,9 @@
 //! Files use the same canonical streaming arena path as capsule content.
 
 use std::fs::File;
+use std::io::Cursor;
 
-use crate::content::{ContentIngest, ContentName};
+use crate::content::{ChunkingProfile, ContentIngest, ContentName};
 use crate::error::{StorageError, StorageResult};
 
 use super::{RuntimePrincipalStore, StateOwner};
@@ -25,6 +26,18 @@ impl ContiguousFileIngest {
             path: path.into(),
             logical_bytes,
         }
+    }
+}
+
+/// Internal packed publication input accepted by the mixed atomic seam.
+pub(crate) enum PackedProjectionIngest {
+    File(ContiguousFileIngest),
+    Bytes { name: ContentName, bytes: Vec<u8> },
+}
+
+impl PackedProjectionIngest {
+    pub(crate) fn bytes(name: ContentName, bytes: Vec<u8>) -> Self {
+        Self::Bytes { name, bytes }
     }
 }
 
@@ -69,13 +82,25 @@ impl RuntimePrincipalStore {
     pub(crate) fn replace_contiguous_files_removing_exact(
         &self,
         owner: StateOwner,
-        files: impl IntoIterator<Item = ContiguousFileIngest>,
+        files: impl IntoIterator<Item = PackedProjectionIngest>,
         removals: &[ContentName],
     ) -> StorageResult<()> {
         let mut ingests = Vec::new();
         for file in files {
-            let source = open_home_source(&file)?;
-            ingests.push(ContentIngest::new(file.name, source));
+            let (name, source): (_, Box<dyn std::io::Read + Send>) = match file {
+                PackedProjectionIngest::File(file) => {
+                    let source = open_home_source(&file)?;
+                    (file.name, Box::new(source))
+                },
+                PackedProjectionIngest::Bytes { name, bytes } => {
+                    (name, Box::new(Cursor::new(bytes)))
+                },
+            };
+            ingests.push(ContentIngest::with_profile(
+                name,
+                source,
+                ChunkingProfile::ASTRID_V1,
+            ));
         }
         if ingests.is_empty() {
             return if removals.is_empty() {

--- a/crates/astrid-storage/src/principal_state/contiguous_ingest.rs
+++ b/crates/astrid-storage/src/principal_state/contiguous_ingest.rs
@@ -59,6 +59,41 @@ impl RuntimePrincipalStore {
             })?;
         Ok(())
     }
+
+    /// Publish packed files and remove exact obsolete names in one catalog
+    /// owner-root transition.
+    ///
+    /// This is the internal crash-recovery publication seam. Removals must not
+    /// overlap ingests, so the caller states the obsolete projection names
+    /// explicitly instead of deriving a prefix delete.
+    pub(crate) fn replace_contiguous_files_removing_exact(
+        &self,
+        owner: StateOwner,
+        files: impl IntoIterator<Item = ContiguousFileIngest>,
+        removals: &[ContentName],
+    ) -> StorageResult<()> {
+        let mut ingests = Vec::new();
+        for file in files {
+            let source = open_home_source(&file)?;
+            ingests.push(ContentIngest::new(file.name, source));
+        }
+        if ingests.is_empty() {
+            return if removals.is_empty() {
+                Ok(())
+            } else {
+                self.content
+                    .delete_batch(&owner, removals)
+                    .map(|_| ())
+                    .map_err(|error| {
+                        StorageError::Internal(format!("remove packed home names: {error}"))
+                    })
+            };
+        }
+        self.content
+            .replace_streaming_batch_removing_exact(&owner, ingests, removals)
+            .map(|_| ())
+            .map_err(|error| StorageError::Internal(format!("replace packed home batch: {error}")))
+    }
 }
 
 fn open_home_source(file: &ContiguousFileIngest) -> StorageResult<File> {

--- a/crates/astrid-storage/src/principal_state/contiguous_ingest.rs
+++ b/crates/astrid-storage/src/principal_state/contiguous_ingest.rs
@@ -5,7 +5,7 @@
 use std::fs::File;
 use std::io::Cursor;
 
-use crate::content::{ChunkingProfile, ContentIngest, ContentName};
+use crate::content::{ChunkingProfile, ContentIngest, ContentName, PrepareDerivedBatchContent};
 use crate::error::{StorageError, StorageResult};
 
 use super::{RuntimePrincipalStore, StateOwner};
@@ -79,11 +79,12 @@ impl RuntimePrincipalStore {
     /// This is the internal crash-recovery publication seam. Removals must not
     /// overlap ingests, so the caller states the obsolete projection names
     /// explicitly instead of deriving a prefix delete.
-    pub(crate) fn replace_contiguous_files_removing_exact(
+    pub(crate) fn replace_contiguous_files_removing_exact<'a>(
         &self,
         owner: StateOwner,
         files: impl IntoIterator<Item = PackedProjectionIngest>,
-        removals: &[ContentName],
+        removals: &'a [ContentName],
+        derived: Option<&'a mut dyn PrepareDerivedBatchContent>,
     ) -> StorageResult<()> {
         let mut ingests = Vec::new();
         for file in files {
@@ -115,7 +116,7 @@ impl RuntimePrincipalStore {
             };
         }
         self.content
-            .replace_streaming_batch_removing_exact(&owner, ingests, removals)
+            .replace_streaming_batch_removing_exact(&owner, ingests, removals, derived)
             .map(|_| ())
             .map_err(|error| StorageError::Internal(format!("replace packed home batch: {error}")))
     }

--- a/crates/astrid-storage/src/principal_state/format_identity_tests.rs
+++ b/crates/astrid-storage/src/principal_state/format_identity_tests.rs
@@ -1,0 +1,254 @@
+use super::runtime_tests::*;
+use super::*;
+use super::{
+    DestinationFormat, PRE_DERIVATION_FORMAT_SPEC_ID, STORE_FORMAT_SPEC, STORE_METADATA_FILE,
+    atomic_write, bootstrap, legacy_store_metadata, object_id_hex, persist_format_specification,
+    prepare_catalog_specification, prepare_destination, prepare_format_specification,
+    store_metadata,
+};
+use crate::storage_model::{
+    ObjectFormatVersion, ObjectKind, ProfileKind, ReconstructionBounds, RepresentationProfile,
+};
+
+#[test]
+fn owner_codec_round_trips_only_canonical_values() {
+    let codec = StateOwnerCodecV2;
+    let owners = [
+        StateOwner::System,
+        test_owner("alice"),
+        StateOwner::Fleet(astrid_core::FleetUid::from_bytes([7; 32])),
+    ];
+    for owner in owners {
+        let encoded = codec.encode(&owner);
+        assert_eq!(codec.decode(&encoded), Some(owner));
+    }
+    assert_eq!(codec.decode(&[]), None);
+    assert_eq!(codec.decode(&[0, 0]), None);
+    assert_eq!(codec.decode(&[1]), None);
+    assert_eq!(codec.decode(&[1, b':']), None);
+}
+
+#[test]
+fn object_identity_v1_has_a_stable_golden_vector() {
+    let record = ObjectRecord::new(
+        ObjectKind::KvLeaf,
+        ObjectFormatVersion::V1,
+        b"hello".to_vec(),
+        Vec::new(),
+        0,
+        ObjectClass::Data,
+    )
+    .unwrap();
+    assert_eq!(
+        Blake3ObjectIdentityV1.identify(&record).as_bytes(),
+        &[
+            14, 77, 237, 193, 155, 81, 194, 119, 35, 35, 59, 81, 40, 49, 0, 31, 232, 131, 137, 111,
+            27, 237, 250, 91, 151, 7, 135, 21, 99, 27, 128, 55,
+        ]
+    );
+}
+
+#[test]
+fn physical_identity_v1_matches_the_runatal_golden_vector() {
+    let profile = RepresentationProfile::new_builtin(
+        ProfileKind::DirectCanonical,
+        ReconstructionBounds::new(
+            8,
+            32,
+            8 * 1024 * 1024,
+            16 * 1024 * 1024,
+            1_000_000,
+            32 * 1024 * 1024,
+            5_000_000,
+        )
+        .unwrap(),
+        ObjectId::new([1; 32]),
+    )
+    .unwrap()
+    .encode()
+    .unwrap();
+    assert_eq!(
+        Blake3PhysicalIdentityV1.identify("astrid-representation-profile-v1\0", &profile),
+        [
+            0x59, 0xc0, 0x99, 0x24, 0xb3, 0xb0, 0x72, 0x12, 0xc4, 0xbc, 0x10, 0x35, 0x35, 0xcf,
+            0xbb, 0xe1, 0x0d, 0xee, 0xe3, 0x1d, 0x1b, 0x15, 0x7d, 0x21, 0x53, 0x8b, 0x17, 0x75,
+            0x95, 0x23, 0x58, 0x04,
+        ]
+    );
+}
+
+#[test]
+fn format_specification_has_a_tagged_metadata_identity() {
+    let record = bootstrap::format_specification().unwrap();
+    let id = Blake3ObjectIdentityV1.identify(&record);
+    let catalog_id = Blake3ObjectIdentityV1
+        .identify(&bootstrap::content_catalog_format_specification().unwrap());
+    let metadata = String::from_utf8(store_metadata(id, catalog_id)).unwrap();
+
+    assert_eq!(record.kind(), ObjectKind::Evidence);
+    assert_eq!(record.canonical_bytes(), STORE_FORMAT_SPEC);
+    assert!(record.references().is_empty());
+    assert_eq!(
+        object_id_hex(id),
+        "ac3e1ab1e82be24dae7cdef949698dd54d2407bc7f39fb30709dc36677eea61d"
+    );
+    assert_eq!(
+        object_id_hex(catalog_id),
+        "8f3999b066b666396259c4a92f9de7c5b8e67df9d38a69fb4fb824968b56ecdb"
+    );
+    assert_eq!(
+        metadata,
+        "format=astrid-principal-store-v1\n\
+         identity=blake3-object-identity-v1\n\
+         identity-wire=tagged-identity-v1\n\
+         format-spec-object=1:1:32:ac3e1ab1e82be24dae7cdef949698dd54d2407bc7f39fb30709dc36677eea61d\n\
+         content-catalog-spec-object=1:1:32:8f3999b066b666396259c4a92f9de7c5b8e67df9d38a69fb4fb824968b56ecdb\n\
+         representations=authoritative-direct-v1\n\
+         principal-codec=state-owner-v2\n\
+         projection=kv-transition-bplus-v4\n"
+    );
+}
+
+#[test]
+fn pre_derivation_v1_runatal_upgrade_is_idempotent_and_preserves_history() {
+    let directory = tempfile::tempdir().unwrap();
+    let store_path = directory.path().join("principal-store");
+    std::fs::create_dir_all(&store_path).unwrap();
+    let engine = RuntimeEngine::open(
+        &store_path,
+        Blake3ObjectIdentityV1,
+        StateOwnerCodecV2,
+        RecoveryLimits::process_addressable(),
+    )
+    .unwrap();
+    let legacy_spec = ObjectRecord::new(
+        ObjectKind::Evidence,
+        ObjectFormatVersion::V1,
+        b"pre-derivation format 1 specification".to_vec(),
+        Vec::new(),
+        0,
+        ObjectClass::Metadata,
+    )
+    .unwrap();
+    let (legacy_spec_id, _) = engine.persist_standalone_object(&legacy_spec).unwrap();
+    let current_spec = bootstrap::format_specification().unwrap();
+    let current_spec_id = Blake3ObjectIdentityV1.identify(&current_spec);
+    let catalog_spec = bootstrap::content_catalog_format_specification().unwrap();
+    let catalog_spec_id = Blake3ObjectIdentityV1.identify(&catalog_spec);
+    let current_metadata = store_metadata(current_spec_id, catalog_spec_id);
+    atomic_write(
+        &store_path.join(STORE_METADATA_FILE),
+        &legacy_store_metadata(legacy_spec_id),
+    )
+    .unwrap();
+
+    // Simulate a crash after the successor RÚNATAL object became durable
+    // but before store.meta changed.
+    persist_format_specification(&engine, &current_spec).unwrap();
+    prepare_format_specification(
+        &engine,
+        DestinationFormat::PriorV1 {
+            format_spec: legacy_spec_id,
+            catalog_spec_was_declared: false,
+        },
+        &current_spec,
+        current_spec_id,
+    )
+    .unwrap();
+    prepare_catalog_specification(
+        &engine,
+        DestinationFormat::PriorV1 {
+            format_spec: legacy_spec_id,
+            catalog_spec_was_declared: false,
+        },
+        &catalog_spec,
+        catalog_spec_id,
+    )
+    .unwrap();
+    atomic_write(&store_path.join(STORE_METADATA_FILE), &current_metadata).unwrap();
+
+    assert_eq!(
+        std::fs::read(store_path.join(STORE_METADATA_FILE)).unwrap(),
+        current_metadata
+    );
+    assert_eq!(engine.object(legacy_spec_id).unwrap(), Some(legacy_spec));
+    assert_eq!(
+        engine.object(current_spec_id).unwrap(),
+        Some(current_spec.clone())
+    );
+    prepare_format_specification(
+        &engine,
+        DestinationFormat::Current,
+        &current_spec,
+        current_spec_id,
+    )
+    .unwrap();
+    prepare_catalog_specification(
+        &engine,
+        DestinationFormat::Current,
+        &catalog_spec,
+        catalog_spec_id,
+    )
+    .unwrap();
+    engine.close().unwrap();
+}
+
+#[test]
+fn prior_metadata_that_declared_a_catalog_specification_requires_it() {
+    let directory = tempfile::tempdir().unwrap();
+    let engine = RuntimeEngine::open(
+        directory.path(),
+        Blake3ObjectIdentityV1,
+        StateOwnerCodecV2,
+        RecoveryLimits::process_addressable(),
+    )
+    .unwrap();
+    let catalog_spec = bootstrap::content_catalog_format_specification().unwrap();
+    let catalog_spec_id = Blake3ObjectIdentityV1.identify(&catalog_spec);
+    let destination = DestinationFormat::PriorV1 {
+        format_spec: PRE_DERIVATION_FORMAT_SPEC_ID,
+        catalog_spec_was_declared: true,
+    };
+
+    let error = prepare_catalog_specification(&engine, destination, &catalog_spec, catalog_spec_id)
+        .unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("completed principal store is missing its content catalog specification"),
+        "{error}"
+    );
+}
+
+#[tokio::test]
+async fn completed_pre_derivation_v1_store_is_selected_for_runatal_amendment() {
+    let directory = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(directory.path());
+    super::format_migration_tests::seed_current_directory_store(&home);
+
+    let store_path = home.principal_store_path();
+    std::fs::write(
+        store_path.join(STORE_METADATA_FILE),
+        legacy_store_metadata(PRE_DERIVATION_FORMAT_SPEC_ID),
+    )
+    .unwrap();
+    let current_spec = bootstrap::format_specification().unwrap();
+    let current_spec_id = Blake3ObjectIdentityV1.identify(&current_spec);
+    let catalog_spec = bootstrap::content_catalog_format_specification().unwrap();
+    let current_metadata = store_metadata(
+        current_spec_id,
+        Blake3ObjectIdentityV1.identify(&catalog_spec),
+    );
+    assert_eq!(
+        prepare_destination(
+            &store_path,
+            &current_metadata,
+            Blake3ObjectIdentityV1.identify(&catalog_spec),
+        )
+        .unwrap(),
+        DestinationFormat::PriorV1 {
+            format_spec: PRE_DERIVATION_FORMAT_SPEC_ID,
+            catalog_spec_was_declared: false,
+        }
+    );
+}

--- a/crates/astrid-storage/src/principal_state/hosted_volume_tests.rs
+++ b/crates/astrid-storage/src/principal_state/hosted_volume_tests.rs
@@ -1,0 +1,207 @@
+use super::runtime_tests::*;
+use super::*;
+
+#[cfg(not(target_os = "windows"))]
+#[tokio::test]
+async fn hosted_volume_retires_a_torn_tail_and_reopens_committed_roots() {
+    let directory = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(directory.path());
+    let store = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    let alice_uid = create_test_principal(&store, "alice").await;
+    store
+        .kv()
+        .set("alice:capsule:shell", "cwd", b"/workspace".to_vec())
+        .await
+        .unwrap();
+    store
+        .kv()
+        .set("alice:capsule:shell", "theme", b"raven".to_vec())
+        .await
+        .unwrap();
+    store.engine.close().unwrap();
+    drop(store);
+
+    let path = home.storage_volume_path();
+    let committed_len = std::fs::metadata(&path).unwrap().len();
+    let mut file = std::fs::OpenOptions::new()
+        .append(true)
+        .open(&path)
+        .unwrap();
+    file.write_all(&[0xA5; 17]).unwrap();
+    file.sync_all().unwrap();
+    drop(file);
+
+    let reopened = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    assert_eq!(std::fs::metadata(&path).unwrap().len(), committed_len);
+    assert_eq!(
+        reopened
+            .engine
+            .root(&StateOwner::Principal(alice_uid))
+            .unwrap()
+            .unwrap()
+            .generation,
+        RootGeneration::new(1)
+    );
+    assert_eq!(
+        reopened
+            .kv()
+            .get("alice:capsule:shell", "theme")
+            .await
+            .unwrap(),
+        Some(b"raven".to_vec())
+    );
+}
+
+#[cfg(not(target_os = "windows"))]
+#[tokio::test]
+async fn hosted_volume_rejects_interior_container_corruption_on_header_fallback() {
+    let directory = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(directory.path());
+    let store = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    store.engine.close().unwrap();
+    drop(store);
+
+    let path = home.storage_volume_path();
+    let mut bytes = std::fs::read(&path).unwrap();
+    bytes[8] ^= 0x80;
+    std::fs::write(&path, bytes).unwrap();
+
+    let reopened = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .expect("valid footer should bypass interior journal scanning");
+    reopened.engine.close().unwrap();
+    drop(reopened);
+
+    let mut bytes = std::fs::read(&path).unwrap();
+    *bytes.last_mut().unwrap() ^= 0x80;
+    std::fs::write(&path, bytes).unwrap();
+
+    let Err(error) = open_runtime_principal_store(&home, unlimited_quota()).await else {
+        panic!("corrupt Astrid volume unexpectedly reopened");
+    };
+    assert!(error.to_string().contains("record magic"), "{error}");
+}
+
+#[tokio::test]
+async fn independent_reader_accepts_a_rust_produced_volume() {
+    let directory = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(directory.path());
+    let store = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    let alice_uid = create_test_principal(&store, "alice").await;
+    let alice = alice_uid.to_string();
+    store
+        .kv()
+        .set("alice:capsule:shell", "cwd", b"/workspace".to_vec())
+        .await
+        .unwrap();
+    let owner = StateOwner::Principal(alice_uid);
+    let name = ContentName::new("workspace/fastcdc-golden.bin").unwrap();
+    store
+        .content()
+        .put(&owner, &name, &chunker_golden_source(1024 * 1024))
+        .unwrap();
+    drop(store);
+
+    let script = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../scripts/runatal_v1_reader.py");
+    let output = std::process::Command::new("python3")
+        .arg(&script)
+        .arg(home.storage_volume_path())
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "independent reader failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let decoded: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(decoded["roots"][alice.as_str()]["generation"], 1);
+    assert_eq!(decoded["roots"][alice.as_str()]["kv"]["entries"], 1);
+    assert_eq!(
+        decoded["roots"][alice.as_str()]["kv"]["logical_bytes"],
+        b"/workspace".len()
+    );
+    assert!(
+        decoded["roots"][alice.as_str()]["commit"]
+            .as_str()
+            .unwrap()
+            .starts_with("1:1:32:")
+    );
+    assert!(
+        decoded["objects"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|object| object["kind"] == "Evidence")
+    );
+    assert!(
+        decoded["objects"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|object| object["kind"] == "Commit")
+    );
+    assert!(
+        decoded["objects"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|object| object["kind"] == "File")
+    );
+    assert_eq!(
+        decoded["content_catalog_spec_object"],
+        format!(
+            "1:1:32:{}",
+            object_id_hex(
+                Blake3ObjectIdentityV1
+                    .identify(&bootstrap::content_catalog_format_specification().unwrap(),)
+            )
+        )
+    );
+
+    let volume_path = home.storage_volume_path();
+    let mut volume = std::fs::read(&volume_path).unwrap();
+    volume[43] ^= 0x80;
+    std::fs::write(&volume_path, volume).unwrap();
+    let rejected = std::process::Command::new("python3")
+        .arg(Path::new(env!("CARGO_MANIFEST_DIR")).join("../../scripts/runatal_v1_reader.py"))
+        .arg(volume_path)
+        .output()
+        .unwrap();
+    assert!(
+        !rejected.status.success(),
+        "independent reader accepted a corrupt Rust-produced volume"
+    );
+}
+
+#[test]
+fn independent_volume_validator_rejects_the_full_unicode_control_set() {
+    let script_directory = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../scripts");
+    let output = std::process::Command::new("python3")
+        .current_dir(script_directory)
+        .arg("-c")
+        .arg(
+            r#"from runatal_v1_volume import VolumeFormatError, volume_region_name
+for codepoint in range(0x80, 0xa0):
+    try:
+        volume_region_name(chr(codepoint).encode())
+    except VolumeFormatError:
+        continue
+    raise AssertionError(f"U+{codepoint:04X} was accepted")
+assert volume_region_name(" Astrid ".encode()) == " Astrid ""#,
+        )
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "independent validator failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/crates/astrid-storage/src/principal_state/native_io.rs
+++ b/crates/astrid-storage/src/principal_state/native_io.rs
@@ -778,6 +778,62 @@ pub(super) fn open_private_file(path: &Path) -> StorageResult<File> {
     open_private_file_with_access(path, false)
 }
 
+pub(super) fn snapshot_private_file(path: &Path) -> StorageResult<Option<Vec<u8>>> {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.is_file() => {
+            let parent = path.parent().ok_or_else(|| {
+                connection(format!("private file {} has no parent", path.display()))
+            })?;
+            let name = path.file_name().ok_or_else(|| {
+                connection(format!("private file {} has no name", path.display()))
+            })?;
+            let directory = PrivateDirectory::open(parent)?;
+            let mut file = directory.open_file(Path::new(name))?;
+            let mut bytes = Vec::new();
+            std::io::Read::read_to_end(&mut file, &mut bytes).map_err(|error| {
+                connection(format!("read private file {}: {error}", path.display()))
+            })?;
+            Ok(Some(bytes))
+        },
+        Ok(_) => Err(connection(format!(
+            "private projection destination is not a regular file: {}",
+            path.display()
+        ))),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(connection(format!(
+            "inspect private projection destination {}: {error}",
+            path.display()
+        ))),
+    }
+}
+
+pub(super) fn rollback_private_file(path: &Path, previous: Option<Vec<u8>>) -> StorageResult<()> {
+    if let Some(bytes) = previous {
+        return astrid_core::platform_fs::atomic_write_private_file(path, &bytes).map_err(
+            |error| connection(format!("restore private file {}: {error}", path.display())),
+        );
+    }
+    let parent = path
+        .parent()
+        .ok_or_else(|| connection(format!("private file {} has no parent", path.display())))?;
+    let name = path
+        .file_name()
+        .ok_or_else(|| connection(format!("private file {} has no name", path.display())))?;
+    PrivateDirectory::open(parent)?.remove_file(Path::new(name))
+}
+
+pub(super) fn rollback_private_files(written: Vec<(PathBuf, Option<Vec<u8>>)>) -> Vec<String> {
+    written
+        .into_iter()
+        .rev()
+        .filter_map(|(path, previous)| {
+            rollback_private_file(&path, previous)
+                .err()
+                .map(|error| format!("{}: {error}", path.display()))
+        })
+        .collect()
+}
+
 fn open_private_file_with_access(path: &Path, write: bool) -> StorageResult<File> {
     validate_private_regular_file(path)?;
     let mut options = OpenOptions::new();

--- a/crates/astrid-storage/src/principal_state/native_kv_scale_probe_tests.rs
+++ b/crates/astrid-storage/src/principal_state/native_kv_scale_probe_tests.rs
@@ -1,0 +1,103 @@
+use std::sync::Arc;
+use std::time::Instant;
+
+use astrid_core::identity::PrincipalUid;
+use astrid_core::principal::PrincipalId;
+
+use super::*;
+
+fn test_directory(aliases: &[&str]) -> PrincipalDirectory {
+    let directory = PrincipalDirectory::default();
+    for alias in aliases {
+        let mut hasher = blake3::Hasher::new_derive_key("astrid principal uid test fixture v1");
+        hasher.update(alias.as_bytes());
+        let uid = PrincipalUid::from_bytes(*hasher.finalize().as_bytes());
+        directory
+            .register(PrincipalId::new(*alias).unwrap(), uid)
+            .unwrap();
+    }
+    directory
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+#[ignore = "explicit native KV group-commit throughput probe"]
+async fn native_kv_group_commit_scale_probe() {
+    const COMMITS_PER_WRITER: u8 = 64;
+
+    for writers in [1_u8, 2, 4, 8] {
+        let directory = tempfile::tempdir().unwrap();
+        let aliases = (0..writers)
+            .map(|writer| format!("principal-{writer}"))
+            .collect::<Vec<_>>();
+        let alias_refs = aliases.iter().map(String::as_str).collect::<Vec<_>>();
+        let engine = Arc::new(
+            RuntimeEngine::open(
+                directory.path(),
+                Blake3ObjectIdentityV1,
+                StateOwnerCodecV2,
+                RecoveryLimits::process_addressable(),
+            )
+            .unwrap(),
+        );
+        let specification = bootstrap::format_specification().unwrap();
+        let specification_id = engine.identify(&specification);
+        engine.persist_standalone_object(&specification).unwrap();
+        engine
+            .ensure_direct_representation_catalogue(specification_id, &[specification_id])
+            .unwrap();
+        let store = Arc::new(RuntimeStore::from_engine(
+            Arc::clone(&engine),
+            StateOwnerResolver::new(test_directory(&alias_refs)),
+        ));
+        let barrier = Arc::new(tokio::sync::Barrier::new(usize::from(writers) + 1));
+        let mut tasks = Vec::new();
+        for writer in 0..writers {
+            let store = Arc::clone(&store);
+            let barrier = Arc::clone(&barrier);
+            tasks.push(tokio::spawn(async move {
+                let namespace = format!("principal-{writer}:capsule:probe");
+                let mut latencies = Vec::new();
+                barrier.wait().await;
+                for sequence in 0..COMMITS_PER_WRITER {
+                    let mut value = vec![0_u8; 128];
+                    value[..2].copy_from_slice(&[writer, sequence]);
+                    let started = Instant::now();
+                    store.set(&namespace, "state", value).await.unwrap();
+                    latencies.push(started.elapsed());
+                }
+                latencies
+            }));
+        }
+        barrier.wait().await;
+        let started = Instant::now();
+        let mut writer_latencies = Vec::new();
+        for task in tasks {
+            writer_latencies.push(task.await.unwrap());
+        }
+        let elapsed = started.elapsed();
+        let mut latencies: Vec<_> = writer_latencies.iter().flatten().copied().collect();
+        latencies.sort_unstable();
+        let operations = u32::from(writers) * u32::from(COMMITS_PER_WRITER);
+        let p50 = latencies[latencies.len() / 2];
+        let p95 = latencies[(latencies.len() * 95 / 100).min(latencies.len() - 1)];
+        let per_writer_p95: Vec<_> = writer_latencies
+            .iter_mut()
+            .map(|latencies| {
+                latencies.sort_unstable();
+                latencies[(latencies.len() * 95 / 100).min(latencies.len() - 1)].as_micros()
+            })
+            .collect();
+        let per_writer_max: Vec<_> = writer_latencies
+            .iter()
+            .map(|latencies| latencies.last().unwrap().as_micros())
+            .collect();
+        println!(
+            "native_kv_group_commit writers={writers} operations={operations} ops_per_second={:.1} p50_us={} p95_us={} per_writer_p95_us={per_writer_p95:?} per_writer_max_us={per_writer_max:?} wall_ms={}",
+            f64::from(operations) / elapsed.as_secs_f64(),
+            p50.as_micros(),
+            p95.as_micros(),
+            elapsed.as_millis(),
+        );
+        store.close().await.unwrap();
+    }
+}

--- a/crates/astrid-storage/src/principal_state/owner_migration.rs
+++ b/crates/astrid-storage/src/principal_state/owner_migration.rs
@@ -612,11 +612,21 @@ mod tests {
         })
     }
 
+    fn seed_legacy_layout(home: &AstridHome) {
+        std::fs::create_dir_all(home.etc_dir()).unwrap();
+        std::fs::write(
+            home.layout_version_path(),
+            astrid_core::dirs::LEGACY_LAYOUT_VERSION,
+        )
+        .unwrap();
+    }
+
     #[tokio::test]
     #[allow(clippy::too_many_lines)]
     async fn alias_roots_migrate_without_changing_generation_or_commit() {
         let directory = tempfile::tempdir().unwrap();
         let home = AstridHome::from_path(directory.path());
+        seed_legacy_layout(&home);
         let alias = PrincipalId::new("Alice").unwrap();
         let initial_public_key = [0x42; 32];
         let mut profile = PrincipalProfile::default();

--- a/crates/astrid-storage/src/principal_state/release_fixture_tests.rs
+++ b/crates/astrid-storage/src/principal_state/release_fixture_tests.rs
@@ -195,6 +195,16 @@ async fn published_v0104_home_imports_verifies_and_retires_legacy_store() {
         .await
         .unwrap();
 
+    // Kernel boot establishes ACTIVE, completes layout v2, then republishes
+    // host records written by that completion. Storage-only cutover follows
+    // the same sequence so pack-only stop can retire the live tree.
+    store
+        .establish_runtime_projection_receipt(&home)
+        .expect("establish ACTIVE after layout cutover");
+    store
+        .publish_runtime_projection(&home)
+        .expect("publish post-cutover host projection");
+
     drop(store);
     home.ensure().unwrap();
 

--- a/crates/astrid-storage/src/principal_state/release_fixture_tests.rs
+++ b/crates/astrid-storage/src/principal_state/release_fixture_tests.rs
@@ -63,6 +63,71 @@ fn assert_fixture_identity() {
     );
 }
 
+fn unbounded_quota() -> Arc<dyn KvQuotaResolver<StateOwner>> {
+    Arc::new(|owner: &StateOwner| {
+        Ok(match owner {
+            StateOwner::System => None,
+            StateOwner::Principal(_) | StateOwner::Fleet(_) => Some(u64::MAX),
+        })
+    })
+}
+
+async fn pack_home_to_volume_only(home: &AstridHome) {
+    let packer = crate::principal_state::open_runtime_principal_store_for_pack(
+        home,
+        Arc::new(|_: &StateOwner| Ok(None)),
+    )
+    .await
+    .unwrap();
+    packer
+        .pack_and_retire_runtime_projection(home)
+        .expect("pack post-cutover projection");
+    drop(packer);
+
+    let stopped = std::fs::read_dir(home.root())
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    assert_eq!(stopped.len(), 1);
+    assert_eq!(
+        stopped[0].file_name(),
+        std::ffi::OsStr::new("astrid.volume")
+    );
+}
+
+async fn assert_reopened_cutover_inventory(home: &AstridHome) {
+    let reopened = open_runtime_principal_store(home, Arc::new(|_: &StateOwner| Ok(None)))
+        .await
+        .unwrap();
+    assert_eq!(
+        std::fs::read_to_string(home.layout_version_path())
+            .unwrap()
+            .trim(),
+        astrid_core::dirs::LAYOUT_VERSION
+    );
+    assert!(
+        home.migrations_dir()
+            .join("layout-v1-to-v2.complete")
+            .is_file()
+    );
+    assert!(
+        reopened
+            .kv()
+            .get("system:identity", "link/cli/local")
+            .await
+            .unwrap()
+            .is_some()
+    );
+    assert_eq!(
+        reopened
+            .kv()
+            .get("system:identity", "post-cutover")
+            .await
+            .unwrap(),
+        Some(b"live-volume-write".to_vec())
+    );
+}
+
 #[tokio::test]
 async fn published_v0104_home_imports_verifies_and_retires_legacy_store() {
     assert_fixture_identity();
@@ -87,14 +152,9 @@ async fn published_v0104_home_imports_verifies_and_retires_legacy_store() {
     )
     .unwrap();
     home.begin_layout_v2_migration(&migration_target).unwrap();
-    let quota: Arc<dyn KvQuotaResolver<StateOwner>> = Arc::new(|owner: &StateOwner| {
-        Ok(match owner {
-            StateOwner::System => None,
-            StateOwner::Principal(_) | StateOwner::Fleet(_) => Some(u64::MAX),
-        })
-    });
-
-    let store = open_runtime_principal_store(&home, quota).await.unwrap();
+    let store = open_runtime_principal_store(&home, unbounded_quota())
+        .await
+        .unwrap();
 
     assert!(
         store
@@ -137,25 +197,12 @@ async fn published_v0104_home_imports_verifies_and_retires_legacy_store() {
 
     drop(store);
     home.ensure().unwrap();
-    let reopened = open_runtime_principal_store(&home, Arc::new(|_: &StateOwner| Ok(None)))
-        .await
-        .unwrap();
-    assert!(
-        reopened
-            .kv()
-            .get("system:identity", "link/cli/local")
-            .await
-            .unwrap()
-            .is_some()
-    );
-    assert_eq!(
-        reopened
-            .kv()
-            .get("system:identity", "post-cutover")
-            .await
-            .unwrap(),
-        Some(b"live-volume-write".to_vec())
-    );
+
+    // A pre-repair stop could retire the post-cutover host records without
+    // ever packing them. The next boot then saw the stale layout-one intent
+    // and rejected the legitimate restart.
+    pack_home_to_volume_only(&home).await;
+    assert_reopened_cutover_inventory(&home).await;
 }
 
 #[test]

--- a/crates/astrid-storage/src/principal_state/runtime_tests.rs
+++ b/crates/astrid-storage/src/principal_state/runtime_tests.rs
@@ -1,27 +1,27 @@
-use std::collections::BTreeMap;
-use std::io::{Read as _, Seek as _, SeekFrom, Write as _};
-use std::num::NonZeroU64;
-use std::path::Path;
-use std::time::{Duration, Instant};
+pub(super) use std::collections::BTreeMap;
+pub(super) use std::io::{Read as _, Seek as _, SeekFrom, Write as _};
+pub(super) use std::num::NonZeroU64;
+pub(super) use std::path::Path;
+pub(super) use std::time::{Duration, Instant};
 
-use crate::engine::{ObjectCacheCapacity, ObjectCacheController, RootTransaction};
-use crate::resources::ResidentMemoryAuthority;
-use crate::storage_model::{
-    ObjectClass, ObjectFormatVersion, ObjectKind, ObjectReference, PhysicalIdentity, ProfileKind,
-    ReconstructionBounds, ReferenceLabel, RepresentationProfile, RootGeneration, RootState,
+pub(super) use crate::engine::{ObjectCacheCapacity, ObjectCacheController, RootTransaction};
+pub(super) use crate::resources::ResidentMemoryAuthority;
+pub(super) use crate::storage_model::{
+    ObjectFormatVersion, ObjectKind, ObjectReference, ReferenceLabel, RootGeneration, RootState,
 };
-use crate::volume::AstridVolume as _;
-use crate::{AstridFilesystem, FilesystemPath};
+pub(super) use crate::{AstridFilesystem, FilesystemPath};
 #[cfg(feature = "legacy-surrealkv")]
-use astrid_core::profile::{DeviceKey, DeviceScope, PrincipalProfile};
+pub(super) use astrid_core::profile::{DeviceKey, DeviceScope, PrincipalProfile};
 
 use super::*;
-use crate::content::{CONTENT_COMPONENT_LABEL, CatalogValue, LegacyCatalog, encode_legacy_catalog};
-use crate::{ChunkingProfile, ContentIngest, ContentName};
+pub(super) use crate::content::{
+    CONTENT_COMPONENT_LABEL, CatalogValue, LegacyCatalog, encode_legacy_catalog,
+};
+pub(super) use crate::{ChunkingProfile, ContentIngest, ContentName};
 
 mod staging_batch_tests;
 
-fn unlimited_quota() -> Arc<dyn KvQuotaResolver<StateOwner>> {
+pub(super) fn unlimited_quota() -> Arc<dyn KvQuotaResolver<StateOwner>> {
     Arc::new(|owner: &StateOwner| {
         Ok(match owner {
             StateOwner::System => None,
@@ -29,18 +29,17 @@ fn unlimited_quota() -> Arc<dyn KvQuotaResolver<StateOwner>> {
         })
     })
 }
-
 fn test_uid(alias: &str) -> PrincipalUid {
     let mut hasher = blake3::Hasher::new_derive_key("astrid principal uid test fixture v1");
     hasher.update(alias.as_bytes());
     PrincipalUid::from_bytes(*hasher.finalize().as_bytes())
 }
 
-fn test_owner(alias: &str) -> StateOwner {
+pub(super) fn test_owner(alias: &str) -> StateOwner {
     StateOwner::Principal(test_uid(alias))
 }
 
-fn test_directory(aliases: &[&str]) -> PrincipalDirectory {
+pub(super) fn test_directory(aliases: &[&str]) -> PrincipalDirectory {
     let directory = PrincipalDirectory::default();
     for alias in aliases {
         directory
@@ -50,7 +49,10 @@ fn test_directory(aliases: &[&str]) -> PrincipalDirectory {
     directory
 }
 
-async fn create_test_principal(store: &RuntimePrincipalStore, alias: &str) -> PrincipalUid {
+pub(super) async fn create_test_principal(
+    store: &RuntimePrincipalStore,
+    alias: &str,
+) -> PrincipalUid {
     let identities = KvIdentityStore::with_principal_directory(
         ScopedKvStore::new(store.kv(), "system:identity").unwrap(),
         store.principal_directory(),
@@ -70,7 +72,7 @@ async fn create_test_principal(store: &RuntimePrincipalStore, alias: &str) -> Pr
         .uid
 }
 
-fn chunker_golden_source(length: usize) -> Vec<u8> {
+pub(super) fn chunker_golden_source(length: usize) -> Vec<u8> {
     let mut state = 0x4d59_5df4_d0f3_3173_u64;
     (0..length)
         .map(|_| {
@@ -80,6 +82,24 @@ fn chunker_golden_source(length: usize) -> Vec<u8> {
             ((state >> 37) & 0xff) as u8
         })
         .collect()
+}
+
+pub(super) fn seed_legacy_layout(home: &AstridHome) {
+    std::fs::create_dir_all(home.etc_dir()).unwrap();
+    std::fs::write(
+        home.layout_version_path(),
+        astrid_core::dirs::LEGACY_LAYOUT_VERSION,
+    )
+    .unwrap();
+}
+
+pub(super) fn seed_legacy_surrealkv(home: &AstridHome, bytes: &[u8]) -> std::path::PathBuf {
+    let manifest = home.state_db_path().join("manifest");
+    std::fs::create_dir_all(&manifest).unwrap();
+    std::fs::write(home.state_db_path().join("LOCK"), b"lock").unwrap();
+    let file = manifest.join("00000000000000000001.manifest");
+    std::fs::write(&file, bytes).unwrap();
+    file
 }
 
 #[tokio::test]
@@ -239,1115 +259,11 @@ async fn closing_a_governed_cache_releases_physical_and_logical_leases() {
     authority.remove_principal(&owner).unwrap();
 }
 
-#[test]
-fn owner_codec_round_trips_only_canonical_values() {
-    let codec = StateOwnerCodecV2;
-    let owners = [
-        StateOwner::System,
-        test_owner("alice"),
-        StateOwner::Fleet(astrid_core::FleetUid::from_bytes([7; 32])),
-    ];
-    for owner in owners {
-        let encoded = codec.encode(&owner);
-        assert_eq!(codec.decode(&encoded), Some(owner));
-    }
-    assert_eq!(codec.decode(&[]), None);
-    assert_eq!(codec.decode(&[0, 0]), None);
-    assert_eq!(codec.decode(&[1]), None);
-    assert_eq!(codec.decode(&[1, b':']), None);
-}
-
-#[test]
-fn object_identity_v1_has_a_stable_golden_vector() {
-    let record = ObjectRecord::new(
-        ObjectKind::KvLeaf,
-        ObjectFormatVersion::V1,
-        b"hello".to_vec(),
-        Vec::new(),
-        0,
-        ObjectClass::Data,
-    )
-    .unwrap();
-    assert_eq!(
-        Blake3ObjectIdentityV1.identify(&record).as_bytes(),
-        &[
-            14, 77, 237, 193, 155, 81, 194, 119, 35, 35, 59, 81, 40, 49, 0, 31, 232, 131, 137, 111,
-            27, 237, 250, 91, 151, 7, 135, 21, 99, 27, 128, 55,
-        ]
-    );
-}
-
-#[test]
-fn physical_identity_v1_matches_the_runatal_golden_vector() {
-    let profile = RepresentationProfile::new_builtin(
-        ProfileKind::DirectCanonical,
-        ReconstructionBounds::new(
-            8,
-            32,
-            8 * 1024 * 1024,
-            16 * 1024 * 1024,
-            1_000_000,
-            32 * 1024 * 1024,
-            5_000_000,
-        )
-        .unwrap(),
-        ObjectId::new([1; 32]),
-    )
-    .unwrap()
-    .encode()
-    .unwrap();
-    assert_eq!(
-        Blake3PhysicalIdentityV1.identify("astrid-representation-profile-v1\0", &profile),
-        [
-            0x59, 0xc0, 0x99, 0x24, 0xb3, 0xb0, 0x72, 0x12, 0xc4, 0xbc, 0x10, 0x35, 0x35, 0xcf,
-            0xbb, 0xe1, 0x0d, 0xee, 0xe3, 0x1d, 0x1b, 0x15, 0x7d, 0x21, 0x53, 0x8b, 0x17, 0x75,
-            0x95, 0x23, 0x58, 0x04,
-        ]
-    );
-}
-
-#[test]
-fn format_specification_has_a_tagged_metadata_identity() {
-    let record = bootstrap::format_specification().unwrap();
-    let id = Blake3ObjectIdentityV1.identify(&record);
-    let catalog_id = Blake3ObjectIdentityV1
-        .identify(&bootstrap::content_catalog_format_specification().unwrap());
-    let metadata = String::from_utf8(store_metadata(id, catalog_id)).unwrap();
-
-    assert_eq!(record.kind(), ObjectKind::Evidence);
-    assert_eq!(record.canonical_bytes(), STORE_FORMAT_SPEC);
-    assert!(record.references().is_empty());
-    assert_eq!(
-        object_id_hex(id),
-        "ac3e1ab1e82be24dae7cdef949698dd54d2407bc7f39fb30709dc36677eea61d"
-    );
-    assert_eq!(
-        object_id_hex(catalog_id),
-        "8f3999b066b666396259c4a92f9de7c5b8e67df9d38a69fb4fb824968b56ecdb"
-    );
-    assert_eq!(
-        metadata,
-        "format=astrid-principal-store-v1\n\
-         identity=blake3-object-identity-v1\n\
-         identity-wire=tagged-identity-v1\n\
-         format-spec-object=1:1:32:ac3e1ab1e82be24dae7cdef949698dd54d2407bc7f39fb30709dc36677eea61d\n\
-         content-catalog-spec-object=1:1:32:8f3999b066b666396259c4a92f9de7c5b8e67df9d38a69fb4fb824968b56ecdb\n\
-         representations=authoritative-direct-v1\n\
-         principal-codec=state-owner-v2\n\
-         projection=kv-transition-bplus-v4\n"
-    );
-}
-
-#[test]
-fn pre_derivation_v1_runatal_upgrade_is_idempotent_and_preserves_history() {
-    let directory = tempfile::tempdir().unwrap();
-    let store_path = directory.path().join("principal-store");
-    std::fs::create_dir_all(&store_path).unwrap();
-    let engine = RuntimeEngine::open(
-        &store_path,
-        Blake3ObjectIdentityV1,
-        StateOwnerCodecV2,
-        RecoveryLimits::process_addressable(),
-    )
-    .unwrap();
-    let legacy_spec = ObjectRecord::new(
-        ObjectKind::Evidence,
-        ObjectFormatVersion::V1,
-        b"pre-derivation format 1 specification".to_vec(),
-        Vec::new(),
-        0,
-        ObjectClass::Metadata,
-    )
-    .unwrap();
-    let (legacy_spec_id, _) = engine.persist_standalone_object(&legacy_spec).unwrap();
-    let current_spec = bootstrap::format_specification().unwrap();
-    let current_spec_id = Blake3ObjectIdentityV1.identify(&current_spec);
-    let catalog_spec = bootstrap::content_catalog_format_specification().unwrap();
-    let catalog_spec_id = Blake3ObjectIdentityV1.identify(&catalog_spec);
-    let current_metadata = store_metadata(current_spec_id, catalog_spec_id);
-    atomic_write(
-        &store_path.join(STORE_METADATA_FILE),
-        &legacy_store_metadata(legacy_spec_id),
-    )
-    .unwrap();
-
-    // Simulate a crash after the successor RÚNATAL object became durable
-    // but before store.meta changed.
-    persist_format_specification(&engine, &current_spec).unwrap();
-    prepare_format_specification(
-        &engine,
-        DestinationFormat::PriorV1 {
-            format_spec: legacy_spec_id,
-            catalog_spec_was_declared: false,
-        },
-        &current_spec,
-        current_spec_id,
-    )
-    .unwrap();
-    prepare_catalog_specification(
-        &engine,
-        DestinationFormat::PriorV1 {
-            format_spec: legacy_spec_id,
-            catalog_spec_was_declared: false,
-        },
-        &catalog_spec,
-        catalog_spec_id,
-    )
-    .unwrap();
-    atomic_write(&store_path.join(STORE_METADATA_FILE), &current_metadata).unwrap();
-
-    assert_eq!(
-        std::fs::read(store_path.join(STORE_METADATA_FILE)).unwrap(),
-        current_metadata
-    );
-    assert_eq!(engine.object(legacy_spec_id).unwrap(), Some(legacy_spec));
-    assert_eq!(
-        engine.object(current_spec_id).unwrap(),
-        Some(current_spec.clone())
-    );
-    prepare_format_specification(
-        &engine,
-        DestinationFormat::Current,
-        &current_spec,
-        current_spec_id,
-    )
-    .unwrap();
-    prepare_catalog_specification(
-        &engine,
-        DestinationFormat::Current,
-        &catalog_spec,
-        catalog_spec_id,
-    )
-    .unwrap();
-    engine.close().unwrap();
-}
-
-#[test]
-fn prior_metadata_that_declared_a_catalog_specification_requires_it() {
-    let directory = tempfile::tempdir().unwrap();
-    let engine = RuntimeEngine::open(
-        directory.path(),
-        Blake3ObjectIdentityV1,
-        StateOwnerCodecV2,
-        RecoveryLimits::process_addressable(),
-    )
-    .unwrap();
-    let catalog_spec = bootstrap::content_catalog_format_specification().unwrap();
-    let catalog_spec_id = Blake3ObjectIdentityV1.identify(&catalog_spec);
-    let destination = DestinationFormat::PriorV1 {
-        format_spec: PRE_DERIVATION_FORMAT_SPEC_ID,
-        catalog_spec_was_declared: true,
-    };
-
-    let error = prepare_catalog_specification(&engine, destination, &catalog_spec, catalog_spec_id)
-        .unwrap_err();
-    assert!(
-        error
-            .to_string()
-            .contains("completed principal store is missing its content catalog specification"),
-        "{error}"
-    );
-}
-
-#[tokio::test]
-async fn completed_pre_derivation_v1_store_is_selected_for_runatal_amendment() {
-    let directory = tempfile::tempdir().unwrap();
-    let home = AstridHome::from_path(directory.path());
-    super::format_migration_tests::seed_current_directory_store(&home);
-
-    let store_path = home.principal_store_path();
-    std::fs::write(
-        store_path.join(STORE_METADATA_FILE),
-        legacy_store_metadata(PRE_DERIVATION_FORMAT_SPEC_ID),
-    )
-    .unwrap();
-    let current_spec = bootstrap::format_specification().unwrap();
-    let current_spec_id = Blake3ObjectIdentityV1.identify(&current_spec);
-    let catalog_spec = bootstrap::content_catalog_format_specification().unwrap();
-    let current_metadata = store_metadata(
-        current_spec_id,
-        Blake3ObjectIdentityV1.identify(&catalog_spec),
-    );
-    assert_eq!(
-        prepare_destination(
-            &store_path,
-            &current_metadata,
-            Blake3ObjectIdentityV1.identify(&catalog_spec),
-        )
-        .unwrap(),
-        DestinationFormat::PriorV1 {
-            format_spec: PRE_DERIVATION_FORMAT_SPEC_ID,
-            catalog_spec_was_declared: false,
-        }
-    );
-}
-
-#[tokio::test]
-async fn new_store_persists_and_verifies_the_in_band_specification() {
-    let directory = tempfile::tempdir().unwrap();
-    let home = AstridHome::from_path(directory.path());
-    let store = open_runtime_principal_store(&home, unlimited_quota())
-        .await
-        .unwrap();
-
-    let record = bootstrap::format_specification().unwrap();
-    let id = Blake3ObjectIdentityV1.identify(&record);
-    assert_eq!(store.engine.object(id).unwrap(), Some(record.clone()));
-    assert!(home.storage_volume_path().is_file());
-    assert!(home.principal_store_path().is_dir());
-    store.engine.close().unwrap();
-    drop(store);
-
-    let reopened = open_runtime_principal_store(&home, unlimited_quota())
-        .await
-        .unwrap();
-    assert_eq!(reopened.engine.object(id).unwrap(), Some(record));
-    assert!(home.principal_store_path().is_dir());
-    reopened
-        .retire_verified_legacy_directory_store(&home)
-        .unwrap();
-    assert!(!home.principal_store_path().exists());
-}
-
-#[tokio::test]
-async fn explicit_close_releases_the_hosted_volume_while_store_references_remain() {
-    let directory = tempfile::tempdir().unwrap();
-    let home = AstridHome::from_path(directory.path());
-    let store = open_runtime_principal_store(&home, unlimited_quota())
-        .await
-        .unwrap();
-    let retained_engine = Arc::clone(&store.engine);
-    retained_engine.close().unwrap();
-
-    let reopened = open_runtime_principal_store(&home, unlimited_quota())
-        .await
-        .unwrap();
-    reopened.engine.close().unwrap();
-    drop(reopened);
-    drop(store);
-    drop(retained_engine);
-}
-
-#[tokio::test]
-async fn volume_without_its_cutover_receipt_fails_closed() {
-    let directory = tempfile::tempdir().unwrap();
-    let home = AstridHome::from_path(directory.path());
-    let store = open_runtime_kv(&home, unlimited_quota()).await.unwrap();
-    store.close().await.unwrap();
-    drop(store);
-
-    let volume = crate::volume::HostedFileVolume::open(home.storage_volume_path()).unwrap();
-    let receipt =
-        crate::volume::VolumeRegion::new("system/migrations/directory-store-to-volume-v1").unwrap();
-    volume.remove_region(&receipt).unwrap();
-    volume.sync().unwrap();
-    drop(volume);
-
-    let Err(error) = open_runtime_kv(&home, unlimited_quota()).await else {
-        panic!("volume without a cutover receipt unexpectedly reopened");
-    };
-    assert!(error.to_string().contains("cutover receipt"), "{error}");
-}
-
-#[tokio::test]
-async fn changed_surviving_directory_store_is_rejected_by_post_barrier_retirement() {
-    let directory = tempfile::tempdir().unwrap();
-    let home = AstridHome::from_path(directory.path());
-    super::format_migration_tests::seed_current_directory_store(&home);
-    let migrated = open_runtime_principal_store(&home, unlimited_quota())
-        .await
-        .unwrap();
-    migrated.engine.close().unwrap();
-    drop(migrated);
-    assert!(home.principal_store_path().is_dir());
-    let source = Arc::new(
-        RuntimeEngine::open(
-            home.principal_store_path(),
-            Blake3ObjectIdentityV1,
-            StateOwnerCodecV2,
-            RecoveryLimits::process_addressable(),
-        )
-        .unwrap(),
-    );
-    let changed = RuntimeStore::from_engine(
-        Arc::clone(&source),
-        StateOwnerResolver::new(test_directory(&["alice"])),
-    );
-    changed
-        .set("alice:capsule:shell", "drift", b"changed".to_vec())
-        .await
-        .unwrap();
-    source.close().unwrap();
-    drop(changed);
-    drop(source);
-
-    let reopened = open_runtime_principal_store(&home, unlimited_quota())
-        .await
-        .unwrap();
-    let error = reopened
-        .retire_verified_legacy_directory_store(&home)
-        .expect_err("changed surviving source must not be retired");
-    assert!(error.to_string().contains("cutover receipt"), "{error}");
-    assert!(home.principal_store_path().exists());
-}
-
-fn replace_catalog_with_legacy(
-    engine: &RuntimeEngine,
-    owner: &StateOwner,
-    name: &ContentName,
-    file: ObjectId,
-    logical_bytes: u64,
-) -> RootState {
-    let previous = engine.root(owner).unwrap().unwrap();
-    let quota_bytes = logical_bytes
-        .checked_add(u64::try_from(name.as_str().len()).unwrap())
-        .unwrap();
-    let legacy = LegacyCatalog {
-        entries: BTreeMap::from([(
-            name.clone(),
-            CatalogValue {
-                file,
-                logical_bytes,
-            },
-        )]),
-        logical_bytes,
-        quota_bytes,
-    };
-    let catalog = encode_legacy_catalog(&legacy).unwrap();
-    let catalog_id = Blake3ObjectIdentityV1.identify(&catalog);
-    let graph_version = ObjectFormatVersion::new(3).unwrap();
-    let state = ObjectRecord::new(
-        ObjectKind::PrincipalState,
-        graph_version,
-        Vec::new(),
-        vec![ObjectReference::owns(
-            ReferenceLabel::new(CONTENT_COMPONENT_LABEL.to_vec()),
-            catalog_id,
-        )],
-        0,
-        ObjectClass::Metadata,
-    )
-    .unwrap();
-    let state_id = Blake3ObjectIdentityV1.identify(&state);
-    let commit = ObjectRecord::new(
-        ObjectKind::Commit,
-        graph_version,
-        Vec::new(),
-        vec![
-            ObjectReference::new(
-                ReferenceLabel::new(b"parent".to_vec()),
-                previous.commit,
-                ReferenceKind::Lineage,
-            ),
-            ObjectReference::owns(ReferenceLabel::new(b"state".to_vec()), state_id),
-        ],
-        0,
-        ObjectClass::Metadata,
-    )
-    .unwrap();
-    let commit_id = Blake3ObjectIdentityV1.identify(&commit);
-    engine
-        .commit(RootTransaction::new(
-            *owner,
-            Some(previous),
-            commit_id,
-            vec![
-                (catalog_id, catalog),
-                (state_id, state),
-                (commit_id, commit),
-            ],
-        ))
-        .unwrap()
-        .root()
-}
-
-fn mark_store_as_legacy(home: &AstridHome) {
-    std::fs::write(
-        home.principal_store_path()
-            .join(migrations::MIGRATION_MARKER_FILE),
-        migrations::LEGACY_TO_V1_MARKER,
-    )
-    .unwrap();
-}
-
-fn install_legacy_catalog_fixtures(
-    home: &AstridHome,
-    fixtures: &[(&StateOwner, &ContentName, &[u8])],
-) -> BTreeMap<StateOwner, RootState> {
-    super::format_migration_tests::seed_current_directory_store(home);
-    let engine = Arc::new(
-        RuntimeEngine::open(
-            home.principal_store_path(),
-            Blake3ObjectIdentityV1,
-            StateOwnerCodecV2,
-            RecoveryLimits::process_addressable(),
-        )
-        .unwrap(),
-    );
-    let store = NativePrincipalContentStore::from_engine(Arc::clone(&engine));
-    let published: Vec<_> = fixtures
-        .iter()
-        .map(|(owner, name, bytes)| {
-            (
-                **owner,
-                (*name).clone(),
-                store.put(owner, name, bytes).unwrap(),
-            )
-        })
-        .collect();
-    let legacy_roots = published
-        .into_iter()
-        .map(|(owner, name, outcome)| {
-            let descriptor = outcome.descriptor();
-            let root = replace_catalog_with_legacy(
-                engine.as_ref(),
-                &owner,
-                &name,
-                descriptor.file(),
-                descriptor.logical_bytes(),
-            );
-            (owner, root)
-        })
-        .collect();
-    drop(store);
-    engine.close().unwrap();
-    drop(engine);
-    mark_store_as_legacy(home);
-    legacy_roots
-}
-
-#[derive(Debug)]
-struct CatalogWorkloadMetrics {
-    arena_bytes: u64,
-    root_journal_bytes: u64,
-    representation_metadata_bytes: u64,
-    publication_time: Duration,
-    reopen_time: Duration,
-}
-
-fn durable_file_len(store: &RuntimePrincipalStore, name: &str) -> u64 {
-    store.engine.durable_region_len(name).unwrap()
-}
-
-fn volume_file_len(home: &AstridHome) -> u64 {
-    std::fs::metadata(home.storage_volume_path()).unwrap().len()
-}
-
-async fn measure_catalog_publications(unique_content: bool) -> CatalogWorkloadMetrics {
-    const PUBLICATIONS: u64 = 1_000;
-    const CONTENT_BYTES: usize = 4 * 1024;
-
-    let directory = tempfile::tempdir().unwrap();
-    let home = AstridHome::from_path(directory.path());
-    let owner = test_owner("catalog-probe");
-    let store = open_runtime_principal_store_with_directory(
-        &home,
-        unlimited_quota(),
-        test_directory(&["catalog-probe"]),
-    )
-    .await
-    .unwrap();
-    let arena_before = durable_file_len(&store, "objects.arena");
-    let roots_before = durable_file_len(&store, "roots.journal");
-    let volume_before = volume_file_len(&home);
-    let started = Instant::now();
-    for index in 0..PUBLICATIONS {
-        let name = ContentName::new(format!("workspace/fixture/{index:04}")).unwrap();
-        let mut bytes = vec![7_u8; CONTENT_BYTES];
-        if unique_content {
-            bytes[..8].copy_from_slice(&index.to_le_bytes());
-        }
-        store.content().put(&owner, &name, &bytes).unwrap();
-    }
-    let publication_time = started.elapsed();
-    let arena_bytes = durable_file_len(&store, "objects.arena")
-        .checked_sub(arena_before)
-        .unwrap();
-    let root_journal_bytes = durable_file_len(&store, "roots.journal")
-        .checked_sub(roots_before)
-        .unwrap();
-    let representation_metadata_bytes = volume_file_len(&home).checked_sub(volume_before).unwrap();
-    drop(store);
-
-    let reopen_started = Instant::now();
-    let reopened = open_runtime_principal_store(&home, unlimited_quota())
-        .await
-        .unwrap();
-    let reopen_time = reopen_started.elapsed();
-    assert_eq!(
-        reopened.content().list(&owner).unwrap().len(),
-        usize::try_from(PUBLICATIONS).unwrap()
-    );
-    drop(reopened);
-
-    CatalogWorkloadMetrics {
-        arena_bytes,
-        root_journal_bytes,
-        representation_metadata_bytes,
-        publication_time,
-        reopen_time,
-    }
-}
-
-#[tokio::test]
-async fn thousand_deduplicated_four_kib_publications_bound_durable_arena_growth() {
-    const PUBLICATIONS: u64 = 1_000;
-    const MAX_ARENA_BYTES_PER_PUBLICATION: u64 = 16 * 1024;
-
-    let metrics = measure_catalog_publications(false).await;
-    assert!(
-        metrics.arena_bytes
-            < PUBLICATIONS
-                .checked_mul(MAX_ARENA_BYTES_PER_PUBLICATION)
-                .unwrap(),
-        "deduplicated publications appended unexpected arena bytes: {metrics:?}"
-    );
-}
-
-#[tokio::test]
-#[ignore = "explicit durable catalog amplification and reopen probe"]
-async fn catalog_durable_performance_probe() {
-    let duplicate = measure_catalog_publications(false).await;
-    let unique = measure_catalog_publications(true).await;
-    for (name, metrics) in [("duplicate", duplicate), ("unique", unique)] {
-        eprintln!(
-            "{name}: arena={} roots={} representations={} publication={:?} reopen={:?}",
-            metrics.arena_bytes,
-            metrics.root_journal_bytes,
-            metrics.representation_metadata_bytes,
-            metrics.publication_time,
-            metrics.reopen_time
-        );
-    }
-}
-
-#[tokio::test]
-async fn flat_content_catalog_migration_resumes_and_is_idempotent() {
-    let directory = tempfile::tempdir().unwrap();
-    let home = AstridHome::from_path(directory.path());
-    let alice = test_owner("alice");
-    let bob = test_owner("bob");
-    let alice_name = ContentName::new("workspace/alice-legacy.bin").unwrap();
-    let bob_name = ContentName::new("workspace/bob-legacy.bin").unwrap();
-    let alice_bytes = b"alice content survives the catalog migration";
-    let bob_bytes = b"bob content survives the catalog migration";
-    let legacy_roots = install_legacy_catalog_fixtures(
-        &home,
-        &[
-            (&alice, &alice_name, alice_bytes),
-            (&bob, &bob_name, bob_bytes),
-        ],
-    );
-
-    let engine = Arc::new(
-        RuntimeEngine::open(
-            home.principal_store_path(),
-            Blake3ObjectIdentityV1,
-            StateOwnerCodecV2,
-            RecoveryLimits::process_addressable(),
-        )
-        .unwrap(),
-    );
-    let content = NativePrincipalContentStore::from_engine(Arc::clone(&engine));
-    assert!(content.migrate_legacy_catalog(&alice).unwrap());
-    let partially_migrated_alice_root = engine.root(&alice).unwrap().unwrap();
-    assert_eq!(engine.root(&bob).unwrap(), legacy_roots.get(&bob).copied());
-    drop(content);
-    engine.close().unwrap();
-    drop(engine);
-
-    let migrated = open_runtime_principal_store(&home, unlimited_quota())
-        .await
-        .unwrap();
-    assert_eq!(
-        migrated.content().read(&alice, &alice_name).unwrap(),
-        Some(alice_bytes.to_vec())
-    );
-    assert_eq!(
-        migrated.content().read(&bob, &bob_name).unwrap(),
-        Some(bob_bytes.to_vec())
-    );
-    let migrated_alice_root = migrated.engine.root(&alice).unwrap().unwrap();
-    let migrated_bob_root = migrated.engine.root(&bob).unwrap().unwrap();
-    assert_eq!(migrated_alice_root, partially_migrated_alice_root);
-    assert_eq!(
-        migrated_bob_root.generation,
-        legacy_roots
-            .get(&bob)
-            .unwrap()
-            .generation
-            .checked_next()
-            .unwrap()
-    );
-    migrated.engine.close().unwrap();
-    drop(migrated);
-    assert!(home.storage_volume_path().is_file());
-    assert!(home.principal_store_path().is_dir());
-
-    let reopened = open_runtime_principal_store(&home, unlimited_quota())
-        .await
-        .unwrap();
-    assert_eq!(
-        reopened.content().read(&alice, &alice_name).unwrap(),
-        Some(alice_bytes.to_vec())
-    );
-    assert_eq!(
-        reopened.content().read(&bob, &bob_name).unwrap(),
-        Some(bob_bytes.to_vec())
-    );
-    assert_eq!(
-        reopened.engine.root(&alice).unwrap(),
-        Some(migrated_alice_root)
-    );
-    assert_eq!(reopened.engine.root(&bob).unwrap(), Some(migrated_bob_root));
-}
-
-#[tokio::test]
-async fn native_stage_acknowledges_before_ingest_and_publishes_on_a_blocking_worker() {
-    let directory = tempfile::tempdir().unwrap();
-    let home = AstridHome::from_path(directory.path());
-    let store = open_runtime_principal_store(&home, unlimited_quota())
-        .await
-        .unwrap();
-    let owner = test_owner("alice");
-    let name = ContentName::new("workspace/target/release/game").unwrap();
-    let mut writer = store
-        .staging()
-        .begin(owner, name.clone(), ChunkingProfile::ASTRID_V1)
-        .unwrap();
-    writer.write_all(b"linux build.......").unwrap();
-    writer.seek(SeekFrom::Start(12)).unwrap();
-    writer.write_all(b"artifact").unwrap();
-    writer.set_len(20).unwrap();
-    let staged = writer.seal().unwrap();
-
-    assert_eq!(staged.logical_bytes(), 20);
-    assert_eq!(store.content().describe(&owner, &name).unwrap(), None);
-    assert_eq!(store.staging().ready().unwrap(), vec![staged.clone()]);
-
-    let outcome = store.publish_staged(staged).await.unwrap();
-    assert_eq!(outcome.descriptor().logical_bytes(), 20);
-    assert_eq!(
-        store.content().read(&owner, &name).unwrap(),
-        Some(b"linux build.artifact".to_vec())
-    );
-    let snapshot = store.content().engine().snapshot(&owner).unwrap().unwrap();
-    assert!(
-        snapshot
-            .records()
-            .iter()
-            .any(|(_, record)| record.kind() == ObjectKind::Chunk),
-        "archival snapshots must materialize canonical chunk records"
-    );
-    assert!(store.staging().ready().unwrap().is_empty());
-    drop(store);
-
-    let reopened = open_runtime_principal_store(&home, unlimited_quota())
-        .await
-        .unwrap();
-    assert_eq!(
-        reopened.content().read(&owner, &name).unwrap(),
-        Some(b"linux build.artifact".to_vec())
-    );
-}
-
-#[tokio::test]
-async fn native_staging_batch_publishes_one_atomic_root_and_reaps_together() {
-    let directory = tempfile::tempdir().unwrap();
-    let home = AstridHome::from_path(directory.path());
-    let store = open_runtime_principal_store(&home, unlimited_quota())
-        .await
-        .unwrap();
-    let owner = test_owner("alice");
-    let values = [
-        ("workspace/a.txt", b"alpha".as_slice()),
-        ("workspace/b.txt", b"bravo".as_slice()),
-        ("workspace/c.txt", b"charlie".as_slice()),
-    ];
-    let mut staged = Vec::new();
-    for (name, value) in values {
-        let mut writer = store
-            .staging()
-            .begin(
-                owner,
-                ContentName::new(name).unwrap(),
-                ChunkingProfile::ASTRID_V1,
-            )
-            .unwrap();
-        writer.write_all(value).unwrap();
-        staged.push(writer.seal().unwrap());
-    }
-
-    let outcome = store.publish_staged_batch(staged).await.unwrap();
-
-    assert_eq!(outcome.principal_root().generation, RootGeneration::INITIAL);
-    assert_eq!(outcome.entries().len(), values.len());
-    assert!(store.staging().ready().unwrap().is_empty());
-    for (name, value) in values {
-        assert_eq!(
-            store
-                .content()
-                .read(&owner, &ContentName::new(name).unwrap())
-                .unwrap(),
-            Some(value.to_vec())
-        );
-    }
-    drop(store);
-
-    let reopened = open_runtime_principal_store(&home, unlimited_quota())
-        .await
-        .unwrap();
-    for (name, value) in values {
-        assert_eq!(
-            reopened
-                .content()
-                .read(&owner, &ContentName::new(name).unwrap())
-                .unwrap(),
-            Some(value.to_vec())
-        );
-    }
-}
-
-#[tokio::test]
-async fn native_staging_batch_rejects_mixed_owners_without_consuming_generations() {
-    let directory = tempfile::tempdir().unwrap();
-    let home = AstridHome::from_path(directory.path());
-    let store = open_runtime_principal_store(&home, unlimited_quota())
-        .await
-        .unwrap();
-    let mut staged = Vec::new();
-    for owner in [test_owner("alice"), test_owner("bob")] {
-        let mut writer = store
-            .staging()
-            .begin(
-                owner,
-                ContentName::new("workspace/shared.txt").unwrap(),
-                ChunkingProfile::ASTRID_V1,
-            )
-            .unwrap();
-        writer.write_all(b"owner-specific bytes").unwrap();
-        staged.push(writer.seal().unwrap());
-    }
-
-    let error = store
-        .publish_staged_batch(staged.clone())
-        .await
-        .unwrap_err();
-
-    assert!(error.to_string().contains("multiple owners"));
-    assert_eq!(store.staging().ready().unwrap(), staged);
-}
-
-#[tokio::test]
-async fn staged_publication_rejects_a_generation_truncated_after_seal() {
-    let directory = tempfile::tempdir().unwrap();
-    let home = AstridHome::from_path(directory.path());
-    let store = open_runtime_principal_store(&home, unlimited_quota())
-        .await
-        .unwrap();
-    let owner = test_owner("alice");
-    let name = ContentName::new("workspace/truncated.bin").unwrap();
-    let mut writer = store
-        .staging()
-        .begin(owner, name.clone(), ChunkingProfile::ASTRID_V1)
-        .unwrap();
-    writer.write_all(b"durable staged bytes").unwrap();
-    let staged = writer.seal().unwrap();
-    let path = staged.content_path();
-
-    std::fs::OpenOptions::new()
-        .write(true)
-        .open(&path)
-        .unwrap()
-        .set_len(staged.logical_bytes().saturating_sub(1))
-        .unwrap();
-
-    let error = store.publish_staged(staged).await.unwrap_err();
-    assert!(error.to_string().contains("footer"));
-    assert_eq!(store.content().describe(&owner, &name).unwrap(), None);
-    assert!(
-        path.exists(),
-        "failed publication must retain staged evidence"
-    );
-}
-
-#[tokio::test]
-async fn staged_publication_retries_after_root_commit_before_cleanup() {
-    let directory = tempfile::tempdir().unwrap();
-    let home = AstridHome::from_path(directory.path());
-    let store = open_runtime_principal_store(&home, unlimited_quota())
-        .await
-        .unwrap();
-    let owner = test_owner("alice");
-    let name = ContentName::new("workspace/retry.bin").unwrap();
-    let mut writer = store
-        .staging()
-        .begin(owner, name.clone(), ChunkingProfile::ASTRID_V1)
-        .unwrap();
-    writer.write_all(b"one identity").unwrap();
-    let staged = writer.seal().unwrap();
-
-    let source = native_io::open_private_file(&staged.content_path())
-        .unwrap()
-        .take(staged.logical_bytes());
-    let first = store
-        .content()
-        .put_streaming(&owner, &name, source)
-        .unwrap();
-    assert_eq!(store.staging().ready().unwrap(), vec![staged.clone()]);
-
-    let retried = store.publish_staged(staged).await.unwrap();
-    assert_eq!(retried.descriptor(), first.descriptor());
-    assert_eq!(retried.principal_root(), first.principal_root());
-    assert_eq!(
-        retried.objects_inserted(),
-        0,
-        "retry must not count immutable objects admitted by the first publication"
-    );
-    assert!(store.staging().ready().unwrap().is_empty());
-}
-
-#[tokio::test]
-async fn staged_publication_enforces_close_order_for_the_same_name() {
-    let directory = tempfile::tempdir().unwrap();
-    let home = AstridHome::from_path(directory.path());
-    let store = open_runtime_principal_store(&home, unlimited_quota())
-        .await
-        .unwrap();
-    let owner = test_owner("alice");
-    let name = ContentName::new("workspace/order.txt").unwrap();
-    let mut first = store
-        .staging()
-        .begin(owner, name.clone(), ChunkingProfile::ASTRID_V1)
-        .unwrap();
-    first.write_all(b"first close").unwrap();
-    let first = first.seal().unwrap();
-    let mut second = store
-        .staging()
-        .begin(owner, name.clone(), ChunkingProfile::ASTRID_V1)
-        .unwrap();
-    second.write_all(b"second close").unwrap();
-    let second = second.seal().unwrap();
-
-    let error = store.publish_staged(second.clone()).await.unwrap_err();
-    assert!(error.to_string().contains("earlier close"));
-    store.publish_staged(first).await.unwrap();
-    store.publish_staged(second).await.unwrap();
-    assert_eq!(
-        store.content().read(&owner, &name).unwrap(),
-        Some(b"second close".to_vec())
-    );
-}
-
-#[cfg(not(target_os = "windows"))]
-#[tokio::test]
-async fn hosted_volume_retires_a_torn_tail_and_reopens_committed_roots() {
-    let directory = tempfile::tempdir().unwrap();
-    let home = AstridHome::from_path(directory.path());
-    let store = open_runtime_principal_store(&home, unlimited_quota())
-        .await
-        .unwrap();
-    let alice_uid = create_test_principal(&store, "alice").await;
-    store
-        .kv()
-        .set("alice:capsule:shell", "cwd", b"/workspace".to_vec())
-        .await
-        .unwrap();
-    store
-        .kv()
-        .set("alice:capsule:shell", "theme", b"raven".to_vec())
-        .await
-        .unwrap();
-    store.engine.close().unwrap();
-    drop(store);
-
-    let path = home.storage_volume_path();
-    let committed_len = std::fs::metadata(&path).unwrap().len();
-    let mut file = std::fs::OpenOptions::new()
-        .append(true)
-        .open(&path)
-        .unwrap();
-    file.write_all(&[0xA5; 17]).unwrap();
-    file.sync_all().unwrap();
-    drop(file);
-
-    let reopened = open_runtime_principal_store(&home, unlimited_quota())
-        .await
-        .unwrap();
-    assert_eq!(std::fs::metadata(&path).unwrap().len(), committed_len);
-    assert_eq!(
-        reopened
-            .engine
-            .root(&StateOwner::Principal(alice_uid))
-            .unwrap()
-            .unwrap()
-            .generation,
-        RootGeneration::new(1)
-    );
-    assert_eq!(
-        reopened
-            .kv()
-            .get("alice:capsule:shell", "theme")
-            .await
-            .unwrap(),
-        Some(b"raven".to_vec())
-    );
-}
-
-#[cfg(not(target_os = "windows"))]
-#[tokio::test]
-async fn hosted_volume_rejects_interior_container_corruption_on_header_fallback() {
-    let directory = tempfile::tempdir().unwrap();
-    let home = AstridHome::from_path(directory.path());
-    let store = open_runtime_principal_store(&home, unlimited_quota())
-        .await
-        .unwrap();
-    store.engine.close().unwrap();
-    drop(store);
-
-    let path = home.storage_volume_path();
-    let mut bytes = std::fs::read(&path).unwrap();
-    bytes[8] ^= 0x80;
-    std::fs::write(&path, bytes).unwrap();
-
-    let reopened = open_runtime_principal_store(&home, unlimited_quota())
-        .await
-        .expect("valid footer should bypass interior journal scanning");
-    reopened.engine.close().unwrap();
-    drop(reopened);
-
-    let mut bytes = std::fs::read(&path).unwrap();
-    *bytes.last_mut().unwrap() ^= 0x80;
-    std::fs::write(&path, bytes).unwrap();
-
-    let Err(error) = open_runtime_principal_store(&home, unlimited_quota()).await else {
-        panic!("corrupt Astrid volume unexpectedly reopened");
-    };
-    assert!(error.to_string().contains("record magic"), "{error}");
-}
-
-#[tokio::test]
-async fn independent_reader_accepts_a_rust_produced_volume() {
-    let directory = tempfile::tempdir().unwrap();
-    let home = AstridHome::from_path(directory.path());
-    let store = open_runtime_principal_store(&home, unlimited_quota())
-        .await
-        .unwrap();
-    let alice_uid = create_test_principal(&store, "alice").await;
-    let alice = alice_uid.to_string();
-    store
-        .kv()
-        .set("alice:capsule:shell", "cwd", b"/workspace".to_vec())
-        .await
-        .unwrap();
-    let owner = StateOwner::Principal(alice_uid);
-    let name = ContentName::new("workspace/fastcdc-golden.bin").unwrap();
-    store
-        .content()
-        .put(&owner, &name, &chunker_golden_source(1024 * 1024))
-        .unwrap();
-    drop(store);
-
-    let script = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../scripts/runatal_v1_reader.py");
-    let output = std::process::Command::new("python3")
-        .arg(&script)
-        .arg(home.storage_volume_path())
-        .output()
-        .unwrap();
-    assert!(
-        output.status.success(),
-        "independent reader failed: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    let decoded: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
-    assert_eq!(decoded["roots"][alice.as_str()]["generation"], 1);
-    assert_eq!(decoded["roots"][alice.as_str()]["kv"]["entries"], 1);
-    assert_eq!(
-        decoded["roots"][alice.as_str()]["kv"]["logical_bytes"],
-        b"/workspace".len()
-    );
-    assert!(
-        decoded["roots"][alice.as_str()]["commit"]
-            .as_str()
-            .unwrap()
-            .starts_with("1:1:32:")
-    );
-    assert!(
-        decoded["objects"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .any(|object| object["kind"] == "Evidence")
-    );
-    assert!(
-        decoded["objects"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .any(|object| object["kind"] == "Commit")
-    );
-    assert!(
-        decoded["objects"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .any(|object| object["kind"] == "File")
-    );
-    assert_eq!(
-        decoded["content_catalog_spec_object"],
-        format!(
-            "1:1:32:{}",
-            object_id_hex(
-                Blake3ObjectIdentityV1
-                    .identify(&bootstrap::content_catalog_format_specification().unwrap(),)
-            )
-        )
-    );
-
-    let volume_path = home.storage_volume_path();
-    let mut volume = std::fs::read(&volume_path).unwrap();
-    volume[43] ^= 0x80;
-    std::fs::write(&volume_path, volume).unwrap();
-    let rejected = std::process::Command::new("python3")
-        .arg(Path::new(env!("CARGO_MANIFEST_DIR")).join("../../scripts/runatal_v1_reader.py"))
-        .arg(volume_path)
-        .output()
-        .unwrap();
-    assert!(
-        !rejected.status.success(),
-        "independent reader accepted a corrupt Rust-produced volume"
-    );
-}
-
-#[test]
-fn independent_volume_validator_rejects_the_full_unicode_control_set() {
-    let script_directory = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../scripts");
-    let output = std::process::Command::new("python3")
-        .current_dir(script_directory)
-        .arg("-c")
-        .arg(
-            r#"from runatal_v1_volume import VolumeFormatError, volume_region_name
-for codepoint in range(0x80, 0xa0):
-    try:
-        volume_region_name(chr(codepoint).encode())
-    except VolumeFormatError:
-        continue
-    raise AssertionError(f"U+{codepoint:04X} was accepted")
-assert volume_region_name(" Astrid ".encode()) == " Astrid ""#,
-        )
-        .output()
-        .unwrap();
-    assert!(
-        output.status.success(),
-        "independent validator failed: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-}
-
 #[tokio::test]
 async fn completed_store_does_not_self_heal_a_missing_runatal_object() {
     let directory = tempfile::tempdir().unwrap();
     let home = AstridHome::from_path(directory.path());
+    seed_legacy_layout(&home);
     let path = home.principal_store_path();
     std::fs::create_dir_all(&path).unwrap();
     let record = bootstrap::format_specification().unwrap();
@@ -1388,6 +304,7 @@ async fn completed_store_does_not_self_heal_a_missing_runatal_object() {
 async fn current_metadata_does_not_self_heal_a_missing_catalog_specification() {
     let directory = tempfile::tempdir().unwrap();
     let home = AstridHome::from_path(directory.path());
+    seed_legacy_layout(&home);
     let path = home.principal_store_path();
     std::fs::create_dir_all(&path).unwrap();
     let format_spec = bootstrap::format_specification().unwrap();
@@ -1493,6 +410,7 @@ fn control_namespaces_require_admitted_immutable_uids() {
 async fn first_boot_migrates_verifies_and_preserves_legacy_state() {
     let directory = tempfile::tempdir().unwrap();
     let home = AstridHome::from_path(directory.path());
+    seed_legacy_layout(&home);
     let legacy = Arc::new(SurrealKvStore::open(home.state_db_path()).unwrap());
     let legacy_kv: Arc<dyn KvStore> = legacy.clone();
     let identities = KvIdentityStore::new(
@@ -1718,19 +636,112 @@ async fn rejected_streaming_writes_do_not_grow_the_physical_volume() {
 async fn incomplete_destination_is_quarantined_before_reimport() {
     let directory = tempfile::tempdir().unwrap();
     let home = AstridHome::from_path(directory.path());
+    seed_legacy_layout(&home);
     std::fs::create_dir_all(home.principal_store_path()).unwrap();
     std::fs::write(home.principal_store_path().join("partial"), b"incomplete").unwrap();
 
-    let store = open_runtime_kv(&home, unlimited_quota()).await.unwrap();
-    assert!(
-        home.var_dir()
-            .join("principal-store.incomplete.0")
-            .join("partial")
-            .exists()
-    );
+    let store = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    assert!(!home.principal_store_path().exists());
+    assert!(!home.var_dir().join("principal-store.incomplete.0").exists());
     assert!(home.storage_volume_path().is_file());
-    assert!(home.principal_store_path().is_dir());
+    let quarantine_name =
+        ContentName::new("quarantine/principal-store/0/partial").expect("valid quarantine name");
+    assert_eq!(
+        store
+            .content()
+            .read(&StateOwner::System, &quarantine_name)
+            .unwrap(),
+        Some(b"incomplete".to_vec())
+    );
+    store.engine.close().unwrap();
     drop(store);
+
+    let packer = open_runtime_principal_store_for_pack(&home, unlimited_quota())
+        .await
+        .unwrap();
+    packer
+        .pack_and_retire_runtime_projection(&home)
+        .expect("pack quarantine");
+    assert_eq!(std::fs::read_dir(home.root()).unwrap().count(), 1);
+    packer.engine.close().unwrap();
+    drop(packer);
+
+    let reopened = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    assert_eq!(
+        std::fs::read(home.root().join("quarantine/principal-store/0/partial")).unwrap(),
+        b"incomplete"
+    );
+    reopened
+        .pack_and_retire_runtime_projection(&home)
+        .expect("retire quarantine projection");
+    assert_eq!(std::fs::read_dir(home.root()).unwrap().count(), 1);
+}
+
+#[test]
+fn layout_retirement_resumes_exact_source_and_fails_closed_on_mismatch() {
+    let directory = tempfile::tempdir().unwrap();
+    let outside = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(directory.path());
+    seed_legacy_layout(&home);
+    home.ensure().unwrap();
+    seed_legacy_surrealkv(&home, b"exact-source");
+    let target = astrid_core::dirs::LayoutMigrationTarget::new(
+        "test-store/3;state-owner-codec/2",
+        "test-binary/1",
+    )
+    .unwrap();
+    home.begin_layout_v2_migration(&target).unwrap();
+    std::fs::write(home.storage_volume_path(), b"cutover-volume").unwrap();
+    home.complete_layout_v2(&target).unwrap();
+
+    std::fs::write(home.storage_volume_path(), b"post-cutover-write").unwrap();
+    let drifted = seed_legacy_surrealkv(&home, b"pack-restored-drift");
+    home.complete_layout_v2(&target).unwrap();
+    assert!(!drifted.exists());
+
+    let foreign_volume = outside.path().join("foreign.volume");
+    std::fs::write(&foreign_volume, b"foreign-volume").unwrap();
+    std::fs::remove_file(home.storage_volume_path()).unwrap();
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(&foreign_volume, home.storage_volume_path()).unwrap();
+    let mismatched = seed_legacy_surrealkv(&home, b"changed-source");
+    let error = home.complete_layout_v2(&target).unwrap_err();
+    assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+    assert!(error.to_string().contains("redirected"), "{error}");
+    assert!(mismatched.exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn layout_retirement_rejects_redirected_residue_before_retirement() {
+    let directory = tempfile::tempdir().unwrap();
+    let outside = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(directory.path());
+    seed_legacy_layout(&home);
+    home.ensure().unwrap();
+    seed_legacy_surrealkv(&home, b"exact-source");
+    let target = astrid_core::dirs::LayoutMigrationTarget::new(
+        "test-store/3;state-owner-codec/2",
+        "test-binary/1",
+    )
+    .unwrap();
+    home.begin_layout_v2_migration(&target).unwrap();
+    std::fs::write(home.storage_volume_path(), b"cutover-volume").unwrap();
+    home.complete_layout_v2(&target).unwrap();
+
+    let external_source = outside.path().join("foreign-state");
+    std::fs::write(&external_source, b"outside").unwrap();
+    std::os::unix::fs::symlink(&external_source, home.state_db_path()).unwrap();
+    let error = home.complete_layout_v2(&target).unwrap_err();
+
+    assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+    assert!(error.to_string().contains("redirected"), "{error}");
+    assert!(home.state_db_path().symlink_metadata().is_ok());
+    assert!(external_source.is_file());
 }
 
 #[cfg(not(feature = "legacy-surrealkv"))]
@@ -1738,6 +749,8 @@ async fn incomplete_destination_is_quarantined_before_reimport() {
 async fn legacy_source_requires_the_transition_feature() {
     let directory = tempfile::tempdir().unwrap();
     let home = AstridHome::from_path(directory.path());
+    seed_legacy_layout(&home);
+    home.ensure().unwrap();
     std::fs::create_dir_all(home.state_db_path()).unwrap();
 
     let Err(error) = open_runtime_kv(&home, unlimited_quota()).await else {
@@ -1806,87 +819,4 @@ async fn durable_point_update_has_height_bounded_write_amplification() {
         store.get("alice:capsule:build", "0128").await.unwrap(),
         Some(b"replacement".to_vec())
     );
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
-#[ignore = "explicit native KV group-commit throughput probe"]
-async fn native_kv_group_commit_scale_probe() {
-    const COMMITS_PER_WRITER: u8 = 64;
-
-    for writers in [1_u8, 2, 4, 8] {
-        let directory = tempfile::tempdir().unwrap();
-        let aliases = (0..writers)
-            .map(|writer| format!("principal-{writer}"))
-            .collect::<Vec<_>>();
-        let alias_refs = aliases.iter().map(String::as_str).collect::<Vec<_>>();
-        let engine = Arc::new(
-            RuntimeEngine::open(
-                directory.path(),
-                Blake3ObjectIdentityV1,
-                StateOwnerCodecV2,
-                RecoveryLimits::process_addressable(),
-            )
-            .unwrap(),
-        );
-        let specification = bootstrap::format_specification().unwrap();
-        let specification_id = engine.identify(&specification);
-        engine.persist_standalone_object(&specification).unwrap();
-        engine
-            .ensure_direct_representation_catalogue(specification_id, &[specification_id])
-            .unwrap();
-        let store = Arc::new(RuntimeStore::from_engine(
-            Arc::clone(&engine),
-            StateOwnerResolver::new(test_directory(&alias_refs)),
-        ));
-        let barrier = Arc::new(tokio::sync::Barrier::new(usize::from(writers) + 1));
-        let mut tasks = Vec::new();
-        for writer in 0..writers {
-            let store = Arc::clone(&store);
-            let barrier = Arc::clone(&barrier);
-            tasks.push(tokio::spawn(async move {
-                let namespace = format!("principal-{writer}:capsule:probe");
-                let mut latencies = Vec::new();
-                barrier.wait().await;
-                for sequence in 0..COMMITS_PER_WRITER {
-                    let mut value = vec![0_u8; 128];
-                    value[..2].copy_from_slice(&[writer, sequence]);
-                    let started = Instant::now();
-                    store.set(&namespace, "state", value).await.unwrap();
-                    latencies.push(started.elapsed());
-                }
-                latencies
-            }));
-        }
-        barrier.wait().await;
-        let started = Instant::now();
-        let mut writer_latencies = Vec::new();
-        for task in tasks {
-            writer_latencies.push(task.await.unwrap());
-        }
-        let elapsed = started.elapsed();
-        let mut latencies: Vec<_> = writer_latencies.iter().flatten().copied().collect();
-        latencies.sort_unstable();
-        let operations = u32::from(writers) * u32::from(COMMITS_PER_WRITER);
-        let p50 = latencies[latencies.len() / 2];
-        let p95 = latencies[(latencies.len() * 95 / 100).min(latencies.len() - 1)];
-        let per_writer_p95: Vec<_> = writer_latencies
-            .iter_mut()
-            .map(|latencies| {
-                latencies.sort_unstable();
-                latencies[(latencies.len() * 95 / 100).min(latencies.len() - 1)].as_micros()
-            })
-            .collect();
-        let per_writer_max: Vec<_> = writer_latencies
-            .iter()
-            .map(|latencies| latencies.last().unwrap().as_micros())
-            .collect();
-        println!(
-            "native_kv_group_commit writers={writers} operations={operations} ops_per_second={:.1} p50_us={} p95_us={} per_writer_p95_us={per_writer_p95:?} per_writer_max_us={per_writer_max:?} wall_ms={}",
-            f64::from(operations) / elapsed.as_secs_f64(),
-            p50.as_micros(),
-            p95.as_micros(),
-            elapsed.as_millis(),
-        );
-        store.close().await.unwrap();
-    }
 }

--- a/crates/astrid-storage/src/principal_state/runtime_tests.rs
+++ b/crates/astrid-storage/src/principal_state/runtime_tests.rs
@@ -1,5 +1,4 @@
 pub(super) use std::collections::BTreeMap;
-pub(super) use std::io::{Read as _, Seek as _, SeekFrom, Write as _};
 pub(super) use std::num::NonZeroU64;
 pub(super) use std::path::Path;
 pub(super) use std::time::{Duration, Instant};

--- a/crates/astrid-storage/src/principal_state/runtime_tests/staging_batch_tests.rs
+++ b/crates/astrid-storage/src/principal_state/runtime_tests/staging_batch_tests.rs
@@ -2,6 +2,7 @@
 
 use std::io::Write as _;
 
+use super::super::content_staging_tests::volume_file_len;
 use super::*;
 
 #[tokio::test]

--- a/crates/astrid-storage/src/principal_state/runtime_tree.rs
+++ b/crates/astrid-storage/src/principal_state/runtime_tree.rs
@@ -274,6 +274,10 @@ pub(super) fn restore_projection(
             continue;
         };
         write_projection_file(home.root(), name, &bytes)?;
+        if is_staging_generation(name) {
+            let path = confined_projection_path(home.root(), name)?;
+            super::rebind_staging_generation(&path)?;
+        }
     }
     Ok(())
 }
@@ -578,6 +582,11 @@ fn write_projection_file(root: &Path, relative: &str, bytes: &[u8]) -> StorageRe
     Ok(())
 }
 
+fn is_staging_generation(name: &str) -> bool {
+    name.strip_prefix("var/content-staging/generations/")
+        .is_some_and(|name| name.ends_with(".sealed"))
+}
+
 fn retire_projection(home: &AstridHome) -> StorageResult<()> {
     let root = home.root();
     astrid_core::dirs::retire_projection_root(root)
@@ -769,6 +778,7 @@ fn tree_error(path: &Path, detail: impl std::fmt::Display) -> StorageError {
 pub(super) fn reconcile_running_projection(
     home: &AstridHome,
     store: &RuntimePrincipalStore,
+    allow_receiptless_bootstrap: bool,
 ) -> StorageResult<()> {
     let layout_version = home
         .layout_version()
@@ -782,7 +792,9 @@ pub(super) fn reconcile_running_projection(
     match receipt {
         None => {
             let scanned = scan(home.root())?;
-            if surviving && !is_bootstrap_surviving_projection(&scanned) {
+            if surviving
+                && (!allow_receiptless_bootstrap || !is_bootstrap_surviving_projection(&scanned))
+            {
                 let names = scanned
                     .iter()
                     .map(|entry| entry.name().as_str())
@@ -799,14 +811,14 @@ pub(super) fn reconcile_running_projection(
             // A portable active-volume copy is volume-authoritative. Host
             // bytes are neither admitted nor allowed beyond trusted bootstrap
             // sentinels; the copied receipt is simply rebound to the new root.
-            if receipt.phase() != ReceiptPhase::Active || !surviving {
+            if receipt.phase() != ReceiptPhase::Active {
                 return Err(tree_error(
                     home.root(),
                     "active projection receipt root does not match this durable root",
                 ));
             }
             let scanned = scan(home.root())?;
-            if !is_bootstrap_surviving_projection(&scanned) {
+            if surviving && !is_bootstrap_surviving_projection(&scanned) {
                 return Err(tree_error(
                     home.root(),
                     "relocated active receipt is permitted only for trusted bootstrap files",
@@ -816,10 +828,6 @@ pub(super) fn reconcile_running_projection(
         },
         Some(receipt) => match receipt.phase() {
             ReceiptPhase::Active => {
-                // `AstridHome::ensure` creates bootstrap sentinels before the
-                // volume is opened. Those host files alone are not a live
-                // projection; publishing them would CAS-delete the volume-only
-                // generation before it can be restored.
                 let scanned = scan(home.root())?;
                 if surviving && !is_bootstrap_surviving_projection(&scanned) {
                     publish_active_projection(home, store)?;

--- a/crates/astrid-storage/src/principal_state/runtime_tree.rs
+++ b/crates/astrid-storage/src/principal_state/runtime_tree.rs
@@ -6,7 +6,8 @@
 
 use std::path::{Component, Path, PathBuf};
 
-use crate::content::ContentName;
+use crate::content::{ContentName, PrepareDerivedBatchContent};
+use crate::engine::PrincipalProjectionError;
 use crate::error::{StorageError, StorageResult};
 use astrid_core::dirs::AstridHome;
 
@@ -540,7 +541,7 @@ fn active_projection_entries(
         .filter(|entry| !is_retired_legacy_projection(home, entry.name().as_str()))
         .map(|entry| ActiveProjectionEntry {
             name: entry.name().clone(),
-            file: Some(entry.file()),
+            file: entry.file(),
             logical_bytes: entry.logical_bytes(),
         })
         .collect())
@@ -564,7 +565,7 @@ fn rotate_active_receipt(
     entries: &[ActiveProjectionEntry],
 ) -> StorageResult<()> {
     let receipt = receipt_ingest(home, ReceiptPhase::Active, entries)?;
-    store.replace_contiguous_files_removing_exact(StateOwner::System, [receipt], &[])?;
+    store.replace_contiguous_files_removing_exact(StateOwner::System, [receipt], &[], None)?;
     store
         .content()
         .flush()
@@ -574,6 +575,47 @@ fn rotate_active_receipt(
 fn establish_active_receipt(home: &AstridHome, store: &RuntimePrincipalStore) -> StorageResult<()> {
     let entries = active_projection_entries(home, store)?;
     rotate_active_receipt(home, store, &entries)
+}
+
+struct ActiveReceiptDeriver {
+    home: AstridHome,
+    entries: Vec<(ContentName, u64)>,
+}
+
+impl PrepareDerivedBatchContent for ActiveReceiptDeriver {
+    fn prepare(
+        &mut self,
+        prepared: &std::collections::BTreeMap<ContentName, crate::content::ContentDescriptor>,
+    ) -> Result<(ContentName, Vec<u8>), crate::content::PrincipalContentError> {
+        let entries = self
+            .entries
+            .iter()
+            .map(|(name, logical_bytes)| {
+                let descriptor = prepared.get(name).ok_or_else(|| {
+                    PrincipalProjectionError::Engine(format!(
+                        "prepared runtime projection omitted {}",
+                        name.as_str()
+                    ))
+                })?;
+                if descriptor.logical_bytes() != *logical_bytes {
+                    return Err(PrincipalProjectionError::Engine(format!(
+                        "prepared runtime projection changed {}",
+                        name.as_str()
+                    )));
+                }
+                Ok(ActiveProjectionEntry {
+                    name: name.clone(),
+                    file: descriptor.file(),
+                    logical_bytes: *logical_bytes,
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let bytes = active::encode(&self.home, ReceiptPhase::Active, &entries)
+            .map_err(|error| PrincipalProjectionError::Engine(error.to_string()))?;
+        let name = active::active_projection_name()
+            .map_err(|error| PrincipalProjectionError::Engine(error.to_string()))?;
+        Ok((name, bytes))
+    }
 }
 
 fn publish_active_projection(
@@ -595,13 +637,12 @@ fn publish_active_projection(
     let removals = active::removals(&receipt, &surviving)?;
     let receipt_entries = scanned
         .iter()
-        .map(|entry| ActiveProjectionEntry {
-            name: entry.name().clone(),
-            file: None,
-            logical_bytes: entry.logical_bytes(),
-        })
+        .map(|entry| (entry.name().clone(), entry.logical_bytes()))
         .collect::<Vec<_>>();
-    let receipt = receipt_ingest(home, ReceiptPhase::Active, &receipt_entries)?;
+    let mut derived = ActiveReceiptDeriver {
+        home: home.clone(),
+        entries: receipt_entries,
+    };
     let ingests = scanned.into_iter().map(|entry| {
         PackedProjectionIngest::File(ContiguousFileIngest::new(
             entry.name,
@@ -609,8 +650,12 @@ fn publish_active_projection(
             entry.logical_bytes,
         ))
     });
-    let ingests = std::iter::once(receipt).chain(ingests);
-    store.replace_contiguous_files_removing_exact(StateOwner::System, ingests, &removals)?;
+    store.replace_contiguous_files_removing_exact(
+        StateOwner::System,
+        ingests,
+        &removals,
+        Some(&mut derived),
+    )?;
     store
         .content()
         .flush()
@@ -631,7 +676,7 @@ fn transition_retiring_projection(
     }
     let entries = active_projection_entries(home, store)?;
     let receipt = receipt_ingest(home, ReceiptPhase::Retiring, &entries)?;
-    store.replace_contiguous_files_removing_exact(StateOwner::System, [receipt], &[])?;
+    store.replace_contiguous_files_removing_exact(StateOwner::System, [receipt], &[], None)?;
     store
         .content()
         .flush()

--- a/crates/astrid-storage/src/principal_state/runtime_tree.rs
+++ b/crates/astrid-storage/src/principal_state/runtime_tree.rs
@@ -10,7 +10,12 @@ use crate::content::ContentName;
 use crate::error::{StorageError, StorageResult};
 use astrid_core::dirs::AstridHome;
 
-use super::{ContiguousFileIngest, RuntimePrincipalStore, StateOwner};
+use super::{
+    ContiguousFileIngest, RuntimePrincipalStore, StateOwner,
+    runtime_tree_active::{ACTIVE_PROJECTION_NAME, ActiveProjectionEntry},
+};
+
+use super::runtime_tree_active as active;
 
 const VOLUME_PATH_PREFIX: &str = "volume";
 const SOCKET_PATH: &str = "run/system.sock";
@@ -214,8 +219,9 @@ fn is_path_or_descendant(relative: &str, prefix: &str) -> bool {
     relative == prefix || relative.starts_with(&format!("{prefix}/"))
 }
 
-fn is_excluded(relative: &str) -> bool {
+pub(super) fn is_excluded(relative: &str) -> bool {
     relative == CANONICAL_VOLUME
+        || relative == ACTIVE_PROJECTION_NAME
         || relative == LEGACY_VAR_VOLUME
         || is_path_or_descendant(relative, VOLUME_PATH_PREFIX)
         || (relative.starts_with(&format!("{TRANSIENT_PREFIX}/"))
@@ -482,12 +488,26 @@ pub(super) fn pack_and_retire_projection(
     home: &AstridHome,
     store: &RuntimePrincipalStore,
 ) -> StorageResult<()> {
-    admit(store, home.root())?;
-    store
-        .content()
-        .flush()
-        .map_err(|error| tree_error(home.root(), format!("flush volume projection: {error}")))?;
-    retire_projection(home)
+    if home
+        .layout_version()
+        .map_err(|error| tree_io_error(&error))?
+        .as_deref()
+        == Some(astrid_core::dirs::LEGACY_LAYOUT_VERSION)
+    {
+        return legacy_projection_pack(home, store);
+    }
+    if validate_surviving_projection(home.root(), home.root())? {
+        let receipt = active::read(home, store)?;
+        if receipt.is_none() {
+            return Err(tree_error(
+                home.root(),
+                "active projection receipt is missing for surviving host projection",
+            ));
+        }
+        publish_active_projection(home, store)?;
+    }
+    retire_projection(home)?;
+    active::clear(store, home).map(|_| ())
 }
 
 fn write_projection_file(root: &Path, relative: &str, bytes: &[u8]) -> StorageResult<()> {
@@ -503,40 +523,71 @@ fn write_projection_file(root: &Path, relative: &str, bytes: &[u8]) -> StorageRe
 
 fn retire_projection(home: &AstridHome) -> StorageResult<()> {
     let root = home.root();
-    let mut entries = std::fs::read_dir(root)
-        .map_err(|error| tree_error(root, format!("read durable root: {error}")))?
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|error| tree_error(root, format!("read durable root entry: {error}")))?;
-    entries.sort_by_key(std::fs::DirEntry::file_name);
-    for entry in entries {
-        let path = entry.path();
-        if entry.file_name() == std::ffi::OsStr::new(CANONICAL_VOLUME) {
-            continue;
-        }
-        let metadata = std::fs::symlink_metadata(&path)
-            .map_err(|error| tree_error(&path, format!("inspect projection: {error}")))?;
-        if metadata.file_type().is_symlink() {
-            return Err(tree_error(
-                &path,
-                "running projection contains a symbolic link".to_owned(),
-            ));
-        }
-        if metadata.is_dir() {
-            astrid_core::dirs::retire_legacy_source_tree(&path)
-                .map_err(|error| tree_error(&path, format!("retire projection: {error}")))?;
-        } else if metadata.is_file() {
-            std::fs::remove_file(&path)
-                .map_err(|error| tree_error(&path, format!("retire projection: {error}")))?;
-        } else {
-            return Err(tree_error(
-                &path,
-                "running projection contains a special file".to_owned(),
-            ));
-        }
-    }
-    super::native_io::sync_directory(root)
+    astrid_core::dirs::retire_projection_root(root)
+        .map_err(|error| tree_error(root, format!("retire projection: {error}")))
 }
 
+fn active_projection_entries(
+    home: &AstridHome,
+    store: &RuntimePrincipalStore,
+) -> StorageResult<Vec<ActiveProjectionEntry>> {
+    let entries = store
+        .content()
+        .list(&StateOwner::System)
+        .map_err(|error| tree_error(home.root(), format!("list active projection: {error}")))?;
+    Ok(entries
+        .into_iter()
+        .filter(|entry| !is_excluded(entry.name().as_str()))
+        .filter(|entry| !is_retired_legacy_projection(home, entry.name().as_str()))
+        .map(|entry| ActiveProjectionEntry {
+            name: entry.name().clone(),
+            file: entry.file(),
+            logical_bytes: entry.logical_bytes(),
+        })
+        .collect())
+}
+
+fn establish_active_receipt(home: &AstridHome, store: &RuntimePrincipalStore) -> StorageResult<()> {
+    let entries = active_projection_entries(home, store)?;
+    active::write(home, store, &entries)
+}
+
+fn publish_active_projection(
+    home: &AstridHome,
+    store: &RuntimePrincipalStore,
+) -> StorageResult<()> {
+    let receipt = active::read(home, store)?.ok_or_else(|| {
+        tree_error(
+            home.root(),
+            "active projection receipt is missing for host publication",
+        )
+    })?;
+    let scanned = scan(home.root())?;
+    let surviving = scanned
+        .iter()
+        .map(RuntimeTreeEntry::name)
+        .cloned()
+        .collect::<Vec<_>>();
+    let removals = active::removals(&receipt, &surviving)?;
+    let ingests = scanned
+        .into_iter()
+        .map(|entry| ContiguousFileIngest::new(entry.name, entry.source_path, entry.logical_bytes));
+    store.replace_contiguous_files_removing_exact(StateOwner::System, ingests, &removals)?;
+    store
+        .content()
+        .flush()
+        .map_err(|error| tree_error(home.root(), format!("flush active projection: {error}")))?;
+    establish_active_receipt(home, store)
+}
+
+fn legacy_projection_pack(home: &AstridHome, store: &RuntimePrincipalStore) -> StorageResult<()> {
+    admit(store, home.root())?;
+    store
+        .content()
+        .flush()
+        .map_err(|error| tree_error(home.root(), format!("flush volume projection: {error}")))?;
+    retire_projection(home)
+}
 fn tree_io_error(error: &std::io::Error) -> StorageError {
     StorageError::Connection(error.to_string())
 }
@@ -563,15 +614,43 @@ pub(super) fn reconcile_running_projection(
         return Ok(());
     }
 
-    if !validate_surviving_projection(home.root(), home.root())? {
-        return Ok(());
+    let surviving = validate_surviving_projection(home.root(), home.root())?;
+    if surviving {
+        let receipt = active::read(home, store)?;
+        if receipt.is_none() {
+            let scanned = scan(home.root())?;
+            if !is_bootstrap_surviving_projection(&scanned) {
+                let names = scanned
+                    .iter()
+                    .map(|entry| entry.name().as_str())
+                    .collect::<Vec<_>>();
+                return Err(tree_error(
+                    home.root(),
+                    format!(
+                        "active projection receipt is missing for surviving host projection: {names:?}"
+                    ),
+                ));
+            }
+            restore_projection(home, store, &store.content)?;
+            return establish_active_receipt(home, store);
+        }
+        publish_active_projection(home, store)?;
+    } else {
+        restore_projection(home, store, &store.content)?;
     }
-    admit(store, home.root())?;
-    store
-        .content()
-        .flush()
-        .map_err(|error| tree_error(home.root(), format!("flush running projection: {error}")))?;
-    restore_projection(home, store, &store.content)
+    establish_active_receipt(home, store)
+}
+
+fn is_bootstrap_surviving_projection(scanned: &[RuntimeTreeEntry]) -> bool {
+    !scanned.is_empty()
+        && scanned.iter().all(|entry| {
+            matches!(
+                entry.name().as_str(),
+                "etc/layout-version"
+                    | RUNTIME_KEY_PROJECTION
+                    | "var/content-staging/intents.v1.log"
+            )
+        })
 }
 
 /// Validate redirects and unadmitted specials before any destructive restore.
@@ -623,6 +702,21 @@ fn validate_surviving_projection(root: &Path, directory: &Path) -> StorageResult
 
 /// Publish the live running projection without retiring its host files.
 pub(super) fn publish_running_projection(
+    home: &AstridHome,
+    store: &RuntimePrincipalStore,
+) -> StorageResult<()> {
+    if home
+        .layout_version()
+        .map_err(|error| tree_io_error(&error))?
+        .as_deref()
+        == Some(astrid_core::dirs::LEGACY_LAYOUT_VERSION)
+    {
+        return legacy_projection_pack_publish_only(home, store);
+    }
+    publish_active_projection(home, store)
+}
+
+fn legacy_projection_pack_publish_only(
     home: &AstridHome,
     store: &RuntimePrincipalStore,
 ) -> StorageResult<()> {

--- a/crates/astrid-storage/src/principal_state/runtime_tree.rs
+++ b/crates/astrid-storage/src/principal_state/runtime_tree.rs
@@ -15,11 +15,18 @@ use super::{ContiguousFileIngest, RuntimePrincipalStore, StateOwner};
 const VOLUME_PATH_PREFIX: &str = "volume";
 const SOCKET_PATH: &str = "run/system.sock";
 const CANONICAL_VOLUME: &str = "astrid.volume";
+const MIGRATING_VOLUME: &str = "astrid.migrating";
 const LEGACY_VAR_VOLUME: &str = "var/astrid.volume";
 const DIRECTORY_STORE_PREFIX: &str = "var/principal-store";
 const QUARANTINE_PREFIX: &str = "quarantine/principal-store";
 const TRANSIENT_PREFIX: &str = "run";
 const RUNTIME_KEY_PROJECTION: &str = "keys/runtime.key";
+const TRANSACTION_STAGING_PATHS: &[&str] = &[
+    "etc/.layout-version.next",
+    "var/migrations/.layout-v1-to-v2.intent.next",
+    "var/migrations/.layout-v1-to-v2.retiring.next",
+    "var/migrations/.layout-v1-to-v2.complete.next",
+];
 const HOST_EXECUTABLES: &[&str] = &["astrid", "astrid-daemon", "bin/astrid", "bin/astrid-daemon"];
 
 /// One regular file discovered in the native runtime tree.
@@ -216,14 +223,8 @@ fn is_excluded(relative: &str) -> bool {
         || is_path_or_descendant(relative, DIRECTORY_STORE_PREFIX)
         || HOST_EXECUTABLES.contains(&relative)
         || relative == SOCKET_PATH
-        || std::path::Path::new(relative)
-            .extension()
-            .is_some_and(|extension| {
-                matches!(
-                    extension.to_ascii_lowercase().to_str(),
-                    Some("next" | "migrating")
-                )
-            })
+        || relative == MIGRATING_VOLUME
+        || TRANSACTION_STAGING_PATHS.contains(&relative)
 }
 
 /// Replace durable host files with volume-backed running projections.
@@ -611,6 +612,30 @@ mod tests {
     }
 
     #[test]
+    fn excludes_only_named_transaction_paths() {
+        for path in [
+            MIGRATING_VOLUME,
+            "etc/.layout-version.next",
+            "var/migrations/.layout-v1-to-v2.intent.next",
+            "var/migrations/.layout-v1-to-v2.retiring.next",
+            "var/migrations/.layout-v1-to-v2.complete.next",
+        ] {
+            assert!(is_excluded(path), "transaction path was admitted: {path}");
+        }
+
+        for path in [
+            "etc/user.next",
+            "etc/user.migrating",
+            "var/user.next",
+            "var/user.migrating",
+            "astrid.migrating.previous",
+            "etc/.layout-version.next.old",
+        ] {
+            assert!(!is_excluded(path), "ordinary path was excluded: {path}");
+        }
+    }
+
+    #[test]
     fn allows_run_capsule_projections() {
         let normalized = normalize_relative_path("run/capsules/example/component.wasm");
         assert!(!is_excluded(&normalized));
@@ -921,5 +946,54 @@ mod tests {
             .pack_and_retire_runtime_projection(&home)
             .expect("retire restarted projection");
         assert_eq!(std::fs::read_dir(home.root()).unwrap().count(), 1);
+    }
+
+    #[tokio::test]
+    async fn preserves_ordinary_suffix_files_across_clean_stop() {
+        let home_dir = tempfile::tempdir().unwrap();
+        let home = AstridHome::from_path(home_dir.path());
+        let store = open_runtime_principal_store(&home, unlimited_quota())
+            .await
+            .unwrap();
+
+        let next_path = home.root().join("etc/user.next");
+        let migrating_path = home.root().join("etc/user.migrating");
+        std::fs::create_dir_all(next_path.parent().unwrap()).unwrap();
+        std::fs::write(&next_path, b"queued-by-user").unwrap();
+        std::fs::write(&migrating_path, b"kept-by-user").unwrap();
+
+        drop(store);
+        let store = open_runtime_principal_store_for_pack(&home, unlimited_quota())
+            .await
+            .unwrap();
+        store
+            .pack_and_retire_runtime_projection(&home)
+            .expect("pack ordinary suffix files");
+
+        let stopped = std::fs::read_dir(home.root())
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(stopped.len(), 1);
+        assert_eq!(
+            stopped[0].file_name(),
+            std::ffi::OsStr::new(CANONICAL_VOLUME)
+        );
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            assert_eq!(
+                stopped[0].metadata().unwrap().permissions().mode() & 0o777,
+                0o600
+            );
+        }
+        drop(store);
+
+        let reopened = open_runtime_principal_store(&home, unlimited_quota())
+            .await
+            .unwrap();
+        assert_eq!(std::fs::read(&next_path).unwrap(), b"queued-by-user");
+        assert_eq!(std::fs::read(&migrating_path).unwrap(), b"kept-by-user");
+        drop(reopened);
     }
 }

--- a/crates/astrid-storage/src/principal_state/runtime_tree.rs
+++ b/crates/astrid-storage/src/principal_state/runtime_tree.rs
@@ -259,25 +259,47 @@ pub(super) fn restore_projection(
         }
         confined_projection_path(home.root(), name)?;
     }
-    for entry in entries {
-        let name = entry.name().as_str();
-        if is_excluded(name) {
-            continue;
-        }
-        if is_retired_legacy_projection(home, name) {
-            continue;
-        }
-        let Some(bytes) = content
-            .read(&StateOwner::System, entry.name())
-            .map_err(|error| tree_error(home.root(), format!("read projection {name}: {error}")))?
-        else {
-            continue;
-        };
-        write_projection_file(home.root(), name, &bytes)?;
-        if is_staging_generation(name) {
+    let mut written = Vec::new();
+    let result = (|| -> StorageResult<()> {
+        for entry in entries {
+            let name = entry.name().as_str();
+            if is_excluded(name) || is_retired_legacy_projection(home, name) {
+                continue;
+            }
+            let Some(bytes) = content
+                .read(&StateOwner::System, entry.name())
+                .map_err(|error| {
+                    tree_error(home.root(), format!("read projection {name}: {error}"))
+                })?
+            else {
+                continue;
+            };
             let path = confined_projection_path(home.root(), name)?;
-            super::rebind_staging_generation(&path)?;
+            let previous = super::native_io::snapshot_private_file(&path)?;
+            written.push((path, previous));
+            write_projection_file(home.root(), name, &bytes)?;
+            if is_staging_generation(name) {
+                let path = confined_projection_path(home.root(), name)?;
+                super::rebind_staging_generation(&path)?;
+            }
         }
+        Ok(())
+    })();
+    if let Err(error) = result {
+        let rollback_errors = super::native_io::rollback_private_files(written);
+        if !rollback_errors.is_empty() {
+            let retirement = match transition_retiring_projection(home, store) {
+                Ok(()) => "durable RETIRING receipt recorded".to_owned(),
+                Err(retirement) => format!("failed to force RETIRING receipt: {retirement}"),
+            };
+            return Err(tree_error(
+                home.root(),
+                format!(
+                    "restore failed: {error}; rollback failures: {rollback_errors:?}; {retirement}"
+                ),
+            ));
+        }
+        return Err(error);
     }
     Ok(())
 }
@@ -293,7 +315,6 @@ fn is_retired_legacy_projection(home: &AstridHome, name: &str) -> bool {
         })
         .any(|relative| normalize_relative_path(&relative) == name)
 }
-
 /// Admit an incomplete legacy-store tree as durable System-owned quarantine.
 ///
 /// Residue is published only after its source bytes are read without
@@ -832,10 +853,6 @@ pub(super) fn reconcile_running_projection(
                 if surviving && !is_bootstrap_surviving_projection(&scanned) {
                     publish_active_projection(home, store)?;
                 } else {
-                    // A restore can fail after writing one volume entry. Mark
-                    // the receipt RETIRING first so a retry restores from the
-                    // volume instead of adopting that partial host tree.
-                    transition_retiring_projection(home, store)?;
                     restore_projection(home, store, &store.content)?;
                 }
             },

--- a/crates/astrid-storage/src/principal_state/runtime_tree.rs
+++ b/crates/astrid-storage/src/principal_state/runtime_tree.rs
@@ -27,6 +27,7 @@ const DIRECTORY_STORE_PREFIX: &str = "var/principal-store";
 const QUARANTINE_PREFIX: &str = "quarantine/principal-store";
 const TRANSIENT_PREFIX: &str = "run";
 const RUNTIME_KEY_PROJECTION: &str = "keys/runtime.key";
+const STAGING_JOURNAL_PROJECTION: &str = "var/content-staging/intents.v1.log";
 const TRANSACTION_STAGING_PATHS: &[&str] = &[
     "etc/.layout-version.next",
     "var/migrations/.layout-v1-to-v2.intent.next",
@@ -251,6 +252,13 @@ pub(super) fn restore_projection(
     let entries = content
         .list(&StateOwner::System)
         .map_err(|error| tree_error(home.root(), format!("list volume projection: {error}")))?;
+    for entry in &entries {
+        let name = entry.name().as_str();
+        if is_excluded(name) || is_retired_legacy_projection(home, name) {
+            continue;
+        }
+        confined_projection_path(home.root(), name)?;
+    }
     for entry in entries {
         let name = entry.name().as_str();
         if is_excluded(name) {
@@ -499,10 +507,29 @@ pub(super) fn pack_and_retire_projection(
     }
     if validate_surviving_projection(home.root(), home.root())? {
         let receipt = active::read(home, store)?;
-        if let Some(receipt) = receipt
-            && receipt.phase() == ReceiptPhase::Active
-        {
-            publish_active_projection(home, store)?;
+        match receipt {
+            Some(receipt) if receipt.phase() == ReceiptPhase::Active => {
+                publish_active_projection(home, store)?;
+            },
+            Some(receipt) => {
+                let scanned = scan(home.root())?;
+                validate_retiring_host_subset(home, &receipt, &scanned)?;
+            },
+            None => {
+                let scanned = scan(home.root())?;
+                if !scanned.is_empty() && !is_exactly_pack_open_staging_journal(&scanned) {
+                    let names = scanned
+                        .iter()
+                        .map(|entry| entry.name().as_str())
+                        .collect::<Vec<_>>();
+                    return Err(tree_error(
+                        home.root(),
+                        format!(
+                            "active projection receipt is missing for surviving host projection: {names:?}"
+                        ),
+                    ));
+                }
+            },
         }
     }
     transition_retiring_projection(home, store)?;
@@ -510,8 +537,38 @@ pub(super) fn pack_and_retire_projection(
     active::clear(store, home).map(|_| ())
 }
 
+fn confined_projection_path(root: &Path, relative: &str) -> StorageResult<PathBuf> {
+    let normalized = normalize_relative_path(relative);
+    let escaped = || {
+        tree_error(
+            root,
+            format!("projection name escaped runtime root: {relative}"),
+        )
+    };
+    if normalized.is_empty() || normalized.starts_with('/') || Path::new(relative).is_absolute() {
+        return Err(escaped());
+    }
+    let mut path = root.to_path_buf();
+    for segment in normalized.split('/') {
+        if segment.is_empty() || segment == "." || segment == ".." {
+            return Err(tree_error(
+                root,
+                format!("projection name has a non-normal path component: {relative}"),
+            ));
+        }
+        if segment.len() == 2 && segment.as_bytes()[1] == b':' {
+            return Err(escaped());
+        }
+        path.push(segment);
+    }
+    if !path.starts_with(root) {
+        return Err(escaped());
+    }
+    Ok(path)
+}
+
 fn write_projection_file(root: &Path, relative: &str, bytes: &[u8]) -> StorageResult<()> {
-    let path = root.join(relative);
+    let path = confined_projection_path(root, relative)?;
     let parent = path
         .parent()
         .ok_or_else(|| tree_error(&path, "projection path has no parent".to_owned()))?;
@@ -572,7 +629,10 @@ fn rotate_active_receipt(
         .map_err(|error| tree_error(home.root(), format!("flush active receipt: {error}")))
 }
 
-fn establish_active_receipt(home: &AstridHome, store: &RuntimePrincipalStore) -> StorageResult<()> {
+pub(super) fn establish_active_receipt(
+    home: &AstridHome,
+    store: &RuntimePrincipalStore,
+) -> StorageResult<()> {
     let entries = active_projection_entries(home, store)?;
     rotate_active_receipt(home, store, &entries)
 }
@@ -756,7 +816,12 @@ pub(super) fn reconcile_running_projection(
         },
         Some(receipt) => match receipt.phase() {
             ReceiptPhase::Active => {
-                if surviving {
+                // `AstridHome::ensure` creates bootstrap sentinels before the
+                // volume is opened. Those host files alone are not a live
+                // projection; publishing them would CAS-delete the volume-only
+                // generation before it can be restored.
+                let scanned = scan(home.root())?;
+                if surviving && !is_bootstrap_surviving_projection(&scanned) {
                     publish_active_projection(home, store)?;
                 } else {
                     restore_projection(home, store, &store.content)?;
@@ -802,11 +867,22 @@ fn is_bootstrap_surviving_projection(scanned: &[RuntimeTreeEntry]) -> bool {
         && scanned.iter().all(|entry| {
             matches!(
                 entry.name().as_str(),
-                "etc/layout-version"
-                    | RUNTIME_KEY_PROJECTION
-                    | "var/content-staging/intents.v1.log"
+                "etc/layout-version" | RUNTIME_KEY_PROJECTION | STAGING_JOURNAL_PROJECTION
             )
         })
+}
+
+/// Pack-open materializes the staging journal before retirement can run.
+///
+/// That one enumerated regular file is not a surviving projection and must not
+/// be admitted without an ACTIVE receipt. Directories, symlinks, siblings,
+/// alternate spellings, and the broader bootstrap set keep fail-closed;
+/// redirects still fail in preflight.
+fn is_exactly_pack_open_staging_journal(scanned: &[RuntimeTreeEntry]) -> bool {
+    matches!(
+        scanned,
+        [entry] if entry.name().as_str() == STAGING_JOURNAL_PROJECTION
+    )
 }
 
 /// Validate redirects and unadmitted specials before any destructive restore.
@@ -839,10 +915,17 @@ fn validate_surviving_projection(root: &Path, directory: &Path) -> StorageResult
         let relative = relative
             .to_str()
             .ok_or_else(|| tree_error(&path, "projection path is not valid UTF-8".to_owned()))?;
-        if is_excluded(normalize_relative_path(relative).as_str()) {
+        let relative = normalize_relative_path(relative);
+        if is_excluded(relative.as_str()) {
             continue;
         }
         if metadata.is_dir() {
+            if relative.as_str() == STAGING_JOURNAL_PROJECTION {
+                return Err(tree_error(
+                    &path,
+                    "pack-open staging journal is not a regular file".to_owned(),
+                ));
+            }
             has_projection |= validate_surviving_projection(root, &path)?;
         } else if metadata.is_file() {
             has_projection = true;

--- a/crates/astrid-storage/src/principal_state/runtime_tree.rs
+++ b/crates/astrid-storage/src/principal_state/runtime_tree.rs
@@ -8,11 +8,19 @@ use std::path::{Component, Path, PathBuf};
 
 use crate::content::ContentName;
 use crate::error::{StorageError, StorageResult};
+use astrid_core::dirs::AstridHome;
 
 use super::{ContiguousFileIngest, RuntimePrincipalStore, StateOwner};
 
 const VOLUME_PATH_PREFIX: &str = "volume";
 const SOCKET_PATH: &str = "run/system.sock";
+const CANONICAL_VOLUME: &str = "astrid.volume";
+const LEGACY_VAR_VOLUME: &str = "var/astrid.volume";
+const DIRECTORY_STORE_PREFIX: &str = "var/principal-store";
+const QUARANTINE_PREFIX: &str = "quarantine/principal-store";
+const TRANSIENT_PREFIX: &str = "run";
+const RUNTIME_KEY_PROJECTION: &str = "keys/runtime.key";
+const HOST_EXECUTABLES: &[&str] = &["astrid", "astrid-daemon", "bin/astrid", "bin/astrid-daemon"];
 
 /// One regular file discovered in the native runtime tree.
 ///
@@ -195,8 +203,341 @@ fn normalize_relative_path(relative: &str) -> String {
     relative.replace('\\', "/")
 }
 
+fn is_path_or_descendant(relative: &str, prefix: &str) -> bool {
+    relative == prefix || relative.starts_with(&format!("{prefix}/"))
+}
+
 fn is_excluded(relative: &str) -> bool {
-    relative.starts_with(VOLUME_PATH_PREFIX) || relative == SOCKET_PATH
+    relative == CANONICAL_VOLUME
+        || relative == LEGACY_VAR_VOLUME
+        || is_path_or_descendant(relative, VOLUME_PATH_PREFIX)
+        || (relative.starts_with(&format!("{TRANSIENT_PREFIX}/"))
+            && !is_path_or_descendant(relative, &format!("{TRANSIENT_PREFIX}/capsules")))
+        || is_path_or_descendant(relative, DIRECTORY_STORE_PREFIX)
+        || HOST_EXECUTABLES.contains(&relative)
+        || relative == SOCKET_PATH
+        || std::path::Path::new(relative)
+            .extension()
+            .is_some_and(|extension| {
+                matches!(
+                    extension.to_ascii_lowercase().to_str(),
+                    Some("next" | "migrating")
+                )
+            })
+}
+
+/// Replace durable host files with volume-backed running projections.
+pub(super) fn restore_projection(
+    home: &AstridHome,
+    store: &RuntimePrincipalStore,
+    content: &super::NativePrincipalContentStore,
+) -> StorageResult<()> {
+    let layout_version = home
+        .layout_version()
+        .map_err(|error| tree_io_error(&error))?;
+    if layout_version.as_deref() == Some(astrid_core::dirs::LEGACY_LAYOUT_VERSION) {
+        return Ok(());
+    }
+    ingest_runtime_key(home, store)?;
+    seed_layout_version(home, store)?;
+    let entries = content
+        .list(&StateOwner::System)
+        .map_err(|error| tree_error(home.root(), format!("list volume projection: {error}")))?;
+    for entry in entries {
+        let name = entry.name().as_str();
+        if is_excluded(name) {
+            continue;
+        }
+        if is_retired_legacy_projection(home, name) {
+            continue;
+        }
+        let Some(bytes) = content
+            .read(&StateOwner::System, entry.name())
+            .map_err(|error| tree_error(home.root(), format!("read projection {name}: {error}")))?
+        else {
+            continue;
+        };
+        write_projection_file(home.root(), name, &bytes)?;
+    }
+    Ok(())
+}
+
+fn is_retired_legacy_projection(home: &AstridHome, name: &str) -> bool {
+    [home.state_db_path(), home.cow_dir()]
+        .into_iter()
+        .filter_map(|path| {
+            path.strip_prefix(home.root())
+                .ok()
+                .and_then(|relative| relative.to_str())
+                .map(ToOwned::to_owned)
+        })
+        .any(|relative| normalize_relative_path(&relative) == name)
+}
+
+/// Admit an incomplete legacy-store tree as durable System-owned quarantine.
+///
+/// Residue is published only after its source bytes are read without
+/// following redirects. The host tree is removed only after the complete
+/// quarantine batch is flushed, so an interrupted quarantine fails closed
+/// with the source still present and retries under a fresh generation.
+pub(super) fn quarantine_principal_store(
+    home: &AstridHome,
+    store: &RuntimePrincipalStore,
+) -> StorageResult<()> {
+    let source = home.principal_store_path();
+    validate_legacy_retirement_candidate(&source)?;
+    let mut files = Vec::new();
+    collect_files(&source, &source, &mut files)?;
+    files.sort_by(|left, right| left.0.cmp(&right.0));
+
+    let generation = next_quarantine_generation(store)?;
+    let mut ingests = Vec::with_capacity(files.len());
+    for (relative, path, metadata) in files {
+        let name = ContentName::new(format!("{QUARANTINE_PREFIX}/{generation}/{relative}"))
+            .map_err(|error| tree_error(&path, format!("validate quarantine name: {error}")))?;
+        ingests.push(ContiguousFileIngest::new(name, path, metadata.len()));
+    }
+    store.put_contiguous_files(StateOwner::System, ingests)?;
+    store
+        .content()
+        .flush()
+        .map_err(|error| tree_error(&source, format!("flush quarantine: {error}")))?;
+    astrid_core::dirs::retire_legacy_source_tree(&source)
+        .map_err(|error| tree_error(&source, format!("retire quarantine source: {error}")))
+}
+
+/// Refuse ingest before publication unless the source is a real same-device
+/// tree with no redirects or special entries.
+fn validate_legacy_retirement_candidate(source: &Path) -> StorageResult<()> {
+    let metadata = std::fs::symlink_metadata(source)
+        .map_err(|error| tree_error(source, format!("inspect retirement source: {error}")))?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err(tree_error(
+            source,
+            "retirement source is redirected or not a directory".to_owned(),
+        ));
+    }
+    let root_device = legacy_tree_device(&metadata);
+    validate_retirement_tree(source, root_device)
+}
+
+#[cfg(unix)]
+fn legacy_tree_device(metadata: &std::fs::Metadata) -> u64 {
+    use std::os::unix::fs::MetadataExt as _;
+
+    metadata.dev()
+}
+
+#[cfg(not(unix))]
+fn legacy_tree_device(_metadata: &std::fs::Metadata) -> u64 {
+    0
+}
+
+fn validate_retirement_tree(path: &Path, root_device: u64) -> StorageResult<()> {
+    let metadata = std::fs::symlink_metadata(path)
+        .map_err(|error| tree_error(path, format!("inspect retirement source: {error}")))?;
+    if metadata.file_type().is_symlink() {
+        return Err(tree_error(
+            path,
+            "retirement source contains a symbolic link".to_owned(),
+        ));
+    }
+    if !metadata.is_dir() && !metadata.is_file() {
+        return Err(tree_error(
+            path,
+            "retirement source contains a special file".to_owned(),
+        ));
+    }
+    if legacy_tree_device(&metadata) != root_device {
+        return Err(tree_error(
+            path,
+            "retirement source crosses a filesystem boundary".to_owned(),
+        ));
+    }
+    astrid_core::platform_fs::verify_no_redirects(path)
+        .map_err(|error| tree_error(path, format!("validate retirement source: {error}")))?;
+    if !metadata.is_dir() {
+        return Ok(());
+    }
+    for entry in std::fs::read_dir(path)
+        .map_err(|error| tree_error(path, format!("read retirement source: {error}")))?
+    {
+        let child = entry
+            .map_err(|error| tree_error(path, format!("read retirement entry: {error}")))?
+            .path();
+        validate_retirement_tree(&child, root_device)?;
+    }
+    Ok(())
+}
+
+fn next_quarantine_generation(store: &RuntimePrincipalStore) -> StorageResult<u32> {
+    let names = store
+        .content()
+        .list_prefix(&StateOwner::System, QUARANTINE_PREFIX)
+        .map_err(|error| tree_error_home(QUARANTINE_PREFIX, error))?;
+    let mut next = 0_u32;
+    for entry in names {
+        let Some(relative) = entry.name().as_str().strip_prefix(QUARANTINE_PREFIX) else {
+            continue;
+        };
+        let Some(generation) = relative.trim_start_matches('/').split('/').next() else {
+            continue;
+        };
+        if let Ok(value) = generation.parse::<u32>() {
+            next = next.max(value.saturating_add(1));
+        }
+    }
+    Ok(next)
+}
+
+fn tree_error_home(path: &str, error: impl std::fmt::Display) -> StorageError {
+    StorageError::Connection(format!("runtime tree {path}: {error}"))
+}
+
+/// Preserve a pre-cutover runtime signing key across volume initialization.
+///
+/// A first open may discover an installed runtime key before a volume exists.
+/// The key must enter system-owned volume content before the durable-root
+/// cleanup, or later capsule verification sees a newly generated identity.
+fn ingest_runtime_key(home: &AstridHome, store: &RuntimePrincipalStore) -> StorageResult<()> {
+    let source = home.runtime_key_path();
+    let metadata = match std::fs::symlink_metadata(&source) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(tree_error(&source, format!("inspect runtime key: {error}"))),
+    };
+    if metadata.file_type().is_symlink() {
+        return Err(tree_error(
+            &source,
+            "runtime key contains a symbolic link".to_owned(),
+        ));
+    }
+    if !metadata.is_file() {
+        return Err(tree_error(
+            &source,
+            "runtime key is not a regular file".to_owned(),
+        ));
+    }
+
+    let name = ContentName::new(RUNTIME_KEY_PROJECTION.to_owned()).map_err(|error| {
+        tree_error(
+            &source,
+            format!("runtime key is not a valid content name: {error}"),
+        )
+    })?;
+    if store
+        .content()
+        .describe(&StateOwner::System, &name)
+        .map_err(|error| tree_error(&source, format!("inspect runtime key: {error}")))?
+        .is_some()
+    {
+        return Ok(());
+    }
+
+    store.put_contiguous_files(
+        StateOwner::System,
+        [ContiguousFileIngest::new(name, source, metadata.len())],
+    )
+}
+
+/// Materialize the compatibility sentinel from durable volume authority.
+fn seed_layout_version(home: &AstridHome, store: &RuntimePrincipalStore) -> StorageResult<()> {
+    let name = ContentName::new("etc/layout-version".to_owned())
+        .map_err(|error| tree_error(home.root(), format!("validate layout sentinel: {error}")))?;
+    if store
+        .content()
+        .describe(&StateOwner::System, &name)
+        .map_err(|error| tree_error(home.root(), format!("inspect layout sentinel: {error}")))?
+        .is_some()
+    {
+        return Ok(());
+    }
+    let staging = std::env::temp_dir().join(format!(
+        "astrid-layout-{}.tmp",
+        uuid::Uuid::new_v4().simple()
+    ));
+    let result = (|| {
+        std::fs::write(&staging, astrid_core::dirs::LAYOUT_VERSION).map_err(|error| {
+            tree_error(
+                home.root(),
+                format!("write layout sentinel source: {error}"),
+            )
+        })?;
+        store.put_contiguous_files(
+            StateOwner::System,
+            [ContiguousFileIngest::new(
+                name,
+                &staging,
+                astrid_core::dirs::LAYOUT_VERSION.len() as u64,
+            )],
+        )
+    })();
+    let _ = std::fs::remove_file(&staging);
+    result
+}
+
+/// Publish current running projection changes, then retire their host files.
+pub(super) fn pack_and_retire_projection(
+    home: &AstridHome,
+    store: &RuntimePrincipalStore,
+) -> StorageResult<()> {
+    admit(store, home.root())?;
+    store
+        .content()
+        .flush()
+        .map_err(|error| tree_error(home.root(), format!("flush volume projection: {error}")))?;
+    retire_projection(home)
+}
+
+fn write_projection_file(root: &Path, relative: &str, bytes: &[u8]) -> StorageResult<()> {
+    let path = root.join(relative);
+    let parent = path
+        .parent()
+        .ok_or_else(|| tree_error(&path, "projection path has no parent".to_owned()))?;
+    super::native_io::ensure_private_directory(parent)?;
+    astrid_core::platform_fs::atomic_write_private_file(&path, bytes)
+        .map_err(|error| tree_error(&path, format!("project volume-backed file: {error}")))?;
+    Ok(())
+}
+
+fn retire_projection(home: &AstridHome) -> StorageResult<()> {
+    let root = home.root();
+    let mut entries = std::fs::read_dir(root)
+        .map_err(|error| tree_error(root, format!("read durable root: {error}")))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| tree_error(root, format!("read durable root entry: {error}")))?;
+    entries.sort_by_key(std::fs::DirEntry::file_name);
+    for entry in entries {
+        let path = entry.path();
+        if entry.file_name() == std::ffi::OsStr::new(CANONICAL_VOLUME) {
+            continue;
+        }
+        let metadata = std::fs::symlink_metadata(&path)
+            .map_err(|error| tree_error(&path, format!("inspect projection: {error}")))?;
+        if metadata.file_type().is_symlink() {
+            return Err(tree_error(
+                &path,
+                "running projection contains a symbolic link".to_owned(),
+            ));
+        }
+        if metadata.is_dir() {
+            astrid_core::dirs::retire_legacy_source_tree(&path)
+                .map_err(|error| tree_error(&path, format!("retire projection: {error}")))?;
+        } else if metadata.is_file() {
+            std::fs::remove_file(&path)
+                .map_err(|error| tree_error(&path, format!("retire projection: {error}")))?;
+        } else {
+            return Err(tree_error(
+                &path,
+                "running projection contains a special file".to_owned(),
+            ));
+        }
+    }
+    super::native_io::sync_directory(root)
+}
+
+fn tree_io_error(error: &std::io::Error) -> StorageError {
+    StorageError::Connection(error.to_string())
 }
 
 fn tree_error(path: &Path, detail: impl std::fmt::Display) -> StorageError {
@@ -211,6 +552,7 @@ mod tests {
     use sha2::{Digest as _, Sha256};
 
     use super::*;
+    use crate::principal_state::open_runtime_principal_store_for_pack;
     use crate::volume::{AstridVolume as _, HostedFileVolume};
     use crate::{AstridFilesystem, FilesystemPath, KvQuotaResolver, open_runtime_principal_store};
     use astrid_core::dirs::AstridHome;
@@ -236,38 +578,69 @@ mod tests {
         );
     }
 
-    fn durable_files(wasm_hash: &str, wasm: &[u8], nested_wasm: &[u8]) -> Vec<(String, Vec<u8>)> {
+    #[test]
+    fn excludes_paths_only_at_exact_or_directory_boundaries() {
+        for path in [
+            "volume",
+            "volume/compacting",
+            "volume2",
+            "volumetric.txt",
+            "volume.previous",
+            "var/principal-store",
+            "var/principal-store/agent.json",
+            "var/principal-store2",
+            "var/principal-store2/agent.json",
+            "run/capsulesX",
+            "run/capsulesX/example/component.wasm",
+            "run/capsules/example/component.wasm",
+        ] {
+            let normalized = normalize_relative_path(path);
+            let excluded = is_excluded(&normalized);
+            let expected = !matches!(
+                path,
+                "volume2"
+                    | "volumetric.txt"
+                    | "volume.previous"
+                    | "var/principal-store2"
+                    | "var/principal-store2/agent.json"
+                    | "run/capsules/example/component.wasm"
+            );
+            assert_eq!(excluded, expected, "unexpected admission for {path}");
+        }
+        assert!(!is_excluded("run/capsules"));
+    }
+
+    #[test]
+    fn allows_run_capsule_projections() {
+        let normalized = normalize_relative_path("run/capsules/example/component.wasm");
+        assert!(!is_excluded(&normalized));
+        assert!(!is_excluded("run"));
+        assert!(!is_excluded("run/capsules"));
+
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("run/capsules/example/component.wasm");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, b"run-capsule").unwrap();
+        let entries = scan(directory.path()).unwrap();
+        assert_eq!(entries.len(), 1, "scan entries: {entries:?}");
+        assert_eq!(
+            entries[0].name().as_str(),
+            "run/capsules/example/component.wasm"
+        );
+    }
+
+    fn durable_files(wasm_hash: &str, wasm: &[u8]) -> Vec<(String, Vec<u8>)> {
         vec![
             (format!("bin/{wasm_hash}.wasm"), wasm.to_vec()),
-            (
-                "run/capsules/example/meta.json".to_owned(),
-                format!("{{\"wasm_hash\":\"{wasm_hash}\"}}").into_bytes(),
-            ),
-            (
-                "run/capsules/example/component.wasm".to_owned(),
-                nested_wasm.to_vec(),
-            ),
             (
                 "wit/astrid-contracts.wit".to_owned(),
                 b"package astrid:contracts;".to_vec(),
             ),
             ("etc/layout-version".to_owned(), b"2".to_vec()),
             ("keys/runtime.key".to_owned(), b"runtime-key".to_vec()),
-            ("run/system.lock".to_owned(), b"lock".to_vec()),
-            ("run/system.pid".to_owned(), b"pid".to_vec()),
-            ("run/system.ready".to_owned(), b"ready".to_vec()),
-            ("run/system.token".to_owned(), b"token".to_vec()),
             ("var/content-staging/payload".to_owned(), b"staged".to_vec()),
             ("var/config.json".to_owned(), b"{\"durable\":true}".to_vec()),
             ("var/migrations/marker".to_owned(), b"migration".to_vec()),
-            ("var/principal-store/legacy".to_owned(), b"legacy".to_vec()),
-            ("bin/astrid".to_owned(), b"bootstrap".to_vec()),
-            ("bin/astrid-daemon".to_owned(), b"bootstrap-daemon".to_vec()),
-            ("astrid".to_owned(), b"root-bootstrap".to_vec()),
-            (
-                "astrid-daemon".to_owned(),
-                b"root-bootstrap-daemon".to_vec(),
-            ),
         ]
     }
 
@@ -278,9 +651,8 @@ mod tests {
         let home = AstridHome::from_path(home_dir.path());
         home.ensure().unwrap();
         let wasm = b"\0asm\x01\0\0\0runtime-wasm-unique".to_vec();
-        let nested_wasm = b"\0asm\x01\0\0\0nested-wasm-unique".to_vec();
         let wasm_hash = blake3::hash(&wasm).to_hex().to_string();
-        let durable = durable_files(&wasm_hash, &wasm, &nested_wasm);
+        let durable = durable_files(&wasm_hash, &wasm);
         for (relative, bytes) in &durable {
             let path = source.path().join(relative);
             std::fs::create_dir_all(path.parent().unwrap()).unwrap();
@@ -313,6 +685,7 @@ mod tests {
             .iter()
             .map(|(name, _)| name.clone())
             .collect::<Vec<_>>();
+        expected_names.extend(["volume.compacting", "volume.previous"].map(str::to_owned));
         expected_names.sort();
         assert_eq!(names, expected_names);
 
@@ -380,5 +753,173 @@ mod tests {
                 .collect::<Vec<_>>(),
             ["regular"]
         );
+    }
+
+    #[tokio::test]
+    async fn preserves_runtime_key_across_initialization_and_restart() {
+        let home_dir = tempfile::tempdir().unwrap();
+        let home = AstridHome::from_path(home_dir.path());
+        let key_path = home.runtime_key_path();
+        std::fs::create_dir_all(key_path.parent().unwrap()).unwrap();
+        std::fs::write(&key_path, b"original-runtime-key").unwrap();
+
+        let store = open_runtime_principal_store(&home, unlimited_quota())
+            .await
+            .unwrap();
+        assert_eq!(std::fs::read(&key_path).unwrap(), b"original-runtime-key");
+        let runtime_key = ContentName::new(RUNTIME_KEY_PROJECTION).unwrap();
+        assert!(
+            store
+                .content()
+                .describe(&StateOwner::System, &runtime_key)
+                .unwrap()
+                .is_some()
+        );
+        drop(store);
+
+        let store = open_runtime_principal_store_for_pack(&home, unlimited_quota())
+            .await
+            .unwrap();
+        store
+            .pack_and_retire_runtime_projection(&home)
+            .expect("pack runtime key");
+        drop(store);
+        assert!(!key_path.exists());
+        assert!(!home.keys_dir().exists());
+        let stopped = std::fs::read_dir(home.root())
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(stopped.len(), 1);
+        assert_eq!(
+            stopped[0].file_name(),
+            std::ffi::OsStr::new(CANONICAL_VOLUME)
+        );
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            assert_eq!(
+                stopped[0].metadata().unwrap().permissions().mode() & 0o777,
+                0o600
+            );
+        }
+
+        let reopened = open_runtime_principal_store(&home, unlimited_quota())
+            .await
+            .unwrap();
+        assert_eq!(std::fs::read(&key_path).unwrap(), b"original-runtime-key");
+        drop(reopened);
+    }
+
+    #[tokio::test]
+    async fn packs_trust_projection_and_excludes_run_on_clean_stop() {
+        let home_dir = tempfile::tempdir().unwrap();
+        let home = AstridHome::from_path(home_dir.path());
+        let store = open_runtime_principal_store(&home, unlimited_quota())
+            .await
+            .unwrap();
+        let trust = home.root().join("trust/test.pub");
+        std::fs::create_dir_all(trust.parent().unwrap()).unwrap();
+        std::fs::write(&trust, b"ed25519:test").unwrap();
+        let transient = home.run_dir().join("system.pid");
+        std::fs::create_dir_all(transient.parent().unwrap()).unwrap();
+        std::fs::write(&transient, b"pid").unwrap();
+
+        drop(store);
+        let store = open_runtime_principal_store_for_pack(&home, unlimited_quota())
+            .await
+            .unwrap();
+        store
+            .pack_and_retire_runtime_projection(&home)
+            .expect("pack running projection");
+        assert!(!trust.exists());
+        assert!(!home.run_dir().exists());
+
+        let catalog = store
+            .content()
+            .list(&StateOwner::System)
+            .unwrap()
+            .into_iter()
+            .map(|entry| entry.name().as_str().to_owned())
+            .collect::<Vec<_>>();
+        assert!(catalog.iter().any(|name| name == "trust/test.pub"));
+        assert!(!catalog.iter().any(|name| name.starts_with("run/")));
+
+        drop(store);
+        let reopened = open_runtime_principal_store(&home, unlimited_quota())
+            .await
+            .unwrap();
+        assert!(trust.is_file(), "trusted pin must be mounted on restart");
+        assert!(!home.run_dir().exists());
+        reopened
+            .pack_and_retire_runtime_projection(&home)
+            .expect("retire restarted projection");
+
+        let stopped = std::fs::read_dir(home.root())
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(stopped.len(), 1);
+        assert_eq!(
+            stopped[0].file_name(),
+            std::ffi::OsStr::new("astrid.volume")
+        );
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            assert_eq!(
+                stopped[0].metadata().unwrap().permissions().mode() & 0o777,
+                0o600
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn clean_stop_restores_capsules_and_layout_receipts_on_restart() {
+        let home_dir = tempfile::tempdir().unwrap();
+        let home = AstridHome::from_path(home_dir.path());
+        let store = open_runtime_principal_store(&home, unlimited_quota())
+            .await
+            .unwrap();
+        drop(store);
+
+        let capsule = home
+            .home_dir()
+            .join("default/.local/capsules/example/capsule.json");
+        let receipt = home.migrations_dir().join("layout-v1-to-v2.complete");
+        let retirement = home.migrations_dir().join("layout-v1-to-v2.retiring");
+        std::fs::create_dir_all(capsule.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(receipt.parent().unwrap()).unwrap();
+        std::fs::write(&capsule, br#"{"id":"example"}"#).unwrap();
+        std::fs::write(&receipt, b"layout-v1-to-v2\n").unwrap();
+        std::fs::write(&retirement, b"retirement-source\n").unwrap();
+
+        let store = open_runtime_principal_store_for_pack(&home, unlimited_quota())
+            .await
+            .unwrap();
+        store
+            .pack_and_retire_runtime_projection(&home)
+            .expect("pack capsule and receipt");
+        let stopped = std::fs::read_dir(home.root())
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(stopped.len(), 1);
+        assert_eq!(
+            stopped[0].file_name(),
+            std::ffi::OsStr::new(CANONICAL_VOLUME)
+        );
+        drop(store);
+
+        let reopened = open_runtime_principal_store(&home, unlimited_quota())
+            .await
+            .unwrap();
+        assert_eq!(std::fs::read(&capsule).unwrap(), br#"{"id":"example"}"#);
+        assert_eq!(std::fs::read(&receipt).unwrap(), b"layout-v1-to-v2\n");
+        assert_eq!(std::fs::read(&retirement).unwrap(), b"retirement-source\n");
+        reopened
+            .pack_and_retire_runtime_projection(&home)
+            .expect("retire restarted projection");
+        assert_eq!(std::fs::read_dir(home.root()).unwrap().count(), 1);
     }
 }

--- a/crates/astrid-storage/src/principal_state/runtime_tree.rs
+++ b/crates/astrid-storage/src/principal_state/runtime_tree.rs
@@ -832,6 +832,10 @@ pub(super) fn reconcile_running_projection(
                 if surviving && !is_bootstrap_surviving_projection(&scanned) {
                     publish_active_projection(home, store)?;
                 } else {
+                    // A restore can fail after writing one volume entry. Mark
+                    // the receipt RETIRING first so a retry restores from the
+                    // volume instead of adopting that partial host tree.
+                    transition_retiring_projection(home, store)?;
                     restore_projection(home, store, &store.content)?;
                 }
             },

--- a/crates/astrid-storage/src/principal_state/runtime_tree.rs
+++ b/crates/astrid-storage/src/principal_state/runtime_tree.rs
@@ -563,7 +563,7 @@ pub(super) fn reconcile_running_projection(
         return Ok(());
     }
 
-    if !validate_surviving_projection(home.root())? {
+    if !validate_surviving_projection(home.root(), home.root())? {
         return Ok(());
     }
     admit(store, home.root())?;
@@ -579,7 +579,7 @@ pub(super) fn reconcile_running_projection(
 /// Returns whether the tree contains a regular projection candidate. Excluded
 /// host endpoints and media paths remain outside authority and cannot make an
 /// otherwise volume-only home look like a surviving projection.
-fn validate_surviving_projection(directory: &Path) -> StorageResult<bool> {
+fn validate_surviving_projection(root: &Path, directory: &Path) -> StorageResult<bool> {
     let mut entries = std::fs::read_dir(directory)
         .map_err(|error| tree_error(directory, format!("read running projection: {error}")))?
         .collect::<Result<Vec<_>, _>>()
@@ -599,7 +599,7 @@ fn validate_surviving_projection(directory: &Path) -> StorageResult<bool> {
         }
 
         let relative = path
-            .strip_prefix(directory)
+            .strip_prefix(root)
             .map_err(|_| tree_error(&path, "projection entry escaped runtime root".to_owned()))?;
         let relative = relative
             .to_str()
@@ -608,7 +608,7 @@ fn validate_surviving_projection(directory: &Path) -> StorageResult<bool> {
             continue;
         }
         if metadata.is_dir() {
-            has_projection |= validate_surviving_projection(&path)?;
+            has_projection |= validate_surviving_projection(root, &path)?;
         } else if metadata.is_file() {
             has_projection = true;
         } else {

--- a/crates/astrid-storage/src/principal_state/runtime_tree.rs
+++ b/crates/astrid-storage/src/principal_state/runtime_tree.rs
@@ -11,8 +11,8 @@ use crate::error::{StorageError, StorageResult};
 use astrid_core::dirs::AstridHome;
 
 use super::{
-    ContiguousFileIngest, RuntimePrincipalStore, StateOwner,
-    runtime_tree_active::{ACTIVE_PROJECTION_NAME, ActiveProjectionEntry},
+    ContiguousFileIngest, PackedProjectionIngest, RuntimePrincipalStore, StateOwner,
+    runtime_tree_active::{ACTIVE_PROJECTION_NAME, ActiveProjectionEntry, ReceiptPhase},
 };
 
 use super::runtime_tree_active as active;
@@ -498,14 +498,13 @@ pub(super) fn pack_and_retire_projection(
     }
     if validate_surviving_projection(home.root(), home.root())? {
         let receipt = active::read(home, store)?;
-        if receipt.is_none() {
-            return Err(tree_error(
-                home.root(),
-                "active projection receipt is missing for surviving host projection",
-            ));
+        if let Some(receipt) = receipt
+            && receipt.phase() == ReceiptPhase::Active
+        {
+            publish_active_projection(home, store)?;
         }
-        publish_active_projection(home, store)?;
     }
+    transition_retiring_projection(home, store)?;
     retire_projection(home)?;
     active::clear(store, home).map(|_| ())
 }
@@ -541,15 +540,40 @@ fn active_projection_entries(
         .filter(|entry| !is_retired_legacy_projection(home, entry.name().as_str()))
         .map(|entry| ActiveProjectionEntry {
             name: entry.name().clone(),
-            file: entry.file(),
+            file: Some(entry.file()),
             logical_bytes: entry.logical_bytes(),
         })
         .collect())
 }
 
+fn receipt_ingest(
+    home: &AstridHome,
+    phase: ReceiptPhase,
+    entries: &[ActiveProjectionEntry],
+) -> StorageResult<PackedProjectionIngest> {
+    let bytes = active::encode(home, phase, entries)?;
+    Ok(PackedProjectionIngest::bytes(
+        active::active_projection_name()?,
+        bytes,
+    ))
+}
+
+fn rotate_active_receipt(
+    home: &AstridHome,
+    store: &RuntimePrincipalStore,
+    entries: &[ActiveProjectionEntry],
+) -> StorageResult<()> {
+    let receipt = receipt_ingest(home, ReceiptPhase::Active, entries)?;
+    store.replace_contiguous_files_removing_exact(StateOwner::System, [receipt], &[])?;
+    store
+        .content()
+        .flush()
+        .map_err(|error| tree_error(home.root(), format!("flush active receipt: {error}")))
+}
+
 fn establish_active_receipt(home: &AstridHome, store: &RuntimePrincipalStore) -> StorageResult<()> {
     let entries = active_projection_entries(home, store)?;
-    active::write(home, store, &entries)
+    rotate_active_receipt(home, store, &entries)
 }
 
 fn publish_active_projection(
@@ -569,15 +593,49 @@ fn publish_active_projection(
         .cloned()
         .collect::<Vec<_>>();
     let removals = active::removals(&receipt, &surviving)?;
-    let ingests = scanned
-        .into_iter()
-        .map(|entry| ContiguousFileIngest::new(entry.name, entry.source_path, entry.logical_bytes));
+    let receipt_entries = scanned
+        .iter()
+        .map(|entry| ActiveProjectionEntry {
+            name: entry.name().clone(),
+            file: None,
+            logical_bytes: entry.logical_bytes(),
+        })
+        .collect::<Vec<_>>();
+    let receipt = receipt_ingest(home, ReceiptPhase::Active, &receipt_entries)?;
+    let ingests = scanned.into_iter().map(|entry| {
+        PackedProjectionIngest::File(ContiguousFileIngest::new(
+            entry.name,
+            entry.source_path,
+            entry.logical_bytes,
+        ))
+    });
+    let ingests = std::iter::once(receipt).chain(ingests);
     store.replace_contiguous_files_removing_exact(StateOwner::System, ingests, &removals)?;
     store
         .content()
         .flush()
         .map_err(|error| tree_error(home.root(), format!("flush active projection: {error}")))?;
-    establish_active_receipt(home, store)
+    Ok(())
+}
+
+fn transition_retiring_projection(
+    home: &AstridHome,
+    store: &RuntimePrincipalStore,
+) -> StorageResult<()> {
+    let receipt = active::read(home, store)?;
+    let Some(receipt) = receipt else {
+        return Ok(());
+    };
+    if receipt.phase() == ReceiptPhase::Retiring {
+        return Ok(());
+    }
+    let entries = active_projection_entries(home, store)?;
+    let receipt = receipt_ingest(home, ReceiptPhase::Retiring, &entries)?;
+    store.replace_contiguous_files_removing_exact(StateOwner::System, [receipt], &[])?;
+    store
+        .content()
+        .flush()
+        .map_err(|error| tree_error(home.root(), format!("flush retiring receipt: {error}")))
 }
 
 fn legacy_projection_pack(home: &AstridHome, store: &RuntimePrincipalStore) -> StorageResult<()> {
@@ -615,11 +673,11 @@ pub(super) fn reconcile_running_projection(
     }
 
     let surviving = validate_surviving_projection(home.root(), home.root())?;
-    if surviving {
-        let receipt = active::read(home, store)?;
-        if receipt.is_none() {
+    let receipt = active::read_relocatable(home, store)?;
+    match receipt {
+        None => {
             let scanned = scan(home.root())?;
-            if !is_bootstrap_surviving_projection(&scanned) {
+            if surviving && !is_bootstrap_surviving_projection(&scanned) {
                 let names = scanned
                     .iter()
                     .map(|entry| entry.name().as_str())
@@ -631,14 +689,67 @@ pub(super) fn reconcile_running_projection(
                     ),
                 ));
             }
+        },
+        Some(receipt) if !receipt.root_matches(home)? => {
+            // A portable active-volume copy is volume-authoritative. Host
+            // bytes are neither admitted nor allowed beyond trusted bootstrap
+            // sentinels; the copied receipt is simply rebound to the new root.
+            if receipt.phase() != ReceiptPhase::Active || !surviving {
+                return Err(tree_error(
+                    home.root(),
+                    "active projection receipt root does not match this durable root",
+                ));
+            }
+            let scanned = scan(home.root())?;
+            if !is_bootstrap_surviving_projection(&scanned) {
+                return Err(tree_error(
+                    home.root(),
+                    "relocated active receipt is permitted only for trusted bootstrap files",
+                ));
+            }
             restore_projection(home, store, &store.content)?;
-            return establish_active_receipt(home, store);
-        }
-        publish_active_projection(home, store)?;
+        },
+        Some(receipt) => match receipt.phase() {
+            ReceiptPhase::Active => {
+                if surviving {
+                    publish_active_projection(home, store)?;
+                } else {
+                    restore_projection(home, store, &store.content)?;
+                }
+            },
+            ReceiptPhase::Retiring => {
+                let scanned = scan(home.root())?;
+                validate_retiring_host_subset(home, &receipt, &scanned)?;
+                restore_projection(home, store, &store.content)?;
+            },
+        },
+    }
+    if active::read_relocatable(home, store)?.is_some() {
+        establish_active_receipt(home, store)?;
     } else {
         restore_projection(home, store, &store.content)?;
+        establish_active_receipt(home, store)?;
     }
-    establish_active_receipt(home, store)
+    Ok(())
+}
+
+fn validate_retiring_host_subset(
+    home: &AstridHome,
+    receipt: &super::runtime_tree_active::ActiveProjectionReceipt,
+    scanned: &[RuntimeTreeEntry],
+) -> StorageResult<()> {
+    for entry in scanned {
+        if !receipt.contains_inventory_name(entry.name().as_str()) {
+            return Err(tree_error(
+                home.root(),
+                format!(
+                    "retiring projection contains unreceipted host file {}",
+                    entry.name().as_str()
+                ),
+            ));
+        }
+    }
+    Ok(())
 }
 
 fn is_bootstrap_surviving_projection(scanned: &[RuntimeTreeEntry]) -> bool {

--- a/crates/astrid-storage/src/principal_state/runtime_tree.rs
+++ b/crates/astrid-storage/src/principal_state/runtime_tree.rs
@@ -545,455 +545,94 @@ fn tree_error(path: &Path, detail: impl std::fmt::Display) -> StorageError {
     StorageError::Connection(format!("runtime tree {}: {detail}", path.display()))
 }
 
-#[cfg(test)]
-mod tests {
-    use std::collections::BTreeMap;
-    use std::sync::Arc;
-
-    use sha2::{Digest as _, Sha256};
-
-    use super::*;
-    use crate::principal_state::open_runtime_principal_store_for_pack;
-    use crate::volume::{AstridVolume as _, HostedFileVolume};
-    use crate::{AstridFilesystem, FilesystemPath, KvQuotaResolver, open_runtime_principal_store};
-    use astrid_core::dirs::AstridHome;
-
-    fn unlimited_quota() -> Arc<dyn KvQuotaResolver<StateOwner>> {
-        Arc::new(|owner: &StateOwner| {
-            Ok(match owner {
-                StateOwner::System => None,
-                StateOwner::Principal(_) | StateOwner::Fleet(_) => Some(u64::MAX),
-            })
-        })
+/// Reconcile a surviving running projection before volume-backed restore.
+///
+/// A stopped CLI home has only the hosted volume. A daemon interrupted before
+/// post-exit retirement still owns its host projection, however, and that tree
+/// may contain generations newer than the last packed volume. Admit and flush
+/// it first so the subsequent projection restore mounts the newest admitted
+/// generation instead of rewinding the host tree.
+pub(super) fn reconcile_running_projection(
+    home: &AstridHome,
+    store: &RuntimePrincipalStore,
+) -> StorageResult<()> {
+    let layout_version = home
+        .layout_version()
+        .map_err(|error| tree_io_error(&error))?;
+    if layout_version.as_deref() == Some(astrid_core::dirs::LEGACY_LAYOUT_VERSION) {
+        return Ok(());
     }
 
-    #[test]
-    fn excludes_windows_separator_paths() {
-        for path in ["volume", "volume\\compacting", "run\\system.sock"] {
-            let normalized = normalize_relative_path(path);
-            assert!(is_excluded(&normalized), "path was not excluded: {path}");
-        }
-        assert_eq!(
-            normalize_relative_path("run\\system.ready"),
-            "run/system.ready"
-        );
+    if !validate_surviving_projection(home.root())? {
+        return Ok(());
     }
-
-    #[test]
-    fn excludes_paths_only_at_exact_or_directory_boundaries() {
-        for path in [
-            "volume",
-            "volume/compacting",
-            "volume2",
-            "volumetric.txt",
-            "volume.previous",
-            "var/principal-store",
-            "var/principal-store/agent.json",
-            "var/principal-store2",
-            "var/principal-store2/agent.json",
-            "run/capsulesX",
-            "run/capsulesX/example/component.wasm",
-            "run/capsules/example/component.wasm",
-        ] {
-            let normalized = normalize_relative_path(path);
-            let excluded = is_excluded(&normalized);
-            let expected = !matches!(
-                path,
-                "volume2"
-                    | "volumetric.txt"
-                    | "volume.previous"
-                    | "var/principal-store2"
-                    | "var/principal-store2/agent.json"
-                    | "run/capsules/example/component.wasm"
-            );
-            assert_eq!(excluded, expected, "unexpected admission for {path}");
-        }
-        assert!(!is_excluded("run/capsules"));
-    }
-
-    #[test]
-    fn excludes_only_named_transaction_paths() {
-        for path in [
-            MIGRATING_VOLUME,
-            "etc/.layout-version.next",
-            "var/migrations/.layout-v1-to-v2.intent.next",
-            "var/migrations/.layout-v1-to-v2.retiring.next",
-            "var/migrations/.layout-v1-to-v2.complete.next",
-        ] {
-            assert!(is_excluded(path), "transaction path was admitted: {path}");
-        }
-
-        for path in [
-            "etc/user.next",
-            "etc/user.migrating",
-            "var/user.next",
-            "var/user.migrating",
-            "astrid.migrating.previous",
-            "etc/.layout-version.next.old",
-        ] {
-            assert!(!is_excluded(path), "ordinary path was excluded: {path}");
-        }
-    }
-
-    #[test]
-    fn allows_run_capsule_projections() {
-        let normalized = normalize_relative_path("run/capsules/example/component.wasm");
-        assert!(!is_excluded(&normalized));
-        assert!(!is_excluded("run"));
-        assert!(!is_excluded("run/capsules"));
-
-        let directory = tempfile::tempdir().unwrap();
-        let path = directory.path().join("run/capsules/example/component.wasm");
-        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
-        std::fs::write(&path, b"run-capsule").unwrap();
-        let entries = scan(directory.path()).unwrap();
-        assert_eq!(entries.len(), 1, "scan entries: {entries:?}");
-        assert_eq!(
-            entries[0].name().as_str(),
-            "run/capsules/example/component.wasm"
-        );
-    }
-
-    fn durable_files(wasm_hash: &str, wasm: &[u8]) -> Vec<(String, Vec<u8>)> {
-        vec![
-            (format!("bin/{wasm_hash}.wasm"), wasm.to_vec()),
-            (
-                "wit/astrid-contracts.wit".to_owned(),
-                b"package astrid:contracts;".to_vec(),
-            ),
-            ("etc/layout-version".to_owned(), b"2".to_vec()),
-            ("keys/runtime.key".to_owned(), b"runtime-key".to_vec()),
-            ("var/content-staging/payload".to_owned(), b"staged".to_vec()),
-            ("var/config.json".to_owned(), b"{\"durable\":true}".to_vec()),
-            ("var/migrations/marker".to_owned(), b"migration".to_vec()),
-        ]
-    }
-
-    #[tokio::test]
-    async fn admits_runtime_tree_and_reopens_from_preclose_volume_copy() {
-        let source = tempfile::tempdir().unwrap();
-        let home_dir = tempfile::tempdir().unwrap();
-        let home = AstridHome::from_path(home_dir.path());
-        home.ensure().unwrap();
-        let wasm = b"\0asm\x01\0\0\0runtime-wasm-unique".to_vec();
-        let wasm_hash = blake3::hash(&wasm).to_hex().to_string();
-        let durable = durable_files(&wasm_hash, &wasm);
-        for (relative, bytes) in &durable {
-            let path = source.path().join(relative);
-            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
-            std::fs::write(path, bytes).unwrap();
-        }
-        for relative in [
-            "volume",
-            "volume.compacting",
-            "volume.previous",
-            "run/system.sock",
-        ] {
-            let path = source.path().join(relative);
-            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
-            std::fs::write(path, b"host-only").unwrap();
-        }
-
-        let store = open_runtime_principal_store(&home, unlimited_quota())
-            .await
-            .unwrap();
-        store.admit_runtime_tree(source.path()).unwrap();
-
-        let names = store
-            .content()
-            .list(&StateOwner::System)
-            .unwrap()
-            .into_iter()
-            .map(|entry| entry.name().as_str().to_owned())
-            .collect::<Vec<_>>();
-        let mut expected_names = durable
-            .iter()
-            .map(|(name, _)| name.clone())
-            .collect::<Vec<_>>();
-        expected_names.extend(["volume.compacting", "volume.previous"].map(str::to_owned));
-        expected_names.sort();
-        assert_eq!(names, expected_names);
-
-        let copied_home_dir = tempfile::tempdir().unwrap();
-        let copied_home = AstridHome::from_path(copied_home_dir.path());
-        copied_home.ensure().unwrap();
-        std::fs::copy(
-            home.storage_volume_path(),
-            copied_home.storage_volume_path(),
-        )
-        .unwrap();
-        let volume = HostedFileVolume::open(copied_home.storage_volume_path()).unwrap();
-        assert!(
-            volume
-                .list_regions("representations/blobs/loose")
-                .unwrap()
-                .is_empty()
-        );
-        drop(volume);
-
-        let reopened = open_runtime_principal_store(&copied_home, unlimited_quota())
-            .await
-            .unwrap();
-        let filesystem = AstridFilesystem::new(reopened.content(), StateOwner::System);
-        let expected_count = durable.len();
-        let mut reconstructed = BTreeMap::new();
-        for (name, bytes) in durable {
-            let path = FilesystemPath::new(name).unwrap();
-            let entry = filesystem.stat(&path).unwrap();
-            let actual = filesystem.read(&path, 0, entry.logical_bytes()).unwrap();
-            let expected_digest = Sha256::digest(&bytes);
-            assert_eq!(Sha256::digest(&actual), expected_digest);
-            reconstructed.insert(path.as_str().to_owned(), actual);
-        }
-        assert_eq!(reconstructed.len(), expected_count);
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn rejects_redirects_before_publication() {
-        use std::os::unix::fs::symlink;
-
-        let root = tempfile::tempdir().unwrap();
-        let outside = tempfile::tempdir().unwrap();
-        symlink(outside.path(), root.path().join("redirect")).unwrap();
-        let error = scan(root.path()).unwrap_err();
-        assert!(error.to_string().contains("symbolic link"));
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn skips_special_entries_without_failing_scan() {
-        use std::os::unix::net::UnixListener;
-
-        let root = tempfile::tempdir().unwrap();
-        std::fs::create_dir_all(root.path().join("run")).unwrap();
-        std::fs::write(root.path().join("regular"), b"durable").unwrap();
-        let _socket = UnixListener::bind(root.path().join("run/other.sock")).unwrap();
-
-        let entries = scan(root.path()).unwrap();
-        assert_eq!(
-            entries
-                .iter()
-                .map(|entry| entry.name().as_str())
-                .collect::<Vec<_>>(),
-            ["regular"]
-        );
-    }
-
-    #[tokio::test]
-    async fn preserves_runtime_key_across_initialization_and_restart() {
-        let home_dir = tempfile::tempdir().unwrap();
-        let home = AstridHome::from_path(home_dir.path());
-        let key_path = home.runtime_key_path();
-        std::fs::create_dir_all(key_path.parent().unwrap()).unwrap();
-        std::fs::write(&key_path, b"original-runtime-key").unwrap();
-
-        let store = open_runtime_principal_store(&home, unlimited_quota())
-            .await
-            .unwrap();
-        assert_eq!(std::fs::read(&key_path).unwrap(), b"original-runtime-key");
-        let runtime_key = ContentName::new(RUNTIME_KEY_PROJECTION).unwrap();
-        assert!(
-            store
-                .content()
-                .describe(&StateOwner::System, &runtime_key)
-                .unwrap()
-                .is_some()
-        );
-        drop(store);
-
-        let store = open_runtime_principal_store_for_pack(&home, unlimited_quota())
-            .await
-            .unwrap();
-        store
-            .pack_and_retire_runtime_projection(&home)
-            .expect("pack runtime key");
-        drop(store);
-        assert!(!key_path.exists());
-        assert!(!home.keys_dir().exists());
-        let stopped = std::fs::read_dir(home.root())
-            .unwrap()
-            .collect::<Result<Vec<_>, _>>()
-            .unwrap();
-        assert_eq!(stopped.len(), 1);
-        assert_eq!(
-            stopped[0].file_name(),
-            std::ffi::OsStr::new(CANONICAL_VOLUME)
-        );
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt as _;
-            assert_eq!(
-                stopped[0].metadata().unwrap().permissions().mode() & 0o777,
-                0o600
-            );
-        }
-
-        let reopened = open_runtime_principal_store(&home, unlimited_quota())
-            .await
-            .unwrap();
-        assert_eq!(std::fs::read(&key_path).unwrap(), b"original-runtime-key");
-        drop(reopened);
-    }
-
-    #[tokio::test]
-    async fn packs_trust_projection_and_excludes_run_on_clean_stop() {
-        let home_dir = tempfile::tempdir().unwrap();
-        let home = AstridHome::from_path(home_dir.path());
-        let store = open_runtime_principal_store(&home, unlimited_quota())
-            .await
-            .unwrap();
-        let trust = home.root().join("trust/test.pub");
-        std::fs::create_dir_all(trust.parent().unwrap()).unwrap();
-        std::fs::write(&trust, b"ed25519:test").unwrap();
-        let transient = home.run_dir().join("system.pid");
-        std::fs::create_dir_all(transient.parent().unwrap()).unwrap();
-        std::fs::write(&transient, b"pid").unwrap();
-
-        drop(store);
-        let store = open_runtime_principal_store_for_pack(&home, unlimited_quota())
-            .await
-            .unwrap();
-        store
-            .pack_and_retire_runtime_projection(&home)
-            .expect("pack running projection");
-        assert!(!trust.exists());
-        assert!(!home.run_dir().exists());
-
-        let catalog = store
-            .content()
-            .list(&StateOwner::System)
-            .unwrap()
-            .into_iter()
-            .map(|entry| entry.name().as_str().to_owned())
-            .collect::<Vec<_>>();
-        assert!(catalog.iter().any(|name| name == "trust/test.pub"));
-        assert!(!catalog.iter().any(|name| name.starts_with("run/")));
-
-        drop(store);
-        let reopened = open_runtime_principal_store(&home, unlimited_quota())
-            .await
-            .unwrap();
-        assert!(trust.is_file(), "trusted pin must be mounted on restart");
-        assert!(!home.run_dir().exists());
-        reopened
-            .pack_and_retire_runtime_projection(&home)
-            .expect("retire restarted projection");
-
-        let stopped = std::fs::read_dir(home.root())
-            .unwrap()
-            .collect::<Result<Vec<_>, _>>()
-            .unwrap();
-        assert_eq!(stopped.len(), 1);
-        assert_eq!(
-            stopped[0].file_name(),
-            std::ffi::OsStr::new("astrid.volume")
-        );
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt as _;
-            assert_eq!(
-                stopped[0].metadata().unwrap().permissions().mode() & 0o777,
-                0o600
-            );
-        }
-    }
-
-    #[tokio::test]
-    async fn clean_stop_restores_capsules_and_layout_receipts_on_restart() {
-        let home_dir = tempfile::tempdir().unwrap();
-        let home = AstridHome::from_path(home_dir.path());
-        let store = open_runtime_principal_store(&home, unlimited_quota())
-            .await
-            .unwrap();
-        drop(store);
-
-        let capsule = home
-            .home_dir()
-            .join("default/.local/capsules/example/capsule.json");
-        let receipt = home.migrations_dir().join("layout-v1-to-v2.complete");
-        let retirement = home.migrations_dir().join("layout-v1-to-v2.retiring");
-        std::fs::create_dir_all(capsule.parent().unwrap()).unwrap();
-        std::fs::create_dir_all(receipt.parent().unwrap()).unwrap();
-        std::fs::write(&capsule, br#"{"id":"example"}"#).unwrap();
-        std::fs::write(&receipt, b"layout-v1-to-v2\n").unwrap();
-        std::fs::write(&retirement, b"retirement-source\n").unwrap();
-
-        let store = open_runtime_principal_store_for_pack(&home, unlimited_quota())
-            .await
-            .unwrap();
-        store
-            .pack_and_retire_runtime_projection(&home)
-            .expect("pack capsule and receipt");
-        let stopped = std::fs::read_dir(home.root())
-            .unwrap()
-            .collect::<Result<Vec<_>, _>>()
-            .unwrap();
-        assert_eq!(stopped.len(), 1);
-        assert_eq!(
-            stopped[0].file_name(),
-            std::ffi::OsStr::new(CANONICAL_VOLUME)
-        );
-        drop(store);
-
-        let reopened = open_runtime_principal_store(&home, unlimited_quota())
-            .await
-            .unwrap();
-        assert_eq!(std::fs::read(&capsule).unwrap(), br#"{"id":"example"}"#);
-        assert_eq!(std::fs::read(&receipt).unwrap(), b"layout-v1-to-v2\n");
-        assert_eq!(std::fs::read(&retirement).unwrap(), b"retirement-source\n");
-        reopened
-            .pack_and_retire_runtime_projection(&home)
-            .expect("retire restarted projection");
-        assert_eq!(std::fs::read_dir(home.root()).unwrap().count(), 1);
-    }
-
-    #[tokio::test]
-    async fn preserves_ordinary_suffix_files_across_clean_stop() {
-        let home_dir = tempfile::tempdir().unwrap();
-        let home = AstridHome::from_path(home_dir.path());
-        let store = open_runtime_principal_store(&home, unlimited_quota())
-            .await
-            .unwrap();
-
-        let next_path = home.root().join("etc/user.next");
-        let migrating_path = home.root().join("etc/user.migrating");
-        std::fs::create_dir_all(next_path.parent().unwrap()).unwrap();
-        std::fs::write(&next_path, b"queued-by-user").unwrap();
-        std::fs::write(&migrating_path, b"kept-by-user").unwrap();
-
-        drop(store);
-        let store = open_runtime_principal_store_for_pack(&home, unlimited_quota())
-            .await
-            .unwrap();
-        store
-            .pack_and_retire_runtime_projection(&home)
-            .expect("pack ordinary suffix files");
-
-        let stopped = std::fs::read_dir(home.root())
-            .unwrap()
-            .collect::<Result<Vec<_>, _>>()
-            .unwrap();
-        assert_eq!(stopped.len(), 1);
-        assert_eq!(
-            stopped[0].file_name(),
-            std::ffi::OsStr::new(CANONICAL_VOLUME)
-        );
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt as _;
-            assert_eq!(
-                stopped[0].metadata().unwrap().permissions().mode() & 0o777,
-                0o600
-            );
-        }
-        drop(store);
-
-        let reopened = open_runtime_principal_store(&home, unlimited_quota())
-            .await
-            .unwrap();
-        assert_eq!(std::fs::read(&next_path).unwrap(), b"queued-by-user");
-        assert_eq!(std::fs::read(&migrating_path).unwrap(), b"kept-by-user");
-        drop(reopened);
-    }
+    admit(store, home.root())?;
+    store
+        .content()
+        .flush()
+        .map_err(|error| tree_error(home.root(), format!("flush running projection: {error}")))?;
+    restore_projection(home, store, &store.content)
 }
+
+/// Validate redirects and unadmitted specials before any destructive restore.
+///
+/// Returns whether the tree contains a regular projection candidate. Excluded
+/// host endpoints and media paths remain outside authority and cannot make an
+/// otherwise volume-only home look like a surviving projection.
+fn validate_surviving_projection(directory: &Path) -> StorageResult<bool> {
+    let mut entries = std::fs::read_dir(directory)
+        .map_err(|error| tree_error(directory, format!("read running projection: {error}")))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| tree_error(directory, format!("read projection entry: {error}")))?;
+    entries.sort_by_key(std::fs::DirEntry::file_name);
+
+    let mut has_projection = false;
+    for entry in entries {
+        let path = entry.path();
+        let metadata = std::fs::symlink_metadata(&path)
+            .map_err(|error| tree_error(&path, format!("inspect projection: {error}")))?;
+        if metadata.file_type().is_symlink() {
+            return Err(tree_error(
+                &path,
+                "running projection contains a symbolic link".to_owned(),
+            ));
+        }
+
+        let relative = path
+            .strip_prefix(directory)
+            .map_err(|_| tree_error(&path, "projection entry escaped runtime root".to_owned()))?;
+        let relative = relative
+            .to_str()
+            .ok_or_else(|| tree_error(&path, "projection path is not valid UTF-8".to_owned()))?;
+        if is_excluded(normalize_relative_path(relative).as_str()) {
+            continue;
+        }
+        if metadata.is_dir() {
+            has_projection |= validate_surviving_projection(&path)?;
+        } else if metadata.is_file() {
+            has_projection = true;
+        } else {
+            return Err(tree_error(
+                &path,
+                "running projection contains an unadmitted special entry".to_owned(),
+            ));
+        }
+    }
+    Ok(has_projection)
+}
+
+/// Publish the live running projection without retiring its host files.
+pub(super) fn publish_running_projection(
+    home: &AstridHome,
+    store: &RuntimePrincipalStore,
+) -> StorageResult<()> {
+    admit(store, home.root())?;
+    store
+        .content()
+        .flush()
+        .map_err(|error| tree_error(home.root(), format!("flush running projection: {error}")))
+}
+
+#[cfg(test)]
+#[path = "runtime_tree_tests.rs"]
+mod tests;

--- a/crates/astrid-storage/src/principal_state/runtime_tree_active.rs
+++ b/crates/astrid-storage/src/principal_state/runtime_tree_active.rs
@@ -1,8 +1,9 @@
 //! Private active-projection receipt retained inside durable volume media.
 //!
 //! The receipt is ordinary system-owned catalog content at a `run/` name that
-//! projection restore never materializes. It proves that a prior process owned
-//! a running projection; arbitrary host files without it are not authority.
+//! projection restore never materializes. ACTIVE proves a run owned a host
+//! projection and authorizes reconciliation. RETIRING is a durable inventory
+//! publication and never infers deletions from a partially retired host.
 
 use std::path::Path;
 
@@ -24,23 +25,45 @@ const MAX_RECEIPT_BYTES: u64 = 4 * 1024 * 1024;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(super) struct ActiveProjectionEntry {
     pub(super) name: ContentName,
-    pub(super) file: ObjectId,
+    pub(super) file: Option<ObjectId>,
     pub(super) logical_bytes: u64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub(super) enum ReceiptPhase {
+    Active,
+    Retiring,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(super) struct ActiveProjectionReceipt {
     schema: u32,
+    phase: ReceiptPhase,
     root: String,
     entries: Vec<ActiveReceiptEntry>,
+}
+
+impl ActiveProjectionReceipt {
+    pub(super) const fn phase(&self) -> ReceiptPhase {
+        self.phase
+    }
+
+    pub(super) fn root_matches(&self, home: &AstridHome) -> StorageResult<bool> {
+        Ok(self.root == canonical_root(home)?)
+    }
+
+    pub(super) fn contains_inventory_name(&self, name: &str) -> bool {
+        self.entries.iter().any(|entry| entry.name == name)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct ActiveReceiptEntry {
     name: String,
-    file: String,
+    file: Option<String>,
     logical_bytes: u64,
 }
 
@@ -50,6 +73,26 @@ pub(super) fn active_projection_name() -> StorageResult<ContentName> {
 }
 
 pub(super) fn read(
+    home: &AstridHome,
+    store: &RuntimePrincipalStore,
+) -> StorageResult<Option<ActiveProjectionReceipt>> {
+    let receipt = read_relocatable(home, store)?;
+    if let Some(receipt) = &receipt
+        && receipt.root != canonical_root(home)?
+    {
+        return Err(tree_error(
+            &home.root().join(ACTIVE_PROJECTION_NAME),
+            "active projection receipt is stale or redirected",
+        ));
+    }
+    Ok(receipt)
+}
+
+/// Parse and validate inventory without rejecting a root mismatch.
+///
+/// Only the caller's bootstrap-only volume-copy recovery may accept a root
+/// mismatch; all other relocation is rejected by the caller.
+pub(super) fn read_relocatable(
     home: &AstridHome,
     store: &RuntimePrincipalStore,
 ) -> StorageResult<Option<ActiveProjectionReceipt>> {
@@ -91,51 +134,38 @@ pub(super) fn read(
             format!("parse active projection receipt: {error}"),
         )
     })?;
-    if receipt.schema != RECEIPT_SCHEMA || receipt.root != canonical_root(home)? {
+    if receipt.schema != RECEIPT_SCHEMA {
         return Err(tree_error(
             &host_receipt,
-            "active projection receipt is stale or redirected",
+            "active projection receipt has an unsupported schema",
         ));
     }
     for entry in &receipt.entries {
-        validate_receipt_entry(store, entry)?;
+        validate_receipt_entry(store, receipt.phase, entry)?;
     }
     Ok(Some(receipt))
 }
 
-pub(super) fn write(
+pub(super) fn encode(
     home: &AstridHome,
-    store: &RuntimePrincipalStore,
+    phase: ReceiptPhase,
     entries: &[ActiveProjectionEntry],
-) -> StorageResult<()> {
+) -> StorageResult<Vec<u8>> {
     let receipt = ActiveProjectionReceipt {
         schema: RECEIPT_SCHEMA,
+        phase,
         root: canonical_root(home)?,
         entries: entries
             .iter()
             .map(|entry| ActiveReceiptEntry {
                 name: entry.name.as_str().to_owned(),
-                file: hex::encode(entry.file.as_bytes()),
+                file: entry.file.map(|file| hex::encode(file.as_bytes())),
                 logical_bytes: entry.logical_bytes,
             })
             .collect(),
     };
-    let bytes = serde_json::to_vec(&receipt)
-        .map_err(|error| tree_error(home.root(), format!("encode active receipt: {error}")))?;
-    let name = active_projection_name()?;
-    store
-        .content()
-        .put(&StateOwner::System, &name, &bytes)
-        .map_err(|error| {
-            tree_error(
-                home.root(),
-                format!("publish active projection receipt: {error}"),
-            )
-        })?;
-    store
-        .content()
-        .flush()
-        .map_err(|error| tree_error(home.root(), format!("flush active receipt: {error}")))
+    serde_json::to_vec(&receipt)
+        .map_err(|error| tree_error(home.root(), format!("encode active receipt: {error}")))
 }
 
 pub(super) fn clear(store: &RuntimePrincipalStore, home: &AstridHome) -> StorageResult<bool> {
@@ -159,6 +189,9 @@ pub(super) fn removals(
     receipt: &ActiveProjectionReceipt,
     surviving: &[ContentName],
 ) -> StorageResult<Vec<ContentName>> {
+    if receipt.phase != ReceiptPhase::Active {
+        return Ok(Vec::new());
+    }
     receipt
         .entries
         .iter()
@@ -178,24 +211,13 @@ pub(super) fn removals(
 
 fn validate_receipt_entry(
     store: &RuntimePrincipalStore,
+    phase: ReceiptPhase,
     entry: &ActiveReceiptEntry,
 ) -> StorageResult<()> {
     let name = ContentName::new(&entry.name).map_err(|error| {
         tree_error(
             Path::new(&entry.name),
             format!("validate receipt catalog name: {error}"),
-        )
-    })?;
-    let bytes = hex::decode(&entry.file).map_err(|error| {
-        tree_error(
-            Path::new(&entry.name),
-            format!("decode receipt object identity: {error}"),
-        )
-    })?;
-    let expected: [u8; 32] = bytes.as_slice().try_into().map_err(|_| {
-        tree_error(
-            Path::new(&entry.name),
-            "receipt object identity is not 32 bytes",
         )
     })?;
     let actual = store
@@ -208,7 +230,35 @@ fn validate_receipt_entry(
                 "active receipt names absent durable projection",
             )
         })?;
-    if actual.file().as_bytes() != &expected
+
+    // ACTIVE is written from projected logical sizes in the same owner-root
+    // transaction, before immutable identities are available to this caller.
+    // RETIRING is written only after publication and is identity-bound.
+    let identity_matches = match (&phase, &entry.file) {
+        (ReceiptPhase::Active, _) => true,
+        (ReceiptPhase::Retiring, Some(file)) => {
+            let bytes = hex::decode(file).map_err(|error| {
+                tree_error(
+                    Path::new(&entry.name),
+                    format!("decode receipt object identity: {error}"),
+                )
+            })?;
+            let expected: [u8; 32] = bytes.as_slice().try_into().map_err(|_| {
+                tree_error(
+                    Path::new(&entry.name),
+                    "receipt object identity is not 32 bytes",
+                )
+            })?;
+            actual.file().as_bytes() == &expected
+        },
+        (ReceiptPhase::Retiring, None) => {
+            return Err(tree_error(
+                Path::new(&entry.name),
+                "retiring receipt has no object identity",
+            ));
+        },
+    };
+    if !identity_matches
         || actual.logical_bytes() != entry.logical_bytes
         || is_excluded(&entry.name)
     {

--- a/crates/astrid-storage/src/principal_state/runtime_tree_active.rs
+++ b/crates/astrid-storage/src/principal_state/runtime_tree_active.rs
@@ -1,0 +1,240 @@
+//! Private active-projection receipt retained inside durable volume media.
+//!
+//! The receipt is ordinary system-owned catalog content at a `run/` name that
+//! projection restore never materializes. It proves that a prior process owned
+//! a running projection; arbitrary host files without it are not authority.
+
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use crate::content::ContentName;
+use crate::error::{StorageError, StorageResult};
+use crate::storage_model::ObjectId;
+use astrid_core::dirs::AstridHome;
+
+use super::{RuntimePrincipalStore, StateOwner, runtime_tree::is_excluded};
+
+pub(super) const ACTIVE_PROJECTION_NAME: &str = "run/.active-projection-v1.json";
+const RECEIPT_SCHEMA: u32 = 1;
+// A projection inventory is catalog metadata, not a quota. This bounds a
+// corrupted or hostile receipt before allocating its JSON payload.
+const MAX_RECEIPT_BYTES: u64 = 4 * 1024 * 1024;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct ActiveProjectionEntry {
+    pub(super) name: ContentName,
+    pub(super) file: ObjectId,
+    pub(super) logical_bytes: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct ActiveProjectionReceipt {
+    schema: u32,
+    root: String,
+    entries: Vec<ActiveReceiptEntry>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ActiveReceiptEntry {
+    name: String,
+    file: String,
+    logical_bytes: u64,
+}
+
+pub(super) fn active_projection_name() -> StorageResult<ContentName> {
+    ContentName::new(ACTIVE_PROJECTION_NAME)
+        .map_err(|error| StorageError::Internal(format!("validate active receipt: {error}")))
+}
+
+pub(super) fn read(
+    home: &AstridHome,
+    store: &RuntimePrincipalStore,
+) -> StorageResult<Option<ActiveProjectionReceipt>> {
+    let host_receipt = home.root().join(ACTIVE_PROJECTION_NAME);
+    if std::fs::symlink_metadata(&host_receipt).is_ok() {
+        return Err(tree_error(
+            &host_receipt,
+            "active projection receipt must never be materialized on the host",
+        ));
+    }
+
+    let name = active_projection_name()?;
+    let metadata = store
+        .content()
+        .describe(&StateOwner::System, &name)
+        .map_err(receipt_error("inspect active projection receipt"))?;
+    let Some(metadata) = metadata else {
+        return Ok(None);
+    };
+    if metadata.logical_bytes() > MAX_RECEIPT_BYTES {
+        return Err(tree_error(
+            &host_receipt,
+            format!("active projection receipt exceeds {MAX_RECEIPT_BYTES} bytes"),
+        ));
+    }
+    let bytes = store
+        .content()
+        .read(&StateOwner::System, &name)
+        .map_err(receipt_error("read active projection receipt"))?
+        .ok_or_else(|| {
+            tree_error(
+                &host_receipt,
+                "active projection receipt disappeared while being read",
+            )
+        })?;
+    let receipt = serde_json::from_slice::<ActiveProjectionReceipt>(&bytes).map_err(|error| {
+        tree_error(
+            &host_receipt,
+            format!("parse active projection receipt: {error}"),
+        )
+    })?;
+    if receipt.schema != RECEIPT_SCHEMA || receipt.root != canonical_root(home)? {
+        return Err(tree_error(
+            &host_receipt,
+            "active projection receipt is stale or redirected",
+        ));
+    }
+    for entry in &receipt.entries {
+        validate_receipt_entry(store, entry)?;
+    }
+    Ok(Some(receipt))
+}
+
+pub(super) fn write(
+    home: &AstridHome,
+    store: &RuntimePrincipalStore,
+    entries: &[ActiveProjectionEntry],
+) -> StorageResult<()> {
+    let receipt = ActiveProjectionReceipt {
+        schema: RECEIPT_SCHEMA,
+        root: canonical_root(home)?,
+        entries: entries
+            .iter()
+            .map(|entry| ActiveReceiptEntry {
+                name: entry.name.as_str().to_owned(),
+                file: hex::encode(entry.file.as_bytes()),
+                logical_bytes: entry.logical_bytes,
+            })
+            .collect(),
+    };
+    let bytes = serde_json::to_vec(&receipt)
+        .map_err(|error| tree_error(home.root(), format!("encode active receipt: {error}")))?;
+    let name = active_projection_name()?;
+    store
+        .content()
+        .put(&StateOwner::System, &name, &bytes)
+        .map_err(|error| {
+            tree_error(
+                home.root(),
+                format!("publish active projection receipt: {error}"),
+            )
+        })?;
+    store
+        .content()
+        .flush()
+        .map_err(|error| tree_error(home.root(), format!("flush active receipt: {error}")))
+}
+
+pub(super) fn clear(store: &RuntimePrincipalStore, home: &AstridHome) -> StorageResult<bool> {
+    let name = active_projection_name()?;
+    let removed = store
+        .content()
+        .delete(&StateOwner::System, &name)
+        .map_err(|error| tree_error(home.root(), format!("remove active receipt: {error}")))?;
+    if removed {
+        store.content().flush().map_err(|error| {
+            tree_error(
+                home.root(),
+                format!("flush active receipt removal: {error}"),
+            )
+        })?;
+    }
+    Ok(removed)
+}
+
+pub(super) fn removals(
+    receipt: &ActiveProjectionReceipt,
+    surviving: &[ContentName],
+) -> StorageResult<Vec<ContentName>> {
+    receipt
+        .entries
+        .iter()
+        .map(|entry| {
+            let name = ContentName::new(&entry.name).map_err(|error| {
+                tree_error(Path::new(&entry.name), format!("receipt name: {error}"))
+            })?;
+            if surviving.contains(&name) {
+                Ok(None)
+            } else {
+                Ok(Some(name))
+            }
+        })
+        .collect::<StorageResult<Vec<Option<ContentName>>>>()
+        .map(|names| names.into_iter().flatten().collect())
+}
+
+fn validate_receipt_entry(
+    store: &RuntimePrincipalStore,
+    entry: &ActiveReceiptEntry,
+) -> StorageResult<()> {
+    let name = ContentName::new(&entry.name).map_err(|error| {
+        tree_error(
+            Path::new(&entry.name),
+            format!("validate receipt catalog name: {error}"),
+        )
+    })?;
+    let bytes = hex::decode(&entry.file).map_err(|error| {
+        tree_error(
+            Path::new(&entry.name),
+            format!("decode receipt object identity: {error}"),
+        )
+    })?;
+    let expected: [u8; 32] = bytes.as_slice().try_into().map_err(|_| {
+        tree_error(
+            Path::new(&entry.name),
+            "receipt object identity is not 32 bytes",
+        )
+    })?;
+    let actual = store
+        .content()
+        .describe(&StateOwner::System, &name)
+        .map_err(receipt_error("validate active receipt entry"))?
+        .ok_or_else(|| {
+            tree_error(
+                Path::new(&entry.name),
+                "active receipt names absent durable projection",
+            )
+        })?;
+    if actual.file().as_bytes() != &expected
+        || actual.logical_bytes() != entry.logical_bytes
+        || is_excluded(&entry.name)
+    {
+        return Err(tree_error(
+            Path::new(&entry.name),
+            "active receipt does not match durable projection",
+        ));
+    }
+    Ok(())
+}
+
+fn canonical_root(home: &AstridHome) -> StorageResult<String> {
+    home.root()
+        .canonicalize()
+        .map_err(|error| tree_error(home.root(), format!("resolve projection root: {error}")))?
+        .into_os_string()
+        .into_string()
+        .map_err(|_| tree_error(home.root(), "projection root is not valid UTF-8"))
+}
+
+fn receipt_error(
+    detail: &'static str,
+) -> impl Fn(crate::content::PrincipalContentError) -> StorageError {
+    move |error| StorageError::Internal(format!("{detail}: {error}"))
+}
+
+fn tree_error(path: &Path, detail: impl std::fmt::Display) -> StorageError {
+    StorageError::Connection(format!("runtime tree {}: {detail}", path.display()))
+}

--- a/crates/astrid-storage/src/principal_state/runtime_tree_active.rs
+++ b/crates/astrid-storage/src/principal_state/runtime_tree_active.rs
@@ -25,7 +25,7 @@ const MAX_RECEIPT_BYTES: u64 = 4 * 1024 * 1024;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(super) struct ActiveProjectionEntry {
     pub(super) name: ContentName,
-    pub(super) file: Option<ObjectId>,
+    pub(super) file: ObjectId,
     pub(super) logical_bytes: u64,
 }
 
@@ -57,13 +57,33 @@ impl ActiveProjectionReceipt {
     pub(super) fn contains_inventory_name(&self, name: &str) -> bool {
         self.entries.iter().any(|entry| entry.name == name)
     }
+
+    #[cfg(test)]
+    pub(super) fn inventory_identity(&self, name: &str) -> StorageResult<Option<ObjectId>> {
+        let Some(entry) = self.entries.iter().find(|entry| entry.name == name) else {
+            return Ok(None);
+        };
+        let bytes = hex::decode(&entry.file).map_err(|error| {
+            tree_error(
+                Path::new(&entry.name),
+                format!("decode receipt object identity: {error}"),
+            )
+        })?;
+        let expected: [u8; 32] = bytes.as_slice().try_into().map_err(|_| {
+            tree_error(
+                Path::new(&entry.name),
+                "receipt object identity is not 32 bytes",
+            )
+        })?;
+        Ok(Some(ObjectId::new(expected)))
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct ActiveReceiptEntry {
     name: String,
-    file: Option<String>,
+    file: String,
     logical_bytes: u64,
 }
 
@@ -141,7 +161,7 @@ pub(super) fn read_relocatable(
         ));
     }
     for entry in &receipt.entries {
-        validate_receipt_entry(store, receipt.phase, entry)?;
+        validate_receipt_entry(store, entry)?;
     }
     Ok(Some(receipt))
 }
@@ -159,7 +179,7 @@ pub(super) fn encode(
             .iter()
             .map(|entry| ActiveReceiptEntry {
                 name: entry.name.as_str().to_owned(),
-                file: entry.file.map(|file| hex::encode(file.as_bytes())),
+                file: hex::encode(entry.file.as_bytes()),
                 logical_bytes: entry.logical_bytes,
             })
             .collect(),
@@ -211,7 +231,6 @@ pub(super) fn removals(
 
 fn validate_receipt_entry(
     store: &RuntimePrincipalStore,
-    phase: ReceiptPhase,
     entry: &ActiveReceiptEntry,
 ) -> StorageResult<()> {
     let name = ContentName::new(&entry.name).map_err(|error| {
@@ -231,33 +250,19 @@ fn validate_receipt_entry(
             )
         })?;
 
-    // ACTIVE is written from projected logical sizes in the same owner-root
-    // transaction, before immutable identities are available to this caller.
-    // RETIRING is written only after publication and is identity-bound.
-    let identity_matches = match (&phase, &entry.file) {
-        (ReceiptPhase::Active, _) => true,
-        (ReceiptPhase::Retiring, Some(file)) => {
-            let bytes = hex::decode(file).map_err(|error| {
-                tree_error(
-                    Path::new(&entry.name),
-                    format!("decode receipt object identity: {error}"),
-                )
-            })?;
-            let expected: [u8; 32] = bytes.as_slice().try_into().map_err(|_| {
-                tree_error(
-                    Path::new(&entry.name),
-                    "receipt object identity is not 32 bytes",
-                )
-            })?;
-            actual.file().as_bytes() == &expected
-        },
-        (ReceiptPhase::Retiring, None) => {
-            return Err(tree_error(
-                Path::new(&entry.name),
-                "retiring receipt has no object identity",
-            ));
-        },
-    };
+    let bytes = hex::decode(&entry.file).map_err(|error| {
+        tree_error(
+            Path::new(&entry.name),
+            format!("decode receipt object identity: {error}"),
+        )
+    })?;
+    let expected: [u8; 32] = bytes.as_slice().try_into().map_err(|_| {
+        tree_error(
+            Path::new(&entry.name),
+            "receipt object identity is not 32 bytes",
+        )
+    })?;
+    let identity_matches = actual.file().as_bytes() == &expected;
     if !identity_matches
         || actual.logical_bytes() != entry.logical_bytes
         || is_excluded(&entry.name)

--- a/crates/astrid-storage/src/principal_state/runtime_tree_tests.rs
+++ b/crates/astrid-storage/src/principal_state/runtime_tree_tests.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
+use serde_json::json;
 use sha2::{Digest as _, Sha256};
 
 use super::*;
@@ -16,6 +17,47 @@ fn unlimited_quota() -> Arc<dyn KvQuotaResolver<StateOwner>> {
             StateOwner::Principal(_) | StateOwner::Fleet(_) => Some(u64::MAX),
         })
     })
+}
+
+fn write_active_identity_receipt(
+    home: &AstridHome,
+    store: &RuntimePrincipalStore,
+    name: &ContentName,
+    file: Option<&str>,
+) {
+    let descriptor = store
+        .content()
+        .describe(&StateOwner::System, name)
+        .unwrap()
+        .expect("receipt entry is durable");
+    let entry = if let Some(file) = file {
+        json!({
+            "name": name.as_str(),
+            "file": file,
+            "logical_bytes": descriptor.logical_bytes(),
+        })
+    } else {
+        json!({
+            "name": name.as_str(),
+            "logical_bytes": descriptor.logical_bytes(),
+        })
+    };
+    let receipt = json!({
+        "schema": 1,
+        "phase": "active",
+        "root": home.root().canonicalize().unwrap().into_os_string().into_string().unwrap(),
+        "entries": [entry],
+    });
+    let receipt_name = ContentName::new("run/.active-projection-v1.json").unwrap();
+    store
+        .content()
+        .put(
+            &StateOwner::System,
+            &receipt_name,
+            receipt.to_string().as_bytes(),
+        )
+        .unwrap();
+    store.content().flush().unwrap();
 }
 
 #[test]
@@ -505,8 +547,15 @@ async fn active_projection_publication_rotates_receipt_inventory() {
     let running = open_runtime_principal_store(&home, unlimited_quota())
         .await
         .unwrap();
+    let old_name = ContentName::new("etc/old.conf").unwrap();
+    let old_id = running
+        .content()
+        .describe(&StateOwner::System, &old_name)
+        .unwrap()
+        .expect("old generation is published")
+        .file();
     let new_path = home.root().join("etc/new.conf");
-    std::fs::write(&new_path, b"new-generation\n").unwrap();
+    std::fs::write(&new_path, b"new\n").unwrap();
     std::fs::remove_file(&old_path).unwrap();
     drop(running);
 
@@ -520,12 +569,23 @@ async fn active_projection_publication_rotates_receipt_inventory() {
     assert!(receipt.contains_inventory_name("etc/new.conf"));
     assert!(!receipt.contains_inventory_name("etc/old.conf"));
     let new_name = ContentName::new("etc/new.conf").unwrap();
+    let new_id = reopened
+        .content()
+        .describe(&StateOwner::System, &new_name)
+        .unwrap()
+        .expect("new generation is published")
+        .file();
+    assert_ne!(old_id, new_id, "same-size mutation reused file identity");
+    assert_eq!(
+        receipt.inventory_identity("etc/new.conf").unwrap(),
+        Some(new_id)
+    );
     assert_eq!(
         reopened
             .content()
             .read(&StateOwner::System, &new_name)
             .unwrap(),
-        Some(b"new-generation\n".to_vec())
+        Some(b"new\n".to_vec())
     );
 }
 
@@ -846,6 +906,62 @@ async fn unadmitted_special_entry_fails_closed_before_restore() {
     };
     assert!(
         error.to_string().contains("unadmitted special entry"),
+        "{error}"
+    );
+}
+
+#[tokio::test]
+async fn active_receipt_missing_object_identity_fails_closed() {
+    let home_dir = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(home_dir.path());
+    let running = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    let config_path = home.root().join("etc/identity.conf");
+    std::fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+    std::fs::write(&config_path, b"identity").unwrap();
+    let config_name = ContentName::new("etc/identity.conf").unwrap();
+    running
+        .content()
+        .put(&StateOwner::System, &config_name, b"identity")
+        .unwrap();
+    write_active_identity_receipt(&home, &running, &config_name, None);
+    drop(running);
+
+    let Err(error) = open_runtime_principal_store(&home, unlimited_quota()).await else {
+        panic!("ACTIVE receipt without an object identity must fail closed");
+    };
+    assert!(
+        error.to_string().contains("missing field `file`"),
+        "{error}"
+    );
+}
+
+#[tokio::test]
+async fn active_receipt_wrong_object_identity_fails_closed() {
+    let home_dir = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(home_dir.path());
+    let running = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    let config_path = home.root().join("etc/identity.conf");
+    std::fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+    std::fs::write(&config_path, b"identity").unwrap();
+    let config_name = ContentName::new("etc/identity.conf").unwrap();
+    running
+        .content()
+        .put(&StateOwner::System, &config_name, b"identity")
+        .unwrap();
+    write_active_identity_receipt(&home, &running, &config_name, Some(&"00".repeat(32)));
+    drop(running);
+
+    let Err(error) = open_runtime_principal_store(&home, unlimited_quota()).await else {
+        panic!("ACTIVE receipt with a wrong object identity must fail closed");
+    };
+    assert!(
+        error
+            .to_string()
+            .contains("active receipt does not match durable projection"),
         "{error}"
     );
 }

--- a/crates/astrid-storage/src/principal_state/runtime_tree_tests.rs
+++ b/crates/astrid-storage/src/principal_state/runtime_tree_tests.rs
@@ -490,6 +490,15 @@ async fn reopen_admits_surviving_projection_appended_after_last_pack() {
     std::fs::write(&config_path, b"allow=generation-2\n").unwrap();
     drop(running);
 
+    #[cfg(unix)]
+    let _socket = {
+        use std::os::unix::net::UnixListener;
+
+        let socket_path = home.root().join(SOCKET_PATH);
+        std::fs::create_dir_all(socket_path.parent().unwrap()).unwrap();
+        UnixListener::bind(socket_path).unwrap()
+    };
+
     let reopened = open_runtime_principal_store(&home, unlimited_quota())
         .await
         .unwrap();
@@ -553,6 +562,37 @@ async fn unadmitted_special_entry_fails_closed_before_restore() {
     let _socket = UnixListener::bind(home.root().join("ordinary.sock")).unwrap();
     let Err(error) = open_runtime_principal_store(&home, unlimited_quota()).await else {
         panic!("unadmitted special entry must fail before projection restore");
+    };
+    assert!(
+        error.to_string().contains("unadmitted special entry"),
+        "{error}"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn special_inside_run_capsules_fails_closed_before_restore() {
+    use std::os::unix::net::UnixListener;
+
+    let home_dir = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(home_dir.path());
+    let store = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    drop(store);
+    let packer = open_runtime_principal_store_for_pack(&home, unlimited_quota())
+        .await
+        .unwrap();
+    packer
+        .pack_and_retire_runtime_projection(&home)
+        .expect("pack volume-only stop state");
+    drop(packer);
+
+    let socket_path = home.root().join("run/capsules/example.sock");
+    std::fs::create_dir_all(socket_path.parent().unwrap()).unwrap();
+    let _socket = UnixListener::bind(&socket_path).unwrap();
+    let Err(error) = open_runtime_principal_store(&home, unlimited_quota()).await else {
+        panic!("special inside admitted durable namespace must fail before projection restore");
     };
     assert!(
         error.to_string().contains("unadmitted special entry"),

--- a/crates/astrid-storage/src/principal_state/runtime_tree_tests.rs
+++ b/crates/astrid-storage/src/principal_state/runtime_tree_tests.rs
@@ -1,0 +1,561 @@
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use sha2::{Digest as _, Sha256};
+
+use super::*;
+use crate::principal_state::open_runtime_principal_store_for_pack;
+use crate::volume::{AstridVolume as _, HostedFileVolume};
+use crate::{AstridFilesystem, FilesystemPath, KvQuotaResolver, open_runtime_principal_store};
+use astrid_core::dirs::AstridHome;
+
+fn unlimited_quota() -> Arc<dyn KvQuotaResolver<StateOwner>> {
+    Arc::new(|owner: &StateOwner| {
+        Ok(match owner {
+            StateOwner::System => None,
+            StateOwner::Principal(_) | StateOwner::Fleet(_) => Some(u64::MAX),
+        })
+    })
+}
+
+#[test]
+fn excludes_windows_separator_paths() {
+    for path in ["volume", "volume\\compacting", "run\\system.sock"] {
+        let normalized = normalize_relative_path(path);
+        assert!(is_excluded(&normalized), "path was not excluded: {path}");
+    }
+    assert_eq!(
+        normalize_relative_path("run\\system.ready"),
+        "run/system.ready"
+    );
+}
+
+#[test]
+fn excludes_paths_only_at_exact_or_directory_boundaries() {
+    for path in [
+        "volume",
+        "volume/compacting",
+        "volume2",
+        "volumetric.txt",
+        "volume.previous",
+        "var/principal-store",
+        "var/principal-store/agent.json",
+        "var/principal-store2",
+        "var/principal-store2/agent.json",
+        "run/capsulesX",
+        "run/capsulesX/example/component.wasm",
+        "run/capsules/example/component.wasm",
+    ] {
+        let normalized = normalize_relative_path(path);
+        let excluded = is_excluded(&normalized);
+        let expected = !matches!(
+            path,
+            "volume2"
+                | "volumetric.txt"
+                | "volume.previous"
+                | "var/principal-store2"
+                | "var/principal-store2/agent.json"
+                | "run/capsules/example/component.wasm"
+        );
+        assert_eq!(excluded, expected, "unexpected admission for {path}");
+    }
+    assert!(!is_excluded("run/capsules"));
+}
+
+#[test]
+fn excludes_only_named_transaction_paths() {
+    for path in [
+        MIGRATING_VOLUME,
+        "etc/.layout-version.next",
+        "var/migrations/.layout-v1-to-v2.intent.next",
+        "var/migrations/.layout-v1-to-v2.retiring.next",
+        "var/migrations/.layout-v1-to-v2.complete.next",
+    ] {
+        assert!(is_excluded(path), "transaction path was admitted: {path}");
+    }
+
+    for path in [
+        "etc/user.next",
+        "etc/user.migrating",
+        "var/user.next",
+        "var/user.migrating",
+        "astrid.migrating.previous",
+        "etc/.layout-version.next.old",
+    ] {
+        assert!(!is_excluded(path), "ordinary path was excluded: {path}");
+    }
+}
+
+#[test]
+fn allows_run_capsule_projections() {
+    let normalized = normalize_relative_path("run/capsules/example/component.wasm");
+    assert!(!is_excluded(&normalized));
+    assert!(!is_excluded("run"));
+    assert!(!is_excluded("run/capsules"));
+
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("run/capsules/example/component.wasm");
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(&path, b"run-capsule").unwrap();
+    let entries = scan(directory.path()).unwrap();
+    assert_eq!(entries.len(), 1, "scan entries: {entries:?}");
+    assert_eq!(
+        entries[0].name().as_str(),
+        "run/capsules/example/component.wasm"
+    );
+}
+
+fn durable_files(wasm_hash: &str, wasm: &[u8]) -> Vec<(String, Vec<u8>)> {
+    vec![
+        (format!("bin/{wasm_hash}.wasm"), wasm.to_vec()),
+        (
+            "wit/astrid-contracts.wit".to_owned(),
+            b"package astrid:contracts;".to_vec(),
+        ),
+        ("etc/layout-version".to_owned(), b"2".to_vec()),
+        ("keys/runtime.key".to_owned(), b"runtime-key".to_vec()),
+        ("var/content-staging/payload".to_owned(), b"staged".to_vec()),
+        ("var/config.json".to_owned(), b"{\"durable\":true}".to_vec()),
+        ("var/migrations/marker".to_owned(), b"migration".to_vec()),
+    ]
+}
+
+#[tokio::test]
+async fn admits_runtime_tree_and_reopens_from_preclose_volume_copy() {
+    let source = tempfile::tempdir().unwrap();
+    let home_dir = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(home_dir.path());
+    home.ensure().unwrap();
+    let wasm = b"\0asm\x01\0\0\0runtime-wasm-unique".to_vec();
+    let wasm_hash = blake3::hash(&wasm).to_hex().to_string();
+    let durable = durable_files(&wasm_hash, &wasm);
+    for (relative, bytes) in &durable {
+        let path = source.path().join(relative);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, bytes).unwrap();
+    }
+    for relative in [
+        "volume",
+        "volume.compacting",
+        "volume.previous",
+        "run/system.sock",
+    ] {
+        let path = source.path().join(relative);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, b"host-only").unwrap();
+    }
+
+    let store = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    store.admit_runtime_tree(source.path()).unwrap();
+
+    let names = store
+        .content()
+        .list(&StateOwner::System)
+        .unwrap()
+        .into_iter()
+        .map(|entry| entry.name().as_str().to_owned())
+        .collect::<Vec<_>>();
+    let mut expected_names = durable
+        .iter()
+        .map(|(name, _)| name.clone())
+        .collect::<Vec<_>>();
+    expected_names.push("var/content-staging/intents.v1.log".to_owned());
+    expected_names.extend(["volume.compacting", "volume.previous"].map(str::to_owned));
+    expected_names.sort();
+    assert_eq!(names, expected_names);
+
+    let copied_home_dir = tempfile::tempdir().unwrap();
+    let copied_home = AstridHome::from_path(copied_home_dir.path());
+    copied_home.ensure().unwrap();
+    std::fs::copy(
+        home.storage_volume_path(),
+        copied_home.storage_volume_path(),
+    )
+    .unwrap();
+    let volume = HostedFileVolume::open(copied_home.storage_volume_path()).unwrap();
+    assert!(
+        volume
+            .list_regions("representations/blobs/loose")
+            .unwrap()
+            .is_empty()
+    );
+    drop(volume);
+
+    let reopened = open_runtime_principal_store(&copied_home, unlimited_quota())
+        .await
+        .unwrap();
+    let filesystem = AstridFilesystem::new(reopened.content(), StateOwner::System);
+    let expected_count = durable.len();
+    let mut reconstructed = BTreeMap::new();
+    for (name, bytes) in durable {
+        let path = FilesystemPath::new(name).unwrap();
+        let entry = filesystem.stat(&path).unwrap();
+        let actual = filesystem.read(&path, 0, entry.logical_bytes()).unwrap();
+        let expected_digest = Sha256::digest(&bytes);
+        assert_eq!(Sha256::digest(&actual), expected_digest);
+        reconstructed.insert(path.as_str().to_owned(), actual);
+    }
+    assert_eq!(reconstructed.len(), expected_count);
+}
+
+#[cfg(unix)]
+#[test]
+fn rejects_redirects_before_publication() {
+    use std::os::unix::fs::symlink;
+
+    let root = tempfile::tempdir().unwrap();
+    let outside = tempfile::tempdir().unwrap();
+    symlink(outside.path(), root.path().join("redirect")).unwrap();
+    let error = scan(root.path()).unwrap_err();
+    assert!(error.to_string().contains("symbolic link"));
+}
+
+#[cfg(unix)]
+#[test]
+fn skips_special_entries_without_failing_scan() {
+    use std::os::unix::net::UnixListener;
+
+    let root = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(root.path().join("run")).unwrap();
+    std::fs::write(root.path().join("regular"), b"durable").unwrap();
+    let _socket = UnixListener::bind(root.path().join("run/other.sock")).unwrap();
+
+    let entries = scan(root.path()).unwrap();
+    assert_eq!(
+        entries
+            .iter()
+            .map(|entry| entry.name().as_str())
+            .collect::<Vec<_>>(),
+        ["regular"]
+    );
+}
+
+#[tokio::test]
+async fn preserves_runtime_key_across_initialization_and_restart() {
+    let home_dir = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(home_dir.path());
+    let key_path = home.runtime_key_path();
+    std::fs::create_dir_all(key_path.parent().unwrap()).unwrap();
+    std::fs::write(&key_path, b"original-runtime-key").unwrap();
+
+    let store = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    assert_eq!(std::fs::read(&key_path).unwrap(), b"original-runtime-key");
+    let runtime_key = ContentName::new(RUNTIME_KEY_PROJECTION).unwrap();
+    assert!(
+        store
+            .content()
+            .describe(&StateOwner::System, &runtime_key)
+            .unwrap()
+            .is_some()
+    );
+    drop(store);
+
+    let store = open_runtime_principal_store_for_pack(&home, unlimited_quota())
+        .await
+        .unwrap();
+    store
+        .pack_and_retire_runtime_projection(&home)
+        .expect("pack runtime key");
+    drop(store);
+    assert!(!key_path.exists());
+    assert!(!home.keys_dir().exists());
+    let stopped = std::fs::read_dir(home.root())
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    assert_eq!(stopped.len(), 1);
+    assert_eq!(
+        stopped[0].file_name(),
+        std::ffi::OsStr::new(CANONICAL_VOLUME)
+    );
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        assert_eq!(
+            stopped[0].metadata().unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
+
+    let reopened = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    assert_eq!(std::fs::read(&key_path).unwrap(), b"original-runtime-key");
+    drop(reopened);
+}
+
+#[tokio::test]
+async fn packs_trust_projection_and_excludes_run_on_clean_stop() {
+    let home_dir = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(home_dir.path());
+    let store = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    let trust = home.root().join("trust/test.pub");
+    std::fs::create_dir_all(trust.parent().unwrap()).unwrap();
+    std::fs::write(&trust, b"ed25519:test").unwrap();
+    let transient = home.run_dir().join("system.pid");
+    std::fs::create_dir_all(transient.parent().unwrap()).unwrap();
+    std::fs::write(&transient, b"pid").unwrap();
+
+    drop(store);
+    let store = open_runtime_principal_store_for_pack(&home, unlimited_quota())
+        .await
+        .unwrap();
+    store
+        .pack_and_retire_runtime_projection(&home)
+        .expect("pack running projection");
+    assert!(!trust.exists());
+    assert!(!home.run_dir().exists());
+
+    let catalog = store
+        .content()
+        .list(&StateOwner::System)
+        .unwrap()
+        .into_iter()
+        .map(|entry| entry.name().as_str().to_owned())
+        .collect::<Vec<_>>();
+    assert!(catalog.iter().any(|name| name == "trust/test.pub"));
+    assert!(!catalog.iter().any(|name| name.starts_with("run/")));
+
+    drop(store);
+    let reopened = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    assert!(trust.is_file(), "trusted pin must be mounted on restart");
+    assert!(!home.run_dir().exists());
+    reopened
+        .pack_and_retire_runtime_projection(&home)
+        .expect("retire restarted projection");
+
+    let stopped = std::fs::read_dir(home.root())
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    assert_eq!(stopped.len(), 1);
+    assert_eq!(
+        stopped[0].file_name(),
+        std::ffi::OsStr::new("astrid.volume")
+    );
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        assert_eq!(
+            stopped[0].metadata().unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
+}
+
+#[tokio::test]
+async fn clean_stop_restores_capsules_and_layout_receipts_on_restart() {
+    let home_dir = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(home_dir.path());
+    let store = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    drop(store);
+
+    let capsule = home
+        .home_dir()
+        .join("default/.local/capsules/example/capsule.json");
+    let receipt = home.migrations_dir().join("layout-v1-to-v2.complete");
+    let retirement = home.migrations_dir().join("layout-v1-to-v2.retiring");
+    std::fs::create_dir_all(capsule.parent().unwrap()).unwrap();
+    std::fs::create_dir_all(receipt.parent().unwrap()).unwrap();
+    std::fs::write(&capsule, br#"{"id":"example"}"#).unwrap();
+    std::fs::write(&receipt, b"layout-v1-to-v2\n").unwrap();
+    std::fs::write(&retirement, b"retirement-source\n").unwrap();
+
+    let store = open_runtime_principal_store_for_pack(&home, unlimited_quota())
+        .await
+        .unwrap();
+    store
+        .pack_and_retire_runtime_projection(&home)
+        .expect("pack capsule and receipt");
+    let stopped = std::fs::read_dir(home.root())
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    assert_eq!(stopped.len(), 1);
+    assert_eq!(
+        stopped[0].file_name(),
+        std::ffi::OsStr::new(CANONICAL_VOLUME)
+    );
+    drop(store);
+
+    let reopened = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    assert_eq!(std::fs::read(&capsule).unwrap(), br#"{"id":"example"}"#);
+    assert_eq!(std::fs::read(&receipt).unwrap(), b"layout-v1-to-v2\n");
+    assert_eq!(std::fs::read(&retirement).unwrap(), b"retirement-source\n");
+    reopened
+        .pack_and_retire_runtime_projection(&home)
+        .expect("retire restarted projection");
+    assert_eq!(std::fs::read_dir(home.root()).unwrap().count(), 1);
+}
+
+#[tokio::test]
+async fn preserves_ordinary_suffix_files_across_clean_stop() {
+    let home_dir = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(home_dir.path());
+    let store = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+
+    let next_path = home.root().join("etc/user.next");
+    let migrating_path = home.root().join("etc/user.migrating");
+    std::fs::create_dir_all(next_path.parent().unwrap()).unwrap();
+    std::fs::write(&next_path, b"queued-by-user").unwrap();
+    std::fs::write(&migrating_path, b"kept-by-user").unwrap();
+
+    drop(store);
+    let store = open_runtime_principal_store_for_pack(&home, unlimited_quota())
+        .await
+        .unwrap();
+    store
+        .pack_and_retire_runtime_projection(&home)
+        .expect("pack ordinary suffix files");
+
+    let stopped = std::fs::read_dir(home.root())
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    assert_eq!(stopped.len(), 1);
+    assert_eq!(
+        stopped[0].file_name(),
+        std::ffi::OsStr::new(CANONICAL_VOLUME)
+    );
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        assert_eq!(
+            stopped[0].metadata().unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
+    drop(store);
+
+    let reopened = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    assert_eq!(std::fs::read(&next_path).unwrap(), b"queued-by-user");
+    assert_eq!(std::fs::read(&migrating_path).unwrap(), b"kept-by-user");
+    drop(reopened);
+}
+
+#[tokio::test]
+async fn reopen_admits_surviving_projection_appended_after_last_pack() {
+    let home_dir = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(home_dir.path());
+    let store = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+
+    let log_path = home.root().join("log/daemon.log");
+    let config_path = home.root().join("etc/authz.conf");
+    std::fs::create_dir_all(log_path.parent().unwrap()).unwrap();
+    std::fs::write(&log_path, b"generation-1\n").unwrap();
+    std::fs::write(&config_path, b"allow=generation-1\n").unwrap();
+    drop(store);
+
+    let packer = open_runtime_principal_store_for_pack(&home, unlimited_quota())
+        .await
+        .unwrap();
+    packer
+        .pack_and_retire_runtime_projection(&home)
+        .expect("pack baseline running projection");
+    assert_eq!(std::fs::read_dir(home.root()).unwrap().count(), 1);
+    drop(packer);
+
+    let running = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    assert_eq!(std::fs::read(&log_path).unwrap(), b"generation-1\n");
+    {
+        use std::io::Write as _;
+
+        let mut log = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&log_path)
+            .unwrap();
+        log.write_all(b"generation-2\n").unwrap();
+        log.flush().unwrap();
+    }
+    std::fs::write(&config_path, b"allow=generation-2\n").unwrap();
+    drop(running);
+
+    let reopened = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    assert_eq!(
+        std::fs::read(&log_path).unwrap(),
+        b"generation-1\ngeneration-2\n"
+    );
+    assert_eq!(
+        std::fs::read(&config_path).unwrap(),
+        b"allow=generation-2\n"
+    );
+    drop(reopened);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn surviving_redirect_fails_closed_before_restore() {
+    use std::os::unix::fs::symlink;
+
+    let home_dir = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(home_dir.path());
+    let store = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    drop(store);
+    let packer = open_runtime_principal_store_for_pack(&home, unlimited_quota())
+        .await
+        .unwrap();
+    packer
+        .pack_and_retire_runtime_projection(&home)
+        .expect("pack volume-only stop state");
+    drop(packer);
+
+    let outside = tempfile::tempdir().unwrap();
+    symlink(outside.path(), home.root().join("redirect")).unwrap();
+    let Err(error) = open_runtime_principal_store(&home, unlimited_quota()).await else {
+        panic!("redirected surviving tree must fail before projection restore");
+    };
+    assert!(error.to_string().contains("symbolic link"), "{error}");
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn unadmitted_special_entry_fails_closed_before_restore() {
+    use std::os::unix::net::UnixListener;
+
+    let home_dir = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(home_dir.path());
+    let store = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    drop(store);
+    let packer = open_runtime_principal_store_for_pack(&home, unlimited_quota())
+        .await
+        .unwrap();
+    packer
+        .pack_and_retire_runtime_projection(&home)
+        .expect("pack volume-only stop state");
+    drop(packer);
+
+    let _socket = UnixListener::bind(home.root().join("ordinary.sock")).unwrap();
+    let Err(error) = open_runtime_principal_store(&home, unlimited_quota()).await else {
+        panic!("unadmitted special entry must fail before projection restore");
+    };
+    assert!(
+        error.to_string().contains("unadmitted special entry"),
+        "{error}"
+    );
+}

--- a/crates/astrid-storage/src/principal_state/runtime_tree_tests.rs
+++ b/crates/astrid-storage/src/principal_state/runtime_tree_tests.rs
@@ -1151,6 +1151,28 @@ async fn restore_rejects_absolute_and_traversal_catalog_names() {
     let _ = std::fs::remove_file(&sentinel);
 }
 
+#[cfg(unix)]
+#[test]
+fn rebind_staging_generation_rejects_symlink_without_touching_target() {
+    let home_dir = tempfile::tempdir().unwrap();
+    let generations = home_dir.path().join("var/content-staging/generations");
+    std::fs::create_dir_all(&generations).unwrap();
+    let external_dir = tempfile::tempdir().unwrap();
+    let external = external_dir.path().join("crafted.sealed");
+    let crafted = vec![0xa5_u8; 96];
+    std::fs::write(&external, &crafted).unwrap();
+    let projected = generations.join("x.sealed");
+    std::os::unix::fs::symlink(&external, &projected).unwrap();
+
+    let error = super::super::rebind_staging_generation(&projected)
+        .expect_err("redirected staged generation must be rejected");
+    assert!(
+        error.to_string().contains("redirected") || error.to_string().contains("symbolic link"),
+        "{error}"
+    );
+    assert_eq!(std::fs::read(&external).unwrap(), crafted);
+}
+
 #[tokio::test]
 async fn retiring_stop_retains_unreceipted_host_file() {
     let home_dir = tempfile::tempdir().unwrap();
@@ -1185,6 +1207,72 @@ async fn retiring_stop_retains_unreceipted_host_file() {
         "{error}"
     );
     assert_eq!(std::fs::read(&extra).unwrap(), b"do-not-delete\n");
+}
+
+#[tokio::test]
+async fn failed_restore_keeps_later_volume_entries_and_never_adopts_partial_host_tree() {
+    let home_dir = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(home_dir.path());
+    let running = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    drop(running);
+
+    let packer = open_runtime_principal_store_for_pack(&home, unlimited_quota())
+        .await
+        .unwrap();
+    let malformed = ContentName::new("var/content-staging/generations/x.sealed").unwrap();
+    let later = ContentName::new("var/content-staging/generations/z.sealed").unwrap();
+    packer
+        .content()
+        .put(&StateOwner::System, &malformed, &[0xa5_u8; 80])
+        .unwrap();
+    packer
+        .content()
+        .put(&StateOwner::System, &later, b"later-generation")
+        .unwrap();
+    packer.content().flush().unwrap();
+    packer.establish_runtime_projection_receipt(&home).unwrap();
+    drop(packer);
+    astrid_core::dirs::retire_projection_root(home.root()).unwrap();
+
+    let Err(first) = open_runtime_principal_store(&home, unlimited_quota()).await else {
+        panic!("malformed earlier generation must fail restore");
+    };
+    assert!(first.to_string().contains("staged footer"), "{first}");
+    assert!(
+        home.root()
+            .join("var/content-staging/generations/x.sealed")
+            .is_file()
+    );
+    assert!(
+        !home
+            .root()
+            .join("var/content-staging/generations/z.sealed")
+            .exists()
+    );
+
+    let Err(second) = open_runtime_principal_store(&home, unlimited_quota()).await else {
+        panic!("retry must restore, not adopt partial host state");
+    };
+    assert!(second.to_string().contains("staged footer"), "{second}");
+    assert!(
+        !home
+            .root()
+            .join("var/content-staging/generations/z.sealed")
+            .exists()
+    );
+
+    let inspector = open_runtime_principal_store_for_pack(&home, unlimited_quota())
+        .await
+        .unwrap();
+    assert_eq!(
+        inspector
+            .content()
+            .read(&StateOwner::System, &later)
+            .unwrap(),
+        Some(b"later-generation".to_vec())
+    );
 }
 
 #[tokio::test]

--- a/crates/astrid-storage/src/principal_state/runtime_tree_tests.rs
+++ b/crates/astrid-storage/src/principal_state/runtime_tree_tests.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::io::Write as _;
 use std::sync::Arc;
 
 use serde_json::json;
@@ -6,8 +7,12 @@ use sha2::{Digest as _, Sha256};
 
 use super::*;
 use crate::principal_state::open_runtime_principal_store_for_pack;
+use crate::principal_state::runtime_tests::test_owner;
 use crate::volume::{AstridVolume as _, HostedFileVolume};
-use crate::{AstridFilesystem, FilesystemPath, KvQuotaResolver, open_runtime_principal_store};
+use crate::{
+    AstridFilesystem, ChunkingProfile, FilesystemPath, KvQuotaResolver, ReadyStagedContent,
+    open_runtime_principal_store,
+};
 use astrid_core::dirs::AstridHome;
 
 fn unlimited_quota() -> Arc<dyn KvQuotaResolver<StateOwner>> {
@@ -1418,4 +1423,155 @@ async fn pack_open_staging_journal_socket_sentinel_fails_closed() {
         "{message}"
     );
     assert!(intent.symlink_metadata().unwrap().file_type().is_socket());
+}
+
+async fn assert_existing_volume_bootstrap_fails_closed(relative: &str, host_bytes: &[u8]) {
+    let home_dir = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(home_dir.path());
+    let running = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    let active_name = ContentName::new(ACTIVE_PROJECTION_NAME).unwrap();
+    assert!(
+        running
+            .content()
+            .delete(&StateOwner::System, &active_name)
+            .unwrap()
+    );
+    running.content().flush().unwrap();
+    drop(running);
+    std::fs::remove_dir_all(home.content_staging_path()).unwrap();
+
+    let path = home.root().join(relative);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(&path, host_bytes).unwrap();
+    let Err(error) = open_runtime_principal_store(&home, unlimited_quota()).await else {
+        panic!("receipt-less bootstrap on an existing volume must fail closed");
+    };
+    assert!(
+        error
+            .to_string()
+            .contains("active projection receipt is missing"),
+        "{error}"
+    );
+
+    let inspector = open_runtime_principal_store_for_pack(&home, unlimited_quota())
+        .await
+        .unwrap();
+    assert!(
+        inspector
+            .content()
+            .describe(&StateOwner::System, &active_name)
+            .unwrap()
+            .is_none(),
+        "failed reopen must not mint ACTIVE"
+    );
+    let name = ContentName::new(relative).unwrap();
+    assert_ne!(
+        inspector
+            .content()
+            .read(&StateOwner::System, &name)
+            .unwrap(),
+        Some(host_bytes.to_vec()),
+        "host bootstrap bytes acquired volume authority"
+    );
+}
+
+#[tokio::test]
+async fn existing_volume_receiptless_bootstrap_sentinels_fail_closed() {
+    assert_existing_volume_bootstrap_fails_closed("etc/layout-version", b"rogue-layout").await;
+    assert_existing_volume_bootstrap_fails_closed("keys/runtime.key", b"rogue-runtime-key").await;
+}
+
+#[tokio::test]
+async fn first_open_allows_bootstrap_sentinels_before_volume_exists() {
+    let home_dir = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(home_dir.path());
+    home.ensure().unwrap();
+    let layout = home.layout_version_path();
+    let key = home.runtime_key_path();
+    std::fs::create_dir_all(layout.parent().unwrap()).unwrap();
+    std::fs::create_dir_all(key.parent().unwrap()).unwrap();
+    std::fs::write(&layout, b"2").unwrap();
+    std::fs::write(&key, b"first-runtime-key").unwrap();
+    assert!(!home.storage_volume_path().exists());
+
+    let store = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    let layout_name = ContentName::new("etc/layout-version").unwrap();
+    let key_name = ContentName::new(RUNTIME_KEY_PROJECTION).unwrap();
+    assert_eq!(
+        store
+            .content()
+            .read(&StateOwner::System, &layout_name)
+            .unwrap(),
+        Some(b"2".to_vec())
+    );
+    assert_eq!(
+        store
+            .content()
+            .read(&StateOwner::System, &key_name)
+            .unwrap(),
+        Some(b"first-runtime-key".to_vec())
+    );
+}
+
+#[tokio::test]
+async fn restore_rebinds_staging_journal_before_new_seal() {
+    let home_dir = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(home_dir.path());
+    let first_owner = test_owner("restore-journal");
+    let first_name = ContentName::new("workspace/restore-first.txt").unwrap();
+    let second_name = ContentName::new("workspace/restore-second.txt").unwrap();
+    let running = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    let mut writer = running
+        .staging()
+        .begin(first_owner, first_name.clone(), ChunkingProfile::ASTRID_V1)
+        .unwrap();
+    writer.write_all(b"first pending record").unwrap();
+    writer.seal().unwrap();
+    let journal = home.root().join(STAGING_JOURNAL_PROJECTION);
+    drop(running);
+
+    let packer = open_runtime_principal_store_for_pack(&home, unlimited_quota())
+        .await
+        .unwrap();
+    packer
+        .pack_and_retire_runtime_projection(&home)
+        .expect("pack staged journal into the volume");
+    drop(packer);
+    assert!(!journal.exists());
+
+    let restored = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    let ready = restored.staging().ready().unwrap();
+    assert_eq!(ready.len(), 1);
+    assert_eq!(ready[0].name(), &first_name);
+    let mut writer = restored
+        .staging()
+        .begin(first_owner, second_name.clone(), ChunkingProfile::ASTRID_V1)
+        .unwrap();
+    writer.write_all(b"second pending record").unwrap();
+    writer.seal().unwrap();
+    let ready = restored.staging().ready().unwrap();
+    assert_eq!(ready.len(), 2);
+    assert_eq!(ready[0].name(), &first_name);
+    assert_eq!(ready[1].name(), &second_name);
+    drop(restored);
+
+    let reopened = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    let ready = reopened.staging().ready().unwrap();
+    assert_eq!(
+        ready
+            .iter()
+            .map(ReadyStagedContent::name)
+            .collect::<Vec<_>>(),
+        vec![&first_name, &second_name]
+    );
 }

--- a/crates/astrid-storage/src/principal_state/runtime_tree_tests.rs
+++ b/crates/astrid-storage/src/principal_state/runtime_tree_tests.rs
@@ -174,11 +174,12 @@ async fn admits_runtime_tree_and_reopens_from_preclose_volume_copy() {
         copied_home.storage_volume_path(),
     )
     .unwrap();
-    let detached = open_runtime_principal_store_for_pack(&copied_home, unlimited_quota())
-        .await
-        .unwrap();
-    super::active::clear(&detached, &copied_home).unwrap();
-    drop(detached);
+    let relocated_layout = copied_home.root().join("etc/layout-version");
+    let relocated_key = copied_home.root().join("keys/runtime.key");
+    std::fs::create_dir_all(relocated_layout.parent().unwrap()).unwrap();
+    std::fs::create_dir_all(relocated_key.parent().unwrap()).unwrap();
+    std::fs::write(&relocated_layout, b"host-bootstrap-not-authority").unwrap();
+    std::fs::write(&relocated_key, b"host-key-not-authority").unwrap();
     let volume = HostedFileVolume::open(copied_home.storage_volume_path()).unwrap();
     assert!(
         volume
@@ -191,6 +192,16 @@ async fn admits_runtime_tree_and_reopens_from_preclose_volume_copy() {
     let reopened = open_runtime_principal_store(&copied_home, unlimited_quota())
         .await
         .unwrap();
+    assert_eq!(
+        std::fs::read(&relocated_layout).unwrap(),
+        b"2",
+        "bootstrap host bytes must not replace volume authority"
+    );
+    assert_eq!(
+        std::fs::read(&relocated_key).unwrap(),
+        b"runtime-key",
+        "bootstrap host bytes must not replace volume authority"
+    );
     let filesystem = AstridFilesystem::new(reopened.content(), StateOwner::System);
     let expected_count = durable.len();
     let mut reconstructed = BTreeMap::new();
@@ -469,6 +480,128 @@ async fn arbitrary_host_projection_without_active_receipt_fails_closed() {
         std::fs::read(&rogue).unwrap(),
         b"not a surviving projection"
     );
+}
+
+#[tokio::test]
+async fn active_projection_publication_rotates_receipt_inventory() {
+    let home_dir = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(home_dir.path());
+    let running = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    let old_path = home.root().join("etc/old.conf");
+    std::fs::create_dir_all(old_path.parent().unwrap()).unwrap();
+    std::fs::write(&old_path, b"old\n").unwrap();
+    drop(running);
+
+    let packer = open_runtime_principal_store_for_pack(&home, unlimited_quota())
+        .await
+        .unwrap();
+    packer
+        .pack_and_retire_runtime_projection(&home)
+        .expect("pack old generation");
+    drop(packer);
+
+    let running = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    let new_path = home.root().join("etc/new.conf");
+    std::fs::write(&new_path, b"new-generation\n").unwrap();
+    std::fs::remove_file(&old_path).unwrap();
+    drop(running);
+
+    let reopened = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    let receipt = super::super::runtime_tree::active::read(&home, &reopened)
+        .unwrap()
+        .expect("active receipt");
+    assert_eq!(receipt.phase(), super::ReceiptPhase::Active);
+    assert!(receipt.contains_inventory_name("etc/new.conf"));
+    assert!(!receipt.contains_inventory_name("etc/old.conf"));
+    let new_name = ContentName::new("etc/new.conf").unwrap();
+    assert_eq!(
+        reopened
+            .content()
+            .read(&StateOwner::System, &new_name)
+            .unwrap(),
+        Some(b"new-generation\n".to_vec())
+    );
+}
+
+#[tokio::test]
+async fn relocated_volume_rejects_host_files_beyond_trusted_bootstrap() {
+    let home_dir = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(home_dir.path());
+    let running = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    let copy_dir = tempfile::tempdir().unwrap();
+    let copy_home = AstridHome::from_path(copy_dir.path());
+    copy_home.ensure().unwrap();
+    std::fs::copy(home.storage_volume_path(), copy_home.storage_volume_path()).unwrap();
+    drop(running);
+    let layout = copy_home.root().join("etc/layout-version");
+    std::fs::create_dir_all(layout.parent().unwrap()).unwrap();
+    std::fs::write(&layout, b"2").unwrap();
+    let rogue = copy_home.root().join("etc/user.conf");
+    std::fs::write(&rogue, b"arbitrary-not-authority").unwrap();
+
+    let Err(error) = open_runtime_principal_store(&copy_home, unlimited_quota()).await else {
+        panic!("relocated receipt must not admit arbitrary host files");
+    };
+    assert!(
+        error
+            .to_string()
+            .contains("relocated active receipt is permitted only"),
+        "{error}"
+    );
+    assert_eq!(std::fs::read(&rogue).unwrap(), b"arbitrary-not-authority");
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn retiring_failure_restores_published_inventory_and_reactivates() {
+    use std::os::unix::net::UnixListener;
+
+    let home_dir = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(home_dir.path());
+    let running = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    let first = home.root().join("etc/retire-a.conf");
+    let second = home.root().join("etc/retire-b.conf");
+    std::fs::create_dir_all(first.parent().unwrap()).unwrap();
+    std::fs::write(&first, b"published-a\n").unwrap();
+    std::fs::write(&second, b"published-b\n").unwrap();
+    drop(running);
+
+    let packer = open_runtime_principal_store_for_pack(&home, unlimited_quota())
+        .await
+        .unwrap();
+    let socket_path = home.root().join("run/other.sock");
+    std::fs::create_dir_all(socket_path.parent().unwrap()).unwrap();
+    let _socket = UnixListener::bind(&socket_path).unwrap();
+    let error = packer
+        .pack_and_retire_runtime_projection(&home)
+        .expect_err("complete preflight must reject the later special");
+    assert!(error.to_string().contains("special entry"), "{error}");
+    drop(packer);
+
+    // Simulate a mid-retire race after the RETIRING inventory is durable.
+    std::fs::remove_file(&first).unwrap();
+
+    let reopened = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    let receipt = super::super::runtime_tree::active::read(&home, &reopened)
+        .unwrap()
+        .expect("restart must establish fresh ACTIVE authority");
+    assert_eq!(receipt.phase(), super::ReceiptPhase::Active);
+    assert!(receipt.contains_inventory_name("etc/retire-a.conf"));
+    assert!(receipt.contains_inventory_name("etc/retire-b.conf"));
+    assert_eq!(std::fs::read(&first).unwrap(), b"published-a\n");
+    assert_eq!(std::fs::read(&second).unwrap(), b"published-b\n");
 }
 
 #[tokio::test]

--- a/crates/astrid-storage/src/principal_state/runtime_tree_tests.rs
+++ b/crates/astrid-storage/src/principal_state/runtime_tree_tests.rs
@@ -161,7 +161,7 @@ async fn admits_runtime_tree_and_reopens_from_preclose_volume_copy() {
         .iter()
         .map(|(name, _)| name.clone())
         .collect::<Vec<_>>();
-    expected_names.push("var/content-staging/intents.v1.log".to_owned());
+    expected_names.push("run/.active-projection-v1.json".to_owned());
     expected_names.extend(["volume.compacting", "volume.previous"].map(str::to_owned));
     expected_names.sort();
     assert_eq!(names, expected_names);
@@ -174,6 +174,11 @@ async fn admits_runtime_tree_and_reopens_from_preclose_volume_copy() {
         copied_home.storage_volume_path(),
     )
     .unwrap();
+    let detached = open_runtime_principal_store_for_pack(&copied_home, unlimited_quota())
+        .await
+        .unwrap();
+    super::active::clear(&detached, &copied_home).unwrap();
+    drop(detached);
     let volume = HostedFileVolume::open(copied_home.storage_volume_path()).unwrap();
     assert!(
         volume
@@ -295,6 +300,15 @@ async fn packs_trust_projection_and_excludes_run_on_clean_stop() {
     let store = open_runtime_principal_store(&home, unlimited_quota())
         .await
         .unwrap();
+    let active_name = ContentName::new("run/.active-projection-v1.json").unwrap();
+    assert!(
+        store
+            .content()
+            .describe(&StateOwner::System, &active_name)
+            .unwrap()
+            .is_some(),
+        "startup must retain its active receipt"
+    );
     let trust = home.root().join("trust/test.pub");
     std::fs::create_dir_all(trust.parent().unwrap()).unwrap();
     std::fs::write(&trust, b"ed25519:test").unwrap();
@@ -309,6 +323,15 @@ async fn packs_trust_projection_and_excludes_run_on_clean_stop() {
     store
         .pack_and_retire_runtime_projection(&home)
         .expect("pack running projection");
+    let active_name = ContentName::new("run/.active-projection-v1.json").unwrap();
+    assert!(
+        store
+            .content()
+            .describe(&StateOwner::System, &active_name)
+            .unwrap()
+            .is_none(),
+        "clean stop retained active recovery state"
+    );
     assert!(!trust.exists());
     assert!(!home.run_dir().exists());
 
@@ -349,6 +372,131 @@ async fn packs_trust_projection_and_excludes_run_on_clean_stop() {
             0o600
         );
     }
+}
+
+#[tokio::test]
+async fn clean_stop_reconciles_deleted_runtime_file_and_does_not_resurrect_it() {
+    let home_dir = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(home_dir.path());
+    let running = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    let config_path = home.root().join("etc/user.conf");
+    std::fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+    std::fs::write(&config_path, b"user-config").unwrap();
+    drop(running);
+
+    let packer = open_runtime_principal_store_for_pack(&home, unlimited_quota())
+        .await
+        .unwrap();
+    packer
+        .pack_and_retire_runtime_projection(&home)
+        .expect("pack created file");
+    drop(packer);
+
+    let restarted = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    assert_eq!(std::fs::read(&config_path).unwrap(), b"user-config");
+    drop(restarted);
+
+    std::fs::remove_file(&config_path).unwrap();
+    let packer = open_runtime_principal_store_for_pack(&home, unlimited_quota())
+        .await
+        .unwrap();
+    packer
+        .pack_and_retire_runtime_projection(&home)
+        .expect("atomically reconcile deleted file");
+    let config_name = ContentName::new("etc/user.conf").unwrap();
+    assert!(
+        packer
+            .content()
+            .describe(&StateOwner::System, &config_name)
+            .unwrap()
+            .is_none(),
+        "deleted durable name remained in catalog"
+    );
+    drop(packer);
+
+    let remaining = std::fs::read_dir(home.root())
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    assert_eq!(
+        remaining
+            .iter()
+            .map(std::fs::DirEntry::file_name)
+            .collect::<Vec<_>>(),
+        [std::ffi::OsString::from("astrid.volume")]
+    );
+
+    let restarted = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    assert!(!config_path.exists(), "deleted file resurrected on restart");
+    drop(restarted);
+}
+
+#[tokio::test]
+async fn arbitrary_host_projection_without_active_receipt_fails_closed() {
+    let home_dir = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(home_dir.path());
+    let running = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    drop(running);
+    let packer = open_runtime_principal_store_for_pack(&home, unlimited_quota())
+        .await
+        .unwrap();
+    packer
+        .pack_and_retire_runtime_projection(&home)
+        .expect("create clean stopped volume");
+    drop(packer);
+
+    let rogue = home.root().join("etc/user.conf");
+    std::fs::create_dir_all(rogue.parent().unwrap()).unwrap();
+    std::fs::write(&rogue, b"not a surviving projection").unwrap();
+    let Err(error) = open_runtime_principal_store(&home, unlimited_quota()).await else {
+        panic!("arbitrary preboot host file must not acquire catalog authority");
+    };
+    assert!(
+        error
+            .to_string()
+            .contains("active projection receipt is missing"),
+        "{error}"
+    );
+    assert_eq!(
+        std::fs::read(&rogue).unwrap(),
+        b"not a surviving projection"
+    );
+}
+
+#[tokio::test]
+async fn active_receipt_never_materializes_and_malformed_receipt_fails_closed() {
+    let home_dir = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(home_dir.path());
+    let running = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    let receipt_path = home.root().join("run/.active-projection-v1.json");
+    assert!(!receipt_path.try_exists().unwrap());
+    let receipt_name = ContentName::new("run/.active-projection-v1.json").unwrap();
+    running
+        .content()
+        .put(&StateOwner::System, &receipt_name, b"{bad")
+        .unwrap();
+    drop(running);
+
+    let Err(error) = open_runtime_principal_store(&home, unlimited_quota()).await else {
+        panic!("malformed active receipt must fail closed");
+    };
+    assert!(
+        error
+            .to_string()
+            .contains("parse active projection receipt"),
+        "{error}"
+    );
+    assert!(!receipt_path.try_exists().unwrap());
 }
 
 #[tokio::test]
@@ -598,4 +746,35 @@ async fn special_inside_run_capsules_fails_closed_before_restore() {
         error.to_string().contains("unadmitted special entry"),
         "{error}"
     );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn stop_preflight_retains_regular_file_when_special_comes_later() {
+    use std::os::unix::net::UnixListener;
+
+    let home_dir = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(home_dir.path());
+    let running = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    let regular = home.root().join("regular");
+    std::fs::write(&regular, b"must survive failed retirement").unwrap();
+    let socket_path = home.root().join("run/other.sock");
+    std::fs::create_dir_all(socket_path.parent().unwrap()).unwrap();
+    let _socket = UnixListener::bind(&socket_path).unwrap();
+    drop(running);
+
+    let packer = open_runtime_principal_store_for_pack(&home, unlimited_quota())
+        .await
+        .unwrap();
+    let Err(error) = packer.pack_and_retire_runtime_projection(&home) else {
+        panic!("root special must stop complete-root retirement");
+    };
+    assert!(error.to_string().contains("special entry"), "{error}");
+    assert_eq!(
+        std::fs::read(&regular).unwrap(),
+        b"must survive failed retirement"
+    );
+    assert!(socket_path.symlink_metadata().is_ok());
 }

--- a/crates/astrid-storage/src/principal_state/runtime_tree_tests.rs
+++ b/crates/astrid-storage/src/principal_state/runtime_tree_tests.rs
@@ -1391,6 +1391,7 @@ async fn pack_open_staging_journal_directory_sentinel_fails_closed() {
 #[cfg(unix)]
 #[tokio::test]
 async fn pack_open_staging_journal_socket_sentinel_fails_closed() {
+    use std::os::unix::fs::FileTypeExt as _;
     let home_dir = tempfile::tempdir().unwrap();
     let home = AstridHome::from_path(home_dir.path());
     let running = open_runtime_principal_store(&home, unlimited_quota())
@@ -1407,7 +1408,6 @@ async fn pack_open_staging_journal_socket_sentinel_fails_closed() {
 
     let intent = home.root().join(STAGING_JOURNAL_PROJECTION);
     std::fs::create_dir_all(intent.parent().unwrap()).unwrap();
-    use std::os::unix::fs::FileTypeExt as _;
     let _listener = std::os::unix::net::UnixListener::bind(&intent).unwrap();
     let Err(error) = open_runtime_principal_store_for_pack(&home, unlimited_quota()).await else {
         panic!("socket staging journal must not open for pack");

--- a/crates/astrid-storage/src/principal_state/runtime_tree_tests.rs
+++ b/crates/astrid-storage/src/principal_state/runtime_tree_tests.rs
@@ -60,6 +60,26 @@ fn write_active_identity_receipt(
     store.content().flush().unwrap();
 }
 
+fn assert_stopped_volume_only(home: &AstridHome) {
+    let stopped = std::fs::read_dir(home.root())
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    assert_eq!(stopped.len(), 1);
+    assert_eq!(
+        stopped[0].file_name(),
+        std::ffi::OsStr::new(CANONICAL_VOLUME)
+    );
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        assert_eq!(
+            stopped[0].metadata().unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
+}
+
 #[test]
 fn excludes_windows_separator_paths() {
     for path in ["volume", "volume\\compacting", "run\\system.sock"] {
@@ -762,24 +782,7 @@ async fn preserves_ordinary_suffix_files_across_clean_stop() {
     store
         .pack_and_retire_runtime_projection(&home)
         .expect("pack ordinary suffix files");
-
-    let stopped = std::fs::read_dir(home.root())
-        .unwrap()
-        .collect::<Result<Vec<_>, _>>()
-        .unwrap();
-    assert_eq!(stopped.len(), 1);
-    assert_eq!(
-        stopped[0].file_name(),
-        std::ffi::OsStr::new(CANONICAL_VOLUME)
-    );
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt as _;
-        assert_eq!(
-            stopped[0].metadata().unwrap().permissions().mode() & 0o777,
-            0o600
-        );
-    }
+    assert_stopped_volume_only(&home);
     drop(store);
 
     let reopened = open_runtime_principal_store(&home, unlimited_quota())
@@ -788,6 +791,47 @@ async fn preserves_ordinary_suffix_files_across_clean_stop() {
     assert_eq!(std::fs::read(&next_path).unwrap(), b"queued-by-user");
     assert_eq!(std::fs::read(&migrating_path).unwrap(), b"kept-by-user");
     drop(reopened);
+}
+
+#[tokio::test]
+async fn missing_active_receipt_stop_retains_surviving_host_files() {
+    let home_dir = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(home_dir.path());
+    let running = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    let trust = home.root().join("trust/recovery.pub");
+    std::fs::create_dir_all(trust.parent().unwrap()).unwrap();
+    std::fs::write(&trust, b"ed25519:recovery").unwrap();
+
+    // Host publication without an ACTIVE rotation must not become a stop
+    // admission path. Missing receipt fails closed and retains host bytes.
+    let active_name = ContentName::new(ACTIVE_PROJECTION_NAME).unwrap();
+    assert!(
+        running
+            .content()
+            .delete(&StateOwner::System, &active_name)
+            .unwrap()
+    );
+    running.content().flush().unwrap();
+    drop(running);
+
+    let packer = open_runtime_principal_store_for_pack(&home, unlimited_quota())
+        .await
+        .unwrap();
+    let Err(error) = packer.pack_and_retire_runtime_projection(&home) else {
+        panic!("missing ACTIVE receipt must not retire surviving host files");
+    };
+    assert!(
+        error
+            .to_string()
+            .contains("active projection receipt is missing"),
+        "{error}"
+    );
+    assert_eq!(
+        std::fs::read(&trust).unwrap(),
+        b"ed25519:recovery".as_slice()
+    );
 }
 
 #[tokio::test]
@@ -1026,4 +1070,352 @@ async fn stop_preflight_retains_regular_file_when_special_comes_later() {
         b"must survive failed retirement"
     );
     assert!(socket_path.symlink_metadata().is_ok());
+}
+
+#[test]
+fn projection_restore_paths_stay_inside_runtime_root() {
+    let root = tempfile::tempdir().unwrap();
+    let sentinel = root.path().parent().unwrap().join(format!(
+        "astrid-1833-outside-{}",
+        root.path().file_name().unwrap().to_string_lossy()
+    ));
+    std::fs::write(&sentinel, b"keep-me").unwrap();
+    let absolute = sentinel.to_str().expect("utf-8 sentinel path");
+    for name in [absolute, "/tmp/x", "../x", r"..\x", "foo/../../x"] {
+        let error = confined_projection_path(root.path(), name).expect_err(name);
+        let message = error.to_string();
+        assert!(
+            message.contains("escaped runtime root")
+                || message.contains("non-normal path component"),
+            "{name}: {message}"
+        );
+        assert!(
+            !root.path().join("x").exists(),
+            "{name} wrote inside the root"
+        );
+    }
+    assert_eq!(std::fs::read(&sentinel).unwrap(), b"keep-me");
+    let ok = confined_projection_path(root.path(), "etc/authz.conf").unwrap();
+    assert!(ok.starts_with(root.path()));
+    let _ = std::fs::remove_file(&sentinel);
+}
+
+#[tokio::test]
+async fn restore_rejects_absolute_and_traversal_catalog_names() {
+    let home_dir = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(home_dir.path());
+    let store = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    let sentinel = home_dir.path().parent().unwrap().join(format!(
+        "astrid-1833-restore-{}",
+        home_dir.path().file_name().unwrap().to_string_lossy()
+    ));
+    std::fs::write(&sentinel, b"keep-me").unwrap();
+    let absolute = sentinel.to_str().expect("utf-8 sentinel path").to_owned();
+    for name in [
+        absolute,
+        "/tmp/x".to_owned(),
+        "../x".to_owned(),
+        r"..\x".to_owned(),
+    ] {
+        let content_name = ContentName::new(name.clone()).unwrap();
+        store
+            .content()
+            .put(&StateOwner::System, &content_name, b"escaped")
+            .unwrap();
+        store.content().flush().unwrap();
+        let error = restore_projection(&home, &store, store.content().as_ref())
+            .expect_err("escaped catalog name must not restore");
+        let message = error.to_string();
+        assert!(
+            message.contains("escaped runtime root")
+                || message.contains("non-normal path component"),
+            "{name}: {message}"
+        );
+        assert_eq!(std::fs::read(&sentinel).unwrap(), b"keep-me");
+        assert!(!home.root().join("x").exists());
+        assert!(
+            store
+                .content()
+                .delete(&StateOwner::System, &content_name)
+                .unwrap()
+        );
+        store.content().flush().unwrap();
+    }
+    let _ = std::fs::remove_file(&sentinel);
+}
+
+#[tokio::test]
+async fn retiring_stop_retains_unreceipted_host_file() {
+    let home_dir = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(home_dir.path());
+    let running = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    let receipted = home.root().join("etc/receipted.conf");
+    std::fs::create_dir_all(receipted.parent().unwrap()).unwrap();
+    std::fs::write(&receipted, b"receipted\n").unwrap();
+    running
+        .publish_runtime_projection(&home)
+        .expect("publish receipted projection");
+    let entries = active_projection_entries(&home, &running).unwrap();
+    let retiring = receipt_ingest(&home, ReceiptPhase::Retiring, &entries).unwrap();
+    running
+        .replace_contiguous_files_removing_exact(StateOwner::System, [retiring], &[], None)
+        .unwrap();
+    running.content().flush().unwrap();
+    let extra = home.root().join("etc/unreceipted.conf");
+    std::fs::write(&extra, b"do-not-delete\n").unwrap();
+    drop(running);
+
+    let packer = open_runtime_principal_store_for_pack(&home, unlimited_quota())
+        .await
+        .unwrap();
+    let Err(error) = packer.pack_and_retire_runtime_projection(&home) else {
+        panic!("RETIRING stop must not delete unreceipted host files");
+    };
+    assert!(
+        error.to_string().contains("unreceipted host file"),
+        "{error}"
+    );
+    assert_eq!(std::fs::read(&extra).unwrap(), b"do-not-delete\n");
+}
+
+#[tokio::test]
+async fn pack_open_staging_journal_without_receipt_retires_to_volume() {
+    let home_dir = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(home_dir.path());
+    let running = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    drop(running);
+    let packer = open_runtime_principal_store_for_pack(&home, unlimited_quota())
+        .await
+        .unwrap();
+    packer
+        .pack_and_retire_runtime_projection(&home)
+        .expect("pack initial volume-only stop");
+    drop(packer);
+    assert_stopped_volume_only(&home);
+
+    let intent = home.root().join(STAGING_JOURNAL_PROJECTION);
+    std::fs::create_dir_all(intent.parent().unwrap()).unwrap();
+    std::fs::write(&intent, b"pack-open journal").unwrap();
+    let packer = open_runtime_principal_store_for_pack(&home, unlimited_quota())
+        .await
+        .unwrap();
+    packer
+        .pack_and_retire_runtime_projection(&home)
+        .expect("enumerated staging journal is not a receipt-less projection");
+    drop(packer);
+    assert_stopped_volume_only(&home);
+}
+
+#[tokio::test]
+async fn non_journal_bootstrap_file_without_receipt_fails_closed() {
+    let home_dir = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(home_dir.path());
+    let running = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    drop(running);
+    let packer = open_runtime_principal_store_for_pack(&home, unlimited_quota())
+        .await
+        .unwrap();
+    packer
+        .pack_and_retire_runtime_projection(&home)
+        .expect("pack initial volume-only stop");
+    drop(packer);
+
+    let layout = home.root().join("etc/layout-version");
+    std::fs::create_dir_all(layout.parent().unwrap()).unwrap();
+    std::fs::write(&layout, b"2\n").unwrap();
+    let packer = open_runtime_principal_store_for_pack(&home, unlimited_quota())
+        .await
+        .unwrap();
+    let Err(error) = packer.pack_and_retire_runtime_projection(&home) else {
+        panic!("non-journal bootstrap file must not be admitted without ACTIVE");
+    };
+    assert!(
+        error
+            .to_string()
+            .contains("active projection receipt is missing"),
+        "{error}"
+    );
+    assert_eq!(std::fs::read(&layout).unwrap(), b"2\n");
+}
+
+#[tokio::test]
+async fn pack_open_staging_journal_sibling_file_fails_closed() {
+    let home_dir = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(home_dir.path());
+    let running = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    drop(running);
+    let packer = open_runtime_principal_store_for_pack(&home, unlimited_quota())
+        .await
+        .unwrap();
+    packer
+        .pack_and_retire_runtime_projection(&home)
+        .expect("pack initial volume-only stop");
+    drop(packer);
+
+    let intent = home.root().join(STAGING_JOURNAL_PROJECTION);
+    let sibling = home.root().join("var/content-staging/sibling.log");
+    std::fs::create_dir_all(intent.parent().unwrap()).unwrap();
+    std::fs::write(&intent, b"pack-open journal").unwrap();
+    std::fs::write(&sibling, b"do-not-admit").unwrap();
+    let packer = open_runtime_principal_store_for_pack(&home, unlimited_quota())
+        .await
+        .unwrap();
+    let Err(error) = packer.pack_and_retire_runtime_projection(&home) else {
+        panic!("journal sibling must not be admitted without ACTIVE");
+    };
+    assert!(
+        error
+            .to_string()
+            .contains("active projection receipt is missing"),
+        "{error}"
+    );
+    assert!(
+        intent.is_file(),
+        "pack-open must not delete the enumerated journal before failing closed"
+    );
+    assert_eq!(std::fs::read(&sibling).unwrap(), b"do-not-admit");
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn pack_open_staging_journal_sibling_symlink_fails_closed() {
+    let home_dir = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(home_dir.path());
+    let running = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    drop(running);
+    let packer = open_runtime_principal_store_for_pack(&home, unlimited_quota())
+        .await
+        .unwrap();
+    packer
+        .pack_and_retire_runtime_projection(&home)
+        .expect("pack initial volume-only stop");
+    drop(packer);
+
+    let intent = home.root().join(STAGING_JOURNAL_PROJECTION);
+    let sibling = home.root().join("var/content-staging/link");
+    std::fs::create_dir_all(intent.parent().unwrap()).unwrap();
+    std::fs::write(&intent, b"pack-open journal").unwrap();
+    std::os::unix::fs::symlink(&intent, &sibling).unwrap();
+    let packer = open_runtime_principal_store_for_pack(&home, unlimited_quota())
+        .await
+        .unwrap();
+    let Err(error) = packer.pack_and_retire_runtime_projection(&home) else {
+        panic!("journal sibling symlink must not be admitted without ACTIVE");
+    };
+    let message = error.to_string();
+    assert!(
+        message.contains("symbolic link")
+            || message.contains("active projection receipt is missing"),
+        "{message}"
+    );
+    assert!(
+        intent.is_file(),
+        "pack-open must not delete the enumerated journal before failing closed"
+    );
+    assert!(sibling.symlink_metadata().unwrap().file_type().is_symlink());
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn pack_open_staging_journal_symlink_sentinel_fails_closed() {
+    let home_dir = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(home_dir.path());
+    let running = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    drop(running);
+    let packer = open_runtime_principal_store_for_pack(&home, unlimited_quota())
+        .await
+        .unwrap();
+    packer
+        .pack_and_retire_runtime_projection(&home)
+        .expect("pack initial volume-only stop");
+    drop(packer);
+
+    let intent = home.root().join(STAGING_JOURNAL_PROJECTION);
+    let target = home.root().join("astrid.volume");
+    std::fs::create_dir_all(intent.parent().unwrap()).unwrap();
+    std::os::unix::fs::symlink(&target, &intent).unwrap();
+    let Err(error) = open_runtime_principal_store_for_pack(&home, unlimited_quota()).await else {
+        panic!("symlink staging journal must not open for pack");
+    };
+    let message = error.to_string();
+    assert!(
+        message.contains("not a regular file") || message.contains("redirected"),
+        "{message}"
+    );
+    assert!(intent.symlink_metadata().unwrap().file_type().is_symlink());
+}
+
+#[tokio::test]
+async fn pack_open_staging_journal_directory_sentinel_fails_closed() {
+    let home_dir = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(home_dir.path());
+    let running = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    drop(running);
+    let packer = open_runtime_principal_store_for_pack(&home, unlimited_quota())
+        .await
+        .unwrap();
+    packer
+        .pack_and_retire_runtime_projection(&home)
+        .expect("pack initial volume-only stop");
+    drop(packer);
+
+    let intent = home.root().join(STAGING_JOURNAL_PROJECTION);
+    std::fs::create_dir_all(&intent).unwrap();
+    let Err(error) = open_runtime_principal_store_for_pack(&home, unlimited_quota()).await else {
+        panic!("directory staging journal must not open for pack");
+    };
+    let message = error.to_string();
+    assert!(
+        message.contains("not a regular file") || message.contains("redirected"),
+        "{message}"
+    );
+    assert!(intent.is_dir());
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn pack_open_staging_journal_socket_sentinel_fails_closed() {
+    let home_dir = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(home_dir.path());
+    let running = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    drop(running);
+    let packer = open_runtime_principal_store_for_pack(&home, unlimited_quota())
+        .await
+        .unwrap();
+    packer
+        .pack_and_retire_runtime_projection(&home)
+        .expect("pack initial volume-only stop");
+    drop(packer);
+
+    let intent = home.root().join(STAGING_JOURNAL_PROJECTION);
+    std::fs::create_dir_all(intent.parent().unwrap()).unwrap();
+    use std::os::unix::fs::FileTypeExt as _;
+    let _listener = std::os::unix::net::UnixListener::bind(&intent).unwrap();
+    let Err(error) = open_runtime_principal_store_for_pack(&home, unlimited_quota()).await else {
+        panic!("socket staging journal must not open for pack");
+    };
+    let message = error.to_string();
+    assert!(
+        message.contains("not a regular file") || message.contains("redirected"),
+        "{message}"
+    );
+    assert!(intent.symlink_metadata().unwrap().file_type().is_socket());
 }

--- a/crates/astrid-storage/src/principal_state/runtime_tree_tests.rs
+++ b/crates/astrid-storage/src/principal_state/runtime_tree_tests.rs
@@ -1173,6 +1173,21 @@ fn rebind_staging_generation_rejects_symlink_without_touching_target() {
     assert_eq!(std::fs::read(&external).unwrap(), crafted);
 }
 
+#[test]
+fn rollback_private_files_attempts_every_destination() {
+    let directory = tempfile::tempdir().unwrap();
+    let removed = directory.path().join("removed");
+    std::fs::write(&removed, b"remove").unwrap();
+    let failed = directory.path().join("missing-parent/file");
+
+    let errors = super::super::native_io::rollback_private_files(vec![
+        (removed.clone(), None),
+        (failed, None),
+    ]);
+    assert_eq!(errors.len(), 1, "one destination should fail");
+    assert!(!removed.exists(), "later rollback destination was skipped");
+}
+
 #[tokio::test]
 async fn retiring_stop_retains_unreceipted_host_file() {
     let home_dir = tempfile::tempdir().unwrap();
@@ -1241,9 +1256,11 @@ async fn failed_restore_keeps_later_volume_entries_and_never_adopts_partial_host
     };
     assert!(first.to_string().contains("staged footer"), "{first}");
     assert!(
-        home.root()
+        !home
+            .root()
             .join("var/content-staging/generations/x.sealed")
-            .is_file()
+            .exists(),
+        "failed restore rolled back its partial host file"
     );
     assert!(
         !home

--- a/crates/astrid-storage/src/principal_state/store_open.rs
+++ b/crates/astrid-storage/src/principal_state/store_open.rs
@@ -73,7 +73,7 @@ pub async fn open_runtime_principal_store_for_pack(
             volume_migration::open_existing(home, policy)?.ok_or_else(|| {
                 StorageError::Connection("Astrid volume disappeared while opening".to_owned())
             })?;
-        let store = assemble_runtime_store(
+        let store = assemble_volume_store(
             home,
             quota,
             PrincipalDirectory::default(),
@@ -87,7 +87,7 @@ pub async fn open_runtime_principal_store_for_pack(
         return Ok(store);
     }
     let (engine, receipt) = volume_migration::initialize_volume(home, policy)?;
-    let store = assemble_runtime_store(
+    let store = assemble_volume_store(
         home,
         quota,
         PrincipalDirectory::default(),
@@ -182,7 +182,7 @@ async fn open_runtime_principal_store_with_options(
             volume_migration::open_existing(home, policy)?.ok_or_else(|| {
                 StorageError::Connection("Astrid volume disappeared while opening".to_owned())
             })?;
-        let store = assemble_runtime_store(
+        let store = assemble_volume_store(
             home,
             quota,
             principals,
@@ -201,7 +201,7 @@ async fn open_runtime_principal_store_with_options(
         .map_err(|error| StorageError::Connection(error.to_string()))?;
     if layout_version.as_deref() != Some(astrid_core::dirs::LEGACY_LAYOUT_VERSION) {
         let (engine, receipt) = volume_migration::initialize_volume(home, policy)?;
-        let store = assemble_runtime_store(
+        let store = assemble_volume_store(
             home,
             quota,
             principals,
@@ -217,7 +217,7 @@ async fn open_runtime_principal_store_with_options(
     }
     if unrecognized_principal_store_present(home)? {
         let (engine, receipt) = volume_migration::initialize_volume(home, policy)?;
-        let store = assemble_runtime_store(
+        let store = assemble_volume_store(
             home,
             quota,
             principals,
@@ -231,6 +231,15 @@ async fn open_runtime_principal_store_with_options(
         super::runtime_tree::quarantine_principal_store(home, &store)?;
         return Ok(store);
     }
+    open_migrated_directory_store(home, quota, principals, policy).await
+}
+
+async fn open_migrated_directory_store(
+    home: &AstridHome,
+    quota: Arc<dyn KvQuotaResolver<StateOwner>>,
+    principals: PrincipalDirectory,
+    policy: DurableEnginePolicy<StateOwner>,
+) -> crate::principal_state::StorageResult<RuntimePrincipalStore> {
     let store_path = home.principal_store_path();
     let open_path = store_path.clone();
     let format_spec = bootstrap::format_specification()?;
@@ -295,7 +304,7 @@ async fn open_runtime_principal_store_with_options(
     }
 
     let (engine, receipt) = volume_migration::migrate_directory_store(home, engine, policy)?;
-    assemble_runtime_store(
+    assemble_volume_store(
         home,
         quota,
         principals,
@@ -303,6 +312,27 @@ async fn open_runtime_principal_store_with_options(
         receipt,
         true,
         true,
+    )
+    .await
+}
+
+async fn assemble_volume_store(
+    home: &AstridHome,
+    quota: Arc<dyn KvQuotaResolver<StateOwner>>,
+    principals: PrincipalDirectory,
+    engine: Arc<RuntimeEngine>,
+    directory_cutover_receipt: String,
+    restore_projection: bool,
+    allow_receiptless_bootstrap: bool,
+) -> crate::principal_state::StorageResult<RuntimePrincipalStore> {
+    assemble_runtime_store(
+        home,
+        quota,
+        principals,
+        engine,
+        directory_cutover_receipt,
+        restore_projection,
+        allow_receiptless_bootstrap,
     )
     .await
 }

--- a/crates/astrid-storage/src/principal_state/store_open.rs
+++ b/crates/astrid-storage/src/principal_state/store_open.rs
@@ -1,0 +1,430 @@
+//! Opening and assembling the native runtime principal store.
+
+use std::collections::BTreeMap;
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+
+use crate::content::CatalogValidation;
+use crate::engine::{
+    DurableEnginePolicy, GroupCommitPolicy, ObjectCacheConfig, RecoveryLimits, RecoveryRetryPolicy,
+};
+use crate::error::StorageError;
+use crate::identity::{IdentityStore, KvIdentityStore};
+use crate::kv::{KvQuotaResolver, KvReadCacheConfig, KvStore, ScopedKvStore};
+use crate::principal_state::StorageResult as PrincipalStorageResult;
+use crate::principal_state::bootstrap;
+use crate::principal_state::format_amendment::{
+    PRE_DENSE_RADIX_FORMAT_SPEC_ID, STORE_METADATA_FILE, prepare_catalog_specification,
+    prepare_destination, prepare_format_specification, representation_bootstrap_objects,
+    store_metadata,
+};
+use crate::principal_state::migrations;
+use crate::principal_state::native_io::atomic_write;
+use crate::principal_state::owner_migration;
+use crate::principal_state::volume_migration;
+use crate::principal_state::{
+    Blake3ObjectIdentityV1, NativeContentStagingArea, NativePrincipalContentStore,
+    PrincipalDirectory, RuntimeEngine, RuntimePrincipalStore, RuntimeStore, StateOwner,
+    StateOwnerCodecV2, StateOwnerResolver,
+};
+use crate::storage_model::ObjectIdentity;
+use astrid_core::dirs::AstridHome;
+
+/// Open every native projection over the authoritative principal store.
+///
+/// KV and named content share one object arena, principal-root CAS, and live
+/// quota resolver. The caller must already hold the kernel singleton lock.
+///
+/// # Errors
+///
+/// Returns a storage error if policy, metadata, migration, verification, or
+/// durable recovery fails.
+pub async fn open_runtime_principal_store(
+    home: &AstridHome,
+    quota: Arc<dyn KvQuotaResolver<StateOwner>>,
+) -> crate::principal_state::StorageResult<RuntimePrincipalStore> {
+    open_runtime_principal_store_with_options(
+        home,
+        quota,
+        PrincipalDirectory::default(),
+        DurableEnginePolicy::default(),
+    )
+    .await
+}
+
+/// Open durable authority for a stop-time projection pack without restoring.
+///
+/// Normal store assembly materializes volume-backed projections. During clean
+/// shutdown, the durable tree is still the source of the final generation, so
+/// restoring first would discard newly written authority before it is packed.
+///
+/// # Errors
+///
+/// Returns the same errors as [`open_runtime_principal_store`].
+pub async fn open_runtime_principal_store_for_pack(
+    home: &AstridHome,
+    quota: Arc<dyn KvQuotaResolver<StateOwner>>,
+) -> crate::principal_state::StorageResult<RuntimePrincipalStore> {
+    let policy = DurableEnginePolicy::default();
+    if volume_migration::existing_volume_available(home)? {
+        let (engine, receipt) =
+            volume_migration::open_existing(home, policy)?.ok_or_else(|| {
+                StorageError::Connection("Astrid volume disappeared while opening".to_owned())
+            })?;
+        let store = assemble_runtime_store(
+            home,
+            quota,
+            PrincipalDirectory::default(),
+            Arc::new(engine),
+            receipt,
+            false,
+        )
+        .await?;
+        quarantine_unrecognized_principal_store(home, &store)?;
+        return Ok(store);
+    }
+    let (engine, receipt) = volume_migration::initialize_volume(home, policy)?;
+    let store = assemble_runtime_store(
+        home,
+        quota,
+        PrincipalDirectory::default(),
+        Arc::new(engine),
+        receipt,
+        false,
+    )
+    .await?;
+    quarantine_unrecognized_principal_store(home, &store)?;
+    Ok(store)
+}
+
+/// Open every native projection with an externally shared principal
+/// directory.
+///
+/// Native kernel composition uses this form so namespace resolution,
+/// identity lifecycle, and UID-to-alias quota policy share one mapping.
+///
+/// # Errors
+///
+/// Returns a storage error if policy, metadata, migration, verification, or
+/// durable recovery fails.
+pub async fn open_runtime_principal_store_with_directory(
+    home: &AstridHome,
+    quota: Arc<dyn KvQuotaResolver<StateOwner>>,
+    principals: PrincipalDirectory,
+) -> crate::principal_state::StorageResult<RuntimePrincipalStore> {
+    open_runtime_principal_store_with_options(
+        home,
+        quota,
+        principals,
+        DurableEnginePolicy::default(),
+    )
+    .await
+}
+
+/// Open every native projection with an explicitly governed decoded-object
+/// cache.
+///
+/// The injected policy owns total and per-principal resident budgets. Cache
+/// misses, disabled policy, and eviction always fall back to verified arena
+/// reads.
+///
+/// # Errors
+///
+/// Returns the same errors as [`open_runtime_principal_store`].
+pub async fn open_runtime_principal_store_with_object_cache(
+    home: &AstridHome,
+    quota: Arc<dyn KvQuotaResolver<StateOwner>>,
+    object_cache: ObjectCacheConfig<StateOwner>,
+) -> crate::principal_state::StorageResult<RuntimePrincipalStore> {
+    open_runtime_principal_store_with_options(
+        home,
+        quota,
+        PrincipalDirectory::default(),
+        DurableEnginePolicy::new(
+            GroupCommitPolicy::default(),
+            RecoveryRetryPolicy::default(),
+            object_cache,
+        ),
+    )
+    .await
+}
+
+/// Open every native projection with one complete operator-owned engine policy.
+///
+/// The policy controls durability batching, bounded in-process recovery, and
+/// disposable decoded-object memory. It does not alter the persistent format
+/// or principal quota semantics.
+///
+/// # Errors
+///
+/// Returns the same errors as [`open_runtime_principal_store`].
+pub async fn open_runtime_principal_store_with_policy(
+    home: &AstridHome,
+    quota: Arc<dyn KvQuotaResolver<StateOwner>>,
+    principals: PrincipalDirectory,
+    policy: DurableEnginePolicy<StateOwner>,
+) -> crate::principal_state::StorageResult<RuntimePrincipalStore> {
+    open_runtime_principal_store_with_options(home, quota, principals, policy).await
+}
+
+async fn open_runtime_principal_store_with_options(
+    home: &AstridHome,
+    quota: Arc<dyn KvQuotaResolver<StateOwner>>,
+    principals: PrincipalDirectory,
+    policy: DurableEnginePolicy<StateOwner>,
+) -> crate::principal_state::StorageResult<RuntimePrincipalStore> {
+    if volume_migration::existing_volume_available(home)? {
+        let (engine, receipt) =
+            volume_migration::open_existing(home, policy)?.ok_or_else(|| {
+                StorageError::Connection("Astrid volume disappeared while opening".to_owned())
+            })?;
+        let store =
+            assemble_runtime_store(home, quota, principals, Arc::new(engine), receipt, true).await;
+        let store = store?;
+        quarantine_unrecognized_principal_store(home, &store)?;
+        return Ok(store);
+    }
+    let layout_version = home
+        .layout_version()
+        .map_err(|error| StorageError::Connection(error.to_string()))?;
+    if layout_version.as_deref() != Some(astrid_core::dirs::LEGACY_LAYOUT_VERSION) {
+        let (engine, receipt) = volume_migration::initialize_volume(home, policy)?;
+        let store =
+            assemble_runtime_store(home, quota, principals, Arc::new(engine), receipt, true).await;
+        let store = store?;
+        quarantine_unrecognized_principal_store(home, &store)?;
+        return Ok(store);
+    }
+    if unrecognized_principal_store_present(home)? {
+        let (engine, receipt) = volume_migration::initialize_volume(home, policy)?;
+        let store =
+            assemble_runtime_store(home, quota, principals, Arc::new(engine), receipt, true).await;
+        let store = store?;
+        super::runtime_tree::quarantine_principal_store(home, &store)?;
+        return Ok(store);
+    }
+    let store_path = home.principal_store_path();
+    let open_path = store_path.clone();
+    let format_spec = bootstrap::format_specification()?;
+    let format_spec_id = Blake3ObjectIdentityV1.identify(&format_spec);
+    let catalog_spec = bootstrap::content_catalog_format_specification()?;
+    let catalog_spec_id = Blake3ObjectIdentityV1.identify(&catalog_spec);
+    let metadata = store_metadata(format_spec_id, catalog_spec_id);
+    owner_migration::apply_if_required(home, &principals, &format_spec, &catalog_spec, &metadata)
+        .await?;
+    let metadata_for_open = metadata.clone();
+    let opened = tokio::task::spawn_blocking(move || {
+        let destination_format =
+            prepare_destination(&open_path, &metadata_for_open, catalog_spec_id)?;
+        let metadata_current = destination_format.metadata_is_current();
+        let engine = RuntimeEngine::open_with_policy(
+            &open_path,
+            Blake3ObjectIdentityV1,
+            StateOwnerCodecV2,
+            RecoveryLimits::process_addressable(),
+            DurableEnginePolicy::default(),
+        )
+        .map_err(|error| {
+            StorageError::Connection(format!("open durable principal store: {error}"))
+        })?;
+        prepare_format_specification(&engine, destination_format, &format_spec, format_spec_id)?;
+        prepare_catalog_specification(&engine, destination_format, &catalog_spec, catalog_spec_id)?;
+        let bootstrap_objects = representation_bootstrap_objects(format_spec_id, catalog_spec_id);
+        engine
+            .ensure_direct_representation_catalogue_compatible_with(
+                format_spec_id,
+                &[PRE_DENSE_RADIX_FORMAT_SPEC_ID],
+                &bootstrap_objects,
+            )
+            .map_err(|error| {
+                StorageError::Connection(format!(
+                    "activate direct representation catalogue: {error}"
+                ))
+            })?;
+        Ok((engine, metadata_current))
+    })
+    .await
+    .map_err(|error| {
+        StorageError::Connection(format!(
+            "durable principal-store open worker failed: {error}"
+        ))
+    })??;
+    let (engine, metadata_current) = opened;
+    let engine = Arc::new(engine);
+    let validated_catalogs = Arc::new(Mutex::new(BTreeMap::<StateOwner, CatalogValidation>::new()));
+
+    migrations::apply_required(home, &store_path, &engine, &validated_catalogs, &principals)
+        .await?;
+    if !metadata_current {
+        let metadata_path = store_path.join(STORE_METADATA_FILE);
+        tokio::task::spawn_blocking(move || atomic_write(&metadata_path, &metadata))
+            .await
+            .map_err(|error| {
+                StorageError::Connection(format!(
+                    "principal-store metadata migration worker failed: {error}"
+                ))
+            })??;
+    }
+
+    let (engine, receipt) = volume_migration::migrate_directory_store(home, engine, policy)?;
+    assemble_runtime_store(home, quota, principals, Arc::new(engine), receipt, true).await
+}
+
+fn quarantine_unrecognized_principal_store(
+    home: &AstridHome,
+    store: &RuntimePrincipalStore,
+) -> PrincipalStorageResult<()> {
+    if !unrecognized_principal_store_present(home)? {
+        return Ok(());
+    }
+    super::runtime_tree::quarantine_principal_store(home, store)
+}
+
+fn unrecognized_principal_store_present(home: &AstridHome) -> PrincipalStorageResult<bool> {
+    let source = home.principal_store_path();
+    let metadata = match std::fs::symlink_metadata(&source) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => {
+            return Err(StorageError::Connection(format!(
+                "inspect incomplete principal store {}: {error}",
+                source.display()
+            )));
+        },
+    };
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err(StorageError::Connection(format!(
+            "principal store is redirected or not a directory: {}",
+            source.display()
+        )));
+    }
+    if source.join(STORE_METADATA_FILE).exists()
+        || source.join(migrations::MIGRATION_MARKER_FILE).exists()
+    {
+        return Ok(false);
+    }
+    Ok(true)
+}
+
+async fn assemble_runtime_store(
+    home: &AstridHome,
+    quota: Arc<dyn KvQuotaResolver<StateOwner>>,
+    principals: PrincipalDirectory,
+    engine: Arc<RuntimeEngine>,
+    directory_cutover_receipt: String,
+    restore_projection: bool,
+) -> crate::principal_state::StorageResult<RuntimePrincipalStore> {
+    let format_spec = bootstrap::format_specification()?;
+    let format_spec_id = engine.identify(&format_spec);
+    let catalog_spec = bootstrap::content_catalog_format_specification()?;
+    let catalog_spec_id = engine.identify(&catalog_spec);
+    let bootstrap_objects = representation_bootstrap_objects(format_spec_id, catalog_spec_id);
+    let catalogue_engine = Arc::clone(&engine);
+    tokio::task::spawn_blocking(move || {
+        catalogue_engine.ensure_direct_representation_catalogue_compatible_with(
+            format_spec_id,
+            &[PRE_DENSE_RADIX_FORMAT_SPEC_ID],
+            &bootstrap_objects,
+        )
+    })
+    .await
+    .map_err(|error| {
+        StorageError::Connection(format!(
+            "volume representation-catalogue worker failed: {error}"
+        ))
+    })?
+    .map_err(|error| {
+        StorageError::Connection(format!("activate volume representation catalogue: {error}"))
+    })?;
+    let validated_catalogs = Arc::new(Mutex::new(BTreeMap::<StateOwner, CatalogValidation>::new()));
+    let validated_kv = Arc::new(crate::kv::KvValidationCache::default());
+
+    let runtime_kv = Arc::new(
+        RuntimeStore::from_engine_with_quota_and_content_validation(
+            Arc::clone(&engine),
+            StateOwnerResolver::new(principals.clone()),
+            Arc::clone(&quota),
+            Arc::clone(&validated_kv),
+            Arc::clone(&validated_catalogs),
+        )
+        .with_read_cache(KvReadCacheConfig::bounded(
+            NonZeroUsize::new(256 * 1024 * 1024).expect("256 MiB"),
+            NonZeroUsize::new(64 * 1024 * 1024).expect("64 MiB"),
+            NonZeroUsize::new(4_096).expect("owner limit"),
+            NonZeroUsize::new(65_536).expect("entries per owner"),
+        )),
+    );
+    let kv: Arc<dyn KvStore> = runtime_kv.clone();
+    KvIdentityStore::with_principal_directory(
+        ScopedKvStore::new(Arc::clone(&kv), "system:identity")?,
+        principals.clone(),
+    )
+    .load_principal_directory()
+    .await
+    .map_err(|error| {
+        StorageError::Connection(format!(
+            "load principal identities before serving durable namespaces: {error}"
+        ))
+    })?;
+    let content = Arc::new(
+        NativePrincipalContentStore::from_engine_with_quota_and_validation(
+            Arc::clone(&engine),
+            quota,
+            validated_catalogs,
+            validated_kv,
+        ),
+    );
+    let staging = Arc::new(NativeContentStagingArea::open(home.content_staging_path())?);
+    let store = RuntimePrincipalStore {
+        engine,
+        directory_cutover_receipt: Arc::from(directory_cutover_receipt),
+        runtime_kv,
+        kv,
+        content,
+        staging,
+        principals,
+    };
+    if restore_projection {
+        crate::principal_state::runtime_tree::restore_projection(home, &store, &store.content)?;
+    }
+    Ok(store)
+}
+
+/// Open the native kernel's authoritative KV store.
+///
+/// The caller must already hold the kernel singleton lock. On first cutover,
+/// legacy state is imported and independently verified before the completion
+/// marker is made durable. A partial prior destination is quarantined rather
+/// than trusted or deleted.
+///
+/// # Errors
+///
+/// Returns a storage error if policy, metadata, migration, verification, or
+/// durable recovery fails.
+pub async fn open_runtime_kv(
+    home: &AstridHome,
+    quota: Arc<dyn KvQuotaResolver<StateOwner>>,
+) -> crate::principal_state::StorageResult<Arc<dyn KvStore>> {
+    open_runtime_principal_store(home, quota)
+        .await
+        .map(|store| store.kv())
+}
+
+/// Open the native kernel KV projection with an externally shared principal
+/// directory.
+///
+/// # Errors
+///
+/// Returns a storage error if policy, metadata, migration, verification, or
+/// durable recovery fails.
+pub async fn open_runtime_kv_with_directory(
+    home: &AstridHome,
+    quota: Arc<dyn KvQuotaResolver<StateOwner>>,
+    principals: PrincipalDirectory,
+) -> crate::principal_state::StorageResult<Arc<dyn KvStore>> {
+    open_runtime_principal_store_with_directory(home, quota, principals)
+        .await
+        .map(|store| store.kv())
+}

--- a/crates/astrid-storage/src/principal_state/store_open.rs
+++ b/crates/astrid-storage/src/principal_state/store_open.rs
@@ -387,7 +387,7 @@ async fn assemble_runtime_store(
         principals,
     };
     if restore_projection {
-        crate::principal_state::runtime_tree::restore_projection(home, &store, &store.content)?;
+        crate::principal_state::runtime_tree::reconcile_running_projection(home, &store)?;
     }
     Ok(store)
 }

--- a/crates/astrid-storage/src/principal_state/store_open.rs
+++ b/crates/astrid-storage/src/principal_state/store_open.rs
@@ -2,7 +2,7 @@
 
 use std::collections::BTreeMap;
 use std::num::NonZeroUsize;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use parking_lot::Mutex;
 
@@ -80,6 +80,7 @@ pub async fn open_runtime_principal_store_for_pack(
             Arc::new(engine),
             receipt,
             false,
+            false,
         )
         .await?;
         quarantine_unrecognized_principal_store(home, &store)?;
@@ -92,6 +93,7 @@ pub async fn open_runtime_principal_store_for_pack(
         PrincipalDirectory::default(),
         Arc::new(engine),
         receipt,
+        false,
         false,
     )
     .await?;
@@ -180,8 +182,16 @@ async fn open_runtime_principal_store_with_options(
             volume_migration::open_existing(home, policy)?.ok_or_else(|| {
                 StorageError::Connection("Astrid volume disappeared while opening".to_owned())
             })?;
-        let store =
-            assemble_runtime_store(home, quota, principals, Arc::new(engine), receipt, true).await;
+        let store = assemble_runtime_store(
+            home,
+            quota,
+            principals,
+            Arc::new(engine),
+            receipt,
+            true,
+            false,
+        )
+        .await;
         let store = store?;
         quarantine_unrecognized_principal_store(home, &store)?;
         return Ok(store);
@@ -191,16 +201,32 @@ async fn open_runtime_principal_store_with_options(
         .map_err(|error| StorageError::Connection(error.to_string()))?;
     if layout_version.as_deref() != Some(astrid_core::dirs::LEGACY_LAYOUT_VERSION) {
         let (engine, receipt) = volume_migration::initialize_volume(home, policy)?;
-        let store =
-            assemble_runtime_store(home, quota, principals, Arc::new(engine), receipt, true).await;
+        let store = assemble_runtime_store(
+            home,
+            quota,
+            principals,
+            Arc::new(engine),
+            receipt,
+            true,
+            true,
+        )
+        .await;
         let store = store?;
         quarantine_unrecognized_principal_store(home, &store)?;
         return Ok(store);
     }
     if unrecognized_principal_store_present(home)? {
         let (engine, receipt) = volume_migration::initialize_volume(home, policy)?;
-        let store =
-            assemble_runtime_store(home, quota, principals, Arc::new(engine), receipt, true).await;
+        let store = assemble_runtime_store(
+            home,
+            quota,
+            principals,
+            Arc::new(engine),
+            receipt,
+            true,
+            true,
+        )
+        .await;
         let store = store?;
         super::runtime_tree::quarantine_principal_store(home, &store)?;
         return Ok(store);
@@ -269,7 +295,16 @@ async fn open_runtime_principal_store_with_options(
     }
 
     let (engine, receipt) = volume_migration::migrate_directory_store(home, engine, policy)?;
-    assemble_runtime_store(home, quota, principals, Arc::new(engine), receipt, true).await
+    assemble_runtime_store(
+        home,
+        quota,
+        principals,
+        Arc::new(engine),
+        receipt,
+        true,
+        true,
+    )
+    .await
 }
 
 fn quarantine_unrecognized_principal_store(
@@ -315,6 +350,7 @@ async fn assemble_runtime_store(
     engine: Arc<RuntimeEngine>,
     directory_cutover_receipt: String,
     restore_projection: bool,
+    allow_receiptless_bootstrap: bool,
 ) -> crate::principal_state::StorageResult<RuntimePrincipalStore> {
     let format_spec = bootstrap::format_specification()?;
     let format_spec_id = engine.identify(&format_spec);
@@ -376,19 +412,27 @@ async fn assemble_runtime_store(
             validated_kv,
         ),
     );
-    let staging = Arc::new(NativeContentStagingArea::open(home.content_staging_path())?);
+    let staging = Arc::new(OnceLock::new());
     let store = RuntimePrincipalStore {
         engine,
         directory_cutover_receipt: Arc::from(directory_cutover_receipt),
         runtime_kv,
         kv,
         content,
-        staging,
+        staging: Arc::clone(&staging),
         principals,
     };
     if restore_projection {
-        crate::principal_state::runtime_tree::reconcile_running_projection(home, &store)?;
+        crate::principal_state::runtime_tree::reconcile_running_projection(
+            home,
+            &store,
+            allow_receiptless_bootstrap,
+        )?;
     }
+    let staging_area = NativeContentStagingArea::open(home.content_staging_path())?;
+    staging.set(Arc::new(staging_area)).map_err(|_| {
+        StorageError::Internal("runtime store staging area initialized twice".to_owned())
+    })?;
     Ok(store)
 }
 

--- a/crates/astrid-storage/src/principal_state/store_open_volume_tests.rs
+++ b/crates/astrid-storage/src/principal_state/store_open_volume_tests.rs
@@ -1,0 +1,237 @@
+use super::runtime_tests::*;
+use super::*;
+use crate::volume::AstridVolume as _;
+
+#[tokio::test]
+async fn new_store_persists_and_verifies_the_in_band_specification() {
+    let directory = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(directory.path());
+    let store = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+
+    let record = bootstrap::format_specification().unwrap();
+    let id = Blake3ObjectIdentityV1.identify(&record);
+    assert_eq!(store.engine.object(id).unwrap(), Some(record.clone()));
+    assert!(home.storage_volume_path().is_file());
+    assert!(!home.principal_store_path().exists());
+    store.engine.close().unwrap();
+    drop(store);
+
+    let reopened = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    assert_eq!(reopened.engine.object(id).unwrap(), Some(record));
+    assert!(!home.principal_store_path().exists());
+    reopened
+        .retire_verified_legacy_directory_store(&home)
+        .unwrap();
+    assert!(!home.principal_store_path().exists());
+}
+
+#[tokio::test]
+async fn explicit_close_releases_the_hosted_volume_while_store_references_remain() {
+    let directory = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(directory.path());
+    let store = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    let retained_engine = Arc::clone(&store.engine);
+    retained_engine.close().unwrap();
+
+    let reopened = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    reopened.engine.close().unwrap();
+    drop(reopened);
+    drop(store);
+    drop(retained_engine);
+}
+
+#[tokio::test]
+async fn volume_without_its_cutover_receipt_fails_closed() {
+    let directory = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(directory.path());
+    let store = open_runtime_kv(&home, unlimited_quota()).await.unwrap();
+    store.close().await.unwrap();
+    drop(store);
+
+    let volume = crate::volume::HostedFileVolume::open(home.storage_volume_path()).unwrap();
+    let receipt =
+        crate::volume::VolumeRegion::new("system/migrations/directory-store-to-volume-v1").unwrap();
+    volume.remove_region(&receipt).unwrap();
+    volume.sync().unwrap();
+    drop(volume);
+
+    let Err(error) = open_runtime_kv(&home, unlimited_quota()).await else {
+        panic!("volume without a cutover receipt unexpectedly reopened");
+    };
+    assert!(error.to_string().contains("cutover receipt"), "{error}");
+}
+
+#[tokio::test]
+async fn changed_surviving_directory_store_is_rejected_by_post_barrier_retirement() {
+    let directory = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(directory.path());
+    super::format_migration_tests::seed_current_directory_store(&home);
+    let migrated = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    migrated.engine.close().unwrap();
+    drop(migrated);
+    assert!(home.principal_store_path().is_dir());
+    let source = Arc::new(
+        RuntimeEngine::open(
+            home.principal_store_path(),
+            Blake3ObjectIdentityV1,
+            StateOwnerCodecV2,
+            RecoveryLimits::process_addressable(),
+        )
+        .unwrap(),
+    );
+    let changed = RuntimeStore::from_engine(
+        Arc::clone(&source),
+        StateOwnerResolver::new(test_directory(&["alice"])),
+    );
+    changed
+        .set("alice:capsule:shell", "drift", b"changed".to_vec())
+        .await
+        .unwrap();
+    source.close().unwrap();
+    drop(changed);
+    drop(source);
+
+    let reopened = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    let error = reopened
+        .retire_verified_legacy_directory_store(&home)
+        .expect_err("changed surviving source must not be retired");
+    assert!(error.to_string().contains("cutover receipt"), "{error}");
+    assert!(home.principal_store_path().exists());
+}
+
+fn replace_catalog_with_legacy(
+    engine: &RuntimeEngine,
+    owner: &StateOwner,
+    name: &ContentName,
+    file: ObjectId,
+    logical_bytes: u64,
+) -> RootState {
+    let previous = engine.root(owner).unwrap().unwrap();
+    let quota_bytes = logical_bytes
+        .checked_add(u64::try_from(name.as_str().len()).unwrap())
+        .unwrap();
+    let legacy = LegacyCatalog {
+        entries: BTreeMap::from([(
+            name.clone(),
+            CatalogValue {
+                file,
+                logical_bytes,
+            },
+        )]),
+        logical_bytes,
+        quota_bytes,
+    };
+    let catalog = encode_legacy_catalog(&legacy).unwrap();
+    let catalog_id = Blake3ObjectIdentityV1.identify(&catalog);
+    let graph_version = ObjectFormatVersion::new(3).unwrap();
+    let state = ObjectRecord::new(
+        ObjectKind::PrincipalState,
+        graph_version,
+        Vec::new(),
+        vec![ObjectReference::owns(
+            ReferenceLabel::new(CONTENT_COMPONENT_LABEL.to_vec()),
+            catalog_id,
+        )],
+        0,
+        ObjectClass::Metadata,
+    )
+    .unwrap();
+    let state_id = Blake3ObjectIdentityV1.identify(&state);
+    let commit = ObjectRecord::new(
+        ObjectKind::Commit,
+        graph_version,
+        Vec::new(),
+        vec![
+            ObjectReference::new(
+                ReferenceLabel::new(b"parent".to_vec()),
+                previous.commit,
+                ReferenceKind::Lineage,
+            ),
+            ObjectReference::owns(ReferenceLabel::new(b"state".to_vec()), state_id),
+        ],
+        0,
+        ObjectClass::Metadata,
+    )
+    .unwrap();
+    let commit_id = Blake3ObjectIdentityV1.identify(&commit);
+    engine
+        .commit(RootTransaction::new(
+            *owner,
+            Some(previous),
+            commit_id,
+            vec![
+                (catalog_id, catalog),
+                (state_id, state),
+                (commit_id, commit),
+            ],
+        ))
+        .unwrap()
+        .root()
+}
+
+fn mark_store_as_legacy(home: &AstridHome) {
+    std::fs::write(
+        home.principal_store_path()
+            .join(migrations::MIGRATION_MARKER_FILE),
+        migrations::LEGACY_TO_V1_MARKER,
+    )
+    .unwrap();
+}
+
+pub(super) fn install_legacy_catalog_fixtures(
+    home: &AstridHome,
+    fixtures: &[(&StateOwner, &ContentName, &[u8])],
+) -> BTreeMap<StateOwner, RootState> {
+    super::format_migration_tests::seed_current_directory_store(home);
+    let engine = Arc::new(
+        RuntimeEngine::open(
+            home.principal_store_path(),
+            Blake3ObjectIdentityV1,
+            StateOwnerCodecV2,
+            RecoveryLimits::process_addressable(),
+        )
+        .unwrap(),
+    );
+    let store = NativePrincipalContentStore::from_engine(Arc::clone(&engine));
+    let published: Vec<_> = fixtures
+        .iter()
+        .map(|(owner, name, bytes)| {
+            (
+                **owner,
+                (*name).clone(),
+                store.put(owner, name, bytes).unwrap(),
+            )
+        })
+        .collect();
+    let legacy_roots = published
+        .into_iter()
+        .map(|(owner, name, outcome)| {
+            let descriptor = outcome.descriptor();
+            let root = replace_catalog_with_legacy(
+                engine.as_ref(),
+                &owner,
+                &name,
+                descriptor.file(),
+                descriptor.logical_bytes(),
+            );
+            (owner, root)
+        })
+        .collect();
+    drop(store);
+    engine.close().unwrap();
+    drop(engine);
+    mark_store_as_legacy(home);
+    legacy_roots
+}

--- a/crates/astrid-storage/src/principal_state/unbound_legacy.rs
+++ b/crates/astrid-storage/src/principal_state/unbound_legacy.rs
@@ -343,6 +343,15 @@ mod tests {
         })
     }
 
+    fn seed_legacy_layout(home: &AstridHome) {
+        std::fs::create_dir_all(home.etc_dir()).unwrap();
+        std::fs::write(
+            home.layout_version_path(),
+            astrid_core::dirs::LEGACY_LAYOUT_VERSION,
+        )
+        .unwrap();
+    }
+
     fn write_admitted_profile(home: &AstridHome, alias: &PrincipalId, key: [u8; 32]) {
         let mut profile = PrincipalProfile::default();
         profile.auth.public_keys.push(DeviceKey::new(
@@ -360,6 +369,7 @@ mod tests {
     async fn leftover_alias_home_and_capsule_kv_import_without_prior_identity() {
         let directory = tempfile::tempdir().unwrap();
         let home = AstridHome::from_path(directory.path());
+        seed_legacy_layout(&home);
         let admitted = PrincipalId::new("default").unwrap();
         write_admitted_profile(&home, &admitted, [0x11; 32]);
         let leftover = PrincipalId::new("legacy-agent").unwrap();

--- a/crates/astrid-storage/src/principal_state/volume_migration.rs
+++ b/crates/astrid-storage/src/principal_state/volume_migration.rs
@@ -44,14 +44,14 @@ pub(super) fn open_existing(
     Ok(Some((engine, receipt)))
 }
 
-/// Resolve the canonical volume and promote the released legacy path once.
+/// Resolve the canonical volume and promote a released legacy path once.
 ///
 /// Promotion happens before recovery so the runtime-tree admission walk can
 /// exclude the canonical media file and cannot mistake the legacy file for
 /// ordinary content. Seeing both paths is ambiguous and fails closed.
 fn promote_legacy_volume(home: &AstridHome) -> StorageResult<Option<std::path::PathBuf>> {
     let canonical = home.storage_volume_path();
-    let legacy = home.legacy_storage_volume_path();
+    let legacy = legacy_volume_path(home)?;
     let canonical_present = inspect_volume_entry(&canonical)?;
     let legacy_present = inspect_volume_entry(&legacy)?;
 
@@ -76,6 +76,85 @@ fn promote_legacy_volume(home: &AstridHome) -> StorageResult<Option<std::path::P
         },
         (false, false) => Ok(None),
     }
+}
+
+/// Choose the older media path while refusing ambiguous simultaneous inputs.
+fn legacy_volume_path(home: &AstridHome) -> StorageResult<std::path::PathBuf> {
+    let var_path = home.legacy_storage_volume_path();
+    let root_path = home.retired_root_storage_volume_path();
+    let var_present = inspect_volume_entry(&var_path)?;
+    let root_present = inspect_volume_entry(&root_path)?;
+    if var_present && root_present {
+        return Err(connection(format!(
+            "Astrid storage has both released legacy volumes: {} and {}",
+            var_path.display(),
+            root_path.display()
+        )));
+    }
+    Ok(if root_present { root_path } else { var_path })
+}
+
+/// Create and verify a fresh empty durable volume.
+pub(super) fn initialize_volume(
+    home: &AstridHome,
+    policy: DurableEnginePolicy<StateOwner>,
+) -> StorageResult<(RuntimeEngine, String)> {
+    let destination = home.storage_volume_path();
+    let temporary = destination.with_extension("migrating");
+    if temporary.exists() {
+        return Err(connection(format!(
+            "incomplete Astrid volume already exists: {}",
+            temporary.display()
+        )));
+    }
+    let volume = HostedFileVolume::open(&temporary).map_err(|error| {
+        connection(format!(
+            "create fresh Astrid volume {}: {error}",
+            temporary.display()
+        ))
+    })?;
+    let engine = RuntimeEngine::open_volume(
+        volume.clone(),
+        Blake3ObjectIdentityV1,
+        StateOwnerCodecV2,
+        RecoveryLimits::process_addressable(),
+        DurableEnginePolicy::default(),
+    )
+    .map_err(|error| connection(format!("open fresh Astrid volume: {error}")))?;
+    for bootstrap in super::bootstrap::RuntimeBootstrapObject::registered() {
+        let record = bootstrap.record()?;
+        engine
+            .persist_standalone_object(&record)
+            .map_err(|error| connection(format!("persist volume bootstrap object: {error}")))?;
+    }
+    engine
+        .flush()
+        .map_err(|error| connection(format!("flush fresh Astrid volume: {error}")))?;
+    write_cutover_receipt(volume.as_ref(), &[])?;
+    engine
+        .close()
+        .map_err(|error| connection(format!("close fresh Astrid volume: {error}")))?;
+    drop(engine);
+    drop(volume);
+
+    super::native_io::rename_private_entry(&temporary, &destination)?;
+    super::native_io::sync_directory(home.root())?;
+    let volume = HostedFileVolume::open(&destination).map_err(|error| {
+        connection(format!(
+            "reopen fresh Astrid volume {}: {error}",
+            destination.display()
+        ))
+    })?;
+    let engine = RuntimeEngine::open_volume(
+        volume.clone(),
+        Blake3ObjectIdentityV1,
+        StateOwnerCodecV2,
+        RecoveryLimits::process_addressable(),
+        policy,
+    )
+    .map_err(|error| connection(format!("open verified fresh Astrid volume: {error}")))?;
+    let receipt = require_cutover_receipt(volume.as_ref(), Some(&[]))?;
+    Ok((engine, receipt))
 }
 
 fn inspect_volume_entry(path: &std::path::Path) -> StorageResult<bool> {

--- a/crates/astrid-storage/src/principal_state/volume_migration_tests.rs
+++ b/crates/astrid-storage/src/principal_state/volume_migration_tests.rs
@@ -25,6 +25,7 @@ async fn promotes_released_volume_path_before_opening() {
 
     let canonical = home.storage_volume_path();
     let legacy = home.legacy_storage_volume_path();
+    std::fs::create_dir_all(legacy.parent().unwrap()).unwrap();
     std::fs::rename(&canonical, &legacy).unwrap();
     assert!(!canonical.exists());
     assert!(legacy.is_file());
@@ -45,6 +46,7 @@ fn rejects_conflicting_canonical_and_legacy_volume_paths() {
     home.ensure().unwrap();
 
     std::fs::write(home.storage_volume_path(), b"canonical").unwrap();
+    std::fs::create_dir_all(home.legacy_storage_volume_path().parent().unwrap()).unwrap();
     std::fs::write(home.legacy_storage_volume_path(), b"legacy").unwrap();
 
     let error = super::volume_migration::existing_volume_available(&home).unwrap_err();
@@ -76,6 +78,7 @@ fn rejects_non_regular_legacy_volume_without_promoting() {
     let directory = tempfile::tempdir().unwrap();
     let home = AstridHome::from_path(directory.path());
     home.ensure().unwrap();
+    std::fs::create_dir_all(home.legacy_storage_volume_path().parent().unwrap()).unwrap();
     std::fs::create_dir(home.legacy_storage_volume_path()).unwrap();
 
     let error = super::volume_migration::existing_volume_available(&home).unwrap_err();
@@ -117,6 +120,7 @@ fn rejects_symlink_legacy_volume_without_promoting() {
     let directory = tempfile::tempdir().unwrap();
     let home = AstridHome::from_path(directory.path());
     home.ensure().unwrap();
+    std::fs::create_dir_all(home.legacy_storage_volume_path().parent().unwrap()).unwrap();
     let target = directory.path().join("legacy-target");
     std::fs::write(&target, b"not a volume").unwrap();
     symlink(&target, home.legacy_storage_volume_path()).unwrap();

--- a/crates/astrid-uplink/src/native/tests.rs
+++ b/crates/astrid-uplink/src/native/tests.rs
@@ -265,6 +265,7 @@ async fn token_only_peer_is_anonymous_and_can_round_trip() {
     let temp = tempfile::tempdir().expect("tempdir");
     let home = AstridHome::from_path(temp.path().join("home"));
     home.ensure().expect("create Astrid home");
+    std::fs::create_dir_all(home.run_dir()).expect("create ephemeral runtime directory");
     let token = Arc::new(SessionToken::generate());
     token
         .write_to_file(&home.token_path())
@@ -361,6 +362,7 @@ async fn stalled_handshake_does_not_block_later_clients() {
     let temp = tempfile::tempdir().expect("tempdir");
     let home = AstridHome::from_path(temp.path().join("home"));
     home.ensure().expect("create Astrid home");
+    std::fs::create_dir_all(home.run_dir()).expect("create ephemeral runtime directory");
     let token = Arc::new(SessionToken::generate());
     token
         .write_to_file(&home.token_path())
@@ -410,6 +412,7 @@ async fn established_connections_release_handshake_capacity() {
     let temp = tempfile::tempdir().expect("tempdir");
     let home = AstridHome::from_path(temp.path().join("home"));
     home.ensure().expect("create Astrid home");
+    std::fs::create_dir_all(home.run_dir()).expect("create ephemeral runtime directory");
     let token = Arc::new(SessionToken::generate());
     token
         .write_to_file(&home.token_path())

--- a/scripts/e2e/runtime-distro-smoke.sh
+++ b/scripts/e2e/runtime-distro-smoke.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Local Distro staging and signed offline smoke helpers for runtime E2E.
+
+stage_local_distro() {
+  local root=$1
+  local archive=$2
+  mkdir -p "$root/capsules"
+  cp "$archive" "$root/capsules/astrid-capsule-registry.capsule"
+  cat > "$root/Distro.toml" <<'EOF'
+schema-version = 1
+
+[distro]
+id = "runtime-e2e"
+name = "Runtime E2E"
+version = "0.0.0"
+
+[[capsule]]
+name = "astrid-capsule-registry"
+source = "capsules/astrid-capsule-registry.capsule"
+version = "0.0.0"
+role = "uplink"
+EOF
+}
+
+run_cli_distro_seal_smoke() {
+  local archive=$1
+  local output=$2
+  local distro_root="$ARTIFACTS/seal-distro"
+  rm -rf "$distro_root"
+  stage_local_distro "$distro_root" "$archive"
+
+  local signing_home="$ARTIFACTS/seal-signing-home"
+  rm -rf "$signing_home"
+  mkdir -p "$signing_home"
+  ASTRID_HOME="$signing_home" "$CORE_DIR/target/debug/astrid" keypair generate \
+    --name distro-seal --raw > "$ARTIFACTS/distro-signer.pub.hex"
+  local public_hex
+  public_hex="$(cat "$ARTIFACTS/distro-signer.pub.hex")"
+  python3 - "$public_hex" "$distro_root/Distro.toml" <<'PY'
+import base64, binascii, sys
+public = bytes.fromhex(sys.argv[1])
+assert len(public) == 32
+pubkey = "ed25519:" + base64.b64encode(public).decode("ascii")
+path = sys.argv[2]
+text = open(path, encoding="utf-8").read()
+text += f'\n[distro.signing]\npubkey = "{pubkey}"\n'
+open(path, "w", encoding="utf-8").write(text)
+PY
+
+  ASTRID_HOME="$signing_home" "$CORE_DIR/target/debug/astrid" distro seal "$distro_root/Distro.toml" \
+    --output "$output" \
+    --key "$signing_home/keys/local/distro-seal.ed25519"
+  [[ -f "$output" ]] || fail "sealed distro was not produced"
+}
+
+run_cli_offline_init_smoke() {
+  local archive=$1
+  local shuttle="$ARTIFACTS/offline-init-distro.shuttle"
+  rm -f "$shuttle"
+  run_cli_distro_seal_smoke "$archive" "$shuttle"
+  run_cli init --distro "$shuttle" --offline --yes
+}

--- a/scripts/e2e/runtime-harness.sh
+++ b/scripts/e2e/runtime-harness.sh
@@ -4,7 +4,7 @@ CORE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SCRIPT_DIR="$CORE_DIR/scripts/e2e"
 CAPSULES_DIR="${ASTRID_E2E_CAPSULES_DIR:-$CORE_DIR/../capsules}"
 ASTRID_HOME_GENERATED=0; if [[ -n "${ASTRID_E2E_HOME:-}" ]]; then ASTRID_HOME="$ASTRID_E2E_HOME"; else ASTRID_HOME="$(mktemp -d "${TMPDIR:-/tmp}/astrid-runtime-e2e.XXXXXX")"; ASTRID_HOME_GENERATED=1; fi
-ARTIFACTS="$ASTRID_HOME/artifacts"
+ARTIFACTS="$(mktemp -d "${TMPDIR:-/tmp}/astrid-runtime-e2e-artifacts.XXXXXX")"
 REDACTED_UPLOAD="$ARTIFACTS/redacted-upload"
 GATEWAY_HOST="${ASTRID_E2E_GATEWAY_HOST:-127.0.0.1}"
 PYTHON="${PYTHON:-python3}"
@@ -31,19 +31,24 @@ LAST_HTTP_OUT=""
 REDACTION_SENTINELS=()
 . "$SCRIPT_DIR/runtime-process-helpers.sh"
 cleanup() {
-  local status=$?
+  local status=${ASTRID_E2E_CLEANUP_STATUS:-$?}
   trap - EXIT INT TERM
   terminate_pid "$DAEMON_PID"
   terminate_pid "$SECONDARY_DAEMON_PID"
   terminate_pid "$FAKE_PID"
+  if [[ "$status" -ne 0 && -d "$ASTRID_HOME/log" ]]; then mkdir -p "$ARTIFACTS/astrid-log" && cp -a "$ASTRID_HOME/log/." "$ARTIFACTS/astrid-log/" 2>/dev/null || true; fi
+  if [[ "$status" -ne 0 ]]; then
+    stage_redacted_upload || true
+  fi
+  if [[ "$status" -eq 0 && -d "$ARTIFACTS" ]]; then
+    rm -rf "$ARTIFACTS"
+  elif [[ -d "$ARTIFACTS" ]]; then
+    printf 'kept E2E artifacts=%s\n' "$ARTIFACTS"
+  fi
   if [[ -n "$SECONDARY_HOME" && -z "${ASTRID_E2E_KEEP_HOME:-}" && "$status" -eq 0 ]]; then
     rm -rf "$SECONDARY_HOME"
   elif [[ -n "$SECONDARY_HOME" ]]; then
     printf 'kept secondary ASTRID_HOME=%s\n' "$SECONDARY_HOME"
-  fi
-  if [[ "$status" -ne 0 && -d "$ASTRID_HOME/log" ]]; then mkdir -p "$ARTIFACTS/astrid-log" && cp -a "$ASTRID_HOME/log/." "$ARTIFACTS/astrid-log/" 2>/dev/null || true; fi
-  if [[ "$status" -ne 0 ]]; then
-    stage_redacted_upload || true
   fi
   if [[ -n "$POISON_HOME" && -z "${ASTRID_E2E_KEEP_HOME:-}" ]]; then
     rm -rf "$POISON_HOME"
@@ -58,6 +63,16 @@ cleanup() {
   return "$status"
 }
 trap cleanup EXIT INT TERM
+run_forced_failure_staging_regression() {
+  printf 'forced staging regression\n' > "$ARTIFACTS/cli-transcript.log"
+  if ASTRID_E2E_CLEANUP_STATUS=1 cleanup; then
+    return 1
+  fi
+  [[ -f "$REDACTED_UPLOAD/artifacts/cli-transcript.log" ]] || return 1
+  grep -q 'forced staging regression' \
+    "$REDACTED_UPLOAD/artifacts/cli-transcript.log" || return 1
+  printf '==> forced failure staged redacted artifacts successfully\n'
+}
 . "$SCRIPT_DIR/runtime-json-asserts.sh"
 . "$SCRIPT_DIR/runtime-storage-asserts.sh"
 . "$SCRIPT_DIR/runtime-gateway-smoke.sh"
@@ -88,6 +103,7 @@ run_cli() {
   rm -f "$stdout" "$stderr"
   return "$status"
 }
+. "$SCRIPT_DIR/runtime-distro-smoke.sh"
 run_principal_cli() {
   local principal=$1
   local stdout stderr status
@@ -325,6 +341,8 @@ redaction_check() {
 main() {
   export ASTRID_HOME
 
+  run_forced_failure_staging_regression; trap cleanup EXIT INT TERM
+
   note "building Astrid binaries"
   if [[ -z "${ASTRID_E2E_SKIP_BUILD:-}" ]]; then
     cargo build -p astrid --bins
@@ -350,11 +368,13 @@ main() {
   if [[ ! -d "$registry_source" ]]; then
     registry_source="$CAPSULES_DIR/astrid-capsule-registry"
   fi
-  run_cli capsule build "$registry_source" --output "$capsule_dist"
+  local signing_home="$ARTIFACTS/signing-home"
+  mkdir -p "$signing_home"
+  ASTRID_HOME="$signing_home" run_cli capsule build "$registry_source" --output "$capsule_dist"
   local registry_archive="$capsule_dist/astrid-capsule-registry.capsule"
   [[ -f "$registry_archive" ]] || fail "registry .capsule artifact was not built at $registry_archive"
   run_cli_offline_init_smoke "$registry_archive"
-  run_cli_distro_seal_smoke "$registry_archive"
+  run_cli_distro_seal_smoke "$registry_archive" "$ARTIFACTS/runtime-e2e.shuttle"
 
   note "starting fake OpenAI-compatible server"
   local fake_port_file="$ARTIFACTS/fake-openai.port"
@@ -371,6 +391,7 @@ main() {
   local fake_base_url="http://127.0.0.1:$fake_port"
   curl --connect-timeout 2 --max-time 5 -fsS "$fake_base_url/v1/models" >/dev/null
   note "writing gateway and local-egress config"
+  run_cli start
   cat > "$ASTRID_HOME/etc/gateway-http.toml" <<EOF
 enabled = true
 listen = "$GATEWAY_HOST:$GATEWAY_PORT"
@@ -663,6 +684,8 @@ PY
   run_gateway_quota_write_smoke "$user_principal" "$ops_principal" "$user_bearer" "$admin_bearer"
   run_admin_pair_device_cross_principal_smoke "$user_bearer" "$user_principal" \
     "$ops_principal" "$admin_bearer"
+
+  run_shared_model_baseline_smoke "$user_bearer"
 
   note "checking per-principal capsule env isolation"
   status="$(http_status POST /api/capsules/astrid-capsule-openai-compat/env/model "" \

--- a/scripts/e2e/runtime-harness.sh
+++ b/scripts/e2e/runtime-harness.sh
@@ -357,25 +357,6 @@ main() {
 
   require_capsules
 
-  note "building .capsule artifact for lifecycle coverage"
-  local capsule_dist="$ARTIFACTS/capsule-dist"
-  mkdir -p "$capsule_dist"
-  # AOS keeps capsule sources in one Cargo workspace under `capsule-*`, while
-  # the harness's published/runtime IDs remain `astrid-capsule-*`. Prefer the
-  # canonical workspace member for Cargo resolution; historical independent
-  # checkout layouts continue through the legacy path.
-  local registry_source="$CAPSULES_DIR/capsule-registry"
-  if [[ ! -d "$registry_source" ]]; then
-    registry_source="$CAPSULES_DIR/astrid-capsule-registry"
-  fi
-  local signing_home="$ARTIFACTS/signing-home"
-  mkdir -p "$signing_home"
-  ASTRID_HOME="$signing_home" run_cli capsule build "$registry_source" --output "$capsule_dist"
-  local registry_archive="$capsule_dist/astrid-capsule-registry.capsule"
-  [[ -f "$registry_archive" ]] || fail "registry .capsule artifact was not built at $registry_archive"
-  run_cli_offline_init_smoke "$registry_archive"
-  run_cli_distro_seal_smoke "$registry_archive" "$ARTIFACTS/runtime-e2e.shuttle"
-
   note "starting fake OpenAI-compatible server"
   local fake_port_file="$ARTIFACTS/fake-openai.port"
   "$PYTHON" "$SCRIPT_DIR/fake-openai-compat.py" \
@@ -392,6 +373,24 @@ main() {
   curl --connect-timeout 2 --max-time 5 -fsS "$fake_base_url/v1/models" >/dev/null
   note "writing gateway and local-egress config"
   run_cli start
+
+  note "building runtime-signed .capsule artifact for lifecycle coverage"
+  local capsule_dist="$ARTIFACTS/capsule-dist"
+  mkdir -p "$capsule_dist"
+  # AOS keeps capsule sources in one Cargo workspace under `capsule-*`, while
+  # the harness's published/runtime IDs remain `astrid-capsule-*`. Prefer the
+  # canonical workspace member for Cargo resolution; historical independent
+  # checkout layouts continue through the legacy path.
+  local registry_source="$CAPSULES_DIR/capsule-registry"
+  if [[ ! -d "$registry_source" ]]; then
+    registry_source="$CAPSULES_DIR/astrid-capsule-registry"
+  fi
+  run_cli capsule build "$registry_source" --output "$capsule_dist"
+  local registry_archive="$capsule_dist/astrid-capsule-registry.capsule"
+  [[ -f "$registry_archive" ]] || fail "registry .capsule artifact was not built at $registry_archive"
+  run_cli_offline_init_smoke "$registry_archive"
+  run_cli_distro_seal_smoke "$registry_archive" "$ARTIFACTS/runtime-e2e.shuttle"
+
   cat > "$ASTRID_HOME/etc/gateway-http.toml" <<EOF
 enabled = true
 listen = "$GATEWAY_HOST:$GATEWAY_PORT"

--- a/scripts/e2e/runtime-llm-smoke.sh
+++ b/scripts/e2e/runtime-llm-smoke.sh
@@ -61,6 +61,37 @@ if found != expected_count:
 PY
 }
 
+set_openai_model_env() {
+  local bearer=$1
+  local value=$2
+  local out=$3
+  local status
+
+  status="$(http_status POST /api/capsules/astrid-capsule-openai-compat/env/model "$bearer" \
+    "{\"value\":\"$value\"}" "$out")"
+  assert_status "openai model env write ($value)" "$status" 204
+}
+
+run_shared_model_baseline_smoke() {
+  local bearer=$1
+  local status
+
+  note "checking fake-echo model catalog before scoped overrides"
+  status="$(http_status GET /api/models "$bearer" "" "$ARTIFACTS/shared-models.json")"
+  assert_status "shared model list" "$status" 200
+  json_assert_model_list_contains "$ARTIFACTS/shared-models.json" "openai-compat:fake-echo"
+  assert_model_list_count "$ARTIFACTS/shared-models.json" "openai-compat:fake-echo" 1
+  status="$(http_status PUT /api/models/active "$bearer" \
+    '{"id":"openai-compat:fake-echo"}' \
+    "$ARTIFACTS/shared-set-active-model.json")"
+  assert_status "shared set active model" "$status" 200
+  json_assert_model_id "$ARTIFACTS/shared-set-active-model.json" "openai-compat:fake-echo"
+  status="$(http_status GET /api/models "$bearer" "" "$ARTIFACTS/shared-models-after-active.json")"
+  assert_status "shared model list after active set" "$status" 200
+  json_assert_model_list_contains "$ARTIFACTS/shared-models-after-active.json" \
+    "openai-compat:fake-echo"
+}
+
 run_active_model_isolation_smoke() {
   local user_bearer=$1 ops_bearer=$2 user_principal=$3 ops_principal=$4
   local status deadline
@@ -68,8 +99,8 @@ run_active_model_isolation_smoke() {
   note "checking per-principal active model isolation"
   status="$(http_status GET /api/models "$user_bearer" "" "$ARTIFACTS/agent-models.json")"
   assert_status "agent model list" "$status" 200
-  json_assert_model_list_contains "$ARTIFACTS/agent-models.json" "openai-compat:fake-echo"
   json_assert_model_list_contains "$ARTIFACTS/agent-models.json" "openai-compat:fake-slow"
+  assert_model_list_count "$ARTIFACTS/agent-models.json" "openai-compat:fake-slow" 1
   status="$(http_status PUT /api/models/active "$user_bearer" \
     '{"id":"openai-compat:fake-slow"}' \
     "$ARTIFACTS/agent-set-active-model.json")"
@@ -109,7 +140,36 @@ run_active_model_isolation_smoke() {
     "$ARTIFACTS/agent-set-active-model-body-spoof.json")"
   assert_status "agent active model body spoof ignored" "$status" 200
   json_assert_model_id "$ARTIFACTS/agent-set-active-model-body-spoof.json" "openai-compat:fake-slow"
-  run_concurrent_model_write_smoke "$user_bearer" "$ops_bearer" "$user_principal" "$ops_principal"
+  run_scoped_concurrent_model_write_smoke "$user_bearer" "$ops_bearer"
+}
+
+run_scoped_concurrent_model_write_smoke() {
+  local user_bearer=$1 ops_bearer=$2
+  local user_status_file ops_status_file user_out ops_out user_pid ops_pid
+  local user_wait=0 ops_wait=0
+
+  note "checking concurrent scoped active model writes stay principal-isolated"
+  user_status_file="$ARTIFACTS/scoped-concurrent-model-user.status"
+  ops_status_file="$ARTIFACTS/scoped-concurrent-model-ops.status"
+  user_out="$ARTIFACTS/scoped-concurrent-model-user-set.json"
+  ops_out="$ARTIFACTS/scoped-concurrent-model-ops-set.json"
+
+  (http_status PUT /api/models/active "$user_bearer" \
+    '{"id":"openai-compat:fake-slow"}' "$user_out" > "$user_status_file") &
+  user_pid=$!
+  (http_status PUT /api/models/active "$ops_bearer" \
+    '{"id":"openai-compat:fake-toolish"}' "$ops_out" > "$ops_status_file") &
+  ops_pid=$!
+  wait "$user_pid" || user_wait=$?
+  wait "$ops_pid" || ops_wait=$?
+  [[ "$user_wait" -eq 0 ]] || fail "agent scoped concurrent active model request failed"
+  [[ "$ops_wait" -eq 0 ]] || fail "operator scoped concurrent active model request failed"
+  assert_model_write_status "agent scoped concurrent active model" \
+    "$user_status_file" "$user_out"
+  assert_model_write_status "operator scoped concurrent active model" \
+    "$ops_status_file" "$ops_out"
+  json_assert_model_id "$user_out" "openai-compat:fake-slow"
+  json_assert_model_id "$ops_out" "openai-compat:fake-toolish"
 }
 
 run_empty_model_catalog_smoke() {
@@ -232,39 +292,35 @@ run_llm_provider_smoke() {
   local principal=$2
   local models_file=$3
   local fake_base_url=$4
-  local status
+  local status target
 
   note "checking fake LLM provider failure handling"
-  json_assert_model_list_contains "$models_file" "openai-compat:fake-error"
-  json_assert_model_list_contains "$models_file" "openai-compat:fake-malformed"
-  json_assert_model_list_contains "$models_file" "openai-compat:fake-timeout"
-  assert_model_list_count "$models_file" "openai-compat:duplicate-name" 1
-
   run_empty_model_catalog_smoke "$fake_base_url"
 
-  status="$(http_status PUT /api/models/active "$bearer" \
-    '{"id":"openai-compat:fake-error"}' \
-    "$ARTIFACTS/agent-set-active-model-fake-error.json")"
-  assert_status "agent set fake-error active model" "$status" 200
-  json_assert_model_id "$ARTIFACTS/agent-set-active-model-fake-error.json" "openai-compat:fake-error"
-  assert_bounded_llm_error_surface "$principal" "openai-compat:fake-error" "fake-error" \
-    'fake upstream error\|502\|error'
+  for target in fake-error fake-malformed fake-timeout; do
+    set_openai_model_env "$bearer" "$target" \
+      "$ARTIFACTS/agent-openai-model-$target.json"
+    status="$(http_status GET /api/models "$bearer" "" \
+      "$ARTIFACTS/agent-models-$target.json")"
+    assert_status "agent $target model list" "$status" 200
+    json_assert_model_list_contains "$ARTIFACTS/agent-models-$target.json" \
+      "openai-compat:$target"
+    assert_model_list_count "$ARTIFACTS/agent-models-$target.json" \
+      "openai-compat:$target" 1
+    status="$(http_status PUT /api/models/active "$bearer" \
+      "{\"id\":\"openai-compat:$target\"}" \
+      "$ARTIFACTS/agent-set-active-model-$target.json")"
+    assert_status "agent set $target active model" "$status" 200
+    json_assert_model_id "$ARTIFACTS/agent-set-active-model-$target.json" \
+      "openai-compat:$target"
+    assert_bounded_llm_error_surface "$principal" "openai-compat:$target" "$target" \
+      'fake upstream error\|502\|malformed\|invalid\|json\|timeout\|timed out\|deadline\|error'
+  done
 
-  status="$(http_status PUT /api/models/active "$bearer" \
-    '{"id":"openai-compat:fake-malformed"}' \
-    "$ARTIFACTS/agent-set-active-model-fake-malformed.json")"
-  assert_status "agent set fake-malformed active model" "$status" 200
-  json_assert_model_id "$ARTIFACTS/agent-set-active-model-fake-malformed.json" "openai-compat:fake-malformed"
-  assert_bounded_llm_error_surface "$principal" "openai-compat:fake-malformed" "fake-malformed" \
-    'malformed\|invalid\|json\|error'
-
-  status="$(http_status PUT /api/models/active "$bearer" \
-    '{"id":"openai-compat:fake-timeout"}' \
-    "$ARTIFACTS/agent-set-active-model-fake-timeout.json")"
-  assert_status "agent set fake-timeout active model" "$status" 200
-  json_assert_model_id "$ARTIFACTS/agent-set-active-model-fake-timeout.json" "openai-compat:fake-timeout"
-  assert_bounded_llm_error_surface "$principal" "openai-compat:fake-timeout" "fake-timeout" \
-    'timeout\|timed out\|deadline\|error'
+  set_openai_model_env "$bearer" fake-slow "$ARTIFACTS/agent-openai-model-restore.json"
+  status="$(http_status GET /api/models "$bearer" "" "$models_file")"
+  assert_status "agent restored model list" "$status" 200
+  json_assert_model_list_contains "$models_file" "openai-compat:fake-slow"
 
   status="$(http_status PUT /api/models/active "$bearer" \
     '{"id":"openai-compat:fake-slow"}' \

--- a/scripts/e2e/runtime-multi-home-smoke.sh
+++ b/scripts/e2e/runtime-multi-home-smoke.sh
@@ -84,7 +84,10 @@ run_multi_home_smoke() {
 
   mkdir -p "$secondary_artifacts"
   multi_run_cli "$secondary_home" "$secondary_artifacts" start
-  multi_run_cli "$secondary_home" "$secondary_artifacts" stop
+  # Runtime configuration belongs to the mounted projection. Write it while
+  # Astrid is running and install capsules against that same public
+  # projection. A single later clean stop packs both runtime policy and the
+  # installed capsule set before the harness-owned restart.
   mkdir -p "$secondary_home/etc"
   cat > "$secondary_home/etc/gateway-http.toml" <<EOF
 enabled = true
@@ -138,6 +141,15 @@ EOF
   # Capsule installs auto-start a persistent daemon. Stop it before launching
   # the harness-owned process so cleanup cannot leave an untracked second home.
   multi_run_cli "$secondary_home" "$secondary_artifacts" stop
+  local stopped_entry
+  local stopped_extra=""
+  while IFS= read -r -d '' stopped_entry; do
+    if [[ "$(basename "$stopped_entry")" != "astrid.volume" ]]; then
+      stopped_extra+=" $stopped_entry"
+    fi
+  done < <(find "$secondary_home" -mindepth 1 -maxdepth 1 -print0)
+  [[ -z "$stopped_extra" ]] || fail "clean stop left stopped sidecars:$stopped_extra"
+  [[ -f "$secondary_home/astrid.volume" ]] || fail "clean stop did not leave canonical astrid.volume"
   env ASTRID_HOME="$secondary_home" HOME="$POISON_HOME" \
     "$CORE_DIR/target/debug/astrid-daemon" >> "$secondary_artifacts/daemon.log" 2>&1 &
   SECONDARY_DAEMON_PID=$!

--- a/scripts/test_v0104_linux_upgrade.sh
+++ b/scripts/test_v0104_linux_upgrade.sh
@@ -374,20 +374,24 @@ grep -Fq 'upgrade-restart-probe' "${TEST_ROOT}/agents-after-restart.json" \
   || fail "post-upgrade write did not survive restart"
 grep -Fq 'upgrade-second-alias' "${TEST_ROOT}/agents-after-restart.json" \
   || fail "second post-upgrade principal did not survive restart"
-run_current_bounded 20s stop
 
 python3 - "${ASTRID_HOME}" <<'PY'
 import json
+import stat
 import pathlib
 import sys
 
 home = pathlib.Path(sys.argv[1])
-if (home / "etc/layout-version").read_bytes() != b"2":
-    raise SystemExit("layout-version is not exactly 2")
-if not (home / "volume").is_file():
-    raise SystemExit("Astrid volume is absent after upgrade")
-if (home / "volume").stat().st_size == 0:
+volume = home / "astrid.volume"
+volume_meta = volume.lstat()
+if stat.S_ISLNK(volume_meta.st_mode) or not stat.S_ISREG(volume_meta.st_mode):
+    raise SystemExit("Astrid volume is redirected or not a regular file")
+if volume_meta.st_size == 0:
     raise SystemExit("Astrid volume is empty after upgrade")
+if stat.S_IMODE(volume_meta.st_mode) != 0o600:
+    raise SystemExit("Astrid volume is not private")
+if (home / "etc/layout-version").read_bytes() != b"2":
+    raise SystemExit("projected layout-version is not exactly 2")
 if (home / "var/state.db").exists():
     raise SystemExit("released var/state.db survived verified retirement")
 if (home / "var/principal-store").exists():
@@ -588,6 +592,28 @@ if receipt.get("intent") != intent:
     raise SystemExit("migration receipt does not embed the admitted intent")
 if receipt.get("destination", {}).get("bytes", 0) <= 0:
     raise SystemExit("migration receipt does not bind a non-empty volume")
+PY
+
+run_current_bounded 20s stop
+
+python3 - "${ASTRID_HOME}" <<'PY'
+import os
+import pathlib
+import stat
+import sys
+
+home = pathlib.Path(sys.argv[1])
+entries = sorted(os.listdir(home))
+if entries != ["astrid.volume"]:
+    raise SystemExit(f"stopped Astrid root has sidecars: {entries}")
+volume = home / "astrid.volume"
+meta = volume.lstat()
+if stat.S_ISLNK(meta.st_mode) or not stat.S_ISREG(meta.st_mode):
+    raise SystemExit("stopped Astrid volume is redirected or not a regular file")
+if stat.S_IMODE(meta.st_mode) != 0o600:
+    raise SystemExit(f"stopped Astrid volume mode is {stat.S_IMODE(meta.st_mode):04o}, expected 0600")
+if meta.st_size == 0:
+    raise SystemExit("stopped Astrid volume is empty")
 PY
 
 printf 'v0.10.4 Linux release upgraded, retired, wrote, and reopened successfully\n'

--- a/scripts/test_v0104_macos_upgrade.sh
+++ b/scripts/test_v0104_macos_upgrade.sh
@@ -461,20 +461,24 @@ grep -Fq 'upgrade-restart-probe' "${TEST_ROOT}/agents-after-restart.json" \
   || fail "post-upgrade write did not survive restart"
 grep -Fq 'upgrade-second-alias' "${TEST_ROOT}/agents-after-restart.json" \
   || fail "second post-upgrade principal did not survive restart"
-run_current_bounded 20s stop
 
 python3 - "${ASTRID_HOME}" <<'PY'
 import json
+import stat
 import pathlib
 import sys
 
 home = pathlib.Path(sys.argv[1])
-if (home / "etc/layout-version").read_bytes() != b"2":
-    raise SystemExit("layout-version is not exactly 2")
-if not (home / "volume").is_file():
-    raise SystemExit("Astrid volume is absent after upgrade")
-if (home / "volume").stat().st_size == 0:
+volume = home / "astrid.volume"
+volume_meta = volume.lstat()
+if stat.S_ISLNK(volume_meta.st_mode) or not stat.S_ISREG(volume_meta.st_mode):
+    raise SystemExit("Astrid volume is redirected or not a regular file")
+if volume_meta.st_size == 0:
     raise SystemExit("Astrid volume is empty after upgrade")
+if stat.S_IMODE(volume_meta.st_mode) != 0o600:
+    raise SystemExit("Astrid volume is not private")
+if (home / "etc/layout-version").read_bytes() != b"2":
+    raise SystemExit("projected layout-version is not exactly 2")
 if (home / "var/state.db").exists():
     raise SystemExit("released var/state.db survived verified retirement")
 if (home / "var/principal-store").exists():
@@ -675,6 +679,28 @@ if receipt.get("intent") != intent:
     raise SystemExit("migration receipt does not embed the admitted intent")
 if receipt.get("destination", {}).get("bytes", 0) <= 0:
     raise SystemExit("migration receipt does not bind a non-empty volume")
+PY
+
+run_current_bounded 20s stop
+
+python3 - "${ASTRID_HOME}" <<'PY'
+import os
+import pathlib
+import stat
+import sys
+
+home = pathlib.Path(sys.argv[1])
+entries = sorted(os.listdir(home))
+if entries != ["astrid.volume"]:
+    raise SystemExit(f"stopped Astrid root has sidecars: {entries}")
+volume = home / "astrid.volume"
+meta = volume.lstat()
+if stat.S_ISLNK(meta.st_mode) or not stat.S_ISREG(meta.st_mode):
+    raise SystemExit("stopped Astrid volume is redirected or not a regular file")
+if stat.S_IMODE(meta.st_mode) != 0o600:
+    raise SystemExit(f"stopped Astrid volume mode is {stat.S_IMODE(meta.st_mode):04o}, expected 0600")
+if meta.st_size == 0:
+    raise SystemExit("stopped Astrid volume is empty")
 PY
 
 


### PR DESCRIPTION
## Linked Issue

Closes #1803. After a clean stop, the configured Astrid durable root must contain exactly one owner-only regular file `astrid.volume`.

## Summary

Fresh admission and restart accept an empty durable root or exactly `astrid.volume`. Any other host sidecar, including empty `etc/`, `run/`, `trust/`, `var/`, `keys/`, `log/`, `bin/`, `wit/`, or a leftover `volume` path, fails closed. Running config, keys, WIT, runtime-tree, Distro trust pins, packed capsule sources, and layout-migration receipts are restored from the mounted volume and packed back on daemon exit. Clean stop retires those projections so the stopped listing is exactly `astrid.volume`.

Restore is a volume-backed overlay rather than a destructive host wipe. Packed running files, including principal capsule sources and `run/capsules` projections, rematerialize after restart. Transient run-root sockets, PID, ready, token, and lock files stay excluded, and retired legacy `state.db` / CoW trees are not resurrected as host sidecars.

A runtime signing key present before first volume initialization is ingested into volume content before durable-root cleanup, then restored as the running `keys/runtime.key` projection. Same-runtime capsule authority therefore survives the volume-only cutover. Clean stop still retires that projection; a stopped `keys/` sidecar is not durable.

Stop-time packing reopens the durable volume without first restoring host projections, so a trust pin installed while the runtime is mounted is packed before retirement and rematerializes after restart. Product Distro apply remains pin-first `RequireExistingPin` against the mounted `$ASTRID_HOME/trust/<distro-id>.pub` projection: a missing pin writes nothing, a matching pin applies, and a mismatch fails closed unless the operator explicitly accepts a new key.

Transient sockets, PID, ready, token, and lock files honor generic `ASTRID_RUN_DIR`. That tree is excluded from the packed catalog and is removed from the override or running-only default on clean stop. An override that equals, contains, or is contained in the durable root, including physical aliases, redirected paths, relative paths, and parent-traversal, fails closed at admission before any retirement of that root. `run_dir()` never returns the durable root, and no invalid-env sentinel is planted under `$ASTRID_HOME`.

`start`, `status`, `stop`, `restart`, and MCP `serve` / `gateway` / `ready` / `attach` validate that runtime-directory override before stale-marker cleanup, already-running fallback, lifecycle lock, path fallback, or other mutation. `mcp gc` remains ungated. Preexisting `$ASTRID_HOME/run/{system.ready,system.pid,system.token}` beside a valid `astrid.volume` is left byte-identical when an overlapping override is rejected. An already-running default daemon plus an invalid override fails admission rather than reporting already-running success. Capsule signing in the runtime harness uses a disposable signing home so pre-start `keys/` is not planted in the primary stopped root.

Packed catalog exclusions for `volume`, `var/principal-store`, and `run/capsules` use exact or slash-boundary predicates. Names such as `volume2`, `volumetric.txt`, `var/principal-store2`, and `run/capsulesX` stay transient; `run/capsules/...` remains admitted.

Layout-migration receipts bind restart to the receipt canonical destination path and no-follow regular-file authority. Legitimate live-volume mutation after cutover is admitted; drifted admitted-path residue is then retired. Redirected residue and swapped-path or foreign destinations remain fail-closed. Dual-exact leftover-byte volume matching is not restored. Published v0.10.4 upgrade journeys assert layout-version only while projected and require the stopped durable root to be exactly one symlink-free, non-empty, mode-0600 `astrid.volume`.

Live capsule activation binds load and replacement to the authenticated caller's published `CapsulePackage`. Durable package reads retain authenticated tar directory members. Kernel expected directories are file ancestors plus archive directory names, archive-dir ancestors, and generated sidecar parents. Root and nested empty directories therefore activate, while extra files, extra directories, child redirects/symlinks, and byte mismatches fail closed. Retirement and quarantine records are durable inside `astrid.volume` and are projected only while running, so a clean stop cannot retain `var/` sidecars.

After durable-root admission, the daemon binds `[security.capsule_local_egress]` once before the first capsule load. Reloads and env-write replacements reuse that write-once snapshot; they do not re-read operator policy. Revocation remains daemon-restart-bound. An unblessed loopback port stays fail-closed.

On this head, a surviving running projection is admitted and flushed before volume-backed restore, and graceful shutdown publishes the live projection before durable stores close. Post-exit CLI retirement still leaves exactly `astrid.volume`. Startup classifies every surviving entry relative to the original runtime root, matching packed-tree exclusion: a stale real `run/system.sock` and other excluded host endpoints are ignored as host-transient, while symlinks, unknown root specials, and specials inside admitted durable namespaces including `run/capsules` fail closed. Store open does not unlink host endpoints before that classification.

Crash recovery may admit only a demonstrably prior running projection. The active-projection receipt remains private durable volume content at `run/.active-projection-v1.json`; it is never a public API, WIT, config, or host sidecar, and it does not overload `runtime-tree-v1.json`. ACTIVE publication scans the host and atomically applies ingests/removals plus ACTIVE receipt rotation in one System catalog CAS. Retirement requires ACTIVE, atomically applies ingests/removals and rotates to RETIRING bound to the newly published inventory, then completes tree preflight/retire; success clears the receipt, and failure retains RETIRING. Startup on RETIRING never infers deletions from host absences; it restores from the durable catalog and writes ACTIVE before serving. Both ACTIVE and RETIRING identity-bind every inventory entry to an exact file object ID. Missing or wrong ACTIVE identities fail closed. Receipt bytes are derived after path inputs are prepared and commit with those mutations in the same owner-root CAS. A derived receipt name that collides with a prepared ingest or exact removal fails before that CAS and publishes neither mutation nor a new root. A copied volume at a new root with only the trusted bootstrap host set restores from volume authority and rotates the receipt to the new root without admitting extra host bytes.

Receipt-less host bootstrap is limited to first volume initialization and directory-store migration. Existing-volume reopen restores with that bootstrap gate closed. Stop-time pack still opens without restore, then opens native staging after the skipped reconcile so pack-open can create exactly one regular `var/content-staging/intents.v1.log`. That pack `None` arm is not widened. Restore writes staged generations before native staging reopens and rebinds their source identities to the restored inode so a later seal cannot drop the journal record.

Runtime E2E keeps artifacts outside `$ASTRID_HOME`, stages redacted upload before artifact deletion, and preserves `openai-compat:fake-echo` on `GET /api/models` after that model is set active. Independent-home isolation writes secondary `etc/gateway-http.toml` and `config.toml` and installs capsules only while that home's public projection is running, then requires one clean stop to leave exactly `astrid.volume` before the harness-owned daemon restart. Astrid still does not read `$AOS_HOME` or any vendor Distro identity. Pre-mount client configuration remains the existing generic `ASTRID_CLIENT_CONFIG_PATH` file outside the volume. Distro apply remains current-principal with no `--target-principal` grant surface.

## Changes

- Canonical media path is `$ASTRID_HOME/astrid.volume`; legacy `volume` and `var/astrid.volume` remain migration inputs only.
- `AstridHome::ensure()` admits an empty root or the owner-only media file and refuses other stopped sidecars.
- Running projections are restored after volume open and packed/retired after confirmed daemon exit.
- Packed capsule sources and layout-migration receipts survive clean stop and restart as running projections.
- Retired legacy `state.db` / CoW content is not restored as a host sidecar.
- A pre-cutover `keys/runtime.key` is admitted into volume content before cleanup and restored as the running identity.
- Stop-time packing uses a no-restore open so mounted Distro pins survive clean stop and restart.
- `ASTRID_RUN_DIR` is honored and blocked from capsule spawn environments.
- Runtime-directory overrides that physically overlap the durable root fail admission before start/status/stop/restart and MCP serve/gateway/ready/attach mutation.
- Stale ready/pid/token markers are not deleted when that admission fails.
- Packed exclusions compare exact names or slash-bounded prefixes so similarly named files are not treated as durable catalog members.
- Layout-migration receipts bind destination authority at cutover without freezing live volume bytes on re-entry; an exact surviving legacy source is retired without that live-volume compare.
- Published materialization expected directories include authenticated archive directory names themselves, not only file parents.
- Durable package reads retain tar directory members; extra files/dirs/symlinks/byte mismatches fail closed.
- Gateway stop no longer creates a durable-root `run/` tree on an already-clean runtime.
- Distro trust tests operate against a mounted projection while preserving pin-first semantics.
- Runtime E2E writes gateway config and installs capsules only after volume-only admission and while the public running projection is mounted, keeps artifacts outside `$ASTRID_HOME`, isolates capsule signing in a disposable home, stages Distro member sources inside the authenticated `Distro.toml` directory through a signed sealed archive, and stages redacted upload before artifact cleanup.
- Named kernel fixtures create only the running parents they need.
- Live activation and replacement bind to the caller's published package and rematerialize that principal's durable projection before load.
- Retirement/quarantine residue is volume-backed and projected only while running.
- Published v0.10.4 Linux/macOS upgrade scripts assert projected layout-version while running and exact volume-only stopped roots after stop.
- Runtime E2E artifact upload globs the live `/tmp` and runner-temp redacted-upload paths and stages before cleanup.
- After admission, bind the admitted-home local-egress allowlist once before first capsule load; reloads reuse that snapshot so `openai-compat:fake-error` surfaces after `PUT /api/models/active`.
- Independent-home isolation no longer writes stopped sidecars: secondary config and capsule install happen on the running projection, one clean stop must leave only `astrid.volume`, and the harness-owned daemon starts after that assertion.
- Ordinary `.next` and `.migrating` files are kept; only canonical transaction staging names are excluded from the packed tree.
- Startup admits a valid surviving host projection before restore so a newer running generation is not rewound to the last packed volume.
- Surviving-projection validation classifies recursive entries from the runtime root, so excluded host endpoints including leftover `run/system.sock` are skipped while durable-namespace specials remain fail-closed.
- Keep the active-projection receipt private in system-owned volume content, refuse unproved host projections, and rotate it before restored state is served.
- ACTIVE and RETIRING receipts identity-bind every inventory entry to an exact file object ID; missing or wrong identities fail closed.
- Derive rotated receipt content after path inputs are immutable and publish it with projected mutations under one owner-root CAS.
- Reject derived names that collide with prepared inputs or exact removals before an owner root can change.
- Rebind a relocated active volume only through the trusted bootstrap-only path; extra host files and malformed receipts fail closed.
- Preflight the complete root before retirement removes any entry, and keep the receipt until publication and every retirement step succeed.
- Require exactly one link on durable volume media and keep durable capsule materialization helpers in their own kernel module.
- Adds `changes/1803.fixed.md`.
- Published v0.10.4 upgrade stop republishes layout-completion host records into ACTIVE, then packs to exactly `astrid.volume`.
- Receipt-less bootstrap sentinels are allowed only during first volume initialization or directory-store migration; existing-volume reopen restores with that gate closed.
- Pack-open still skips restore and keeps the one-file staging-journal exception.
- Restore rebinds staged generation source identities before native staging reopens.
- Restore opens staged generations through a no-follow private-directory capability.
- Failed restore rolls back newly written host files so a later reopen cannot adopt a partial host tree.
- RETIRING is forced only if that rollback cannot restore or remove a destination; ordinary reopen does not append receipt segments.
- Directory-store open is split so Clippy `too-many-lines` stays under 100 without an allow.

## Verification

- Head `e248753558d2eaaa279aad2b73cd6b105180f8b3`; unique-range merge-base `bf602358ef8760d56dc3c8d1e27c65855e396275` (`origin/main`, includes landed #1838).
- Unique range versus `origin/main`:
  - `0a47791c` preserve volume authority on current main
  - `b2a32129` keep ordinary suffix files on stop
  - `67f9fe30` preserve newer projections across restart
  - `f453e261` classify surviving projections from runtime root
  - `7654fadd` bind volume-only projections to active receipts
  - `3762fa68` add retiring projection receipt phases
  - `ffb0eaa5` derive identity-bound projection receipts
  - `cf0c3ba2` reject derived projection name collisions
  - `4ca60893` retire the pack-open staging journal without a receipt
  - `a1983d84` publish layout cutover before volume-only stop
  - `be584882` gate bootstrap recovery and rebind staging
  - `d8e312a0` no-follow staging rebind and clippy split
  - `e2487535` roll back failed projection restores
- Unique range closes #1803 only. `git verify-commit` good, full trust, DCO present on the unique range.
- Local focused gates on this head: `principal_state::runtime_tree` 41/41 including torn-tail reopen length identity, failed-restore no-adoption, and rollback-all-destinations; `cargo clippy -p astrid-storage --all-targets --all-features --locked -- -D warnings` pass; `cargo fmt --check` and `git diff --check` pass on the exclusive successor files.
- Predecessor exact-head verdicts and CI do not transfer.

## Claim boundary

This is a local layout cutover, not a release GO. Independent exact-head review must still execute start/status/stop/restart, MCP serve/gateway/ready overlapping-override no-mutation, corruption/recovery, exact stopped-directory listing, packed capsule and layout-receipt survival after restart, pin-first apply after mount, pin survival across clean stop, runtime signing identity through initialize/restore, same-runtime capsule authority, Distro member sources remaining inside the authenticated `Distro.toml` parent, receipt-versus-live-volume without restoring `state.db`/CoW sidecars, `ASTRID_RUN_DIR` fencing so an override cannot delete `astrid.volume` or mutate stale markers before admission, principal-scoped activation binding, mismatched-materialization fail-closed, nested WIT and authenticated empty-directory activation, extra file/dir/symlink rejection, A/B isolation, restart/upgrade after post-upgrade writes, projected-only layout-version assertions, exact volume-only stopped roots, Runtime E2E fake-echo listing after active-model set, `openai-compat:fake-error` surfacing within the bounded probe after env-write reload, write-once local-egress bind with unblessed-port denial, independent-home running-projection config/install plus exact-volume clean stop, crash-restart across leftover host endpoints without unlinking before store open, fail-closed specials in admitted durable namespaces, no stopped `var/` retirement/quarantine sidecars, ACTIVE/RETIRING identity binding, mixed ingest plus derived-receipt CAS, derived-name collision fail-closed, portable bootstrap-only volume copy, and A+B partial-retire restore. Named `e2e-seal-escape` remains an expected fail. A later Runtime E2E `.capsule` artifact-lifecycle remove of an uninstalled `astrid-capsule-cli` for `regular-user` is a harness residual, not authorization to relax volume-only admission. Local Runtime E2E is evidence, not GO. Unix CI including Runtime E2E must still run on this published SHA. It does not authenticate an AOS release, provision an AOS trust pin, prove selected-Distro apply/invoke through AOS, elect FSKit, or change hosted volume-root reclaim. Predecessor exact-head verdicts and CI do not transfer to this SHA. Over-cap residuals remain in `daemon.rs`, `dirs.rs`, and `crates/astrid-kernel/src/lib.rs` after prior splits. Windows/Wasm `OsStringExt` remains out of this vehicle.

## AI / Tool Assistance

Assisted-by: Codex:glm-5.3-flash, Codex:gpt-5.6-luna

A coding agent implemented the volume-only stopped-root cutover, the stop-time pin-pack repair, the runtime-directory overlap fence, the admit-before-mutate lifecycle checks, the MCP serve/gateway/ready/attach admission gate, the slash-boundary packed exclusions, the pre-cutover runtime-key ingest, the packed-tree restore overlay, the Unix CI successor that retires verified layout sources without freezing live volume bytes, the volume-backed retirement/quarantine records, the principal-scoped published-package activation bind, destination-bound layout-receipt restart after legitimate live-volume mutation, authenticated archive-directory inventory for published materialization, the restack onto current main that moves upgrade/layout proof into the projected window while keeping stopped roots volume-only, the admitted-home local-egress boot bind that preserves the same allowlist across capsule reload, the independent-home Runtime E2E repair that writes secondary runtime config and installs capsules only while the public projection is running, surviving-projection admission before restore, root-relative classification of leftover host endpoints, the private ACTIVE/RETIRING projection receipt, identity-bound inventory entries, derived-receipt owner-root CAS, derived-name collision refusal, first-init-only receipt-less bootstrap, and restore-time staged-generation rebind. The maintainer owns the public layout contract and reviewed the unique range against the existing generic Distro pin-first trust on main.

## Checklist

- [x] Linked issues
- [x] Changelog fragment added under `changes/1803.fixed.md`
- [ ] Independent review complete

