### PR TITLE
fix(release): sign macOS FSKit companion and certify archive bytes

### DIFF
--- a/.github/workflows/native-storage-certification.yml
+++ b/.github/workflows/native-storage-certification.yml
@@ -13,6 +13,11 @@ on:
         required: true
         default: false
         type: boolean
+      consume_same_run_artifacts:
+        description: Leave false. Same-run artifacts exist only when Release calls this workflow.
+        required: false
+        default: false
+        type: boolean
   workflow_call:
     inputs:
       source_commit:
@@ -21,6 +26,10 @@ on:
         type: string
       runner_contract_acknowledged:
         description: Dedicated signed-runner contract acknowledged; this is not runtime or Aqua-session proof
+        required: true
+        type: boolean
+      consume_same_run_artifacts:
+        description: Download binary-<triple> from this calling Release run; do not inspect github.event_name
         required: true
         type: boolean
 
@@ -128,6 +137,7 @@ jobs:
       - name: Resolve the exact release build artifact
         env:
           GH_TOKEN: ${{ github.token }}
+          CONSUME_SAME_RUN: ${{ inputs.consume_same_run_artifacts }}
         run: |
           set -euo pipefail
           case "$(uname -m)" in
@@ -139,10 +149,15 @@ jobs:
               ;;
           esac
           echo "CERT_TRIPLE=$CERT_TRIPLE" >> "$GITHUB_ENV"
-          if [[ "$GITHUB_EVENT_NAME" == workflow_call ]]; then
+          # github.event_name is the caller event in a reusable workflow, not workflow_call.
+          if [[ "$CONSUME_SAME_RUN" == true ]]; then
             echo "CERT_ARTIFACT_SOURCE=same-run" >> "$GITHUB_ENV"
             exit 0
           fi
+          [[ "$GITHUB_REF" == refs/heads/main ]] || {
+            echo "standalone native FSKit certification may be dispatched only from protected main" >&2
+            exit 1
+          }
           RUN_ID=$(gh api --paginate \
             "repos/$GITHUB_REPOSITORY/actions/runs?head_sha=$SOURCE_COMMIT" \
             --jq '[.workflow_runs[] |

--- a/.github/workflows/native-storage-certification.yml
+++ b/.github/workflows/native-storage-certification.yml
@@ -175,6 +175,7 @@ jobs:
           }
           {
             echo "CERT_ARTIFACT_SOURCE=release-run"
+            echo "CERT_RELEASE_RUN_ID=$RUN_ID"
             echo "CERT_ARTIFACT_ID=$ARTIFACT_ID"
           } >> "$GITHUB_ENV"
 
@@ -189,7 +190,8 @@ jobs:
         if: env.CERT_ARTIFACT_SOURCE == 'release-run'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          artifact-id: ${{ env.CERT_ARTIFACT_ID }}
+          artifact-ids: ${{ env.CERT_ARTIFACT_ID }}
+          run-id: ${{ env.CERT_RELEASE_RUN_ID }}
           path: ${{ runner.temp }}/fskit-cert-artifact
           github-token: ${{ github.token }}
 

--- a/.github/workflows/native-storage-certification.yml
+++ b/.github/workflows/native-storage-certification.yml
@@ -213,7 +213,7 @@ jobs:
           EXPECTED_VERSION=${EXPECTED_VERSION%-"$CERT_TRIPLE"}
           install -d -m 0700 \
             "$CERT_ROOT" "$CERT_BIN" "$ASTRID_HOME" \
-            "$MOUNTPOINT_INITIAL"
+            "$RELEASE_STAGE" "$MOUNTPOINT_INITIAL"
           chmod -N "$CERT_ROOT" "$CERT_BIN" "$ASTRID_HOME" \
             "$RELEASE_STAGE" "$MOUNTPOINT_INITIAL" 2>/dev/null || true
           tar -xzf "$ARCHIVE" -C "$RELEASE_STAGE"

--- a/.github/workflows/native-storage-certification.yml
+++ b/.github/workflows/native-storage-certification.yml
@@ -13,17 +13,26 @@ on:
         required: true
         default: false
         type: boolean
+  workflow_call:
+    inputs:
+      source_commit:
+        description: Exact 40-character source commit selected for this workflow run
+        required: true
+        type: string
+      runner_contract_acknowledged:
+        description: Dedicated signed-runner contract acknowledged; this is not runtime or Aqua-session proof
+        required: true
+        type: boolean
 
 permissions:
   contents: read
+  actions: read
 
 concurrency:
   group: native-fskit-certification
   cancel-in-progress: false
 
 env:
-  CARGO_TERM_COLOR: always
-  RUST_BACKTRACE: "1"
   ASTRID_FSKIT_APP_DEST: /Applications/AstridFS.app
 
 jobs:
@@ -38,29 +47,26 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-          submodules: recursive
-
       - name: Establish isolated certification paths
         run: |
           set -euo pipefail
           CERT_ROOT="$RUNNER_TEMP/astrid-fskit-cert-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           {
             echo "CERT_ROOT=$CERT_ROOT"
-            echo "CARGO_TARGET_DIR=$CERT_ROOT/cargo-target"
             echo "ASTRID_HOME=$CERT_ROOT/home"
             echo "CERT_BIN=$CERT_ROOT/bin"
+            echo "ASTRID_FSKIT_BIN_DIR=$CERT_ROOT/bin"
             echo "RELEASE_STAGE=$CERT_ROOT/release"
             echo "MOUNTPOINT_INITIAL=$CERT_ROOT/mount-initial"
-            echo "MOUNTPOINT_IGNORED_TEST=$CERT_ROOT/mount-ignored-test"
-            echo "ASTRID_FSKIT_OUTPUT_ROOT=$CERT_ROOT/macos-fskit"
-            echo "ASTRID_FSKIT_BIN_DIR=$CERT_ROOT/bin"
           } >> "$GITHUB_ENV"
 
-      - name: Bind certification to the check-run commit
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: main
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Bind certification to protected-main source
         env:
           ACKNOWLEDGED: ${{ inputs.runner_contract_acknowledged }}
           REQUESTED_SOURCE: ${{ inputs.source_commit }}
@@ -74,13 +80,21 @@ jobs:
             echo "source_commit must be an exact lowercase 40-character commit" >&2
             exit 1
           }
-          EVENT_SOURCE=$(git rev-parse "${GITHUB_SHA}^{commit}")
-          CHECKED_OUT_SOURCE=$(git rev-parse 'HEAD^{commit}')
-          [[ "$REQUESTED_SOURCE" == "$EVENT_SOURCE" ]]
-          [[ "$CHECKED_OUT_SOURCE" == "$EVENT_SOURCE" ]]
+          git fetch --no-tags origin main
+          git merge-base --is-ancestor "$REQUESTED_SOURCE" origin/main || {
+            echo "source_commit $REQUESTED_SOURCE is not an ancestor of protected origin/main" >&2
+            exit 1
+          }
+          [[ "$(git rev-parse "$REQUESTED_SOURCE^{commit}")" == "$REQUESTED_SOURCE" ]] || {
+            echo "source_commit must be the exact full commit SHA" >&2
+            exit 1
+          }
+          git checkout --detach --force "$REQUESTED_SOURCE"
+          [[ "$(git rev-parse 'HEAD^{commit}')" == "$REQUESTED_SOURCE" ]]
           git verify-commit "$REQUESTED_SOURCE^{commit}"
           git diff --exit-code
           git diff --cached --exit-code
+          echo "SOURCE_COMMIT=$REQUESTED_SOURCE" >> "$GITHUB_ENV"
 
       - name: Require the dedicated native runner
         run: |
@@ -111,87 +125,113 @@ jobs:
             exit 1
           fi
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-        with:
-          toolchain: "1.95.0"
-
-      - name: Build the kernel, CLI, and FSKit companion
+      - name: Resolve the exact release build artifact
         env:
-          ASTRID_FSKIT_CODE_SIGN_IDENTITY: ${{ secrets.ASTRID_FSKIT_CODE_SIGN_IDENTITY }}
-          ASTRID_FSKIT_DEVELOPMENT_TEAM: ${{ secrets.ASTRID_FSKIT_DEVELOPMENT_TEAM }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          ASTRID_VERSION=$(sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -n 1)
-          [[ -n "$ASTRID_VERSION" ]]
-          echo "ASTRID_VERSION=$ASTRID_VERSION" >> "$GITHUB_ENV"
-          echo "ASTRID_FSKIT_EXPECTED_VERSION=$ASTRID_VERSION" >> "$GITHUB_ENV"
+          case "$(uname -m)" in
+            arm64) CERT_TRIPLE=aarch64-apple-darwin ;;
+            x86_64) CERT_TRIPLE=x86_64-apple-darwin ;;
+            *)
+              echo "unsupported macOS runner architecture: $(uname -m)" >&2
+              exit 1
+              ;;
+          esac
+          echo "CERT_TRIPLE=$CERT_TRIPLE" >> "$GITHUB_ENV"
+          if [[ "$GITHUB_EVENT_NAME" == workflow_call ]]; then
+            echo "CERT_ARTIFACT_SOURCE=same-run" >> "$GITHUB_ENV"
+            exit 0
+          fi
+          RUN_ID=$(gh api --paginate \
+            "repos/$GITHUB_REPOSITORY/actions/runs?head_sha=$SOURCE_COMMIT" \
+            --jq '[.workflow_runs[] |
+              select(.name == "Release" and .conclusion == "success")][0].id // empty')
+          [[ -n "$RUN_ID" ]] || {
+            echo "no successful Release workflow run exists for $SOURCE_COMMIT" >&2
+            exit 1
+          }
+          ARTIFACT_ID=$(gh api \
+            "repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID/artifacts?per_page=100" \
+            --jq "[.artifacts[] | select(.name == \"binary-$CERT_TRIPLE\" and .expired == false)][0].id // empty")
+          [[ -n "$ARTIFACT_ID" ]] || {
+            echo "successful Release run $RUN_ID has no binary-$CERT_TRIPLE artifact for $SOURCE_COMMIT" >&2
+            exit 1
+          }
+          {
+            echo "CERT_ARTIFACT_SOURCE=release-run"
+            echo "CERT_ARTIFACT_ID=$ARTIFACT_ID"
+          } >> "$GITHUB_ENV"
+
+      - name: Download the same-run build artifact
+        if: env.CERT_ARTIFACT_SOURCE == 'same-run'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: binary-${{ env.CERT_TRIPLE }}
+          path: ${{ runner.temp }}/fskit-cert-artifact
+
+      - name: Download the released build artifact for the certified source
+        if: env.CERT_ARTIFACT_SOURCE == 'release-run'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-id: ${{ env.CERT_ARTIFACT_ID }}
+          path: ${{ runner.temp }}/fskit-cert-artifact
+          github-token: ${{ github.token }}
+
+      - name: Stage the exact release bytes
+        run: |
+          set -euo pipefail
+          DOWNLOAD_DIR="$RUNNER_TEMP/fskit-cert-artifact"
+          ARCHIVES=$(find "$DOWNLOAD_DIR" -maxdepth 1 -type f -name '*.tar.gz')
+          [[ "$(printf '%s\n' "$ARCHIVES" | grep -c .)" -eq 1 ]] || {
+            echo "the artifact must contain exactly one archive, got:" >&2
+            printf '%s\n' "$ARCHIVES" >&2
+            exit 1
+          }
+          ARCHIVE="$ARCHIVES"
+          EXPECTED_VERSION=$(basename "$ARCHIVE" .tar.gz)
+          EXPECTED_VERSION=${EXPECTED_VERSION#astrid-}
+          [[ -n "$EXPECTED_VERSION" && "$EXPECTED_VERSION" == *"-$CERT_TRIPLE" ]] || {
+            echo "the archive does not name $CERT_TRIPLE bytes: $ARCHIVE" >&2
+            exit 1
+          }
+          EXPECTED_VERSION=${EXPECTED_VERSION%-"$CERT_TRIPLE"}
           install -d -m 0700 \
             "$CERT_ROOT" "$CERT_BIN" "$ASTRID_HOME" \
-            "$RELEASE_STAGE/macos" "$MOUNTPOINT_INITIAL" "$MOUNTPOINT_IGNORED_TEST"
+            "$MOUNTPOINT_INITIAL"
           chmod -N "$CERT_ROOT" "$CERT_BIN" "$ASTRID_HOME" \
-            "$RELEASE_STAGE" "$RELEASE_STAGE/macos" \
-            "$MOUNTPOINT_INITIAL" "$MOUNTPOINT_IGNORED_TEST" 2>/dev/null || true
-          cargo build --locked --release \
-            -p astrid --bins \
-            -p astrid-storage-provider-fskit
-          install -m 0755 "$CARGO_TARGET_DIR/release/astrid" "$CERT_BIN/astrid"
-          install -m 0755 "$CARGO_TARGET_DIR/release/astrid-daemon" "$CERT_BIN/astrid-daemon"
-          [[ "$("$CERT_BIN/astrid" --version)" == "astrid $ASTRID_VERSION" ]]
-          PROVIDER_SOURCE_VERSION=$(cargo metadata --locked --no-deps --format-version 1 \
-            | jq -er '.packages[] | select(.name == "astrid-storage-provider-fskit") | .version')
-          [[ "$PROVIDER_SOURCE_VERSION" == "$ASTRID_VERSION" ]]
-          if [[ -z "$ASTRID_FSKIT_CODE_SIGN_IDENTITY" ]]; then
-            ASTRID_FSKIT_CODE_SIGN_IDENTITY="Developer ID Application"
-            export ASTRID_FSKIT_CODE_SIGN_IDENTITY
-          fi
-          security find-identity -v -p codesigning \
-            | grep -F "$ASTRID_FSKIT_CODE_SIGN_IDENTITY" >/dev/null
-          COMPANION_BINARY="$CARGO_TARGET_DIR/release/astrid-storage-provider-fskit"
-          COMPANION_IDENTIFIER=org.astrid.runtime.fs.storage-provider-fskit
-          codesign --force --options runtime --timestamp \
-            --identifier "$COMPANION_IDENTIFIER" \
-            --sign "$ASTRID_FSKIT_CODE_SIGN_IDENTITY" "$COMPANION_BINARY"
-          codesign --verify --strict --verbose=2 "$COMPANION_BINARY"
-          COMPANION_SIGNATURE="$(codesign --display --verbose=4 "$COMPANION_BINARY" 2>&1)"
-          grep -Fx "Identifier=$COMPANION_IDENTIFIER" <<<"$COMPANION_SIGNATURE" >/dev/null
-          grep -Fx "TeamIdentifier=9BDSL5BJAP" <<<"$COMPANION_SIGNATURE" >/dev/null
-          install -m 0755 "$COMPANION_BINARY" \
-            "$RELEASE_STAGE/astrid-storage-provider-fskit"
+            "$RELEASE_STAGE" "$MOUNTPOINT_INITIAL" 2>/dev/null || true
+          tar -xzf "$ARCHIVE" -C "$RELEASE_STAGE"
+          ARCHIVE_DIR="$RELEASE_STAGE/astrid-$EXPECTED_VERSION-$CERT_TRIPLE"
+          [[ -d "$ARCHIVE_DIR" ]]
+          [[ -x "$ARCHIVE_DIR/astrid" && -x "$ARCHIVE_DIR/astrid-daemon" \
+            && -x "$ARCHIVE_DIR/astrid-storage-provider-fskit" ]]
+          [[ -d "$ARCHIVE_DIR/AstridFS.app" ]]
+          [[ -x "$ARCHIVE_DIR/macos/manage-macos-fskit.sh" \
+            && -x "$ARCHIVE_DIR/macos/validate-macos-fskit.sh" ]]
+          install -m 0755 "$ARCHIVE_DIR/astrid" "$ARCHIVE_DIR/astrid-daemon" \
+            "$ARCHIVE_DIR/astrid-storage-provider-fskit" "$CERT_BIN/"
+          {
+            echo "CERT_ARCHIVE_DIR=$ARCHIVE_DIR"
+            echo "ASTRID_VERSION=$EXPECTED_VERSION"
+          } >> "$GITHUB_ENV"
 
-      - name: Build, sign, and notarize the FSKit app
+      - name: Validate the extracted release bundle
         env:
-          ASTRID_FSKIT_CODE_SIGN_IDENTITY: ${{ secrets.ASTRID_FSKIT_CODE_SIGN_IDENTITY }}
-          ASTRID_FSKIT_DEVELOPMENT_TEAM: ${{ secrets.ASTRID_FSKIT_DEVELOPMENT_TEAM }}
-          ASTRID_FSKIT_NOTARY_PROFILE: ${{ secrets.ASTRID_FSKIT_NOTARY_PROFILE }}
-          ASTRID_FSKIT_NOTARIZE: "1"
+          ASTRID_FSKIT_EXPECTED_VERSION: ${{ env.ASTRID_VERSION }}
         run: |
           set -euo pipefail
-          if [[ -z "$ASTRID_FSKIT_CODE_SIGN_IDENTITY" ]]; then
-            ASTRID_FSKIT_CODE_SIGN_IDENTITY="Developer ID Application"
-            export ASTRID_FSKIT_CODE_SIGN_IDENTITY
-          fi
-          scripts/build-macos-fskit.sh
-          APP_PATH="$ASTRID_FSKIT_OUTPUT_ROOT/DerivedData/Build/Products/Release/AstridFS.app"
-          [[ -d "$APP_PATH" ]]
-          ditto "$APP_PATH" "$RELEASE_STAGE/AstridFS.app"
-          install -m 0755 \
-            scripts/manage-macos-fskit.sh \
-            "$RELEASE_STAGE/macos/manage-macos-fskit.sh"
-          install -m 0755 \
-            scripts/validate-macos-fskit.sh \
-            "$RELEASE_STAGE/macos/validate-macos-fskit.sh"
-          ASTRID_FSKIT_EXPECTED_VERSION="$ASTRID_VERSION" \
-            "$RELEASE_STAGE/macos/validate-macos-fskit.sh" "$RELEASE_STAGE/AstridFS.app"
+          "$CERT_ARCHIVE_DIR/macos/validate-macos-fskit.sh" "$CERT_ARCHIVE_DIR/AstridFS.app"
+          [[ "$("$CERT_BIN/astrid" --version)" == "astrid $ASTRID_VERSION" ]]
 
       - name: Install and activate the signed extension
         run: |
           set -euo pipefail
           ASTRID_FSKIT_APP_DEST="$ASTRID_FSKIT_APP_DEST" \
           ASTRID_FSKIT_BIN_DIR="$ASTRID_FSKIT_BIN_DIR" \
-            "$RELEASE_STAGE/macos/manage-macos-fskit.sh" install
+            "$CERT_ARCHIVE_DIR/macos/manage-macos-fskit.sh" install
           ASTRID_FSKIT_EXPECTED_VERSION="$ASTRID_VERSION" \
-            "$RELEASE_STAGE/macos/manage-macos-fskit.sh" validate
+            "$CERT_ARCHIVE_DIR/macos/manage-macos-fskit.sh" validate
           open -gj "$ASTRID_FSKIT_APP_DEST"
           for _ in {1..30}; do
             /usr/bin/pluginkit -m -A -D -i org.astrid.runtime.fs.AppEx \
@@ -204,7 +244,7 @@ jobs:
           # A discovered but ignored extension must fail closed with exact
           # operator remediation; a containing app process is not election.
           /usr/bin/pluginkit -e ignore -i org.astrid.runtime.fs.AppEx
-          if "$RELEASE_STAGE/macos/manage-macos-fskit.sh" status \
+          if "$CERT_ARCHIVE_DIR/macos/manage-macos-fskit.sh" status \
             >"$CERT_ROOT/ignored-status.out" 2>"$CERT_ROOT/ignored-status.err"; then
             echo "ignored FSKit extension unexpectedly passed lifecycle status" >&2
             exit 1
@@ -213,9 +253,9 @@ jobs:
             "$CERT_ROOT/ignored-status.err"
 
           /usr/bin/pluginkit -e use -i org.astrid.runtime.fs.AppEx
-          "$RELEASE_STAGE/macos/manage-macos-fskit.sh" enable
-          "$RELEASE_STAGE/macos/manage-macos-fskit.sh" status
-          "$RELEASE_STAGE/macos/manage-macos-fskit.sh" check-process
+          "$CERT_ARCHIVE_DIR/macos/manage-macos-fskit.sh" enable
+          "$CERT_ARCHIVE_DIR/macos/manage-macos-fskit.sh" status
+          "$CERT_ARCHIVE_DIR/macos/manage-macos-fskit.sh" check-process
 
           for _ in {1..30}; do
             pgrep -x AstridFS >/dev/null && break
@@ -235,7 +275,7 @@ jobs:
           grep -Fq 'type="UIElement"' <<<"$APP_INFO"
           ! grep -Fq 'type="Foreground"' <<<"$APP_INFO"
 
-      - name: Exercise a real mount and the ignored native round-trip
+      - name: Exercise a real mount and the released native round-trip
         run: |
           set -euo pipefail
           "$CERT_BIN/astrid" --principal default start
@@ -293,16 +333,6 @@ jobs:
           /sbin/umount "$MOUNTPOINT_INITIAL"
           [[ "$(stat -f %T "$MOUNTPOINT_INITIAL")" != astridfs ]]
 
-          ASTRID_FSKIT_ACTUAL_RESOURCE="$RESOURCE" \
-          ASTRID_FSKIT_ACTUAL_MOUNTPOINT="$MOUNTPOINT_IGNORED_TEST" \
-          ASTRID_FSKIT_ACTUAL_MOUNT_ID="$MOUNT_ID" \
-          ASTRID_FSKIT_ACTUAL_TOKEN="$LEASE_TOKEN" \
-            cargo test --locked --release \
-              -p astrid-storage-provider-fskit \
-              tests::actual_fskit_mount_and_unmount_round_trip -- \
-              --ignored --exact --nocapture --test-threads=1
-          [[ "$(stat -f %T "$MOUNTPOINT_IGNORED_TEST")" != astridfs ]]
-
           "$CERT_BIN/astrid" --principal default storage unmount "$MOUNTPOINT_INITIAL"
           [[ ! -e "$RESOURCE" ]]
           if "$CERT_BIN/astrid" --principal default storage status "$MOUNTPOINT_INITIAL" \
@@ -317,21 +347,19 @@ jobs:
         run: |
           set +e
           cleanup_status=0
-          for mountpoint in "$MOUNTPOINT_IGNORED_TEST" "$MOUNTPOINT_INITIAL"; do
-            if [[ -d "$mountpoint" && "$(stat -f %T "$mountpoint" 2>/dev/null)" == astridfs ]]; then
-              /sbin/umount "$mountpoint" || cleanup_status=1
-            fi
-          done
+          if [[ -d "$MOUNTPOINT_INITIAL" && "$(stat -f %T "$MOUNTPOINT_INITIAL" 2>/dev/null)" == astridfs ]]; then
+            /sbin/umount "$MOUNTPOINT_INITIAL" || cleanup_status=1
+          fi
           if [[ -x "$CERT_BIN/astrid" ]]; then
             "$CERT_BIN/astrid" --principal default storage unmount "$MOUNTPOINT_INITIAL" \
               >/dev/null 2>&1 || true
             "$CERT_BIN/astrid" --principal default stop >/dev/null 2>&1 || true
           fi
           pkill -x AstridFS >/dev/null 2>&1 || true
-          if [[ -d "$ASTRID_FSKIT_APP_DEST" && -x "$RELEASE_STAGE/macos/manage-macos-fskit.sh" ]]; then
+          if [[ -d "$ASTRID_FSKIT_APP_DEST" && -x "$CERT_ARCHIVE_DIR/macos/manage-macos-fskit.sh" ]]; then
             ASTRID_FSKIT_APP_DEST="$ASTRID_FSKIT_APP_DEST" \
             ASTRID_FSKIT_BIN_DIR="$ASTRID_FSKIT_BIN_DIR" \
-              "$RELEASE_STAGE/macos/manage-macos-fskit.sh" uninstall \
+              "$CERT_ARCHIVE_DIR/macos/manage-macos-fskit.sh" uninstall \
               || cleanup_status=1
           fi
           case "$CERT_ROOT" in

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,6 +207,34 @@ jobs:
           scripts/build-macos-fskit.sh
           echo "ASTRID_FSKIT_APP=$PWD/target/macos-fskit/DerivedData/Build/Products/Release/AstridFS.app" >> "$GITHUB_ENV"
 
+      - name: Sign the macOS FSKit companion
+        if: contains(matrix.target, 'apple-darwin')
+        env:
+          ASTRID_MACOS_DEVELOPMENT_TEAM_ID: ${{ secrets.ASTRID_MACOS_DEVELOPMENT_TEAM_ID }}
+          MACOS_DEVELOPER_ID_IDENTITY: ${{ vars.ASTRID_MACOS_DEVELOPER_ID_IDENTITY }}
+        run: |
+          set -euo pipefail
+          COMPANION_TEAM=9BDSL5BJAP
+          COMPANION_IDENTIFIER=org.astrid.runtime.fs.storage-provider-fskit
+          COMPANION="$PWD/target/${{ matrix.target }}/release/astrid-storage-provider-fskit"
+          [[ -f "$COMPANION" && -x "$COMPANION" ]]
+          [[ -n "$ASTRID_MACOS_DEVELOPMENT_TEAM_ID" ]] || {
+            echo "ASTRID_MACOS_DEVELOPMENT_TEAM_ID is not configured for the FSKit companion" >&2
+            exit 1
+          }
+          [[ "$ASTRID_MACOS_DEVELOPMENT_TEAM_ID" == "$COMPANION_TEAM" ]] || {
+            echo "ASTRID_MACOS_DEVELOPMENT_TEAM_ID does not match the required team $COMPANION_TEAM" >&2
+            exit 1
+          }
+          IDENTITY="${MACOS_DEVELOPER_ID_IDENTITY:-Developer ID Application}"
+          codesign --force --options runtime --timestamp \
+            --identifier "$COMPANION_IDENTIFIER" \
+            --sign "$IDENTITY" "$COMPANION"
+          COMPANION_SIGNATURE="$(codesign --display --verbose=4 "$COMPANION" 2>&1)"
+          grep -Fx "Identifier=$COMPANION_IDENTIFIER" <<<"$COMPANION_SIGNATURE" >/dev/null
+          grep -Fx "TeamIdentifier=$COMPANION_TEAM" <<<"$COMPANION_SIGNATURE" >/dev/null
+          codesign --verify --strict --verbose=2 "$COMPANION"
+
       - name: Select native binary root
         if: matrix.libc == 'native'
         run: echo "BINARY_ROOT=target/${{ matrix.target }}/release" >> "$GITHUB_ENV"
@@ -374,6 +402,7 @@ jobs:
             rm -rf "$EXTRACTION"
             mkdir -p "$EXTRACTION"
             tar -xzf "${DIR}.tar.gz" -C "$EXTRACTION"
+            export ASTRID_FSKIT_EXPECTED_VERSION="$VERSION"
             scripts/validate-macos-fskit.sh "$EXTRACTION/$DIR/AstridFS.app"
           else
             if [[ "$TARGET" == *-unknown-linux-* ]]; then
@@ -391,10 +420,18 @@ jobs:
           name: binary-${{ matrix.target }}
           path: ${{ env.ASSET }}
 
+  fskit-certification:
+    name: Native storage certification gate
+    needs: [classify, build]
+    uses: ./.github/workflows/native-storage-certification.yml
+    with:
+      source_commit: ${{ needs.classify.outputs.source-commit }}
+      runner_contract_acknowledged: true
+
   # ── Create the GitHub release with all binaries ───────────────────
   github-release:
     name: GitHub Release
-    needs: [classify, build]
+    needs: [classify, build, fskit-certification]
     runs-on: ubuntu-latest
     environment: release
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -421,12 +421,16 @@ jobs:
           path: ${{ env.ASSET }}
 
   fskit-certification:
-    name: Native storage certification gate
+    name: Native FSKit mount certification
     needs: [classify, build]
     uses: ./.github/workflows/native-storage-certification.yml
+    permissions:
+      contents: read
+      actions: read
     with:
       source_commit: ${{ needs.classify.outputs.source-commit }}
       runner_contract_acknowledged: true
+      consume_same_run_artifacts: true
 
   # ── Create the GitHub release with all binaries ───────────────────
   github-release:
@@ -848,7 +852,8 @@ jobs:
             --arg name "$CERTIFICATION_CHECK" \
             --arg source "$SOURCE_COMMIT" \
             '[.[] | .check_runs[] |
-              select(.name == $name and .head_sha == $source and
+              select((.name == $name or (.name | endswith(" / " + $name))) and
+                     .head_sha == $source and
                      .app.slug == "github-actions")] |
              sort_by(.started_at) | last |
              .status == "completed" and .conclusion == "success"' \

--- a/changes/1817.fixed.md
+++ b/changes/1817.fixed.md
@@ -1,0 +1,5 @@
+macOS release archives now ship the FSKit storage companion signed with the
+pinned Developer ID team and verify the companion's identity, team, and
+version next to AstridFS.app. Native FSKit mount certification consumes the
+exact released build artifacts for the certified commit instead of rebuilding
+the CLI, daemon, companion, or app.

--- a/scripts/ci/test-release-contracts.sh
+++ b/scripts/ci/test-release-contracts.sh
@@ -17,3 +17,4 @@ python3 scripts/test_channel_metadata.py
 python3 scripts/test_channel_publication.py
 python3 scripts/test_nightly_version.py
 bash scripts/test_channel_workflow_contract.sh
+bash scripts/test_native_storage_certification_contract.sh

--- a/scripts/test_native_storage_certification_contract.sh
+++ b/scripts/test_native_storage_certification_contract.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+workflow="$repo_root/.github/workflows/native-storage-certification.yml"
+
+python3 - "$workflow" <<'PY'
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+workflow_path = Path(sys.argv[1])
+text = workflow_path.read_text(encoding="utf-8")
+
+
+def fail(message: str) -> None:
+    print(f"native storage certification workflow contract: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def step_block(name: str) -> str:
+    marker = f"      - name: {name}\n"
+    start = text.find(marker)
+    if start < 0:
+        fail(f"missing step: {name}")
+    body_start = start + len(marker)
+    next_step = re.search(r"^      - name: ", text[body_start:], flags=re.MULTILINE)
+    end = body_start + next_step.start() if next_step else len(text)
+    return text[body_start:end]
+
+
+resolver = step_block("Resolve the exact release build artifact")
+source_binding = step_block("Bind certification to protected-main source")
+same_run = step_block("Download the same-run build artifact")
+release_run = step_block("Download the released build artifact for the certified source")
+
+
+def require(pattern: str, body: str, description: str) -> None:
+    if not re.search(pattern, body, flags=re.MULTILINE):
+        fail(f"missing {description}")
+
+
+def require_persisted_echo(variable: str, value: str, description: str) -> None:
+    lines = resolver.splitlines()
+    echo = f'echo "{variable}={value}"'
+    for index, line in enumerate(lines):
+        if echo not in line:
+            continue
+        if re.search(r'>>\s*"\$GITHUB_ENV"', line):
+            return
+        # Accept the shell's grouped form: { echo ...; } >> "$GITHUB_ENV".
+        opening = next(
+            (candidate for candidate in range(index - 1, -1, -1) if lines[candidate].strip() == "{"),
+            None,
+        )
+        if opening is None:
+            continue
+        if any(
+            re.search(r'^\s*\}\s*>>\s*"\$GITHUB_ENV"\s*$', lines[candidate])
+            for candidate in range(index + 1, len(lines))
+        ):
+            return
+    fail(f"missing {description}")
+
+
+# The standalone path must resolve a successful Release run and carry both
+# identifiers into the action step; an artifact id alone searches this run.
+require_persisted_echo("CERT_ARTIFACT_SOURCE", "release-run", "release-run source persistence")
+require_persisted_echo("CERT_RELEASE_RUN_ID", "$RUN_ID", "CERT_RELEASE_RUN_ID persistence")
+require_persisted_echo("CERT_ARTIFACT_ID", "$ARTIFACT_ID", "CERT_ARTIFACT_ID persistence")
+
+if re.search(r"^\s*artifact-id\s*:", text, flags=re.MULTILINE):
+    fail("singular artifact-id is unsupported; use artifact-ids")
+require(r"^\s*if: env\.CERT_ARTIFACT_SOURCE == 'release-run'\s*$", release_run, "release-run condition")
+require(
+    r"^\s*uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c\s+# v8\.0\.1\s*$",
+    release_run,
+    "pinned release-run artifact action",
+)
+require(r"^\s*artifact-ids: \$\{\{ env\.CERT_ARTIFACT_ID \}\}\s*$", release_run, "release-run artifact-ids")
+require(r"^\s*run-id: \$\{\{ env\.CERT_RELEASE_RUN_ID \}\}\s*$", release_run, "release-run run-id")
+require(r"^\s*github-token: \$\{\{ github\.token \}\}\s*$", release_run, "release-run github-token")
+require(
+    r"^\s*path: \$\{\{ runner\.temp \}\}/fskit-cert-artifact\s*$",
+    release_run,
+    "release-run artifact path",
+)
+
+# Same-run artifacts are looked up by name in the calling Release run. Keep
+# this branch distinct from the cross-run id-based download contract.
+require(r"^\s*if: env\.CERT_ARTIFACT_SOURCE == 'same-run'\s*$", same_run, "same-run condition")
+require(
+    r"^\s*uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c\s+# v8\.0\.1\s*$",
+    same_run,
+    "pinned same-run artifact action",
+)
+require(r"^\s*name: binary-\$\{\{ env\.CERT_TRIPLE \}\}\s*$", same_run, "same-run artifact name")
+require(
+    r"^\s*path: \$\{\{ runner\.temp \}\}/fskit-cert-artifact\s*$",
+    same_run,
+    "same-run artifact path",
+)
+if re.search(r"^\s*(?:artifact-ids|run-id|github-token)\s*:", same_run, flags=re.MULTILINE):
+    fail("same-run download must remain name-based without cross-run selectors")
+
+# Protected-main dispatch and exact source binding are independent gates.
+require(r'^\s*\[\[ "\$GITHUB_REF" == refs/heads/main \]\]', resolver, "protected-main standalone gate")
+require(
+    r'^\s*\[\[ "\$REQUESTED_SOURCE" =~ \^\[0-9a-f\]\{40\}\$ \]\]',
+    source_binding,
+    "exact source SHA shape gate",
+)
+require(
+    r'git merge-base --is-ancestor "\$REQUESTED_SOURCE" origin/main',
+    source_binding,
+    "protected-main ancestor proof",
+)
+require(
+    r'git checkout --detach --force "\$REQUESTED_SOURCE"',
+    source_binding,
+    "detached source checkout",
+)
+require(
+    r"\[\[ \"\$\(git rev-parse 'HEAD\^\{commit\}'\)\" == \"\$REQUESTED_SOURCE\" \]\]",
+    source_binding,
+    "exact detached source binding",
+)
+require(
+    r'echo "SOURCE_COMMIT=\$REQUESTED_SOURCE"\s*>> "\$GITHUB_ENV"',
+    source_binding,
+    "SOURCE_COMMIT environment binding",
+)
+
+# A reusable workflow is selected through its inputs, never by comparing the
+# caller event name with the literal workflow_call trigger.
+if re.search(
+    r"(?:github\.event_name\s*(?:==|!=|===|!==)\s*['\"]workflow_call['\"]|['\"]workflow_call['\"]\s*(?:==|!=|===|!==)\s*github\.event_name)",
+    text,
+):
+    fail("must not compare github.event_name to workflow_call")
+
+print("native storage certification workflow contract: PASS")
+PY

--- a/scripts/validate-macos-fskit.sh
+++ b/scripts/validate-macos-fskit.sh
@@ -49,3 +49,22 @@ ENTITLEMENTS="$(codesign --display --entitlements - "$EXTENSION_PATH" 2>/dev/nul
 grep -Fq "com.apple.developer.fskit.fsmodule" <<<"$ENTITLEMENTS"
 xcrun stapler validate "$APP_PATH"
 spctl -a -vvv -t exec "$APP_PATH"
+
+COMPANION_PATH="$(dirname "$APP_PATH")/astrid-storage-provider-fskit"
+COMPANION_IDENTIFIER=org.astrid.runtime.fs.storage-provider-fskit
+if [[ -e "$COMPANION_PATH" ]]; then
+  [[ -f "$COMPANION_PATH" && -x "$COMPANION_PATH" ]]
+  codesign --verify --strict --verbose=2 "$COMPANION_PATH"
+  signature="$(codesign --display --verbose=4 "$COMPANION_PATH" 2>&1)"
+  grep -Fx "Identifier=$COMPANION_IDENTIFIER" <<<"$signature" >/dev/null
+  grep -Fx "TeamIdentifier=$CODE_SIGN_TEAM" <<<"$signature" >/dev/null
+  PROVIDER_OUTPUT="$(printf '%s\n' \
+    "{\"protocol_version\":1,\"request_id\":\"$(uuidgen)\",\"acting_principal_hint\":\"default\",\"operation\":{\"operation\":\"status\",\"selector\":{\"kind\":\"native-path\",\"value\":\"/\"}}}" \
+    | "$COMPANION_PATH" --astrid-provider-stdio-v1)"
+  PROVIDER_VERSION="$(sed -nE 's/.*"name":"astrid-storage-provider-fskit","version":"([^"]+)".*/\1/p' \
+    <<<"$PROVIDER_OUTPUT" | head -n 1)"
+  [[ -n "$PROVIDER_VERSION" && "$PROVIDER_VERSION" == "$APP_RELEASE_VERSION" ]] || {
+    echo "FSKit companion version '$PROVIDER_VERSION' does not match AstridFS $APP_RELEASE_VERSION" >&2
+    exit 1
+  }
+fi

--- a/scripts/validate-macos-fskit.sh
+++ b/scripts/validate-macos-fskit.sh
@@ -59,7 +59,7 @@ if [[ -e "$COMPANION_PATH" ]]; then
   grep -Fx "Identifier=$COMPANION_IDENTIFIER" <<<"$signature" >/dev/null
   grep -Fx "TeamIdentifier=$CODE_SIGN_TEAM" <<<"$signature" >/dev/null
   PROVIDER_OUTPUT="$(printf '%s\n' \
-    "{\"protocol_version\":1,\"request_id\":\"$(uuidgen)\",\"acting_principal_hint\":\"default\",\"operation\":{\"operation\":\"status\",\"selector\":{\"kind\":\"native-path\",\"value\":\"/\"}}}" \
+    "{\"protocol_version\":1,\"request_id\":\"$(/usr/bin/uuidgen)\",\"acting_principal_hint\":\"default\",\"operation\":{\"operation\":\"status\",\"selector\":{\"kind\":\"native-path\",\"value\":\"/\"}}}" \
     | "$COMPANION_PATH" --astrid-provider-stdio-v1)"
   PROVIDER_VERSION="$(sed -nE 's/.*"name":"astrid-storage-provider-fskit","version":"([^"]+)".*/\1/p' \
     <<<"$PROVIDER_OUTPUT" | head -n 1)"


### PR DESCRIPTION
## Linked Issue

Related to #1817. This PR does not close the release tracking issue.

## Summary

Sign the macOS FSKit storage companion with the pinned Developer ID team during Darwin release staging, verify that companion next to AstridFS.app in the archive, and make native FSKit mount certification consume the exact `binary-<triple>` produced by the Release `build` job instead of rebuilding CLI, daemon, companion, or app.

Standalone certification now downloads that prior Release artifact with `actions/download-artifact` v8 `artifact-ids` plus `run-id`. Passing only `artifact-id` is ignored, so the action would search the current certification run and never consume the selected Release bytes.

Package identity remains the current truthful `0.10.4`. This does not bump versions, tag, publish, or first-publish a Windows runtime archive.

## Changes

- Darwin `build` Developer-ID-signs `astrid-storage-provider-fskit` after AstridFS notarization and before tar. `ASTRID_MACOS_DEVELOPMENT_TEAM_ID` and the resulting `TeamIdentifier` must equal `9BDSL5BJAP`. The companion is not notarized as an app.
- `scripts/validate-macos-fskit.sh` keeps the one-argument AstridFS.app contract. If a sibling `astrid-storage-provider-fskit` exists (archive layout), it fail-closes on identity, team, and marketing-version match. Installed `/Applications/AstridFS.app` without a sibling keeps app-only behavior.
- `native-storage-certification.yml` accepts `workflow_call` from Release. It checks out exact `source_commit` only after proving that commit is on `origin/main`, then installs and certifies extracted archive bytes. No `cargo build`, no per-job `CARGO_TARGET_DIR`, no app rebuild.
- Same-run artifact consumption is selected by explicit `consume_same_run_artifacts` (Release passes `true`) and still downloads by `name: binary-<triple>`. It does not inspect `github.event_name`, which is the caller event inside a reusable workflow.
- Standalone dispatch may run only from protected `main`. It persists `CERT_RELEASE_RUN_ID` and `CERT_ARTIFACT_ID` from a successful Release run for that SHA, then downloads with `artifact-ids`, `run-id`, and `github-token`. This PR does not add an untagged release-build trigger.
- The certification staging step creates `$RELEASE_STAGE` at mode `0700` with the other cert paths before `tar` extraction.
- `github-release` waits for the certification job and still queries check-run name `Native FSKit mount certification`. Darwin `build` stays outside `environment: release`.
- `scripts/test_native_storage_certification_contract.sh` fail-closes if the singular `artifact-id` input returns, `run-id` is dropped, same-run name mode is lost, or the protected-main/exact-SHA gates disappear. It is wired through `scripts/ci/test-release-contracts.sh`.
- Windows matrix/jobs, musl jobs, classify tag binding, and version/publication composition are unchanged.

## Verification

- Isolated worktree from exact `origin/main` `c21ac34ce41c1ebb2676b535d5c93f321ddb8033`.
- Unique files: `.github/workflows/release.yml`, `.github/workflows/native-storage-certification.yml`, `scripts/validate-macos-fskit.sh`, `scripts/test_native_storage_certification_contract.sh`, `scripts/ci/test-release-contracts.sh`, `changes/1817.fixed.md`.
- Ancestry: `537c560cd2f45b0a5886abd27e15859c5d4502c9` parent `efc548b00fc48639083b0d2020b288289a093f95` parent `608f805989cfec1843490a572d524a78641d156d` parent `608ff9e37ac757468c2be726b5c974769062f14b` parent `c21ac34c`.
- GPG Good [full] key `7CD32E7697286B11593246B9FA53358CB4127512`; DCO present on the unique range.
- Local contract test: `scripts/test_native_storage_certification_contract.sh` PASS.
- Source-only review cannot ACCEPT a certification-execution claim. Reviewers must treat missing Darwin `binary-<triple>` for this untagged SHA as an accepted residual, not as permission to dispatch the secret-bearing cert workflow.

## AI / Tool Assistance

Assisted-by: GLM-5.3-Flash: bounded implementation of companion sign/stage/verify and cert artifact consumption on parent `608ff9e3`.
Assisted-by: Grok-4.6: lead AMEND replacing `github.event_name == workflow_call` with an explicit same-run input, restricting standalone dispatch to protected main, aligning check-run name matching, `/usr/bin/uuidgen` in the archive companion probe, and creating `$RELEASE_STAGE` before tar extraction.
Assisted-by: GPT-5.6-Luna: persist `CERT_RELEASE_RUN_ID` with `CERT_ARTIFACT_ID` and pass `artifact-ids` plus `run-id` to `download-artifact` v8 for standalone Release-run consumption, plus the fail-closed workflow contract test.

Reviewed the unique range against the FSKit successor freeze: team fail-closed to `9BDSL5BJAP`, no companion app notarization, no cert rebuild, one-arg validator, does not close tracking issue 1817, Windows publication surfaces unmodified. Independent exact-head review of `537c560c` is still required; a predecessor source-only ACCEPT does not carry. Source-only ACCEPT is insufficient for cert claims.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/{issue}.{kind}.md` (docs/CI-only may skip; release PRs roll fragments into the version section instead of adding one)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
