### PR TITLE
feat(release): import Developer ID and Apple-ID notary profile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,7 +188,11 @@ jobs:
       - name: Build, sign, and notarize AstridFS
         if: contains(matrix.target, 'apple-darwin')
         env:
-          ASTRID_FSKIT_DEVELOPMENT_TEAM: ${{ secrets.ASTRID_MACOS_DEVELOPMENT_TEAM_ID }}
+          ASTRID_MACOS_DEVELOPMENT_TEAM_ID: ${{ secrets.ASTRID_MACOS_DEVELOPMENT_TEAM_ID }}
+          ASTRID_MACOS_DEVELOPER_ID_P12: ${{ secrets.ASTRID_MACOS_DEVELOPER_ID_P12 }}
+          ASTRID_MACOS_DEVELOPER_ID_P12_PASSWORD: ${{ secrets.ASTRID_MACOS_DEVELOPER_ID_P12_PASSWORD }}
+          ASTRID_MACOS_NOTARY_APPLE_ID: ${{ secrets.ASTRID_MACOS_NOTARY_APPLE_ID }}
+          ASTRID_MACOS_NOTARY_APP_PASSWORD: ${{ secrets.ASTRID_MACOS_NOTARY_APP_PASSWORD }}
           ASTRID_FSKIT_CODE_SIGN_IDENTITY: ${{ vars.ASTRID_MACOS_DEVELOPER_ID_IDENTITY || 'Developer ID Application' }}
           ASTRID_FSKIT_ARCHS: ${{ matrix.target == 'x86_64-apple-darwin' && 'x86_64' || 'arm64' }}
           ASTRID_FSKIT_NOTARIZE: "1"
@@ -196,18 +200,15 @@ jobs:
           ASTRID_FSKIT_NOTARY_ISSUER_ID: ${{ secrets.ASTRID_MACOS_NOTARY_ISSUER_ID }}
           ASTRID_FSKIT_NOTARY_KEY: ${{ secrets.ASTRID_MACOS_NOTARY_KEY }}
         run: |
-          NOTARY_KEY_PATH="$RUNNER_TEMP/astrid-notary.p8"
-          printf '%s' "$ASTRID_FSKIT_NOTARY_KEY" > "$NOTARY_KEY_PATH"
-          chmod 0600 "$NOTARY_KEY_PATH"
-          export ASTRID_FSKIT_NOTARY_KEY_PATH="$NOTARY_KEY_PATH"
-          trap 'rm -f "$NOTARY_KEY_PATH"' EXIT
-          scripts/build-macos-fskit.sh
+          scripts/ci/import_macos_signing.sh
           echo "ASTRID_FSKIT_APP=$PWD/target/macos-fskit/DerivedData/Build/Products/Release/AstridFS.app" >> "$GITHUB_ENV"
 
       - name: Sign the macOS FSKit companion
         if: contains(matrix.target, 'apple-darwin')
         env:
           ASTRID_MACOS_DEVELOPMENT_TEAM_ID: ${{ secrets.ASTRID_MACOS_DEVELOPMENT_TEAM_ID }}
+          ASTRID_MACOS_DEVELOPER_ID_P12: ${{ secrets.ASTRID_MACOS_DEVELOPER_ID_P12 }}
+          ASTRID_MACOS_DEVELOPER_ID_P12_PASSWORD: ${{ secrets.ASTRID_MACOS_DEVELOPER_ID_P12_PASSWORD }}
           MACOS_DEVELOPER_ID_IDENTITY: ${{ vars.ASTRID_MACOS_DEVELOPER_ID_IDENTITY }}
         run: |
           set -euo pipefail
@@ -215,18 +216,11 @@ jobs:
           COMPANION_IDENTIFIER=org.astrid.runtime.fs.storage-provider-fskit
           COMPANION="$PWD/target/${{ matrix.target }}/release/astrid-storage-provider-fskit"
           [[ -f "$COMPANION" && -x "$COMPANION" ]]
-          [[ -n "$ASTRID_MACOS_DEVELOPMENT_TEAM_ID" ]] || {
-            echo "ASTRID_MACOS_DEVELOPMENT_TEAM_ID is not configured for the FSKit companion" >&2
-            exit 1
-          }
-          [[ "$ASTRID_MACOS_DEVELOPMENT_TEAM_ID" == "$COMPANION_TEAM" ]] || {
-            echo "ASTRID_MACOS_DEVELOPMENT_TEAM_ID does not match the required team $COMPANION_TEAM" >&2
-            exit 1
-          }
           IDENTITY="${MACOS_DEVELOPER_ID_IDENTITY:-Developer ID Application}"
-          codesign --force --options runtime --timestamp \
-            --identifier "$COMPANION_IDENTIFIER" \
-            --sign "$IDENTITY" "$COMPANION"
+          scripts/ci/import_macos_signing.sh --identity-only \
+            codesign --force --options runtime --timestamp \
+              --identifier "$COMPANION_IDENTIFIER" \
+              --sign "$IDENTITY" "$COMPANION"
           COMPANION_SIGNATURE="$(codesign --display --verbose=4 "$COMPANION" 2>&1)"
           grep -Fx "Identifier=$COMPANION_IDENTIFIER" <<<"$COMPANION_SIGNATURE" >/dev/null
           grep -Fx "TeamIdentifier=$COMPANION_TEAM" <<<"$COMPANION_SIGNATURE" >/dev/null

--- a/scripts/build-macos-fskit.sh
+++ b/scripts/build-macos-fskit.sh
@@ -18,6 +18,8 @@ ARCHS="${ASTRID_FSKIT_ARCHS:-$(uname -m)}"
 CODE_SIGN_TEAM=9BDSL5BJAP
 APP_IDENTIFIER=org.astrid.runtime.fs
 EXTENSION_IDENTIFIER=org.astrid.runtime.fs.AppEx
+NOTARY_PROFILE="${ASTRID_FSKIT_NOTARY_PROFILE:-}"
+NOTARY_KEYCHAIN="${ASTRID_FSKIT_NOTARY_KEYCHAIN:-}"
 
 if [[ -z "$ASTRID_VERSION" ]]; then
   echo "workspace Astrid version is missing" >&2
@@ -100,9 +102,14 @@ fi
 if [[ "${ASTRID_FSKIT_NOTARIZE:-0}" == 1 ]]; then
   NOTARY_ZIP="$OUTPUT_ROOT/AstridFS-notary.zip"
   ditto -c -k --keepParent "$APP_PATH" "$NOTARY_ZIP"
-  if [[ -n "${ASTRID_FSKIT_NOTARY_PROFILE:-}" ]]; then
+  if [[ -n "$NOTARY_PROFILE" ]]; then
+    if [[ -z "$NOTARY_KEYCHAIN" ]]; then
+      echo "Apple-ID notary submission requires ASTRID_FSKIT_NOTARY_KEYCHAIN" >&2
+      exit 1
+    fi
     xcrun notarytool submit "$NOTARY_ZIP" \
-      --keychain-profile "$ASTRID_FSKIT_NOTARY_PROFILE" --wait
+      --keychain-profile "$NOTARY_PROFILE" \
+      --keychain "$NOTARY_KEYCHAIN" --wait
   elif [[ -n "${ASTRID_FSKIT_NOTARY_KEY_PATH:-}" ]]; then
     : "${ASTRID_FSKIT_NOTARY_KEY_ID:?set ASTRID_FSKIT_NOTARY_KEY_ID}"
     : "${ASTRID_FSKIT_NOTARY_ISSUER_ID:?set ASTRID_FSKIT_NOTARY_ISSUER_ID}"

--- a/scripts/ci/import_macos_signing.sh
+++ b/scripts/ci/import_macos_signing.sh
@@ -19,7 +19,9 @@ cleanup() {
     security list-keychains -s "${RESTORE_KEYCHAINS[@]}" >/dev/null 2>&1
   fi
   if [[ -n "$SIGNING_KEYCHAIN" ]]; then
-    security delete-keychain "$SIGNING_KEYCHAIN" >/dev/null 2>&1
+    if [[ -f "$SIGNING_KEYCHAIN" ]]; then
+      security delete-keychain "$SIGNING_KEYCHAIN" >/dev/null 2>&1
+    fi
   fi
   if [[ -n "$P12_PATH" ]]; then
     rm -f "$P12_PATH"
@@ -105,9 +107,9 @@ create_signing_keychain() {
     RESTORE_KEYCHAINS+=("$original_keychain")
   done < <(security list-keychains -d user | sed -e $'s/^[[:space:]]*//' -e 's/^"//' -e 's/"$//')
 
+  SIGNING_KEYCHAIN="$keychain_path"
   security create-keychain -p "$keychain_password" "$keychain_path"
   security unlock-keychain -p "$keychain_password" "$keychain_path"
-  SIGNING_KEYCHAIN="$keychain_path"
   security list-keychains -s "$SIGNING_KEYCHAIN" "${RESTORE_KEYCHAINS[@]}" >/dev/null
 }
 

--- a/scripts/ci/import_macos_signing.sh
+++ b/scripts/ci/import_macos_signing.sh
@@ -7,6 +7,8 @@ NOTARY_PROFILE_NAME=astrid-fskit
 P12_PATH=
 P8_PATH=
 SIGNING_KEYCHAIN=
+KEYCHAIN_PASSWORD=
+NOTARY_MODE=
 RESTORE_KEYCHAINS=()
 
 cleanup() {
@@ -72,6 +74,7 @@ prepare_notary_input() {
       return 1
     }
     export ASTRID_FSKIT_NOTARY_PROFILE="$NOTARY_PROFILE_NAME"
+    NOTARY_MODE=apple-id
   elif [[ -n "$key_id" || -n "$issuer_id" || -n "$key" ]]; then
     [[ -n "$key_id" && -n "$issuer_id" && -n "$key" ]] || {
       echo "ASTRID_MACOS_NOTARY_KEY_ID, ASTRID_MACOS_NOTARY_ISSUER_ID, and ASTRID_MACOS_NOTARY_KEY are required together" >&2
@@ -82,6 +85,7 @@ prepare_notary_input() {
     printf '%s' "$key" >"$P8_PATH"
     chmod 0600 "$P8_PATH"
     export ASTRID_FSKIT_NOTARY_KEY_PATH="$P8_PATH"
+    NOTARY_MODE=api-key
   else
     echo "Apple-ID notary credentials or a complete App Store Connect API key are required" >&2
     return 1
@@ -94,6 +98,7 @@ create_signing_keychain() {
   local original_keychain
 
   keychain_password="$(openssl rand -hex 32)"
+  KEYCHAIN_PASSWORD="$keychain_password"
   keychain_path="$RUNNER_TEMP/astrid-signing-$$.keychain"
   while IFS= read -r original_keychain; do
     [[ -n "$original_keychain" ]] || continue
@@ -112,7 +117,7 @@ import_developer_id() {
     -P "$ASTRID_MACOS_DEVELOPER_ID_P12_PASSWORD" \
     -T /usr/bin/codesign
   security set-key-partition-list -S apple-tool:,apple: \
-    -k "$ASTRID_MACOS_DEVELOPER_ID_P12_PASSWORD" "$SIGNING_KEYCHAIN" >/dev/null
+    -k "$KEYCHAIN_PASSWORD" "$SIGNING_KEYCHAIN" >/dev/null
   security find-identity -v -p codesigning "$SIGNING_KEYCHAIN" |
     grep -Eq '[[:space:]]1 valid identit(y|ies)'
   rm -f "$P12_PATH"
@@ -137,6 +142,7 @@ else
 fi
 
 require_team
+export ASTRID_FSKIT_DEVELOPMENT_TEAM="$ASTRID_MACOS_DEVELOPMENT_TEAM_ID"
 require_developer_id
 [[ "$(uname -s)" == Darwin ]] || {
   echo "Developer ID signing requires macOS" >&2
@@ -162,11 +168,16 @@ import_developer_id
 
 if [[ "$MODE" == notary-build ]]; then
   prepare_notary_input
-  xcrun notarytool store-credentials "$NOTARY_PROFILE_NAME" \
-    --keychain "$SIGNING_KEYCHAIN" \
-    --apple-id "$ASTRID_MACOS_NOTARY_APPLE_ID" \
-    --password "$ASTRID_MACOS_NOTARY_APP_PASSWORD" \
-    --team-id "$ASTRID_MACOS_DEVELOPMENT_TEAM_ID" >/dev/null
+  if [[ "$NOTARY_MODE" == apple-id ]]; then
+    xcrun notarytool store-credentials "$NOTARY_PROFILE_NAME" \
+      --keychain "$SIGNING_KEYCHAIN" \
+      --apple-id "$ASTRID_MACOS_NOTARY_APPLE_ID" \
+      --password "$ASTRID_MACOS_NOTARY_APP_PASSWORD" \
+      --team-id "$ASTRID_MACOS_DEVELOPMENT_TEAM_ID" >/dev/null
+  elif [[ "$NOTARY_MODE" != api-key ]]; then
+    echo "notary input did not select Apple-ID or the API-key fallback" >&2
+    exit 1
+  fi
   SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
   "$SCRIPT_ROOT/scripts/build-macos-fskit.sh"
 else

--- a/scripts/ci/import_macos_signing.sh
+++ b/scripts/ci/import_macos_signing.sh
@@ -76,6 +76,11 @@ prepare_notary_input() {
       return 1
     }
     export ASTRID_FSKIT_NOTARY_PROFILE="$NOTARY_PROFILE_NAME"
+    [[ -n "$SIGNING_KEYCHAIN" ]] || {
+      echo "Apple-ID notary submission requires the ephemeral signing keychain" >&2
+      return 1
+    }
+    export ASTRID_FSKIT_NOTARY_KEYCHAIN="$SIGNING_KEYCHAIN"
     NOTARY_MODE=apple-id
   elif [[ -n "$key_id" || -n "$issuer_id" || -n "$key" ]]; then
     [[ -n "$key_id" && -n "$issuer_id" && -n "$key" ]] || {

--- a/scripts/ci/import_macos_signing.sh
+++ b/scripts/ci/import_macos_signing.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+set -euo pipefail
+umask 077
+
+REQUIRED_TEAM_ID=9BDSL5BJAP
+NOTARY_PROFILE_NAME=astrid-fskit
+P12_PATH=
+P8_PATH=
+SIGNING_KEYCHAIN=
+RESTORE_KEYCHAINS=()
+
+cleanup() {
+  local status=$?
+  trap - EXIT
+  set +e
+  if [[ "${#RESTORE_KEYCHAINS[@]}" -gt 0 ]]; then
+    security list-keychains -s "${RESTORE_KEYCHAINS[@]}" >/dev/null 2>&1
+  fi
+  if [[ -n "$SIGNING_KEYCHAIN" ]]; then
+    security delete-keychain "$SIGNING_KEYCHAIN" >/dev/null 2>&1
+  fi
+  if [[ -n "$P12_PATH" ]]; then
+    rm -f "$P12_PATH"
+  fi
+  if [[ -n "$P8_PATH" ]]; then
+    rm -f "$P8_PATH"
+  fi
+  exit "$status"
+}
+trap cleanup EXIT
+
+require_team() {
+  [[ -n "${ASTRID_MACOS_DEVELOPMENT_TEAM_ID:-}" ]] || {
+    echo "set ASTRID_MACOS_DEVELOPMENT_TEAM_ID" >&2
+    return 1
+  }
+  [[ "$ASTRID_MACOS_DEVELOPMENT_TEAM_ID" == "$REQUIRED_TEAM_ID" ]] || {
+    echo "ASTRID_MACOS_DEVELOPMENT_TEAM_ID does not match team $REQUIRED_TEAM_ID" >&2
+    return 1
+  }
+}
+
+require_developer_id() {
+  [[ -n "${ASTRID_MACOS_DEVELOPER_ID_P12:-}" ]] || {
+    echo "ASTRID_MACOS_DEVELOPER_ID_P12 is required for Developer ID signing" >&2
+    return 1
+  }
+  [[ -n "${ASTRID_MACOS_DEVELOPER_ID_P12_PASSWORD:-}" ]] || {
+    echo "ASTRID_MACOS_DEVELOPER_ID_P12_PASSWORD is required for Developer ID signing" >&2
+    return 1
+  }
+}
+
+write_developer_id_p12() {
+  P12_PATH="$RUNNER_TEMP/astrid-developer-id.p12.$$"
+  printf '%s' "$ASTRID_MACOS_DEVELOPER_ID_P12" |
+    python3 -c 'import base64, sys; sys.stdout.buffer.write(base64.b64decode(sys.stdin.read()))' \
+      >"$P12_PATH"
+  chmod 0600 "$P12_PATH"
+}
+
+prepare_notary_input() {
+  local apple_id=${ASTRID_MACOS_NOTARY_APPLE_ID:-}
+  local app_password=${ASTRID_MACOS_NOTARY_APP_PASSWORD:-}
+  local key_id=${ASTRID_FSKIT_NOTARY_KEY_ID:-}
+  local issuer_id=${ASTRID_FSKIT_NOTARY_ISSUER_ID:-}
+  local key=${ASTRID_FSKIT_NOTARY_KEY:-}
+
+  if [[ -n "$apple_id" || -n "$app_password" ]]; then
+    [[ -n "$apple_id" && -n "$app_password" ]] || {
+      echo "both ASTRID_MACOS_NOTARY_APPLE_ID and ASTRID_MACOS_NOTARY_APP_PASSWORD are required" >&2
+      return 1
+    }
+    export ASTRID_FSKIT_NOTARY_PROFILE="$NOTARY_PROFILE_NAME"
+  elif [[ -n "$key_id" || -n "$issuer_id" || -n "$key" ]]; then
+    [[ -n "$key_id" && -n "$issuer_id" && -n "$key" ]] || {
+      echo "ASTRID_MACOS_NOTARY_KEY_ID, ASTRID_MACOS_NOTARY_ISSUER_ID, and ASTRID_MACOS_NOTARY_KEY are required together" >&2
+      return 1
+    }
+    unset ASTRID_FSKIT_NOTARY_PROFILE
+    P8_PATH="$RUNNER_TEMP/astrid-notary.p8.$$"
+    printf '%s' "$key" >"$P8_PATH"
+    chmod 0600 "$P8_PATH"
+    export ASTRID_FSKIT_NOTARY_KEY_PATH="$P8_PATH"
+  else
+    echo "Apple-ID notary credentials or a complete App Store Connect API key are required" >&2
+    return 1
+  fi
+}
+
+create_signing_keychain() {
+  local keychain_password
+  local keychain_path
+  local original_keychain
+
+  keychain_password="$(openssl rand -hex 32)"
+  keychain_path="$RUNNER_TEMP/astrid-signing-$$.keychain"
+  while IFS= read -r original_keychain; do
+    [[ -n "$original_keychain" ]] || continue
+    RESTORE_KEYCHAINS+=("$original_keychain")
+  done < <(security list-keychains -d user | sed -e $'s/^[[:space:]]*//' -e 's/^"//' -e 's/"$//')
+
+  security create-keychain -p "$keychain_password" "$keychain_path"
+  security unlock-keychain -p "$keychain_password" "$keychain_path"
+  SIGNING_KEYCHAIN="$keychain_path"
+  security list-keychains -s "$SIGNING_KEYCHAIN" "${RESTORE_KEYCHAINS[@]}" >/dev/null
+}
+
+import_developer_id() {
+  security import "$P12_PATH" \
+    -k "$SIGNING_KEYCHAIN" \
+    -P "$ASTRID_MACOS_DEVELOPER_ID_P12_PASSWORD" \
+    -T /usr/bin/codesign
+  security set-key-partition-list -S apple-tool:,apple: \
+    -k "$ASTRID_MACOS_DEVELOPER_ID_P12_PASSWORD" "$SIGNING_KEYCHAIN" >/dev/null
+  security find-identity -v -p codesigning "$SIGNING_KEYCHAIN" |
+    grep -Eq '[[:space:]]1 valid identit(y|ies)'
+  rm -f "$P12_PATH"
+  P12_PATH=
+}
+
+MODE=notary-build
+if [[ "${1:-}" == "--identity-only" ]]; then
+  MODE=identity-only
+  shift
+fi
+if [[ "$MODE" == identity-only ]]; then
+  [[ $# -gt 0 ]] || {
+    echo "usage: import_macos_signing.sh [--identity-only] command [arguments]" >&2
+    exit 2
+  }
+else
+  [[ $# -eq 0 ]] || {
+    echo "usage: import_macos_signing.sh [--identity-only] command [arguments]" >&2
+    exit 2
+  }
+fi
+
+require_team
+require_developer_id
+[[ "$(uname -s)" == Darwin ]] || {
+  echo "Developer ID signing requires macOS" >&2
+  exit 1
+}
+: "${RUNNER_TEMP:?set RUNNER_TEMP}"
+command -v python3 >/dev/null 2>&1 || {
+  echo "python3 is required to decode the Developer ID identity" >&2
+  exit 1
+}
+command -v security >/dev/null 2>&1 || {
+  echo "security is required to manage the signing keychain" >&2
+  exit 1
+}
+command -v xcrun >/dev/null 2>&1 || {
+  echo "xcrun is required for macOS signing" >&2
+  exit 1
+}
+
+write_developer_id_p12
+create_signing_keychain
+import_developer_id
+
+if [[ "$MODE" == notary-build ]]; then
+  prepare_notary_input
+  xcrun notarytool store-credentials "$NOTARY_PROFILE_NAME" \
+    --keychain "$SIGNING_KEYCHAIN" \
+    --apple-id "$ASTRID_MACOS_NOTARY_APPLE_ID" \
+    --password "$ASTRID_MACOS_NOTARY_APP_PASSWORD" \
+    --team-id "$ASTRID_MACOS_DEVELOPMENT_TEAM_ID" >/dev/null
+  SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+  "$SCRIPT_ROOT/scripts/build-macos-fskit.sh"
+else
+  "$@"
+fi

--- a/scripts/test_channel_workflow_contract.sh
+++ b/scripts/test_channel_workflow_contract.sh
@@ -325,6 +325,183 @@ require(
     "triple-named binary upload",
 )
 
+darwin_signing = step_block("build", "Build, sign, and notarize AstridFS")
+companion_signing = step_block("build", "Sign the macOS FSKit companion")
+for name, value in (
+    (
+        "ASTRID_MACOS_DEVELOPMENT_TEAM_ID",
+        "${{ secrets.ASTRID_MACOS_DEVELOPMENT_TEAM_ID }}",
+    ),
+    (
+        "ASTRID_MACOS_DEVELOPER_ID_P12",
+        "${{ secrets.ASTRID_MACOS_DEVELOPER_ID_P12 }}",
+    ),
+    (
+        "ASTRID_MACOS_DEVELOPER_ID_P12_PASSWORD",
+        "${{ secrets.ASTRID_MACOS_DEVELOPER_ID_P12_PASSWORD }}",
+    ),
+    (
+        "ASTRID_MACOS_NOTARY_APPLE_ID",
+        "${{ secrets.ASTRID_MACOS_NOTARY_APPLE_ID }}",
+    ),
+    (
+        "ASTRID_MACOS_NOTARY_APP_PASSWORD",
+        "${{ secrets.ASTRID_MACOS_NOTARY_APP_PASSWORD }}",
+    ),
+):
+    require(
+        rf"^\s*{re.escape(name)}: {re.escape(value)}\s*$",
+        darwin_signing,
+        f"Darwin signing input {name}",
+    )
+require(
+    r"^\s*ASTRID_FSKIT_CODE_SIGN_IDENTITY: \$\{\{ vars\.ASTRID_MACOS_DEVELOPER_ID_IDENTITY \|\| 'Developer ID Application' \}\}\s*$",
+    darwin_signing,
+    "optional Developer ID identity override",
+)
+require(
+    r'^\s*ASTRID_FSKIT_NOTARIZE: "1"\s*$',
+    darwin_signing,
+    "mandatory AstridFS notarization",
+)
+for secret, github_secret in (
+    ("ASTRID_FSKIT_NOTARY_KEY_ID", "ASTRID_MACOS_NOTARY_KEY_ID"),
+    ("ASTRID_FSKIT_NOTARY_ISSUER_ID", "ASTRID_MACOS_NOTARY_ISSUER_ID"),
+    ("ASTRID_FSKIT_NOTARY_KEY", "ASTRID_MACOS_NOTARY_KEY"),
+):
+    api_key_line = f"{secret}: ${{{{ secrets.{github_secret} }}}}"
+    require(
+        rf"^\s*{re.escape(api_key_line)}\s*$",
+        darwin_signing,
+        f"API-key notarization fallback input {secret}",
+    )
+if "scripts/ci/import_macos_signing.sh" not in darwin_signing:
+    fail("Darwin signing must invoke the named import helper")
+if "ASTRID_NOTARY_KEY_PATH=" in darwin_signing:
+    fail("Darwin signing must not reconstruct the API-key file inline")
+
+for name, value in (
+    (
+        "ASTRID_MACOS_DEVELOPMENT_TEAM_ID",
+        "${{ secrets.ASTRID_MACOS_DEVELOPMENT_TEAM_ID }}",
+    ),
+    (
+        "ASTRID_MACOS_DEVELOPER_ID_P12",
+        "${{ secrets.ASTRID_MACOS_DEVELOPER_ID_P12 }}",
+    ),
+    (
+        "ASTRID_MACOS_DEVELOPER_ID_P12_PASSWORD",
+        "${{ secrets.ASTRID_MACOS_DEVELOPER_ID_P12_PASSWORD }}",
+    ),
+    (
+        "MACOS_DEVELOPER_ID_IDENTITY",
+        "${{ vars.ASTRID_MACOS_DEVELOPER_ID_IDENTITY }}",
+    ),
+):
+    require(
+        rf"^\s*{re.escape(name)}: {re.escape(value)}\s*$",
+        companion_signing,
+        f"companion signing input {name}",
+    )
+if "scripts/ci/import_macos_signing.sh --identity-only" not in companion_signing:
+    fail("companion signing must consume the same imported Developer ID identity")
+if "notarytool" in companion_signing:
+    fail("companion signing must remain separate from notary submission")
+
+helper_relpath = "scripts/ci/import_macos_signing.sh"
+helper_path = repo_root / helper_relpath
+helper = helper_path.read_text(encoding="utf-8")
+for fragment in (
+    "REQUIRED_TEAM_ID=9BDSL5BJAP",
+    '[[ -n "${ASTRID_MACOS_DEVELOPMENT_TEAM_ID:-}" ]] || {',
+    '[[ "$ASTRID_MACOS_DEVELOPMENT_TEAM_ID" == "$REQUIRED_TEAM_ID" ]] || {',
+    '[[ -n "${ASTRID_MACOS_DEVELOPER_ID_P12:-}" ]] || {',
+    '[[ -n "${ASTRID_MACOS_DEVELOPER_ID_P12_PASSWORD:-}" ]] || {',
+    'if [[ -n "$apple_id" || -n "$app_password" ]]; then',
+    'export ASTRID_FSKIT_NOTARY_PROFILE="$NOTARY_PROFILE_NAME"',
+    "unset ASTRID_FSKIT_NOTARY_PROFILE",
+    'P12_PATH="$RUNNER_TEMP/astrid-developer-id.p12.$$"',
+    'P8_PATH="$RUNNER_TEMP/astrid-notary.p8.$$"',
+    'chmod 0600 "$P12_PATH"',
+    'chmod 0600 "$P8_PATH"',
+    "security create-keychain",
+    'security import "$P12_PATH"',
+    'security delete-keychain "$SIGNING_KEYCHAIN"',
+    'rm -f "$P12_PATH"',
+    'rm -f "$P8_PATH"',
+    "trap cleanup EXIT",
+):
+    if fragment not in helper:
+        fail(f"macOS signing helper is missing {fragment}")
+
+apple_branch_start = helper.find('if [[ -n "$apple_id" || -n "$app_password" ]]; then')
+api_branch_start = helper.find(
+    'elif [[ -n "$key_id" || -n "$issuer_id" || -n "$key" ]]; then'
+)
+if apple_branch_start < 0 or api_branch_start < 0 or apple_branch_start > api_branch_start:
+    fail("helper must prefer the Apple-ID profile over the API-key fallback")
+apple_branch = helper[apple_branch_start:api_branch_start]
+api_branch_end = helper.find("else", api_branch_start)
+api_branch = helper[api_branch_start:api_branch_end]
+if 'export ASTRID_FSKIT_NOTARY_PROFILE="$NOTARY_PROFILE_NAME"' not in apple_branch:
+    fail("Apple-ID credentials must select the keychain-profile path")
+if "ASTRID_FSKIT_NOTARY_PROFILE" in api_branch and (
+    "unset ASTRID_FSKIT_NOTARY_PROFILE" not in api_branch
+):
+    fail("API-key fallback must not take the Apple-ID profile path")
+for api_variable in (
+    ("ASTRID_FSKIT_NOTARY_KEY_ID", "key_id"),
+    ("ASTRID_FSKIT_NOTARY_ISSUER_ID", "issuer_id"),
+    ("ASTRID_FSKIT_NOTARY_KEY", "key"),
+):
+    environment_name, local_name = api_variable
+    if f"local {local_name}=" not in helper:
+        fail(f"helper API-key fallback is missing {environment_name}")
+
+for case_name, case_env in (
+    (
+        "missing team",
+        {
+            "ASTRID_MACOS_DEVELOPER_ID_P12": "P12-SENTINEL",
+            "ASTRID_MACOS_DEVELOPER_ID_P12_PASSWORD": "PASSWORD-SENTINEL",
+        },
+    ),
+    (
+        "wrong team",
+        {
+            "ASTRID_MACOS_DEVELOPMENT_TEAM_ID": "WRONGTEAM",
+            "ASTRID_MACOS_DEVELOPER_ID_P12": "P12-SENTINEL",
+            "ASTRID_MACOS_DEVELOPER_ID_P12_PASSWORD": "PASSWORD-SENTINEL",
+        },
+    ),
+    (
+        "missing Developer ID p12",
+        {
+            "ASTRID_MACOS_DEVELOPMENT_TEAM_ID": "9BDSL5BJAP",
+            "ASTRID_MACOS_DEVELOPER_ID_P12_PASSWORD": "PASSWORD-SENTINEL",
+        },
+    ),
+):
+    case_environment = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "HOME": os.environ.get("HOME", "/tmp"),
+    }
+    case_environment.update(case_env)
+    result = subprocess.run(
+        [str(helper_path)],
+        env=case_environment,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode == 0:
+        fail(f"macOS signing helper did not fail closed for {case_name}")
+    helper_output = result.stdout + result.stderr
+    for sentinel in ("P12-SENTINEL", "PASSWORD-SENTINEL"):
+        if sentinel in helper_output:
+            fail(f"macOS signing helper leaked {sentinel} while testing {case_name}")
+print("macOS Developer ID import and Apple-ID notary profile contract: PASS")
+
 fskit = job_block("fskit-certification")
 release = job_block("github-release")
 for name, block in (("fskit-certification", fskit), ("github-release", release)):

--- a/scripts/test_channel_workflow_contract.sh
+++ b/scripts/test_channel_workflow_contract.sh
@@ -123,8 +123,10 @@ from __future__ import annotations
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 
@@ -417,9 +419,12 @@ for fragment in (
     '[[ "$ASTRID_MACOS_DEVELOPMENT_TEAM_ID" == "$REQUIRED_TEAM_ID" ]] || {',
     '[[ -n "${ASTRID_MACOS_DEVELOPER_ID_P12:-}" ]] || {',
     '[[ -n "${ASTRID_MACOS_DEVELOPER_ID_P12_PASSWORD:-}" ]] || {',
+    'export ASTRID_FSKIT_DEVELOPMENT_TEAM="$ASTRID_MACOS_DEVELOPMENT_TEAM_ID"',
     'if [[ -n "$apple_id" || -n "$app_password" ]]; then',
     'export ASTRID_FSKIT_NOTARY_PROFILE="$NOTARY_PROFILE_NAME"',
     "unset ASTRID_FSKIT_NOTARY_PROFILE",
+    "NOTARY_MODE=api-key",
+    "KEYCHAIN_PASSWORD=\"$keychain_password\"",
     'P12_PATH="$RUNNER_TEMP/astrid-developer-id.p12.$$"',
     'P8_PATH="$RUNNER_TEMP/astrid-notary.p8.$$"',
     'chmod 0600 "$P12_PATH"',
@@ -427,6 +432,9 @@ for fragment in (
     "security create-keychain",
     'security import "$P12_PATH"',
     'security delete-keychain "$SIGNING_KEYCHAIN"',
+    '-k "$KEYCHAIN_PASSWORD"',
+    'if [[ "$NOTARY_MODE" == apple-id ]]; then',
+    'elif [[ "$NOTARY_MODE" != api-key ]]; then',
     'rm -f "$P12_PATH"',
     'rm -f "$P8_PATH"',
     "trap cleanup EXIT",
@@ -500,6 +508,170 @@ for case_name, case_env in (
     for sentinel in ("P12-SENTINEL", "PASSWORD-SENTINEL"):
         if sentinel in helper_output:
             fail(f"macOS signing helper leaked {sentinel} while testing {case_name}")
+
+def write_executable(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def behavior_values(path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        key, separator, value = line.partition("=")
+        if separator:
+            values[key] = value
+    return values
+
+
+def run_signing_helper(fixture: Path, mode: str) -> subprocess.CompletedProcess[str]:
+    scripts = fixture / "scripts"
+    (scripts / "ci").mkdir(parents=True)
+    (fixture / "runner").mkdir()
+    shutil.copy2(helper_path, scripts / "ci" / "import_macos_signing.sh")
+
+    write_executable(
+        scripts / "build-macos-fskit.sh",
+        """#!/usr/bin/env bash
+set -euo pipefail
+{
+  printf 'team=%s\\n' "${ASTRID_FSKIT_DEVELOPMENT_TEAM-unset}"
+  printf 'profile=%s\\n' "${ASTRID_FSKIT_NOTARY_PROFILE-unset}"
+  if [[ -n "${ASTRID_FSKIT_NOTARY_KEY_PATH:-}" && -f "${ASTRID_FSKIT_NOTARY_KEY_PATH}" ]]; then
+    printf 'key_file=present\\n'
+  else
+    printf 'key_file=%s\\n' "${ASTRID_FSKIT_NOTARY_KEY_PATH-unset}"
+  fi
+} >> "$ASTRID_TEST_FIXTURE/build.log"
+""",
+    )
+
+    tool_bin = fixture / "bin"
+    tool_bin.mkdir()
+    write_executable(
+        tool_bin / "security",
+        """#!/usr/bin/env bash
+set -euo pipefail
+fixture=${ASTRID_TEST_FIXTURE:?set ASTRID_TEST_FIXTURE}
+printf '%s\\n' "$*" >> "$fixture/security-args.log"
+case "$1" in
+  list-keychains)
+    if [[ "${2:-}" == "-d" ]]; then
+      printf '%s\\n' "$fixture/original.keychain"
+    fi
+    ;;
+  set-key-partition-list)
+    [[ "${2:-}" == "-S" && "${4:-}" == "-k" ]] || exit 90
+    printf 'partition-password=%s\\n' "$5" >> "$fixture/behavior.log"
+    ;;
+  find-identity)
+    printf '%s\\n' '  1) ABC123 "Developer ID Application: Astrid (9BDSL5BJAP)"'
+    printf '%s\\n' '  1 valid identities'
+    ;;
+esac
+""",
+    )
+    write_executable(
+        tool_bin / "xcrun",
+        """#!/usr/bin/env bash
+set -euo pipefail
+fixture=${ASTRID_TEST_FIXTURE:?set ASTRID_TEST_FIXTURE}
+printf '%s\\n' "$*" >> "$fixture/xcrun.log"
+[[ "$1" == notarytool ]] || exit 90
+""",
+    )
+    write_executable(
+        tool_bin / "openssl",
+        """#!/usr/bin/env bash
+printf '%s\\n' TEST-KEYCHAIN-PASSWORD
+""",
+    )
+    write_executable(
+        tool_bin / "uname",
+        """#!/usr/bin/env bash
+printf '%s\\n' Darwin
+""",
+    )
+
+    environment = {
+        "PATH": f"{tool_bin}{os.pathsep}{os.environ.get('PATH', '/usr/bin:/bin')}",
+        "HOME": os.environ.get("HOME", "/tmp"),
+        "ASTRID_TEST_FIXTURE": str(fixture),
+        "RUNNER_TEMP": str(fixture / "runner"),
+        "ASTRID_MACOS_DEVELOPMENT_TEAM_ID": "9BDSL5BJAP",
+        "ASTRID_MACOS_DEVELOPER_ID_P12": "cDEyLXRlc3QtaW5wdXQ=",
+        "ASTRID_MACOS_DEVELOPER_ID_P12_PASSWORD": "P12-FILE-PASSWORD",
+        "ASTRID_FSKIT_NOTARY_PROFILE": "external-profile",
+        "ASTRID_FSKIT_NOTARY_KEY_ID": "",
+        "ASTRID_FSKIT_NOTARY_ISSUER_ID": "",
+        "ASTRID_FSKIT_NOTARY_KEY": "",
+    }
+    if mode == "apple-id":
+        environment.update(
+            {
+                "ASTRID_MACOS_NOTARY_APPLE_ID": "notary-test@example.invalid",
+                "ASTRID_MACOS_NOTARY_APP_PASSWORD": "APP-PASSWORD-TEST",
+            }
+        )
+    elif mode == "api-key":
+        environment.update(
+            {
+                "ASTRID_MACOS_NOTARY_APPLE_ID": "",
+                "ASTRID_MACOS_NOTARY_APP_PASSWORD": "",
+                "ASTRID_FSKIT_NOTARY_KEY_ID": "TEST-KEY-ID",
+                "ASTRID_FSKIT_NOTARY_ISSUER_ID": "TEST-ISSUER-ID",
+                "ASTRID_FSKIT_NOTARY_KEY": "p8-test-input",
+            }
+        )
+    else:
+        fail(f"unknown signing helper test mode {mode}")
+
+    return subprocess.run(
+        [str(scripts / "ci" / "import_macos_signing.sh")],
+        env=environment,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+with tempfile.TemporaryDirectory() as temporary_directory:
+    fixture = Path(temporary_directory)
+    apple = run_signing_helper(fixture / "apple-id", "apple-id")
+    if apple.returncode != 0:
+        fail(f"Apple-ID helper execution failed: {apple.stderr.strip()}")
+    apple_build = behavior_values(fixture / "apple-id" / "build.log")
+    if apple_build.get("team") != "9BDSL5BJAP":
+        fail("Apple-ID path did not execute the build with the mapped FSKit team")
+    if apple_build.get("profile") != "astrid-fskit":
+        fail("Apple-ID path did not export the notary keychain profile")
+    apple_xcrun = (fixture / "apple-id" / "xcrun.log").read_text(encoding="utf-8")
+    if "notarytool store-credentials astrid-fskit" not in apple_xcrun:
+        fail("Apple-ID path did not execute notary profile storage")
+    if behavior_values(fixture / "apple-id" / "behavior.log").get(
+        "partition-password"
+    ) != "TEST-KEYCHAIN-PASSWORD":
+        fail("partition list did not receive the generated ephemeral keychain password")
+
+    api = run_signing_helper(fixture / "api-key", "api-key")
+    if api.returncode != 0:
+        fail(f"API-key helper execution failed: {api.stderr.strip()}")
+    api_build = behavior_values(fixture / "api-key" / "build.log")
+    if api_build.get("team") != "9BDSL5BJAP":
+        fail("API-key path did not execute the build with the mapped FSKit team")
+    if api_build.get("profile") != "unset":
+        fail("API-key path leaked or selected the Apple-ID profile")
+    if api_build.get("key_file") != "present":
+        fail("API-key path did not write and pass the .p8 file")
+    xcrun_log = fixture / "api-key" / "xcrun.log"
+    if xcrun_log.exists() and "notarytool store-credentials" in xcrun_log.read_text(
+        encoding="utf-8"
+    ):
+        fail("API-key path executed Apple-ID profile storage")
+    if behavior_values(fixture / "api-key" / "behavior.log").get(
+        "partition-password"
+    ) != "TEST-KEYCHAIN-PASSWORD":
+        fail("API-key partition list did not receive the ephemeral keychain password")
+
 print("macOS Developer ID import and Apple-ID notary profile contract: PASS")
 
 fskit = job_block("fskit-certification")

--- a/scripts/test_channel_workflow_contract.sh
+++ b/scripts/test_channel_workflow_contract.sh
@@ -523,7 +523,9 @@ def behavior_values(path: Path) -> dict[str, str]:
     return values
 
 
-def run_signing_helper(fixture: Path, mode: str) -> subprocess.CompletedProcess[str]:
+def run_signing_helper(
+    fixture: Path, mode: str, security_failure: str | None = None
+) -> subprocess.CompletedProcess[str]:
     scripts = fixture / "scripts"
     (scripts / "ci").mkdir(parents=True)
     (fixture / "runner").mkdir()
@@ -552,12 +554,27 @@ set -euo pipefail
         """#!/usr/bin/env bash
 set -euo pipefail
 fixture=${ASTRID_TEST_FIXTURE:?set ASTRID_TEST_FIXTURE}
+failure=${ASTRID_TEST_SECURITY_FAILURE:-}
 printf '%s\\n' "$*" >> "$fixture/security-args.log"
 case "$1" in
   list-keychains)
     if [[ "${2:-}" == "-d" ]]; then
       printf '%s\\n' "$fixture/original.keychain"
     fi
+    ;;
+  create-keychain)
+    if [[ "$failure" == create ]]; then
+      exit 91
+    fi
+    : > "${*: -1}"
+    ;;
+  unlock-keychain)
+    if [[ "$failure" == unlock ]]; then
+      exit 92
+    fi
+    ;;
+  delete-keychain)
+    rm -f "${*: -1}"
     ;;
   set-key-partition-list)
     [[ "${2:-}" == "-S" && "${4:-}" == "-k" ]] || exit 90
@@ -625,6 +642,9 @@ printf '%s\\n' Darwin
     else:
         fail(f"unknown signing helper test mode {mode}")
 
+    if security_failure is not None:
+        environment["ASTRID_TEST_SECURITY_FAILURE"] = security_failure
+
     return subprocess.run(
         [str(scripts / "ci" / "import_macos_signing.sh")],
         env=environment,
@@ -671,6 +691,44 @@ with tempfile.TemporaryDirectory() as temporary_directory:
         "partition-password"
     ) != "TEST-KEYCHAIN-PASSWORD":
         fail("API-key partition list did not receive the ephemeral keychain password")
+
+    unlock = run_signing_helper(
+        fixture / "unlock-fail", "apple-id", security_failure="unlock"
+    )
+    if unlock.returncode == 0:
+        fail("macOS signing helper did not fail when unlock-keychain failed")
+    unlock_runner = fixture / "unlock-fail" / "runner"
+    unlock_keychains = list(unlock_runner.glob("*.keychain"))
+    if unlock_keychains:
+        fail("unlock-keychain failure left the ephemeral signing keychain")
+    unlock_args = (fixture / "unlock-fail" / "security-args.log").read_text(
+        encoding="utf-8"
+    )
+    unlock_create_lines = [
+        line for line in unlock_args.splitlines() if line.startswith("create-keychain ")
+    ]
+    unlock_delete_lines = [
+        line for line in unlock_args.splitlines() if line.startswith("delete-keychain ")
+    ]
+    if len(unlock_create_lines) != 1 or len(unlock_delete_lines) != 1:
+        fail("unlock-keychain failure cleanup did not delete exactly one keychain")
+    if unlock_create_lines[0].split(" ")[-1] != unlock_delete_lines[0].split(" ")[-1]:
+        fail("unlock-keychain failure cleanup deleted the wrong keychain path")
+
+    create = run_signing_helper(
+        fixture / "create-fail", "apple-id", security_failure="create"
+    )
+    if create.returncode != 91:
+        fail("create-keychain failure did not preserve the original security failure")
+    if create.stdout or create.stderr:
+        fail("create-keychain failure produced unexpected cleanup output")
+    create_args = (fixture / "create-fail" / "security-args.log").read_text(
+        encoding="utf-8"
+    )
+    if "delete-keychain " in create_args:
+        fail("create-keychain failure cleanup attempted to delete a missing keychain")
+    if list((fixture / "create-fail" / "runner").glob("*.keychain")):
+        fail("create-keychain failure left a keychain-like file")
 
 print("macOS Developer ID import and Apple-ID notary profile contract: PASS")
 

--- a/scripts/test_channel_workflow_contract.sh
+++ b/scripts/test_channel_workflow_contract.sh
@@ -453,6 +453,8 @@ api_branch_end = helper.find("else", api_branch_start)
 api_branch = helper[api_branch_start:api_branch_end]
 if 'export ASTRID_FSKIT_NOTARY_PROFILE="$NOTARY_PROFILE_NAME"' not in apple_branch:
     fail("Apple-ID credentials must select the keychain-profile path")
+if 'export ASTRID_FSKIT_NOTARY_KEYCHAIN="$SIGNING_KEYCHAIN"' not in apple_branch:
+    fail("Apple-ID credentials must bind submit to the ephemeral keychain path")
 if "ASTRID_FSKIT_NOTARY_PROFILE" in api_branch and (
     "unset ASTRID_FSKIT_NOTARY_PROFILE" not in api_branch
 ):
@@ -465,6 +467,19 @@ for api_variable in (
     environment_name, local_name = api_variable
     if f"local {local_name}=" not in helper:
         fail(f"helper API-key fallback is missing {environment_name}")
+
+build_helper_relpath = "scripts/build-macos-fskit.sh"
+build_helper = (repo_root / build_helper_relpath).read_text(encoding="utf-8")
+for fragment in (
+    'NOTARY_PROFILE="${ASTRID_FSKIT_NOTARY_PROFILE:-}"',
+    'NOTARY_KEYCHAIN="${ASTRID_FSKIT_NOTARY_KEYCHAIN:-}"',
+    'if [[ -z "$NOTARY_KEYCHAIN" ]]; then',
+    '"Apple-ID notary submission requires ASTRID_FSKIT_NOTARY_KEYCHAIN"',
+    '--keychain-profile "$NOTARY_PROFILE" \\',
+    '--keychain "$NOTARY_KEYCHAIN" --wait',
+):
+    if fragment not in build_helper:
+        fail(f"FSKit build script is missing {fragment}")
 
 for case_name, case_env in (
     (
@@ -538,12 +553,18 @@ set -euo pipefail
 {
   printf 'team=%s\\n' "${ASTRID_FSKIT_DEVELOPMENT_TEAM-unset}"
   printf 'profile=%s\\n' "${ASTRID_FSKIT_NOTARY_PROFILE-unset}"
+  printf 'notary-keychain=%s\\n' "${ASTRID_FSKIT_NOTARY_KEYCHAIN-unset}"
   if [[ -n "${ASTRID_FSKIT_NOTARY_KEY_PATH:-}" && -f "${ASTRID_FSKIT_NOTARY_KEY_PATH}" ]]; then
     printf 'key_file=present\\n'
   else
     printf 'key_file=%s\\n' "${ASTRID_FSKIT_NOTARY_KEY_PATH-unset}"
   fi
 } >> "$ASTRID_TEST_FIXTURE/build.log"
+if [[ -n "${ASTRID_FSKIT_NOTARY_PROFILE:-}" ]]; then
+  xcrun notarytool submit "$ASTRID_TEST_FIXTURE/notary.zip" \\
+    --keychain-profile "$ASTRID_FSKIT_NOTARY_PROFILE" \\
+    --keychain "$ASTRID_FSKIT_NOTARY_KEYCHAIN" --wait
+fi
 """,
     )
 
@@ -664,13 +685,58 @@ with tempfile.TemporaryDirectory() as temporary_directory:
         fail("Apple-ID path did not execute the build with the mapped FSKit team")
     if apple_build.get("profile") != "astrid-fskit":
         fail("Apple-ID path did not export the notary keychain profile")
+    if apple_build.get("notary-keychain") == "unset":
+        fail("Apple-ID path did not export the existing ephemeral keychain path")
     apple_xcrun = (fixture / "apple-id" / "xcrun.log").read_text(encoding="utf-8")
-    if "notarytool store-credentials astrid-fskit" not in apple_xcrun:
+    apple_xcrun_lines = apple_xcrun.splitlines()
+    store_lines = [
+        line
+        for line in apple_xcrun_lines
+        if line.startswith("notarytool store-credentials astrid-fskit ")
+    ]
+    submit_lines = [
+        line for line in apple_xcrun_lines if line.startswith("notarytool submit ")
+    ]
+    if len(store_lines) != 1 or "--keychain" not in store_lines[0]:
         fail("Apple-ID path did not execute notary profile storage")
+    if len(submit_lines) != 1:
+        fail("Apple-ID build did not execute notary profile submission")
+    store_args = store_lines[0].split(" ")
+    submit_args = submit_lines[0].split(" ")
+    store_keychain = store_args[store_args.index("--keychain") + 1]
+    if "--keychain-profile astrid-fskit" not in submit_lines[0]:
+        fail("Apple-ID submission did not use the stored keychain profile")
+    submit_keychain = submit_args[submit_args.index("--keychain") + 1]
+    if not store_keychain or submit_keychain != store_keychain:
+        fail("Apple-ID store and submit used different ephemeral keychain paths")
+    if submit_keychain != apple_build["notary-keychain"]:
+        fail("Apple-ID build received a different ephemeral keychain path")
     if behavior_values(fixture / "apple-id" / "behavior.log").get(
         "partition-password"
     ) != "TEST-KEYCHAIN-PASSWORD":
         fail("partition list did not receive the generated ephemeral keychain password")
+    apple_runner = fixture / "apple-id" / "runner"
+    if list(apple_runner.glob("*.keychain")):
+        fail("successful Apple-ID path left the ephemeral signing keychain")
+    apple_security_text = (
+        fixture / "apple-id" / "security-args.log"
+    ).read_text(encoding="utf-8")
+    apple_create_lines = [
+        line
+        for line in apple_security_text.splitlines()
+        if line.startswith("create-keychain ")
+    ]
+    apple_delete_lines = [
+        line
+        for line in apple_security_text.splitlines()
+        if line.startswith("delete-keychain ")
+    ]
+    if len(apple_create_lines) != 1 or len(apple_delete_lines) != 1:
+        fail("successful Apple-ID cleanup did not delete exactly one keychain")
+    if apple_create_lines[0].split(" ")[-1] != apple_delete_lines[0].split(" ")[-1]:
+        fail("successful Apple-ID cleanup deleted the wrong keychain path")
+    if apple_delete_lines[0].split(" ")[-1] != store_keychain:
+        fail("successful Apple-ID cleanup deleted a different notary keychain")
 
     api = run_signing_helper(fixture / "api-key", "api-key")
     if api.returncode != 0:
@@ -680,6 +746,8 @@ with tempfile.TemporaryDirectory() as temporary_directory:
         fail("API-key path did not execute the build with the mapped FSKit team")
     if api_build.get("profile") != "unset":
         fail("API-key path leaked or selected the Apple-ID profile")
+    if api_build.get("notary-keychain") != "unset":
+        fail("API-key path leaked the Apple-ID keychain path")
     if api_build.get("key_file") != "present":
         fail("API-key path did not write and pass the .p8 file")
     xcrun_log = fixture / "api-key" / "xcrun.log"


### PR DESCRIPTION
## Linked Issue

Related to #1817. This PR does not close the release tracking issue.

## Summary

Hosted Darwin `macos-latest` currently cannot import a Developer ID identity or reconstruct the Apple-ID notary profile that `scripts/build-macos-fskit.sh` needs. The existing `Release` workflow therefore cannot produce a signed, notarized `AstridFS.app` on GitHub-hosted runners.

This change adds a named helper, `scripts/ci/import_macos_signing.sh`, that:

- fail-closes unless `ASTRID_MACOS_DEVELOPMENT_TEAM_ID` equals `9BDSL5BJAP`;
- imports the Developer ID `.p12` into an ephemeral keychain;
- reconstructs the Apple-ID notary profile `astrid-fskit` in that keychain when Apple-ID credentials are present;
- exports the same ephemeral keychain path as `ASTRID_FSKIT_NOTARY_KEYCHAIN` so Apple-ID `notarytool submit` uses `--keychain-profile` plus `--keychain <path>` and does not fall back to the data-protection keychain;
- fail-closes Apple-ID/profile submit when that path is absent;
- preserves the App Store Connect API-key `.p8` fallback without Apple-ID profile storage or `--keychain`;
- keeps `ASTRID_FSKIT_NOTARIZE=1` so `scripts/build-macos-fskit.sh` notarizes and staples **AstridFS.app only**;
- signs the Unix companion through `import_macos_signing.sh --identity-only` without submitting it to notary.

Darwin `build` stays on `macos-latest` and outside `environment: release`. Workspace identity remains `0.10.4`. This does not tag, publish, promote, bump versions, first-publish a Windows runtime archive, or dispatch prepare-only/native certification.

## Changes

- `.github/workflows/release.yml` Darwin `Build, sign, and notarize AstridFS` supplies Developer ID and Apple-ID notary secret names to the helper and still sets `ASTRID_FSKIT_NOTARIZE: "1"`.
- The companion step reuses the same imported Developer ID via `scripts/ci/import_macos_signing.sh --identity-only` and still fail-closes on Identifier `org.astrid.runtime.fs.storage-provider-fskit` and TeamIdentifier `9BDSL5BJAP`.
- `scripts/ci/import_macos_signing.sh` owns ephemeral-keychain create/import/cleanup, team fail-closed checks, Apple-ID profile plus keychain-path export, and the API-key fallback.
- `scripts/build-macos-fskit.sh` Apple-ID submit now requires `ASTRID_FSKIT_NOTARY_KEYCHAIN` and passes `--keychain` with the stored profile. API-key submit is unchanged. App notarize/staple remains; companion notarization is not added.
- `scripts/test_channel_workflow_contract.sh` executes helper fail-closed cases and mocked Apple-ID/API-key success paths, including identical store/submit keychain paths and EXIT cleanup.

## Verification

- Exact head `f9f86c1859be1fd6da2593fb8c3d3689966bfdbf`. Sole parent `886fd7e2f2baaee1c4478b4fa803bb71cc7192cc`. Base `main`.
- Unique files versus parent: `scripts/ci/import_macos_signing.sh`, `scripts/build-macos-fskit.sh`, `scripts/test_channel_workflow_contract.sh`.
- GPG Good [full] key `7CD32E7697286B11593246B9FA53358CB4127512`; DCO present.
- Local: `scripts/test_channel_workflow_contract.sh` PASS; `scripts/ci/test-release-contracts.sh` PASS.
- Independent exact-head full GLM Max plus Luna Max review is required on this SHA. Predecessor ACCEPT does not transfer.
- The Copilot review thread on Apple-ID `--keychain-profile` submit remains unresolved until those independent reviews prove the bind.
- Source-only review cannot ACCEPT a certification-execution or published-artifact claim. Do not dispatch prepare-only or native certification until this vehicle lands on main and HQ re-verifies the exact main SHA.

## AI / Tool Assistance

Assisted-by: GLM-5.3-Flash: bounded hosted Darwin Developer ID import, Apple-ID notary profile reconstruction, ephemeral-keychain submit bind, companion identity-only signing, and executed channel-contract fail-closed cases.

I reviewed the unique successor diff, ancestry/GPG/DCO, and local contract suites. Independent exact-head review is required; this PR is not merge-ready on author evidence.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/{issue}.{kind}.md` (docs/CI-only may skip; release PRs roll fragments into the version section instead of adding one)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
