### PR TITLE
fix(cli): avoid shell profile writes for isolated homes

### DIFF
--- a/changes/1183.fixed.md
+++ b/changes/1183.fixed.md
@@ -1,0 +1,3 @@
+An explicit non-default `ASTRID_HOME` no longer causes `astrid init` to append
+its PATH block to the account shell startup file. Default-home installations
+keep the existing shell integration. Closes #1183

--- a/crates/astrid-cli/src/commands/self_update.rs
+++ b/crates/astrid-cli/src/commands/self_update.rs
@@ -5,7 +5,7 @@
 //! remain package-manager owned. Discovery can use a mirror or mock, but the
 //! accepted Astrid workflow identities and issuer cannot be overridden.
 
-use std::io::IsTerminal;
+use std::io::{self, IsTerminal};
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, bail};
@@ -36,6 +36,30 @@ const MAX_ARCHIVE_BYTES: usize = 100 * 1024 * 1024;
 const MAX_RELEASE_ASSETS: usize = 1_024;
 const MAX_BUNDLE_BYTES: usize = 256 * 1024;
 const MAX_MANIFEST_BYTES: usize = 256 * 1024;
+
+fn default_astrid_home_path() -> io::Result<PathBuf> {
+    #[cfg(windows)]
+    return astrid_core::platform_fs::default_astrid_home_root();
+
+    #[cfg(not(windows))]
+    {
+        let home = std::env::var_os("HOME").ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                "HOME environment variable is not set",
+            )
+        })?;
+        Ok(PathBuf::from(home).join(".astrid"))
+    }
+}
+
+fn shell_profile_setup_wanted(astrid_home: Option<&Path>, default_home: Option<&Path>) -> bool {
+    let Some(home) = astrid_home else {
+        return true;
+    };
+
+    default_home.is_some_and(|default| home == default)
+}
 
 /// Return every executable managed by an authenticated target's update set.
 fn managed_binaries_for_target(target: &str) -> Vec<&'static str> {
@@ -841,35 +865,19 @@ fn detect_shell_rc() -> Option<PathBuf> {
     }
 }
 
-/// True if the match starting at byte `start` sits on a `#`-commented
-/// (inert) rc line — a `#` appears between the line start and the match.
-///
-/// A commented line is a no-op in the shell, so treating a match inside one
-/// as "already configured" would silently skip the real PATH setup. Both
-/// match paths in [`rc_configures_path`] consult this so a commented block or
-/// token never counts.
+/// True only if the match starts on an active rc line, not a `#`-comment.
 fn match_is_commented(rc: &str, start: usize) -> bool {
     let line_start = rc[..start].rfind('\n').map_or(0, |nl| nl.saturating_add(1));
     rc[line_start..start].contains('#')
 }
 
-/// Whether `rc_contents` already puts the bin dir on PATH, so a second run
-/// must not append a duplicate block.
+/// Whether an active rc entry already puts the whole bin dir on PATH.
 ///
-/// Returns "already configured" (skip the append) only when EITHER the exact
-/// block we emit (`export_line`) is present — the reliable idempotency signal,
-/// since we always write it verbatim — OR `bin_str` appears as a WHOLE path
-/// component: bounded on both sides by a shell PATH-list separator. A bare
-/// substring match must NOT count: an rc containing `.astrid/bin_backup` or
-/// `.astrid/bin/sub` would otherwise make the guard skip the real
-/// `.astrid/bin` setup and silently leave astrid off PATH. A match on a
-/// `#`-commented (inert) line is likewise NOT a match, on both paths. When
-/// unsure we err toward ADDING the block — a duplicate PATH entry is harmless;
-/// a silent skip is not. Pure over its inputs so the guarantee is
-/// unit-testable without a real shell rc.
+/// Exact emitted blocks are authoritative; otherwise require whole-component
+/// bounds and never count comments, prefixes, or subdirectories. Ambiguity
+/// favors adding a duplicate rather than silently leaving Astrid off PATH.
 fn rc_configures_path(rc_contents: &str, bin_str: &str, export_line: &str) -> bool {
-    // Our exact block is the authoritative "already done" marker — unless it
-    // is commented out, in which case it is inert and we must add a live one.
+    // Exact blocks count only when active; commented blocks are inert.
     if let Some(start) = rc_contents.find(export_line)
         && !match_is_commented(rc_contents, start)
     {
@@ -879,10 +887,7 @@ fn rc_configures_path(rc_contents: &str, bin_str: &str, export_line: &str) -> bo
         return false;
     }
 
-    // A PATH entry is bounded by these separators in a shell rc line. The
-    // leading set admits assignment/grouping openers (`=`, `(`); the trailing
-    // set admits a grouping close (`)`). A following `/`, alphanumeric, `_`,
-    // or `-` means `bin_str` is only a prefix of a longer path — NOT a match.
+    // PATH-list bounds reject prefix matches such as `.astrid/bin_backup`.
     let is_lead = |c: char| matches!(c, ':' | '"' | '\'' | '=' | '(' | ' ' | '\t' | '\n' | '\r');
     let is_trail = |c: char| matches!(c, ':' | '"' | '\'' | ')' | ' ' | '\t' | '\n' | '\r');
 
@@ -891,8 +896,7 @@ fn rc_configures_path(rc_contents: &str, bin_str: &str, export_line: &str) -> bo
         let start = from.saturating_add(rel);
         let end = start.saturating_add(bin_str.len());
 
-        // Skip a match inside a commented-out line, e.g.
-        // `# export PATH="…/.astrid/bin:$PATH"`, and keep scanning.
+        // Commented matches are inert; keep scanning.
         if match_is_commented(rc_contents, start) {
             from = end;
             continue;
@@ -913,10 +917,14 @@ fn rc_configures_path(rc_contents: &str, bin_str: &str, export_line: &str) -> bo
     false
 }
 
-/// Ensure `~/.astrid/bin` is in PATH. Prompts user if interactive.
-///
-/// Called by `astrid init` after capsule installation.
+/// Ensure the default-home binary is on PATH after `astrid init`.
 pub(crate) fn ensure_path_setup() -> anyhow::Result<()> {
+    let explicit_home = std::env::var_os("ASTRID_HOME").map(PathBuf::from);
+    let default_home = default_astrid_home_path().ok();
+    if !shell_profile_setup_wanted(explicit_home.as_deref(), default_home.as_deref()) {
+        return Ok(());
+    }
+
     let bin_dir = astrid_bin_dir()?;
     std::fs::create_dir_all(&bin_dir)?;
 
@@ -939,17 +947,13 @@ pub(crate) fn ensure_path_setup() -> anyhow::Result<()> {
         format!("export PATH=\"{bin_str}:$PATH\"")
     };
 
-    // Idempotency: if the rc file already wires the bin dir onto PATH, do
-    // NOT append a second block. `astrid init` (and the first-run auto-init)
-    // calls this on every run, so an unguarded append would accumulate a
-    // duplicate `# Astrid OS` block per invocation.
+    // Avoid appending a duplicate block on repeated init.
     if let Ok(contents) = std::fs::read_to_string(&rc_file)
         && rc_configures_path(&contents, &bin_str, &export_line)
     {
         return Ok(()); // Already configured, just not sourced yet
     }
 
-    // Prompt if interactive
     if std::io::stdin().is_terminal() {
         eprint!(
             "\n{bin_str} is not in your PATH. Add it to {}? [Y/n] ",

--- a/crates/astrid-cli/src/commands/self_update/mod.rs
+++ b/crates/astrid-cli/src/commands/self_update/mod.rs
@@ -5,7 +5,7 @@
 //! remain package-manager owned. Discovery can use a mirror or mock, but the
 //! accepted Astrid workflow identities and issuer cannot be overridden.
 
-use std::io::{self, IsTerminal};
+use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, bail};
@@ -20,10 +20,14 @@ use super::update_auth::{
 };
 use super::update_channel;
 
-#[path = "self_update_notice.rs"]
+#[path = "../self_update_notice.rs"]
 mod notice;
 pub(crate) use notice::print_update_banner;
 use notice::{handle_managed_channel, write_cache};
+
+mod path_setup;
+pub(crate) use path_setup::ensure_path_setup;
+use path_setup::is_in_path;
 
 /// Default Astrid release repository. Discovery overrides never widen the
 /// authenticated publisher identity.
@@ -36,30 +40,6 @@ const MAX_ARCHIVE_BYTES: usize = 100 * 1024 * 1024;
 const MAX_RELEASE_ASSETS: usize = 1_024;
 const MAX_BUNDLE_BYTES: usize = 256 * 1024;
 const MAX_MANIFEST_BYTES: usize = 256 * 1024;
-
-fn default_astrid_home_path() -> io::Result<PathBuf> {
-    #[cfg(windows)]
-    return astrid_core::platform_fs::default_astrid_home_root();
-
-    #[cfg(not(windows))]
-    {
-        let home = std::env::var_os("HOME").ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::NotFound,
-                "HOME environment variable is not set",
-            )
-        })?;
-        Ok(PathBuf::from(home).join(".astrid"))
-    }
-}
-
-fn shell_profile_setup_wanted(astrid_home: Option<&Path>, default_home: Option<&Path>) -> bool {
-    let Some(home) = astrid_home else {
-        return true;
-    };
-
-    default_home.is_some_and(|default| home == default)
-}
 
 /// Return every executable managed by an authenticated target's update set.
 fn managed_binaries_for_target(target: &str) -> Vec<&'static str> {
@@ -109,12 +89,6 @@ fn resolve_repo(source: Option<&str>) -> anyhow::Result<(String, String)> {
         },
         None => Ok((DEFAULT_ORG.to_string(), DEFAULT_REPO.to_string())),
     }
-}
-
-/// The `~/.astrid/bin` directory where `astrid init` puts self-managed binaries.
-fn astrid_bin_dir() -> anyhow::Result<PathBuf> {
-    let home = astrid_core::dirs::AstridHome::resolve()?;
-    Ok(home.root().join("bin"))
 }
 
 /// Map the current platform to the GitHub release asset target triple.
@@ -827,173 +801,6 @@ const fn distro_refresh_action(has_lock: bool) -> DistroRefreshAction {
     }
 }
 
-// ── PATH setup helpers ──────────────────────────────────────────────────
-
-/// Check if a directory is already in the current PATH.
-fn is_in_path(dir: &Path) -> bool {
-    std::env::var_os("PATH").is_some_and(|p| std::env::split_paths(&p).any(|entry| entry == dir))
-}
-
-/// Detect the user's shell RC file.
-fn detect_shell_rc() -> Option<PathBuf> {
-    let home = directories::BaseDirs::new()?.home_dir().to_path_buf();
-    let shell = std::env::var("SHELL").unwrap_or_default();
-
-    if shell.ends_with("zsh") {
-        Some(home.join(".zshrc"))
-    } else if shell.ends_with("bash") {
-        // Prefer .bashrc on Linux, .bash_profile on macOS
-        let bashrc = home.join(".bashrc");
-        let profile = home.join(".bash_profile");
-        if cfg!(target_os = "macos") && profile.exists() {
-            Some(profile)
-        } else if bashrc.exists() {
-            Some(bashrc)
-        } else {
-            Some(home.join(".bashrc"))
-        }
-    } else if shell.ends_with("fish") {
-        Some(home.join(".config/fish/config.fish"))
-    } else {
-        // Fallback: try zshrc (macOS default), then bashrc
-        let zshrc = home.join(".zshrc");
-        if zshrc.exists() {
-            Some(zshrc)
-        } else {
-            Some(home.join(".bashrc"))
-        }
-    }
-}
-
-/// True only if the match starts on an active rc line, not a `#`-comment.
-fn match_is_commented(rc: &str, start: usize) -> bool {
-    let line_start = rc[..start].rfind('\n').map_or(0, |nl| nl.saturating_add(1));
-    rc[line_start..start].contains('#')
-}
-
-/// Whether an active rc entry already puts the whole bin dir on PATH.
-///
-/// Exact emitted blocks are authoritative; otherwise require whole-component
-/// bounds and never count comments, prefixes, or subdirectories. Ambiguity
-/// favors adding a duplicate rather than silently leaving Astrid off PATH.
-fn rc_configures_path(rc_contents: &str, bin_str: &str, export_line: &str) -> bool {
-    // Exact blocks count only when active; commented blocks are inert.
-    if let Some(start) = rc_contents.find(export_line)
-        && !match_is_commented(rc_contents, start)
-    {
-        return true;
-    }
-    if bin_str.is_empty() {
-        return false;
-    }
-
-    // PATH-list bounds reject prefix matches such as `.astrid/bin_backup`.
-    let is_lead = |c: char| matches!(c, ':' | '"' | '\'' | '=' | '(' | ' ' | '\t' | '\n' | '\r');
-    let is_trail = |c: char| matches!(c, ':' | '"' | '\'' | ')' | ' ' | '\t' | '\n' | '\r');
-
-    let mut from = 0;
-    while let Some(rel) = rc_contents[from..].find(bin_str) {
-        let start = from.saturating_add(rel);
-        let end = start.saturating_add(bin_str.len());
-
-        // Commented matches are inert; keep scanning.
-        if match_is_commented(rc_contents, start) {
-            from = end;
-            continue;
-        }
-
-        let lead_ok = start == 0
-            || rc_contents[..start]
-                .chars()
-                .next_back()
-                .is_some_and(is_lead);
-        let trail_ok =
-            end == rc_contents.len() || rc_contents[end..].chars().next().is_some_and(is_trail);
-        if lead_ok && trail_ok {
-            return true;
-        }
-        from = end;
-    }
-    false
-}
-
-/// Ensure the default-home binary is on PATH after `astrid init`.
-pub(crate) fn ensure_path_setup() -> anyhow::Result<()> {
-    let explicit_home = std::env::var_os("ASTRID_HOME").map(PathBuf::from);
-    let default_home = default_astrid_home_path().ok();
-    if !shell_profile_setup_wanted(explicit_home.as_deref(), default_home.as_deref()) {
-        return Ok(());
-    }
-
-    let bin_dir = astrid_bin_dir()?;
-    std::fs::create_dir_all(&bin_dir)?;
-
-    if is_in_path(&bin_dir) {
-        return Ok(());
-    }
-
-    let bin_str = bin_dir.to_string_lossy();
-    let Some(rc_file) = detect_shell_rc() else {
-        println!(
-            "{}",
-            Theme::warning(&format!("Add {bin_str} to your PATH manually."))
-        );
-        return Ok(());
-    };
-
-    let export_line = if rc_file.to_string_lossy().contains("fish") {
-        format!("fish_add_path {bin_str}")
-    } else {
-        format!("export PATH=\"{bin_str}:$PATH\"")
-    };
-
-    // Avoid appending a duplicate block on repeated init.
-    if let Ok(contents) = std::fs::read_to_string(&rc_file)
-        && rc_configures_path(&contents, &bin_str, &export_line)
-    {
-        return Ok(()); // Already configured, just not sourced yet
-    }
-
-    if std::io::stdin().is_terminal() {
-        eprint!(
-            "\n{bin_str} is not in your PATH. Add it to {}? [Y/n] ",
-            rc_file.display()
-        );
-        std::io::Write::flush(&mut std::io::stderr())?;
-        let mut input = String::new();
-        std::io::stdin().read_line(&mut input)?;
-        let input = input.trim();
-        if !input.is_empty() && !input.eq_ignore_ascii_case("y") {
-            println!(
-                "{}",
-                Theme::dimmed(&format!("Skipped. Add manually: {export_line}"))
-            );
-            return Ok(());
-        }
-    }
-
-    // Append to RC file
-    let mut file = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&rc_file)?;
-    std::io::Write::write_all(
-        &mut file,
-        format!("\n# Astrid OS\n{export_line}\n").as_bytes(),
-    )?;
-
-    println!(
-        "{}",
-        Theme::success(&format!("Added to {}", rc_file.display()))
-    );
-    println!(
-        "  Run: {} (or restart your terminal)",
-        Theme::dimmed(&format!("source {}", rc_file.display()))
-    );
-
-    Ok(())
-}
-
 #[cfg(test)]
-#[path = "self_update_tests.rs"]
+#[path = "../self_update_tests.rs"]
 mod tests;

--- a/crates/astrid-cli/src/commands/self_update/path_setup.rs
+++ b/crates/astrid-cli/src/commands/self_update/path_setup.rs
@@ -1,0 +1,247 @@
+//! Private PATH setup for Astrid's account-level install.
+//!
+//! Startup-file edits and the default binary directory are shared account
+//! state. An explicit `ASTRID_HOME` is an isolation boundary, so it must be
+//! resolved before either side effect can happen; failure to classify it as
+//! the default is a reason to do nothing, never a reason to guess.
+
+use std::io;
+use std::io::IsTerminal;
+use std::path::{Path, PathBuf};
+
+use crate::theme::Theme;
+
+/// Return the account-level Astrid home used when `ASTRID_HOME` is absent.
+pub(super) fn default_astrid_home_path() -> io::Result<PathBuf> {
+    #[cfg(windows)]
+    return astrid_core::platform_fs::default_astrid_home_root();
+
+    #[cfg(not(windows))]
+    {
+        let home = std::env::var_os("HOME").ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                "HOME environment variable is not set",
+            )
+        })?;
+        Ok(PathBuf::from(home).join(".astrid"))
+    }
+}
+
+/// Decide whether this run may touch account-level PATH state.
+///
+/// An absent `ASTRID_HOME` means the runtime chose the account home. An
+/// explicit path is allowed only when it equals that home exactly. Any other
+/// explicit selection -- including an invalid or non-UTF-8 value -- stays a
+/// private runtime home: return before creating `bin` or reading or writing a
+/// shell profile.
+pub(super) fn shell_profile_setup_wanted(
+    astrid_home: Option<&Path>,
+    default_home: Option<&Path>,
+) -> bool {
+    let Some(home) = astrid_home else {
+        return true;
+    };
+
+    default_home.is_some_and(|default| home == default)
+}
+
+/// The binary directory belonging to the resolved Astrid home.
+pub(super) fn astrid_bin_dir() -> anyhow::Result<PathBuf> {
+    let home = astrid_core::dirs::AstridHome::resolve()?;
+    Ok(home.root().join("bin"))
+}
+
+/// Check if a directory is already in the current PATH.
+pub(super) fn is_in_path(dir: &Path) -> bool {
+    std::env::var_os("PATH").is_some_and(|p| std::env::split_paths(&p).any(|entry| entry == dir))
+}
+
+/// Detect the user's shell RC file.
+pub(super) fn detect_shell_rc() -> Option<PathBuf> {
+    let home = directories::BaseDirs::new()?.home_dir().to_path_buf();
+    let shell = std::env::var("SHELL").unwrap_or_default();
+
+    if shell.ends_with("zsh") {
+        Some(home.join(".zshrc"))
+    } else if shell.ends_with("bash") {
+        // Prefer .bashrc on Linux, .bash_profile on macOS
+        let bashrc = home.join(".bashrc");
+        let profile = home.join(".bash_profile");
+        if cfg!(target_os = "macos") && profile.exists() {
+            Some(profile)
+        } else if bashrc.exists() {
+            Some(bashrc)
+        } else {
+            Some(home.join(".bashrc"))
+        }
+    } else if shell.ends_with("fish") {
+        Some(home.join(".config/fish/config.fish"))
+    } else {
+        // Fallback: try zshrc (macOS default), then bashrc
+        let zshrc = home.join(".zshrc");
+        if zshrc.exists() {
+            Some(zshrc)
+        } else {
+            Some(home.join(".bashrc"))
+        }
+    }
+}
+
+/// True if the match starting at byte `start` sits on a `#`-commented
+/// (inert) rc line -- a `#` appears between the line start and the match.
+///
+/// A commented line is a no-op in the shell, so treating a match inside one
+/// as "already configured" would silently skip the real PATH setup. Both
+/// match paths in [`rc_configures_path`] consult this so a commented block or
+/// token never counts.
+pub(super) fn match_is_commented(rc: &str, start: usize) -> bool {
+    let line_start = rc[..start].rfind('\n').map_or(0, |nl| nl.saturating_add(1));
+    rc[line_start..start].contains('#')
+}
+
+/// Whether `rc_contents` already puts the bin dir on PATH, so a second run
+/// must not append a duplicate block.
+///
+/// Returns "already configured" (skip the append) only when EITHER the exact
+/// block we emit (`export_line`) is present -- the reliable idempotency
+/// signal, since we always write it verbatim -- OR `bin_str` appears as a
+/// WHOLE path component: bounded on both sides by a shell PATH-list
+/// separator. A bare substring match must NOT count: an rc containing
+/// `.astrid/bin_backup` or `.astrid/bin/sub` would otherwise make the guard
+/// skip the real `.astrid/bin` setup and silently leave astrid off PATH. A
+/// match on a `#`-commented (inert) line is likewise NOT a match, on both
+/// paths. When unsure we err toward ADDING the block -- a duplicate PATH
+/// entry is harmless; a silent skip is not. Pure over its inputs so the
+/// guarantee is unit-testable without a real shell rc.
+pub(super) fn rc_configures_path(rc_contents: &str, bin_str: &str, export_line: &str) -> bool {
+    // Our exact block is the authoritative "already done" marker -- unless it
+    // is commented out, in which case it is inert and we must add a live one.
+    if let Some(start) = rc_contents.find(export_line)
+        && !match_is_commented(rc_contents, start)
+    {
+        return true;
+    }
+    if bin_str.is_empty() {
+        return false;
+    }
+
+    // A PATH entry is bounded by these separators in a shell rc line. The
+    // leading set admits assignment/grouping openers (`=`, `(`); the trailing
+    // set admits a grouping close (`)`). A following `/`, alphanumeric, `_`,
+    // or `-` means `bin_str` is only a prefix of a longer path -- NOT a match.
+    let is_lead = |c: char| matches!(c, ':' | '"' | '\'' | '=' | '(' | ' ' | '\t' | '\n' | '\r');
+    let is_trail = |c: char| matches!(c, ':' | '"' | '\'' | ')' | ' ' | '\t' | '\n' | '\r');
+
+    let mut from = 0;
+    while let Some(rel) = rc_contents[from..].find(bin_str) {
+        let start = from.saturating_add(rel);
+        let end = start.saturating_add(bin_str.len());
+
+        // Skip a match inside a commented-out line, e.g.
+        // `# export PATH=".../.astrid/bin:$PATH"`, and keep scanning.
+        if match_is_commented(rc_contents, start) {
+            from = end;
+            continue;
+        }
+
+        let lead_ok = start == 0
+            || rc_contents[..start]
+                .chars()
+                .next_back()
+                .is_some_and(is_lead);
+        let trail_ok =
+            end == rc_contents.len() || rc_contents[end..].chars().next().is_some_and(is_trail);
+        if lead_ok && trail_ok {
+            return true;
+        }
+        from = end;
+    }
+    false
+}
+
+/// Ensure the account-level binary directory is on PATH after `astrid init`.
+///
+/// This is the only safe order for the home boundary: classify
+/// `ASTRID_HOME` first, then create `bin`, then inspect or update the shell
+/// startup file. An explicit non-default, invalid, or non-UTF-8 home leaves
+/// both `bin` and the profile untouched.
+pub(crate) fn ensure_path_setup() -> anyhow::Result<()> {
+    let explicit_home = std::env::var_os("ASTRID_HOME").map(PathBuf::from);
+    let default_home = default_astrid_home_path().ok();
+    if !shell_profile_setup_wanted(explicit_home.as_deref(), default_home.as_deref()) {
+        return Ok(());
+    }
+
+    let bin_dir = astrid_bin_dir()?;
+    std::fs::create_dir_all(&bin_dir)?;
+
+    if is_in_path(&bin_dir) {
+        return Ok(());
+    }
+
+    let bin_str = bin_dir.to_string_lossy();
+    let Some(rc_file) = detect_shell_rc() else {
+        println!(
+            "{}",
+            Theme::warning(&format!("Add {bin_str} to your PATH manually."))
+        );
+        return Ok(());
+    };
+
+    let export_line = if rc_file.to_string_lossy().contains("fish") {
+        format!("fish_add_path {bin_str}")
+    } else {
+        format!("export PATH=\"{bin_str}:$PATH\"")
+    };
+
+    // Idempotency: if the rc file already wires the bin dir onto PATH, do
+    // NOT append a second block. `astrid init` (and the first-run auto-init)
+    // calls this on every run, so an unguarded append would accumulate a
+    // duplicate `# Astrid OS` block per invocation.
+    if let Ok(contents) = std::fs::read_to_string(&rc_file)
+        && rc_configures_path(&contents, &bin_str, &export_line)
+    {
+        return Ok(()); // Already configured, just not sourced yet
+    }
+
+    // Prompt if interactive.
+    if std::io::stdin().is_terminal() {
+        eprint!(
+            "\n{bin_str} is not in your PATH. Add it to {}? [Y/n] ",
+            rc_file.display()
+        );
+        std::io::Write::flush(&mut std::io::stderr())?;
+        let mut input = String::new();
+        std::io::stdin().read_line(&mut input)?;
+        let input = input.trim();
+        if !input.is_empty() && !input.eq_ignore_ascii_case("y") {
+            println!(
+                "{}",
+                Theme::dimmed(&format!("Skipped. Add manually: {export_line}"))
+            );
+            return Ok(());
+        }
+    }
+
+    // Append to RC file.
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&rc_file)?;
+    std::io::Write::write_all(
+        &mut file,
+        format!("\n# Astrid OS\n{export_line}\n").as_bytes(),
+    )?;
+
+    println!(
+        "{}",
+        Theme::success(&format!("Added to {}", rc_file.display()))
+    );
+    println!(
+        "  Run: {} (or restart your terminal)",
+        Theme::dimmed(&format!("source {}", rc_file.display()))
+    );
+
+    Ok(())
+}

--- a/crates/astrid-cli/src/commands/self_update_tests.rs
+++ b/crates/astrid-cli/src/commands/self_update_tests.rs
@@ -1,7 +1,8 @@
 //! Tests for [`super`] — self-update / PATH-setup helpers. Kept in a
-//! sibling file (via `#[path]`) so `self_update.rs` stays under the
+//! sibling file (via `#[path]`) so `self_update/mod.rs` stays under the
 //! per-file CI line cap.
 
+use super::path_setup::{ensure_path_setup, rc_configures_path, shell_profile_setup_wanted};
 use super::*;
 
 #[test]
@@ -174,6 +175,84 @@ fn shell_profile_setup_skips_invalid_explicit_home() {
     for invalid in ["", "relative/astrid", "/tmp/../astrid"] {
         assert!(!shell_profile_setup_wanted(Some(Path::new(invalid)), None));
     }
+}
+
+/// Exercise the real mutating function in a child process so all process-wide
+/// application-home inputs can be pinned without altering the test runner.
+#[cfg(unix)]
+#[test]
+fn ensure_path_setup_explicit_nondefault_home_subprocess() {
+    let child_marker = "ASTRID_PATH_SETUP_SUBPROCESS";
+    let test_name = concat!(
+        module_path!(),
+        "::ensure_path_setup_explicit_nondefault_home_subprocess"
+    );
+
+    if std::env::var_os(child_marker).is_some() {
+        assert!(
+            std::env::var("ASTRID_HOME")
+                .expect("child must have an explicit ASTRID_HOME")
+                .contains("astrid-path-setup-home"),
+            "child must run against the isolated application home"
+        );
+        assert!(
+            std::env::var("SHELL").is_ok_and(|shell| shell.ends_with("zsh")),
+            "child must select a disposable zsh profile"
+        );
+        ensure_path_setup().expect("explicit isolated home must not fail PATH setup");
+        return;
+    }
+
+    let home = tempfile::tempdir().expect("create isolated HOME");
+    let astrid_home = tempfile::tempdir().expect("create isolated ASTRID_HOME");
+    let profile = home.path().join(".zshrc");
+
+    // Read-only canary: if the guard regresses, it should be obvious whether
+    // the real rc changed during the test rather than before it.
+    let real_rc = directories::BaseDirs::new()
+        .expect("resolve caller BaseDirs")
+        .home_dir()
+        .join(".zshrc");
+    let before = std::fs::metadata(&real_rc).ok().map(|metadata| {
+        (
+            std::fs::read(&real_rc).expect("read rc canary"),
+            metadata.modified().expect("read rc mtime"),
+        )
+    });
+
+    let output = std::process::Command::new(std::env::current_exe().expect("test executable"))
+        .args(["--exact", test_name, "--nocapture"])
+        .env(child_marker, "1")
+        .env("HOME", home.path())
+        .env("ASTRID_HOME", astrid_home.path())
+        .env("SHELL", "/bin/zsh")
+        .env("PATH", "/usr/bin:/bin")
+        .stdin(std::process::Stdio::null())
+        .output()
+        .expect("spawn isolated PATH-setup child");
+
+    assert!(
+        output.status.success(),
+        "isolated PATH-setup child failed:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(!profile.exists(), "explicit isolated home must not edit rc");
+    assert!(
+        !astrid_home.path().join("bin").exists(),
+        "explicit isolated home must not create its bin directory"
+    );
+
+    let after = std::fs::metadata(&real_rc).ok().map(|metadata| {
+        (
+            std::fs::read(&real_rc).expect("read rc canary"),
+            metadata.modified().expect("read rc mtime"),
+        )
+    });
+    assert_eq!(
+        before, after,
+        "real account rc content and mtime must remain unchanged"
+    );
 }
 
 #[test]

--- a/crates/astrid-cli/src/commands/self_update_tests.rs
+++ b/crates/astrid-cli/src/commands/self_update_tests.rs
@@ -152,6 +152,30 @@ fn rc_path_guard_ignores_commented_exact_block() {
     assert!(rc_configures_path(&both_exact, bin, &export));
 }
 
+/// REGRESSION (#1183): an isolated runtime must not rewrite the account's
+/// shell startup file. These cases are pure, so no test reads or mutates the
+/// caller's rc or process environment.
+#[test]
+fn shell_profile_setup_follows_astrid_home_boundary() {
+    let default = Path::new("/home/jb/.astrid");
+    let isolated = Path::new("/tmp/astrid-issue-1183");
+
+    assert!(shell_profile_setup_wanted(None, Some(default)));
+    assert!(
+        shell_profile_setup_wanted(Some(default), Some(default)),
+        "the default home keeps the account-PATH setup behavior"
+    );
+    assert!(!shell_profile_setup_wanted(Some(isolated), Some(default)));
+    assert!(!shell_profile_setup_wanted(Some(isolated), None));
+}
+
+#[test]
+fn shell_profile_setup_skips_invalid_explicit_home() {
+    for invalid in ["", "relative/astrid", "/tmp/../astrid"] {
+        assert!(!shell_profile_setup_wanted(Some(Path::new(invalid)), None));
+    }
+}
+
 #[test]
 fn homebrew_path_is_detected() {
     assert!(is_homebrew_managed(Path::new(

--- a/crates/astrid-cli/src/commands/self_update_tests.rs
+++ b/crates/astrid-cli/src/commands/self_update_tests.rs
@@ -182,17 +182,29 @@ fn shell_profile_setup_skips_invalid_explicit_home() {
 #[cfg(unix)]
 #[test]
 fn ensure_path_setup_explicit_nondefault_home_subprocess() {
-    let child_marker = "ASTRID_PATH_SETUP_SUBPROCESS";
-    let test_name = concat!(
-        module_path!(),
-        "::ensure_path_setup_explicit_nondefault_home_subprocess"
+    const CHILD_MARKER: &str = "ASTRID_PATH_SETUP_SUBPROCESS";
+    const CHILD_COMPLETION_VAR: &str = "ASTRID_PATH_SETUP_COMPLETION";
+    const CHILD_COMPLETION_CONTENT: &[u8] = b"ensure_path_setup returned";
+    let module_path = module_path!();
+    let test_name = format!(
+        "{}::ensure_path_setup_explicit_nondefault_home_subprocess",
+        module_path.strip_prefix("astrid::").unwrap_or(module_path)
     );
 
-    if std::env::var_os(child_marker).is_some() {
+    if std::env::var_os(CHILD_MARKER).is_some() {
+        let home = PathBuf::from(std::env::var_os("HOME").expect("child HOME"));
+        let astrid_home =
+            PathBuf::from(std::env::var_os("ASTRID_HOME").expect("child ASTRID_HOME"));
         assert!(
-            std::env::var("ASTRID_HOME")
-                .expect("child must have an explicit ASTRID_HOME")
-                .contains("astrid-path-setup-home"),
+            home.file_name().is_some_and(|name| name
+                .to_string_lossy()
+                .starts_with("astrid-path-setup-home-profile")),
+            "child must run against the isolated application home"
+        );
+        assert!(
+            astrid_home
+                .file_name()
+                .is_some_and(|name| name.to_string_lossy().starts_with("astrid-path-setup-home")),
             "child must run against the isolated application home"
         );
         assert!(
@@ -200,11 +212,35 @@ fn ensure_path_setup_explicit_nondefault_home_subprocess() {
             "child must select a disposable zsh profile"
         );
         ensure_path_setup().expect("explicit isolated home must not fail PATH setup");
+
+        let completion =
+            PathBuf::from(std::env::var_os(CHILD_COMPLETION_VAR).expect("completion path"));
+        std::fs::write(completion, CHILD_COMPLETION_CONTENT)
+            .expect("record child completion sentinel");
         return;
     }
 
-    let home = tempfile::tempdir().expect("create isolated HOME");
-    let astrid_home = tempfile::tempdir().expect("create isolated ASTRID_HOME");
+    let home = tempfile::Builder::new()
+        .prefix("astrid-path-setup-home-profile")
+        .tempdir()
+        .expect("create isolated HOME");
+    let astrid_home = tempfile::Builder::new()
+        .prefix("astrid-path-setup-home")
+        .tempdir()
+        .expect("create isolated ASTRID_HOME");
+    let completion = home.path().join("child-returned");
+
+    let harness = std::env::current_exe().expect("test executable");
+    assert!(
+        harness
+            .parent()
+            .is_some_and(|parent| parent.ends_with("deps"))
+            && harness
+                .file_name()
+                .is_some_and(|name| name.to_string_lossy().starts_with("astrid-")),
+        "child must be the hashed libtest harness, not the CLI: {}",
+        harness.display()
+    );
     let profile = home.path().join(".zshrc");
 
     // Read-only canary: if the guard regresses, it should be obvious whether
@@ -220,13 +256,18 @@ fn ensure_path_setup_explicit_nondefault_home_subprocess() {
         )
     });
 
-    let output = std::process::Command::new(std::env::current_exe().expect("test executable"))
-        .args(["--exact", test_name, "--nocapture"])
-        .env(child_marker, "1")
+    let output = std::process::Command::new(&harness)
+        .args(["--exact", test_name.as_str(), "--nocapture"])
+        .env_clear()
+        .env(CHILD_MARKER, "1")
+        .env(CHILD_COMPLETION_VAR, &completion)
         .env("HOME", home.path())
         .env("ASTRID_HOME", astrid_home.path())
         .env("SHELL", "/bin/zsh")
         .env("PATH", "/usr/bin:/bin")
+        .env("TMPDIR", home.path())
+        .env("RUST_TEST_THREADS", "1")
+        .env("RUST_BACKTRACE", "1")
         .stdin(std::process::Stdio::null())
         .output()
         .expect("spawn isolated PATH-setup child");
@@ -237,6 +278,14 @@ fn ensure_path_setup_explicit_nondefault_home_subprocess() {
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
+    let child_completion = std::fs::read(&completion).unwrap_or_else(|error| {
+        panic!(
+            "child must return from ensure_path_setup: {error}; filter={test_name}\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    assert_eq!(child_completion.as_slice(), CHILD_COMPLETION_CONTENT);
     assert!(!profile.exists(), "explicit isolated home must not edit rc");
     assert!(
         !astrid_home.path().join("bin").exists(),

--- a/crates/astrid-cli/src/commands/self_update_tests.rs
+++ b/crates/astrid-cli/src/commands/self_update_tests.rs
@@ -177,49 +177,85 @@ fn shell_profile_setup_skips_invalid_explicit_home() {
     }
 }
 
+#[cfg(unix)]
+const CHILD_MARKER: &str = "ASTRID_PATH_SETUP_SUBPROCESS";
+#[cfg(unix)]
+const CHILD_COMPLETION_VAR: &str = "ASTRID_PATH_SETUP_COMPLETION";
+#[cfg(unix)]
+const CHILD_COMPLETION_CONTENT: &[u8] = b"ensure_path_setup returned";
+
 /// Exercise the real mutating function in a child process so all process-wide
 /// application-home inputs can be pinned without altering the test runner.
 #[cfg(unix)]
 #[test]
 fn ensure_path_setup_explicit_nondefault_home_subprocess() {
-    const CHILD_MARKER: &str = "ASTRID_PATH_SETUP_SUBPROCESS";
-    const CHILD_COMPLETION_VAR: &str = "ASTRID_PATH_SETUP_COMPLETION";
-    const CHILD_COMPLETION_CONTENT: &[u8] = b"ensure_path_setup returned";
-    let module_path = module_path!();
-    let test_name = format!(
-        "{}::ensure_path_setup_explicit_nondefault_home_subprocess",
-        module_path.strip_prefix("astrid::").unwrap_or(module_path)
-    );
-
     if std::env::var_os(CHILD_MARKER).is_some() {
-        let home = PathBuf::from(std::env::var_os("HOME").expect("child HOME"));
-        let astrid_home =
-            PathBuf::from(std::env::var_os("ASTRID_HOME").expect("child ASTRID_HOME"));
-        assert!(
-            home.file_name().is_some_and(|name| name
-                .to_string_lossy()
-                .starts_with("astrid-path-setup-home-profile")),
-            "child must run against the isolated application home"
-        );
-        assert!(
-            astrid_home
-                .file_name()
-                .is_some_and(|name| name.to_string_lossy().starts_with("astrid-path-setup-home")),
-            "child must run against the isolated application home"
-        );
-        assert!(
-            std::env::var("SHELL").is_ok_and(|shell| shell.ends_with("zsh")),
-            "child must select a disposable zsh profile"
-        );
-        ensure_path_setup().expect("explicit isolated home must not fail PATH setup");
-
-        let completion =
-            PathBuf::from(std::env::var_os(CHILD_COMPLETION_VAR).expect("completion path"));
-        std::fs::write(completion, CHILD_COMPLETION_CONTENT)
-            .expect("record child completion sentinel");
+        run_explicit_nondefault_home_child();
         return;
     }
+    run_explicit_nondefault_home_parent();
+}
 
+#[cfg(unix)]
+fn run_explicit_nondefault_home_child() {
+    let home = PathBuf::from(std::env::var_os("HOME").expect("child HOME"));
+    let astrid_home = PathBuf::from(std::env::var_os("ASTRID_HOME").expect("child ASTRID_HOME"));
+    assert!(
+        home.file_name().is_some_and(|name| name
+            .to_string_lossy()
+            .starts_with("astrid-path-setup-home-profile")),
+        "child must run against the isolated application home"
+    );
+    assert!(
+        astrid_home
+            .file_name()
+            .is_some_and(|name| name.to_string_lossy().starts_with("astrid-path-setup-home")),
+        "child must run against the isolated application home"
+    );
+    assert!(
+        std::env::var("SHELL").is_ok_and(|shell| shell.ends_with("zsh")),
+        "child must select a disposable zsh profile"
+    );
+    ensure_path_setup().expect("explicit isolated home must not fail PATH setup");
+
+    let completion =
+        PathBuf::from(std::env::var_os(CHILD_COMPLETION_VAR).expect("completion path"));
+    std::fs::write(completion, CHILD_COMPLETION_CONTENT).expect("record child completion sentinel");
+}
+
+#[cfg(unix)]
+fn run_explicit_nondefault_home_parent() {
+    let (home, astrid_home) = create_isolated_path_setup_homes();
+    let profile = home.path().join(".zshrc");
+    let completion = home.path().join("child-returned");
+    let real_rc = directories::BaseDirs::new()
+        .expect("resolve caller BaseDirs")
+        .home_dir()
+        .join(".zshrc");
+    let before = read_real_rc_canary(&real_rc);
+
+    let output = spawn_explicit_nondefault_home_child(home.path(), astrid_home.path(), &completion);
+    assert_child_success(&output);
+
+    let child_completion = std::fs::read(&completion).unwrap_or_else(|error| {
+        panic!(
+            "child must return from ensure_path_setup: {error}\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    assert_eq!(child_completion.as_slice(), CHILD_COMPLETION_CONTENT);
+    assert_isolated_home_untouched(&astrid_home, &profile);
+
+    let after = read_real_rc_canary(&real_rc);
+    assert_eq!(
+        before, after,
+        "real account rc content and mtime must remain unchanged"
+    );
+}
+
+#[cfg(unix)]
+fn create_isolated_path_setup_homes() -> (tempfile::TempDir, tempfile::TempDir) {
     let home = tempfile::Builder::new()
         .prefix("astrid-path-setup-home-profile")
         .tempdir()
@@ -228,8 +264,30 @@ fn ensure_path_setup_explicit_nondefault_home_subprocess() {
         .prefix("astrid-path-setup-home")
         .tempdir()
         .expect("create isolated ASTRID_HOME");
-    let completion = home.path().join("child-returned");
+    (home, astrid_home)
+}
 
+#[cfg(unix)]
+fn read_real_rc_canary(real_rc: &Path) -> Option<(Vec<u8>, std::time::SystemTime)> {
+    std::fs::metadata(real_rc).ok().map(|metadata| {
+        (
+            std::fs::read(real_rc).expect("read rc canary"),
+            metadata.modified().expect("read rc mtime"),
+        )
+    })
+}
+
+#[cfg(unix)]
+fn spawn_explicit_nondefault_home_child(
+    home: &Path,
+    astrid_home: &Path,
+    completion: &Path,
+) -> std::process::Output {
+    let module_path = module_path!();
+    let test_name = format!(
+        "{}::ensure_path_setup_explicit_nondefault_home_subprocess",
+        module_path.strip_prefix("astrid::").unwrap_or(module_path)
+    );
     let harness = std::env::current_exe().expect("test executable");
     assert!(
         harness
@@ -241,66 +299,40 @@ fn ensure_path_setup_explicit_nondefault_home_subprocess() {
         "child must be the hashed libtest harness, not the CLI: {}",
         harness.display()
     );
-    let profile = home.path().join(".zshrc");
 
-    // Read-only canary: if the guard regresses, it should be obvious whether
-    // the real rc changed during the test rather than before it.
-    let real_rc = directories::BaseDirs::new()
-        .expect("resolve caller BaseDirs")
-        .home_dir()
-        .join(".zshrc");
-    let before = std::fs::metadata(&real_rc).ok().map(|metadata| {
-        (
-            std::fs::read(&real_rc).expect("read rc canary"),
-            metadata.modified().expect("read rc mtime"),
-        )
-    });
-
-    let output = std::process::Command::new(&harness)
+    std::process::Command::new(&harness)
         .args(["--exact", test_name.as_str(), "--nocapture"])
         .env_clear()
         .env(CHILD_MARKER, "1")
-        .env(CHILD_COMPLETION_VAR, &completion)
-        .env("HOME", home.path())
-        .env("ASTRID_HOME", astrid_home.path())
+        .env(CHILD_COMPLETION_VAR, completion)
+        .env("HOME", home)
+        .env("ASTRID_HOME", astrid_home)
         .env("SHELL", "/bin/zsh")
         .env("PATH", "/usr/bin:/bin")
-        .env("TMPDIR", home.path())
+        .env("TMPDIR", home)
         .env("RUST_TEST_THREADS", "1")
         .env("RUST_BACKTRACE", "1")
         .stdin(std::process::Stdio::null())
         .output()
-        .expect("spawn isolated PATH-setup child");
+        .expect("spawn isolated PATH-setup child")
+}
 
+#[cfg(unix)]
+fn assert_child_success(output: &std::process::Output) {
     assert!(
         output.status.success(),
         "isolated PATH-setup child failed:\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
-    let child_completion = std::fs::read(&completion).unwrap_or_else(|error| {
-        panic!(
-            "child must return from ensure_path_setup: {error}; filter={test_name}\nstdout:\n{}\nstderr:\n{}",
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        )
-    });
-    assert_eq!(child_completion.as_slice(), CHILD_COMPLETION_CONTENT);
+}
+
+#[cfg(unix)]
+fn assert_isolated_home_untouched(astrid_home: &tempfile::TempDir, profile: &Path) {
     assert!(!profile.exists(), "explicit isolated home must not edit rc");
     assert!(
         !astrid_home.path().join("bin").exists(),
         "explicit isolated home must not create its bin directory"
-    );
-
-    let after = std::fs::metadata(&real_rc).ok().map(|metadata| {
-        (
-            std::fs::read(&real_rc).expect("read rc canary"),
-            metadata.modified().expect("read rc mtime"),
-        )
-    });
-    assert_eq!(
-        before, after,
-        "real account rc content and mtime must remain unchanged"
     );
 }
 


### PR DESCRIPTION
## Linked Issue

Closes #1183

## Summary

`astrid init` no longer appends an `# Astrid OS` PATH block to the account shell startup file when `ASTRID_HOME` is an explicit non-default home. Default-home installations keep the existing shell integration.

PATH setup now lives in a private module so the home-boundary and idempotency contract stay explicit: classify `ASTRID_HOME` before creating `bin` or reading or writing a shell profile.

## Changes

- Gate PATH setup on the selected home: absent `ASTRID_HOME` or an explicit home that matches the resolved default `~/.astrid` still performs account-shell setup.
- Return before profile or bin-dir mutation for explicit non-default, invalid, or non-matching homes, including non-UTF-8 `ASTRID_HOME` values captured via `var_os`.
- Keep the existing default-home idempotency guard: exact emitted blocks and whole-component PATH matches skip a second append; commented or prefix matches do not.
- Move PATH helpers into `commands/self_update/path_setup.rs`. `ensure_path_setup` remains reachable as `commands::self_update::ensure_path_setup`.
- Add helper tests for the home-boundary and invalid-explicit-home cases, plus a Unix subprocess regression that runs the real `ensure_path_setup` under disposable `HOME` / `ASTRID_HOME` / `SHELL` and proves it neither edits the account rc nor creates the isolated bin directory.
- Split that subprocess witness into focused helpers so Clippy `too_many_lines` stays clean without `#[allow]` and without weakening the child-process assertions.

## Verification

- Focused `commands::self_update` tests: 25 passed
- Subprocess regression `ensure_path_setup_explicit_nondefault_home_subprocess`: passed, parent reports running 1 test
- Local Clippy `-D warnings` on `astrid` binary all-targets: passed
- Unique range versus `origin/main` `768fad8a43446bc29aefd02c1a494efc8eddc0a3`: four signed commits, head `f18867ee72af20e281371193a928629b42086afe`
- GPG Good/full `7CD32E7697286B11593246B9FA53358CB4127512`
- Exact DCO `Signed-off-by: Joshua J. Bouw <jjb@unicity-labs.com>`

This PR does not change runtime stop layout, Distro Apply, Windows transport, or live operator homes.

## AI / Tool Assistance

Implemented and tested with Codex. Final source and landing remain subject to independent review and required CI.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/{issue}.{kind}.md` (docs/CI-only may skip; release PRs roll fragments into the version section instead of adding one)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
