### PR TITLE
fix(ci): cancel superseded pull-request runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ on:
       - 'scripts/channel_publication.py'
       - 'scripts/test_channel_publication.py'
       - 'scripts/test_channel_workflow_contract.sh'
+      - 'scripts/test_ci_workflow_contract.sh'
       - 'scripts/nightly_version.py'
       - 'scripts/test_nightly_version.py'
       - 'release/nightly.toml'
@@ -101,6 +102,7 @@ on:
       - 'scripts/channel_publication.py'
       - 'scripts/test_channel_publication.py'
       - 'scripts/test_channel_workflow_contract.sh'
+      - 'scripts/test_ci_workflow_contract.sh'
       - 'scripts/nightly_version.py'
       - 'scripts/test_nightly_version.py'
       - 'release/nightly.toml'
@@ -118,6 +120,10 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('run-{0}', github.run_id) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   linux-release-smoke:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,14 +113,12 @@ on:
       - '.github/workflows/ci.yml'
       - '.github/workflows/native-storage-certification.yml'
       - '.github/workflows/release.yml'
-
 permissions:
   contents: read
 
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('run-{0}', github.run_id) }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,8 +120,8 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('run-{0}', github.run_id) }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.run_attempt == '1' && format('pr-{0}', github.event.pull_request.number) || format('run-{0}-attempt-{1}', github.run_id, github.run_attempt) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.run_attempt == '1' }}
 
 jobs:
   linux-release-smoke:

--- a/scripts/ci/test-release-contracts.sh
+++ b/scripts/ci/test-release-contracts.sh
@@ -18,3 +18,4 @@ python3 scripts/test_channel_publication.py
 python3 scripts/test_nightly_version.py
 bash scripts/test_channel_workflow_contract.sh
 bash scripts/test_native_storage_certification_contract.sh
+bash scripts/test_ci_workflow_contract.sh

--- a/scripts/test_ci_workflow_contract.sh
+++ b/scripts/test_ci_workflow_contract.sh
@@ -3,82 +3,102 @@
 set -euo pipefail
 
 repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
-workflow="$repo_root/.github/workflows/ci.yml"
+workflow="${1:-$repo_root/.github/workflows/ci.yml}"
 
-python3 - "$workflow" <<'PY'
-from __future__ import annotations
+ruby - "$workflow" <<'RB'
+require "yaml"
 
-import sys
-from pathlib import Path
+workflow_path = ARGV.fetch(0)
 
+def fail(message)
+  warn "CI workflow contract: #{message}"
+  exit 1
+end
 
-workflow_path = Path(sys.argv[1])
-text = workflow_path.read_text(encoding="utf-8")
+begin
+  workflow = YAML.safe_load(File.read(workflow_path), aliases: false)
+rescue StandardError => error
+  fail("workflow is not valid YAML: #{error.message}")
+end
+fail("workflow root must be a mapping") unless workflow.is_a?(Hash)
 
+concurrency = workflow.fetch("concurrency") do
+  fail("missing top-level concurrency block")
+end
+fail("concurrency must be a mapping") unless concurrency.is_a?(Hash)
 
-def fail(message: str) -> None:
-    print(f"CI workflow contract: {message}", file=sys.stderr)
-    raise SystemExit(1)
+expected_group = "${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.run_attempt == '1' && format('pr-{0}', github.event.pull_request.number) || format('run-{0}-attempt-{1}', github.run_id, github.run_attempt) }}"
+expected_cancel = "${{ github.event_name == 'pull_request' && github.run_attempt == '1' }}"
 
+unless concurrency["group"] == expected_group
+  fail("group must isolate first-attempt PRs by workflow and number, with run-id/attempt fallback")
+end
+unless concurrency["cancel-in-progress"] == expected_cancel
+  fail("cancel-in-progress must be enabled only for first-attempt pull_request events")
+end
 
-concurrency_marker = "concurrency:\n"
-if text.count(concurrency_marker) != 1:
-    fail("expected exactly one top-level concurrency block")
+# Keep this contract wired to both CI trigger classes. Parse the trigger map so
+# comments or similarly named text cannot make an absent path entry pass.
+triggers = workflow["on"] || workflow[true]
+fail("missing workflow trigger map") unless triggers.is_a?(Hash)
+%w[push pull_request].each do |event_name|
+  event = triggers.fetch(event_name) { fail("missing #{event_name} trigger") }
+  paths = event.fetch("paths") { fail("missing #{event_name}.paths filter") }
+  unless paths.is_a?(Array) && paths.count("scripts/test_ci_workflow_contract.sh") == 1
+    fail("contract test must appear exactly once in #{event_name}.paths")
+  end
+end
 
-concurrency_start = text.index(concurrency_marker)
-jobs_start = text.find("\njobs:\n", concurrency_start)
-if jobs_start < 0:
-    fail("missing jobs section after concurrency block")
-concurrency = text[concurrency_start:jobs_start]
+def group(workflow_name, event_name, pr_number, run_id, run_attempt)
+  if event_name == "pull_request" && run_attempt == "1"
+    "#{workflow_name}-pr-#{pr_number}"
+  else
+    "#{workflow_name}-run-#{run_id}-attempt-#{run_attempt}"
+  end
+end
 
-expected_group = (
-    "  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' "
-    "&& format('pr-{0}', github.event.pull_request.number) || "
-    "format('run-{0}', github.run_id) }}"
-)
-expected_cancel = "  cancel-in-progress: ${{ github.event_name == 'pull_request' }}"
+def cancel(event_name, run_attempt)
+  event_name == "pull_request" && run_attempt == "1"
+end
 
-if expected_group not in concurrency:
-    fail("group must key pull requests by workflow and PR, with unique non-PR run fallback")
-if expected_cancel not in concurrency:
-    fail("cancel-in-progress must be enabled only for pull_request events")
-if "  cancel-in-progress: true" in concurrency or "  cancel-in-progress: false" in concurrency:
-    fail("cancel-in-progress must remain event-scoped, not unconditional")
+# Successive first-attempt pull_request events for one PR cancel the older run;
+# a different PR remains independent.
+first_pr_old = group("CI", "pull_request", 1837, "101", "1")
+first_pr_new = group("CI", "pull_request", 1837, "102", "1")
+fail("successive commits for one pull request must share a group") unless first_pr_old == first_pr_new
+fail("first-attempt pull requests must enable cancellation") unless cancel("pull_request", "1")
+fail("different pull requests must not share a group") if first_pr_new == group("CI", "pull_request", 1838, "103", "1")
 
-# Keep this contract wired to both CI trigger classes. Otherwise changing the
-# test itself could silently stop exercising the workflow on one event class.
-if text.count("      - 'scripts/test_ci_workflow_contract.sh'") != 2:
-    fail("contract test must remain in both push and pull_request path filters")
+# A manual rerun keeps the original run_id but increments run_attempt. It must
+# not join the PR group, cancel, or evict the latest first-attempt PR run.
+stale_rerun = group("CI", "pull_request", 1837, "101", "2")
+fail("stale pull-request reruns must use a unique group") if stale_rerun == first_pr_new
+fail("stale pull-request reruns must not enable cancellation") if cancel("pull_request", "2")
+fail("stale pull-request reruns must not share a group with a newer PR push") if stale_rerun == group("CI", "pull_request", 1837, "104", "1")
 
+# Non-PR runs receive unique run/attempt groups and never cancel, including
+# main pushes, tag pushes, and workflow_dispatch runs.
+[["push", "201", "1"], ["push", "202", "1"], ["push", "203", "2"], ["workflow_dispatch", "204", "1"], ["workflow_dispatch", "205", "1"], ["tag", "206", "1"], ["tag", "207", "1"]].each do |event_name, run_id, run_attempt|
+  fail("#{event_name} runs must not enable cancellation") if cancel(event_name, run_attempt)
+end
+fail("successive main pushes must use independent groups") if group("CI", "push", nil, "201", "1") == group("CI", "push", nil, "202", "1")
+fail("successive tag pushes must use independent groups") if group("CI", "tag", nil, "206", "1") == group("CI", "tag", nil, "207", "1")
+fail("successive manual runs must use independent groups") if group("CI", "workflow_dispatch", nil, "204", "1") == group("CI", "workflow_dispatch", nil, "205", "1")
 
-def group(workflow_name: str, event_name: str, pr_number: int | None, run_id: int) -> str:
-    if event_name == "pull_request":
-        assert pr_number is not None
-        return f"{workflow_name}-pr-{pr_number}"
-    return f"{workflow_name}-run-{run_id}"
+# A commented expected expression is not parsed as a key/value and must not
+# satisfy this contract shape.
+comment_spoof = <<~YAML
+  concurrency:
+    # group: #{expected_group}
+    # cancel-in-progress: #{expected_cancel}
+    group: wrong
+    cancel-in-progress: false
+YAML
+spoofed = YAML.safe_load(comment_spoof, aliases: false)
+spoofed_concurrency = spoofed.fetch("concurrency")
+if spoofed_concurrency["group"] == expected_group || spoofed_concurrency["cancel-in-progress"] == expected_cancel
+  fail("commented expressions must not satisfy the parsed concurrency contract")
+end
 
-
-def cancel(event_name: str) -> bool:
-    return event_name == "pull_request"
-
-
-same_pr_old = group("CI", "pull_request", 1837, 101)
-same_pr_new = group("CI", "pull_request", 1837, 102)
-if same_pr_old != same_pr_new:
-    fail("successive commits for one pull request must share a concurrency group")
-if same_pr_new == group("CI", "pull_request", 1838, 103):
-    fail("different pull requests must not share a concurrency group")
-
-for event_name, run_id in (("push", 201), ("workflow_dispatch", 202)):
-    if cancel(event_name):
-        fail(f"{event_name} runs must not enable cancellation")
-    if group("CI", event_name, None, run_id) == group("CI", event_name, None, run_id + 1):
-        fail(f"successive {event_name} runs must not share a cancellation group")
-
-if cancel("push") or cancel("workflow_dispatch"):
-    fail("non-PR event cancellation guard regressed")
-if group("CI", "push", None, 301) == group("CI", "push", None, 302):
-    fail("main/tag pushes must use independent run groups")
-
-print("CI workflow contract: PASS")
-PY
+puts "CI workflow contract: PASS"
+RB

--- a/scripts/test_ci_workflow_contract.sh
+++ b/scripts/test_ci_workflow_contract.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+workflow="$repo_root/.github/workflows/ci.yml"
+
+python3 - "$workflow" <<'PY'
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+workflow_path = Path(sys.argv[1])
+text = workflow_path.read_text(encoding="utf-8")
+
+
+def fail(message: str) -> None:
+    print(f"CI workflow contract: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+concurrency_marker = "concurrency:\n"
+if text.count(concurrency_marker) != 1:
+    fail("expected exactly one top-level concurrency block")
+
+concurrency_start = text.index(concurrency_marker)
+jobs_start = text.find("\njobs:\n", concurrency_start)
+if jobs_start < 0:
+    fail("missing jobs section after concurrency block")
+concurrency = text[concurrency_start:jobs_start]
+
+expected_group = (
+    "  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' "
+    "&& format('pr-{0}', github.event.pull_request.number) || "
+    "format('run-{0}', github.run_id) }}"
+)
+expected_cancel = "  cancel-in-progress: ${{ github.event_name == 'pull_request' }}"
+
+if expected_group not in concurrency:
+    fail("group must key pull requests by workflow and PR, with unique non-PR run fallback")
+if expected_cancel not in concurrency:
+    fail("cancel-in-progress must be enabled only for pull_request events")
+if "  cancel-in-progress: true" in concurrency or "  cancel-in-progress: false" in concurrency:
+    fail("cancel-in-progress must remain event-scoped, not unconditional")
+
+# Keep this contract wired to both CI trigger classes. Otherwise changing the
+# test itself could silently stop exercising the workflow on one event class.
+if text.count("      - 'scripts/test_ci_workflow_contract.sh'") != 2:
+    fail("contract test must remain in both push and pull_request path filters")
+
+
+def group(workflow_name: str, event_name: str, pr_number: int | None, run_id: int) -> str:
+    if event_name == "pull_request":
+        assert pr_number is not None
+        return f"{workflow_name}-pr-{pr_number}"
+    return f"{workflow_name}-run-{run_id}"
+
+
+def cancel(event_name: str) -> bool:
+    return event_name == "pull_request"
+
+
+same_pr_old = group("CI", "pull_request", 1837, 101)
+same_pr_new = group("CI", "pull_request", 1837, 102)
+if same_pr_old != same_pr_new:
+    fail("successive commits for one pull request must share a concurrency group")
+if same_pr_new == group("CI", "pull_request", 1838, 103):
+    fail("different pull requests must not share a concurrency group")
+
+for event_name, run_id in (("push", 201), ("workflow_dispatch", 202)):
+    if cancel(event_name):
+        fail(f"{event_name} runs must not enable cancellation")
+    if group("CI", event_name, None, run_id) == group("CI", event_name, None, run_id + 1):
+        fail(f"successive {event_name} runs must not share a cancellation group")
+
+if cancel("push") or cancel("workflow_dispatch"):
+    fail("non-PR event cancellation guard regressed")
+if group("CI", "push", None, 301) == group("CI", "push", None, 302):
+    fail("main/tag pushes must use independent run groups")
+
+print("CI workflow contract: PASS")
+PY


### PR DESCRIPTION
## Linked Issue

Closes #1837

## Summary

Cancel superseded primary CI runs for the same pull request while preserving every latest-head job and all non-PR runs.

## Changes

- Group primary CI runs by workflow and pull-request number.
- Cancel only superseded runs for the same pull request.
- Isolate manual reruns by run ID and attempt so stale attempts cannot cancel or displace the latest pull-request run.
- Give each non-PR run a unique run-id group, keeping main, tags, manual runs, and separate pull requests independent.
- Add a parsed workflow contract for same-PR cancellation, rerun isolation, and non-PR preservation.

## Verification

- actionlint and YAML parsing
- ShellCheck and Bash syntax
- Parsed CI workflow contract, including stale-rerun and comment-spoof falsifiers
- Full release-contract suite
- Live same-PR supersession measurement before landing

Recent primary CI baselines completed in 28-29 minutes; an older iteration reached 49m48s with up to 26m49s of queue delay. This is the narrow pilot. It removes no job or platform gate and does not alter main, tag, workflow-dispatch, Runtime E2E, CodeQL, or Windows workflow behavior.

## AI / Tool Assistance

Implemented and tested with Codex. Final source and release decisions remain subject to independent review and CI.
