### PR TITLE
fix(build): resolve capsule artifacts from Cargo target dir

### DIFF
--- a/changes/1807.fixed.md
+++ b/changes/1807.fixed.md
@@ -1,7 +1,8 @@
 Capsule builds now follow Cargo's resolved configuration hierarchy (including
 ancestor and `$CARGO_HOME` files plus environment precedence), preserving
-effective rustflags while injecting the getrandom backend only for
-`wasm32-unknown-unknown`. The exact release cdylib reported by Cargo is bound
+effective rustflags for the selected target and its target dependencies while
+injecting the getrandom backend only for `wasm32-unknown-unknown`. The exact
+release cdylib reported by Cargo is bound
 to one artifact under Cargo's metadata target directory; missing,
 non-regular, symlinked, ambiguous, or escaping artifacts fail closed. Existing
 manifests are rebound to that exact packaged WASM filename so renamed cdylibs

--- a/changes/1807.fixed.md
+++ b/changes/1807.fixed.md
@@ -1,0 +1,8 @@
+Capsule builds now follow Cargo's resolved configuration hierarchy (including
+ancestor and `$CARGO_HOME` files plus environment precedence), preserving
+effective rustflags while injecting the getrandom backend only for
+`wasm32-unknown-unknown`. The exact release cdylib reported by Cargo is bound
+to one artifact under Cargo's metadata target directory; missing,
+non-regular, symlinked, ambiguous, or escaping artifacts fail closed. Existing
+manifests are rebound to that exact packaged WASM filename so renamed cdylibs
+remain executable. Closes #1807

--- a/changes/1807.fixed.md
+++ b/changes/1807.fixed.md
@@ -1,7 +1,9 @@
 Capsule builds now follow Cargo's resolved configuration hierarchy (including
 ancestor and `$CARGO_HOME` files plus environment precedence), preserving
-effective rustflags for the selected target and its target dependencies while
-injecting the getrandom backend only for `wasm32-unknown-unknown`. The exact
+effective rustflags for the selected target and its target dependencies,
+preserving Cargo's string or array form and falling back to `[build]` flags
+when a matching target entry is empty, while injecting the getrandom backend
+only for `wasm32-unknown-unknown`. The exact
 release cdylib reported by Cargo is bound
 to one artifact under Cargo's metadata target directory; missing,
 non-regular, symlinked, ambiguous, or escaping artifacts fail closed. Existing

--- a/crates/astrid-build/src/rust.rs
+++ b/crates/astrid-build/src/rust.rs
@@ -9,6 +9,8 @@ use std::process::{Command, Stdio};
 use tracing::{info, warn};
 
 mod config;
+use config::EffectiveCargoRustflags;
+use config::{cargo_config_effective_rustflags_for_target, cargo_config_target_and_rustflags};
 #[cfg(test)]
 use config::{
     cargo_config_has_matching_target_rustflags_with_home,
@@ -16,7 +18,6 @@ use config::{
     cargo_config_target_and_rustflags_for_target_with_home,
     cargo_config_target_and_rustflags_with_home, resolve_cargo_home,
 };
-use config::{cargo_config_rustflags_for_target, cargo_config_target_and_rustflags};
 
 /// Stub WIT package written when a capsule has no local `wit/` directory.
 /// Gives `push_dir` a main package to anchor on so deps can still be loaded.
@@ -213,10 +214,10 @@ fn compile_wasm(dir: &Path, package_id: &PackageId, wasm_name: &str) -> Result<C
         .ok()
         .filter(|target| !target.trim().is_empty());
     let target = resolve_build_target(config_target, env_target)?;
-    let (config_flags, has_matching_target_rustflags) = if inject_getrandom_for_target(&target) {
-        cargo_config_rustflags_for_target(dir, &target)?
+    let config_rustflags = if inject_getrandom_for_target(&target) {
+        cargo_config_effective_rustflags_for_target(dir, &target)?
     } else {
-        (Vec::new(), false)
+        EffectiveCargoRustflags::default()
     };
     let rustflags = RustflagsEnvironment::from_process(&target);
     compile_wasm_with_target(
@@ -224,8 +225,7 @@ fn compile_wasm(dir: &Path, package_id: &PackageId, wasm_name: &str) -> Result<C
         package_id,
         wasm_name,
         target,
-        &config_flags,
-        has_matching_target_rustflags,
+        &config_rustflags,
         &rustflags,
     )
 }
@@ -235,8 +235,7 @@ fn compile_wasm_with_target(
     package_id: &PackageId,
     wasm_name: &str,
     target: String,
-    config_flags: &[String],
-    has_matching_target_rustflags: bool,
+    config_rustflags: &EffectiveCargoRustflags,
     rustflags: &RustflagsEnvironment,
 ) -> Result<CompiledWasm> {
     info!("   Compiling capsule (release)...");
@@ -257,13 +256,7 @@ fn compile_wasm_with_target(
         .stderr(Stdio::inherit());
     rustflags.configure_command(&mut cmd, &target);
     if inject_getrandom_cfg {
-        append_getrandom_rustflag(
-            &mut cmd,
-            &target,
-            has_matching_target_rustflags,
-            config_flags,
-            rustflags,
-        );
+        append_getrandom_rustflag(&mut cmd, &target, config_rustflags, rustflags);
     }
 
     let mut child = cmd.spawn().context("Failed to spawn cargo build")?;
@@ -335,13 +328,12 @@ fn inject_getrandom_for_target(target: &str) -> bool {
 fn append_getrandom_rustflag(
     cmd: &mut Command,
     target: &str,
-    has_matching_target_rustflags: bool,
-    config_flags: &[String],
+    config_rustflags: &EffectiveCargoRustflags,
     rustflags: &RustflagsEnvironment,
 ) {
     let Some((key, value)) = getrandom_rustflags_override(
         target,
-        config_flags,
+        &config_rustflags.flags,
         rustflags.encoded.as_deref(),
         rustflags.plain.as_deref(),
         rustflags.target_specific.as_deref(),
@@ -352,14 +344,19 @@ fn append_getrandom_rustflag(
     if rustflags.encoded.is_none()
         && rustflags.plain.is_none()
         && rustflags.target_specific.is_none()
-        && (rustflags.build.is_none() || has_matching_target_rustflags)
+        && (rustflags.build.is_none() || config_rustflags.has_matching_target)
     {
-        if has_matching_target_rustflags {
+        if config_rustflags.has_matching_target {
             // Let Cargo merge all matching target triples and cfg expressions,
             // ancestor arrays, and its own config precedence before adding
             // ours. Matching target entries already shadow build rustflags;
             // preserving them here avoids changing that precedence.
-            let config = cargo_config_with_getrandom(&[]);
+            // Reuse the effective caller representation so same-key string
+            // and array entries both remain valid TOML.
+            let config = cargo_config_with_getrandom(
+                &config_rustflags.flags,
+                config_rustflags.flags_are_array,
+            );
             cmd.args(["--config", config.as_str()]);
         } else {
             // With `build.target`, stable Cargo routes these flags to target
@@ -372,15 +369,30 @@ fn append_getrandom_rustflag(
     }
 }
 
-fn cargo_config_with_getrandom(config_flags: &[String]) -> String {
-    let mut flags = toml_edit::Array::new();
-    for flag in config_flags {
-        flags.push(flag.as_str());
-    }
-    if !config_flags.iter().any(|flag| flag == GETRANDOM_CUSTOM_CFG) {
-        flags.push(GETRANDOM_CUSTOM_CFG);
-    }
-    format!("{GETRANDOM_CARGO_CONFIG_TARGET}{flags}")
+fn cargo_config_with_getrandom(config_flags: &[String], flags_are_array: bool) -> String {
+    let value = if flags_are_array {
+        let mut flags = toml_edit::Array::new();
+        for flag in config_flags {
+            flags.push(flag.as_str());
+        }
+        if !config_flags.iter().any(|flag| flag == GETRANDOM_CUSTOM_CFG) {
+            flags.push(GETRANDOM_CUSTOM_CFG);
+        }
+        flags.to_string()
+    } else {
+        let mut flags = config_flags.join(" ");
+        if !flags
+            .split_whitespace()
+            .any(|flag| flag == GETRANDOM_CUSTOM_CFG)
+        {
+            if !flags.is_empty() {
+                flags.push(' ');
+            }
+            flags.push_str(GETRANDOM_CUSTOM_CFG);
+        }
+        toml_edit::Value::from(flags).to_string()
+    };
+    format!("{GETRANDOM_CARGO_CONFIG_TARGET}{value}")
 }
 
 #[derive(Default)]

--- a/crates/astrid-build/src/rust.rs
+++ b/crates/astrid-build/src/rust.rs
@@ -362,12 +362,10 @@ fn append_getrandom_rustflag(
             let config = cargo_config_with_getrandom(&[]);
             cmd.args(["--config", config.as_str()]);
         } else {
-            // A target-specific override shadows `[build].rustflags`, so
-            // carry the effective build flags into the override before adding
-            // the backend cfg. Otherwise the builder silently drops caller
-            // flags for every dependency and the root cdylib alike.
-            let config = cargo_config_with_getrandom(config_flags);
-            cmd.args(["--config", config.as_str()]);
+            // With `build.target`, stable Cargo routes these flags to target
+            // units rather than host units. Encoded rustflags remain the
+            // highest-precedence source for the wasm dependency and cdylib.
+            cmd.env(key, value);
         }
     } else {
         cmd.env(key, value);

--- a/crates/astrid-build/src/rust.rs
+++ b/crates/astrid-build/src/rust.rs
@@ -1,10 +1,22 @@
 //! Rust capsule builder — compiles a Rust crate to `wasm32-wasip2` and packages it.
-
 use crate::archiver::{discover_opaque_assets, pack_capsule_archive};
 use anyhow::{Context, Result, bail};
+use cargo_metadata::{Message, PackageId};
 use std::fs;
+use std::io::BufReader;
 use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
 use tracing::{info, warn};
+
+mod config;
+#[cfg(test)]
+use config::{
+    cargo_config_has_matching_target_rustflags_with_home,
+    cargo_config_rustflags_for_target_with_home,
+    cargo_config_target_and_rustflags_for_target_with_home,
+    cargo_config_target_and_rustflags_with_home, resolve_cargo_home,
+};
+use config::{cargo_config_rustflags_for_target, cargo_config_target_and_rustflags};
 
 /// Stub WIT package written when a capsule has no local `wit/` directory.
 /// Gives `push_dir` a main package to anchor on so deps can still be loaded.
@@ -24,16 +36,16 @@ const GETRANDOM_TARGET: &str = "wasm32-unknown-unknown";
 /// keep it in config for plain `cargo build` / `cargo test`, which don't run
 /// through this builder.
 const GETRANDOM_CUSTOM_CFG: &str = "--cfg=getrandom_backend=\"custom\"";
+const GETRANDOM_CARGO_CONFIG_TARGET: &str = "target.'cfg(all(target_arch = \"wasm32\", target_os = \"unknown\", target_env = \"\", target_pointer_width = \"32\", target_vendor = \"unknown\", target_family = \"wasm\"))'.rustflags=";
 
 /// Cargo's argument separator for `CARGO_ENCODED_RUSTFLAGS` (ASCII unit
-/// separator), used so individual flags may themselves contain spaces. A
-/// `&str` (not `char`) so it can be passed straight to `join` / `split`
-/// without allocating.
+/// separator). Keeping it as a string allows direct concatenation without an
+/// intermediate character allocation.
 const RUSTFLAGS_SEP: &str = "\u{1f}";
 
 /// Build a Rust capsule from a crate directory.
 ///
-/// 1. `cargo build --target wasm32-wasip2 --release`
+/// 1. `cargo build --release` using Cargo's resolved target/configuration
 /// 2. Extract capsule description via Extism (`astrid_export_schemas`)
 /// 3. Merge description into `Capsule.toml`
 /// 4. Pack into `.capsule` archive
@@ -42,11 +54,18 @@ pub(crate) fn build(dir: &Path, output: Option<&str>) -> Result<()> {
 
     verify_cargo_available()?;
 
-    let (meta, crate_name, package_version, wasm_name) = resolve_package_metadata(dir)?;
+    let (meta, crate_name, package_version, wasm_name, package_id) = resolve_package_metadata(dir)?;
 
-    compile_wasm(dir)?;
+    let compiled = compile_wasm(dir, &package_id, &wasm_name)?;
 
-    let wasm_path = locate_wasm_binary(dir, &meta, &wasm_name)?;
+    let wasm_path = locate_wasm_binary(&meta, &compiled.target, &wasm_name)?;
+    if wasm_path != compiled.path {
+        bail!(
+            "Cargo reported compiled WASM at {}, but the exact release artifact is {}",
+            compiled.path.display(),
+            wasm_path.display()
+        );
+    }
     let wasm_path = ensure_component(&wasm_path)?;
 
     let toml_content =
@@ -91,7 +110,7 @@ fn verify_cargo_available() -> Result<()> {
 /// Resolve package metadata for the crate in `dir`.
 fn resolve_package_metadata(
     dir: &Path,
-) -> Result<(cargo_metadata::Metadata, String, String, String)> {
+) -> Result<(cargo_metadata::Metadata, String, String, String, PackageId)> {
     // Resolve the full dependency graph (not no_deps) so we can locate
     // the astrid-sdk source directory for WIT file bundling.
     let meta = cargo_metadata::MetadataCommand::new()
@@ -116,173 +135,410 @@ fn resolve_package_metadata(
 
     let crate_name = package.name.to_string();
     let package_version = package.version.to_string();
-    let wasm_name = crate_name.replace('-', "_");
+    let wasm_name = resolve_wasm_output_name(package)?;
+    let package_id = package.id.clone();
 
-    Ok((meta, crate_name, package_version, wasm_name))
+    Ok((meta, crate_name, package_version, wasm_name, package_id))
 }
 
-/// Compile the capsule in release mode using whatever target the
-/// capsule's own `.cargo/config.toml` selects.
+/// Resolve the exact WASM file stem Cargo will use for the capsule.
+///
+/// Capsules are packaged from a single cdylib target. Cargo metadata reports
+/// the target's output name, which matters when a manifest gives the library
+/// an explicit name instead of using the package name. A package without a
+/// cdylib target cannot produce the artifact this builder packages, so it is
+/// rejected rather than guessing a same-named binary.
+fn resolve_wasm_output_name(package: &cargo_metadata::Package) -> Result<String> {
+    resolve_wasm_output_name_from_targets(
+        package
+            .targets
+            .iter()
+            .filter(|target| target.is_cdylib())
+            .map(|target| target.name.clone()),
+    )
+}
+
+fn resolve_wasm_output_name_from_targets<I>(output_names: I) -> Result<String>
+where
+    I: IntoIterator<Item = String>,
+{
+    let output_names: Vec<String> = output_names.into_iter().collect();
+    match output_names.as_slice() {
+        [] => bail!("Capsule has no cdylib target; refusing to guess a WASM artifact"),
+        [output_name] => validate_wasm_output_name(output_name),
+        _ => bail!(
+            "Capsule has {} cdylib targets; refusing to choose an ambiguous WASM artifact",
+            output_names.len()
+        ),
+    }
+}
+
+fn validate_wasm_output_name(output_name: &str) -> Result<String> {
+    let path = Path::new(output_name);
+    let is_single_normal_component =
+        output_name != "." && output_name != ".." && path.file_name() == Some(path.as_os_str());
+    if !is_single_normal_component {
+        bail!("Unsafe WASM artifact name: {output_name}");
+    }
+    Ok(output_name.to_owned())
+}
+
+/// Compile the capsule in release mode using whatever target Cargo resolves
+/// from its complete configuration hierarchy.
 ///
 /// The Astrid-canonical target is `wasm32-unknown-unknown` — zero
 /// `wasi:*` imports, every host call audited through the
 /// `astrid:*` SDK surface. Capsules may also target `wasm32-wasip2`
 /// during the migration window (the kernel still satisfies wasi:*
 /// for backwards compatibility), so this build step does NOT pass
-/// `--target`; it lets the capsule decide.
+/// `--target`; it lets Cargo's own config and environment precedence decide.
 ///
 /// When the capsule targets `wasm32-unknown-unknown` it additionally
-/// injects the getrandom custom-backend cfg (see
-/// [`encoded_rustflags_with_getrandom`]) so `astrid build` succeeds even
-/// when a capsule's `.cargo/config.toml` is missing
-/// `--cfg=getrandom_backend="custom"`. This is a safety net for the
+/// injects the getrandom custom-backend cfg through target-wide rustflags so
+/// `astrid build` succeeds even when a capsule's `.cargo/config.toml` is
+/// missing `--cfg=getrandom_backend="custom"`. This is a safety net for the
 /// canonical build tool, not a replacement: capsules still carry the flag
 /// in config so a plain `cargo build` / `cargo test` (which never runs
 /// through here) keeps linking `uuid` v4 / `HashMap`.
-fn compile_wasm(dir: &Path) -> Result<()> {
-    info!("   Compiling capsule (release)...");
+struct CompiledWasm {
+    target: String,
+    path: PathBuf,
+}
 
-    let (config_target, config_flags) = cargo_config_target_and_rustflags(dir);
+fn compile_wasm(dir: &Path, package_id: &PackageId, wasm_name: &str) -> Result<CompiledWasm> {
+    let (config_target, _) = cargo_config_target_and_rustflags(dir)?;
     // `CARGO_BUILD_TARGET` (if the caller set it) overrides the config-file
     // target, mirroring Cargo's own precedence.
-    let env_target = std::env::var("CARGO_BUILD_TARGET").ok();
-    let target = env_target.as_deref().or(config_target.as_deref());
-
-    let mut cmd = std::process::Command::new("cargo");
-    cmd.current_dir(dir).args(["build", "--release"]);
-
-    if let Some(encoded) = encoded_rustflags_with_getrandom(
+    let env_target = std::env::var("CARGO_BUILD_TARGET")
+        .ok()
+        .filter(|target| !target.trim().is_empty());
+    let target = resolve_build_target(config_target, env_target)?;
+    let (config_flags, has_matching_target_rustflags) = if inject_getrandom_for_target(&target) {
+        cargo_config_rustflags_for_target(dir, &target)?
+    } else {
+        (Vec::new(), false)
+    };
+    let rustflags = RustflagsEnvironment::from_process(&target);
+    compile_wasm_with_target(
+        dir,
+        package_id,
+        wasm_name,
         target,
         &config_flags,
-        std::env::var("CARGO_ENCODED_RUSTFLAGS").ok().as_deref(),
-        std::env::var("RUSTFLAGS").ok().as_deref(),
-    ) {
-        // Capsule targets `wasm32-unknown-unknown`, so guarantee the getrandom
-        // custom-backend cfg is present. Because host != wasm this is a
-        // cross-compile, so the flag reaches only the wasm artifacts — host
-        // build scripts / proc-macros are untouched. We set
-        // `CARGO_ENCODED_RUSTFLAGS` (and drop `RUSTFLAGS`, whose value we have
-        // already folded in) so the two sources can't both apply and so flags
-        // containing spaces survive.
-        cmd.env("CARGO_ENCODED_RUSTFLAGS", encoded);
-        cmd.env_remove("RUSTFLAGS");
+        has_matching_target_rustflags,
+        &rustflags,
+    )
+}
+
+fn compile_wasm_with_target(
+    dir: &Path,
+    package_id: &PackageId,
+    wasm_name: &str,
+    target: String,
+    config_flags: &[String],
+    has_matching_target_rustflags: bool,
+    rustflags: &RustflagsEnvironment,
+) -> Result<CompiledWasm> {
+    info!("   Compiling capsule (release)...");
+
+    // Cargo itself remains authoritative for the build. For the one target
+    // that needs Astrid's custom getrandom backend, append the cfg to the
+    // highest-precedence environment source or use a Cargo config override;
+    // both reach dependencies as well as the root cdylib.
+    let inject_getrandom_cfg = inject_getrandom_for_target(&target);
+    let mut cmd = Command::new("cargo");
+    cmd.current_dir(dir)
+        .args([
+            "build",
+            "--release",
+            "--message-format=json-render-diagnostics",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit());
+    rustflags.configure_command(&mut cmd, &target);
+    if inject_getrandom_cfg {
+        append_getrandom_rustflag(
+            &mut cmd,
+            &target,
+            has_matching_target_rustflags,
+            config_flags,
+            rustflags,
+        );
     }
 
-    let status = cmd.status().context("Failed to spawn cargo build")?;
+    let mut child = cmd.spawn().context("Failed to spawn cargo build")?;
+    let stdout = child
+        .stdout
+        .take()
+        .context("Cargo build did not expose machine-readable output")?;
+    let expected_filename = format!("{wasm_name}.wasm");
+    let mut artifacts = Vec::new();
+    for message in Message::parse_stream(BufReader::new(stdout)) {
+        let message = message.context("Failed to parse Cargo build output")?;
+        let Message::CompilerArtifact(artifact) = message else {
+            continue;
+        };
+        if artifact.package_id != *package_id
+            || !artifact.target.is_cdylib()
+            || artifact.profile.test
+        {
+            continue;
+        }
+        artifacts.extend(
+            artifact
+                .filenames
+                .into_iter()
+                .filter(|path| {
+                    path.file_name()
+                        .is_some_and(|name| name == expected_filename)
+                })
+                .map(cargo_metadata::camino::Utf8PathBuf::into_std_path_buf),
+        );
+    }
+
+    let status = child.wait().context("Failed to wait for cargo build")?;
 
     if !status.success() {
         bail!(
             "Cargo build failed. Set `[build] target = \"wasm32-unknown-unknown\"` (Astrid-canonical) or `wasm32-wasip2` in `.cargo/config.toml` and install the matching `rustup target` component."
         );
     }
-    Ok(())
+
+    artifacts.sort();
+    artifacts.dedup();
+    match artifacts.as_slice() {
+        [path] => Ok(CompiledWasm {
+            target,
+            path: path.clone(),
+        }),
+        [] => bail!(
+            "Cargo completed without emitting the exact release cdylib artifact {expected_filename}"
+        ),
+        _ => bail!(
+            "Cargo emitted {} release cdylib artifacts named {expected_filename}; refusing to choose an ambiguous artifact",
+            artifacts.len()
+        ),
+    }
 }
 
-/// Read the build target and any author-declared `rustflags` from a capsule's
-/// local `.cargo/config.toml` (or the legacy `.cargo/config`).
-///
-/// Returns `(target, rustflags)`. `target` is the `[build] target` string if
-/// set. `rustflags` is the effective list Cargo would apply to the wasm
-/// target: `[target."wasm32-unknown-unknown"].rustflags` if present, otherwise
-/// `[build].rustflags`, otherwise empty. Cargo honours only one of those two
-/// sources (target-scoped wins), so we mirror that precedence rather than
-/// concatenating them. A `[build] target` written as an array (multi-target
-/// build) is intentionally ignored — we only auto-inject for a single, plain
-/// `wasm32-unknown-unknown` target.
-fn cargo_config_target_and_rustflags(dir: &Path) -> (Option<String>, Vec<String>) {
-    let Some(doc) = [".cargo/config.toml", ".cargo/config"]
-        .iter()
-        .map(|name| dir.join(name))
-        .find_map(|p| fs::read_to_string(p).ok())
-        .and_then(|s| s.parse::<toml_edit::DocumentMut>().ok())
-    else {
-        return (None, Vec::new());
-    };
-
-    let target = doc
-        .get("build")
-        .and_then(|b| b.get("target"))
-        .and_then(toml_edit::Item::as_str)
-        .map(str::to_owned);
-
-    // Cargo accepts `rustflags` as either an array of strings or a single
-    // space-separated string; handle both so a string-form value isn't
-    // silently dropped (which would let our env injection clobber it).
-    let read_flags = |item: Option<&toml_edit::Item>| -> Option<Vec<String>> {
-        item.and_then(|it| {
-            if let Some(arr) = it.as_array() {
-                Some(
-                    arr.iter()
-                        .filter_map(|v| v.as_str().map(str::to_owned))
-                        .collect(),
-                )
-            } else {
-                it.as_str()
-                    .map(|s| s.split_whitespace().map(str::to_owned).collect())
-            }
-        })
-    };
-
-    let target_scoped = doc
-        .get("target")
-        .and_then(|t| t.get(GETRANDOM_TARGET))
-        .and_then(|t| t.get("rustflags"));
-    let build_scoped = doc.get("build").and_then(|b| b.get("rustflags"));
-
-    let rustflags = read_flags(target_scoped)
-        .or_else(|| read_flags(build_scoped))
-        .unwrap_or_default();
-
-    (target, rustflags)
+fn inject_getrandom_for_target(target: &str) -> bool {
+    target == GETRANDOM_TARGET
 }
 
-/// Compute the `CARGO_ENCODED_RUSTFLAGS` value for a capsule build, injecting
-/// the getrandom custom-backend cfg when — and only when — the capsule targets
-/// `wasm32-unknown-unknown`. Returns `None` (leave the environment untouched)
-/// for any other target.
-///
-/// Flags are concatenated in order — inherited environment flags
-/// (`CARGO_ENCODED_RUSTFLAGS` takes precedence over `RUSTFLAGS`), then the
-/// capsule's own config `rustflags`, then the getrandom cfg. We deliberately
-/// *merge* rather than let the env override config (which is Cargo's real
-/// precedence): a build tool silently dropping a flag the author or developer
-/// set would be a nasty surprise. The only flags it can't see are ones set in
-/// a *parent* config (above the capsule dir); capsules keep their `rustflags`
-/// in their own `.cargo/config.toml`, so that's a non-issue in practice.
-///
-/// Only the getrandom cfg is de-duplicated. Inherited and config flags are
-/// kept verbatim: de-duping individual tokens would corrupt multi-token flags
-/// like `-C opt-level=3` followed by `-C debuginfo=2` (the second `-C` would
-/// be dropped, yielding invalid `rustc` input). Duplicate whole flags are
-/// harmless to `rustc`.
-fn encoded_rustflags_with_getrandom(
-    target: Option<&str>,
+/// Append the custom getrandom cfg without replacing any effective Cargo
+/// rustflags. Cargo's precedence is encoded-rustflags env, plain rustflags env,
+/// target-specific rustflags env, matching target config, then build
+/// rustflags. We modify only the first effective environment source. When
+/// config-derived flags are effective (including when `CARGO_BUILD_RUSTFLAGS`
+/// is shadowed by matching target entries), a Cargo config override preserves
+/// Cargo's own hierarchy and reaches every dependency.
+fn append_getrandom_rustflag(
+    cmd: &mut Command,
+    target: &str,
+    has_matching_target_rustflags: bool,
     config_flags: &[String],
-    inherited_encoded: Option<&str>,
-    inherited_plain: Option<&str>,
-) -> Option<String> {
-    if target != Some(GETRANDOM_TARGET) {
+    rustflags: &RustflagsEnvironment,
+) {
+    let Some((key, value)) = getrandom_rustflags_override(
+        target,
+        config_flags,
+        rustflags.encoded.as_deref(),
+        rustflags.plain.as_deref(),
+        rustflags.target_specific.as_deref(),
+        rustflags.build.as_deref(),
+    ) else {
+        return;
+    };
+    if rustflags.encoded.is_none()
+        && rustflags.plain.is_none()
+        && rustflags.target_specific.is_none()
+        && (rustflags.build.is_none() || has_matching_target_rustflags)
+    {
+        if has_matching_target_rustflags {
+            // Let Cargo merge all matching target triples and cfg expressions,
+            // ancestor arrays, and its own config precedence before adding
+            // ours. Matching target entries already shadow build rustflags;
+            // preserving them here avoids changing that precedence.
+            let config = cargo_config_with_getrandom(&[]);
+            cmd.args(["--config", config.as_str()]);
+        } else {
+            // A target-specific override shadows `[build].rustflags`, so
+            // carry the effective build flags into the override before adding
+            // the backend cfg. Otherwise the builder silently drops caller
+            // flags for every dependency and the root cdylib alike.
+            let config = cargo_config_with_getrandom(config_flags);
+            cmd.args(["--config", config.as_str()]);
+        }
+    } else {
+        cmd.env(key, value);
+    }
+}
+
+fn cargo_config_with_getrandom(config_flags: &[String]) -> String {
+    let mut flags = toml_edit::Array::new();
+    for flag in config_flags {
+        flags.push(flag.as_str());
+    }
+    if !config_flags.iter().any(|flag| flag == GETRANDOM_CUSTOM_CFG) {
+        flags.push(GETRANDOM_CUSTOM_CFG);
+    }
+    format!("{GETRANDOM_CARGO_CONFIG_TARGET}{flags}")
+}
+
+#[derive(Default)]
+struct RustflagsEnvironment {
+    encoded: Option<String>,
+    plain: Option<String>,
+    target_specific: Option<String>,
+    build: Option<String>,
+}
+
+impl RustflagsEnvironment {
+    fn from_process(target: &str) -> Self {
+        let target_env_key = cargo_target_rustflags_env_key(target);
+        Self {
+            encoded: std::env::var("CARGO_ENCODED_RUSTFLAGS").ok(),
+            plain: std::env::var("RUSTFLAGS").ok(),
+            target_specific: std::env::var(target_env_key).ok(),
+            build: std::env::var("CARGO_BUILD_RUSTFLAGS").ok(),
+        }
+    }
+
+    fn configure_command(&self, cmd: &mut Command, target: &str) {
+        let target_env_key = cargo_target_rustflags_env_key(target);
+        configure_env(cmd, "CARGO_ENCODED_RUSTFLAGS", self.encoded.as_deref());
+        configure_env(cmd, "RUSTFLAGS", self.plain.as_deref());
+        configure_env(cmd, &target_env_key, self.target_specific.as_deref());
+        configure_env(cmd, "CARGO_BUILD_RUSTFLAGS", self.build.as_deref());
+    }
+}
+
+fn configure_env(cmd: &mut Command, key: &str, value: Option<&str>) {
+    if let Some(value) = value {
+        cmd.env(key, value);
+    } else {
+        cmd.env_remove(key);
+    }
+}
+
+fn cargo_target_rustflags_env_key(target: &str) -> String {
+    let normalized = target
+        .chars()
+        .map(|character| match character {
+            '-' | '.' => '_',
+            character => character.to_ascii_uppercase(),
+        })
+        .collect::<String>();
+    format!("CARGO_TARGET_{normalized}_RUSTFLAGS")
+}
+
+fn getrandom_rustflags_override(
+    target: &str,
+    config_flags: &[String],
+    encoded: Option<&str>,
+    plain: Option<&str>,
+    target_specific: Option<&str>,
+    build_env: Option<&str>,
+) -> Option<(String, String)> {
+    if target != GETRANDOM_TARGET {
         return None;
     }
 
-    let mut flags: Vec<String> = if let Some(enc) = inherited_encoded {
-        enc.split(RUSTFLAGS_SEP)
-            .filter(|s| !s.is_empty())
-            .map(str::to_owned)
-            .collect()
-    } else if let Some(plain) = inherited_plain {
-        plain.split_whitespace().map(str::to_owned).collect()
-    } else {
-        Vec::new()
-    };
-
-    flags.extend(config_flags.iter().cloned());
-
-    if !flags.iter().any(|f| f == GETRANDOM_CUSTOM_CFG) {
-        flags.push(GETRANDOM_CUSTOM_CFG.to_owned());
+    if let Some(encoded) = encoded {
+        let value = if encoded
+            .split(RUSTFLAGS_SEP)
+            .any(|flag| flag == GETRANDOM_CUSTOM_CFG)
+        {
+            encoded.to_owned()
+        } else {
+            let mut value = encoded.to_owned();
+            if !value.is_empty() {
+                value.push_str(RUSTFLAGS_SEP);
+            }
+            value.push_str(GETRANDOM_CUSTOM_CFG);
+            value
+        };
+        return Some(("CARGO_ENCODED_RUSTFLAGS".to_owned(), value));
+    }
+    if let Some(plain) = plain {
+        let value = if plain
+            .split_whitespace()
+            .any(|flag| flag == GETRANDOM_CUSTOM_CFG)
+        {
+            plain.to_owned()
+        } else {
+            let mut value = plain.to_owned();
+            if !value.is_empty() {
+                value.push(' ');
+            }
+            value.push_str(GETRANDOM_CUSTOM_CFG);
+            value
+        };
+        return Some(("RUSTFLAGS".to_owned(), value));
     }
 
-    Some(flags.join(RUSTFLAGS_SEP))
+    let key = cargo_target_rustflags_env_key(target);
+    if let Some(target_specific) = target_specific {
+        let value = if target_specific
+            .split_whitespace()
+            .any(|flag| flag == GETRANDOM_CUSTOM_CFG)
+        {
+            target_specific.to_owned()
+        } else {
+            let mut value = target_specific.to_owned();
+            if !value.is_empty() {
+                value.push(' ');
+            }
+            value.push_str(GETRANDOM_CUSTOM_CFG);
+            value
+        };
+        return Some((key, value));
+    }
+
+    if let Some(build_env) = build_env {
+        let value = if build_env
+            .split_whitespace()
+            .any(|flag| flag == GETRANDOM_CUSTOM_CFG)
+        {
+            build_env.to_owned()
+        } else {
+            let mut value = build_env.to_owned();
+            if !value.is_empty() {
+                value.push(' ');
+            }
+            value.push_str(GETRANDOM_CUSTOM_CFG);
+            value
+        };
+        return Some(("CARGO_BUILD_RUSTFLAGS".to_owned(), value));
+    }
+
+    if config_flags.iter().any(|flag| flag == GETRANDOM_CUSTOM_CFG) {
+        return Some((
+            "CARGO_ENCODED_RUSTFLAGS".to_owned(),
+            config_flags.join(RUSTFLAGS_SEP),
+        ));
+    }
+
+    let mut value = config_flags.join(RUSTFLAGS_SEP);
+    if !value.is_empty() {
+        value.push_str(RUSTFLAGS_SEP);
+    }
+    value.push_str(GETRANDOM_CUSTOM_CFG);
+    Some(("CARGO_ENCODED_RUSTFLAGS".to_owned(), value))
+}
+
+fn resolve_build_target(
+    config_target: Option<String>,
+    env_target: Option<String>,
+) -> Result<String> {
+    env_target
+        .or(config_target)
+        .filter(|target| !target.trim().is_empty())
+        .ok_or_else(|| {
+        anyhow::anyhow!(
+            "No Cargo build target selected. Set `[build] target = \"wasm32-unknown-unknown\"` (Astrid-canonical) or `wasm32-wasip2` in `.cargo/config.toml`, or set CARGO_BUILD_TARGET."
+        )
+    })
 }
 
 /// Wrap a core wasm module into a Component Model component if it isn't
@@ -310,7 +566,7 @@ fn ensure_component(wasm_path: &Path) -> Result<PathBuf> {
         .encode()
         .context("ComponentEncoder failed to emit a component")?;
     // Overwrite the original artifact path so the capsule's
-    // `Capsule.toml [[component]] file = "<crate>.wasm"` directive
+    // `Capsule.toml [[component]] file = "<packaged-basename>.wasm"` directive
     // continues to resolve. Using a `.component.wasm` sibling instead
     // would force every capsule manifest to track which target produced
     // the artifact — that's friction the toolchain should hide.
@@ -323,40 +579,77 @@ fn ensure_component(wasm_path: &Path) -> Result<PathBuf> {
     Ok(wasm_path.to_path_buf())
 }
 
-/// Locate the compiled WASM binary in the target directory. We don't
-/// know which target was used (the capsule's `.cargo/config.toml`
-/// decides), so probe the known guest targets in canonical-first order
-/// and accept the first one that exists. The capsule build wrapping
-/// step below treats `wasm32-unknown-unknown` outputs as core wasm
-/// modules that need to be wrapped into a component; `wasm32-wasip2`
-/// outputs are already components.
+/// Locate the compiled WASM binary in Cargo's resolved target directory.
+///
+/// The guest target is known from the same precedence used to invoke Cargo,
+/// and the artifact is the exact package cdylib built for the release
+/// profile. There is deliberately no recursive search or local-target
+/// fallback: probing other roots could select stale artifacts when a
+/// host-wide target root is configured.
 fn locate_wasm_binary(
-    dir: &Path,
     meta: &cargo_metadata::Metadata,
+    target: &str,
     wasm_name: &str,
 ) -> Result<PathBuf> {
-    const TARGETS: &[&str] = &["wasm32-unknown-unknown", "wasm32-wasip2"];
-    let local_target = dir.join("target");
-    let workspace_target = meta
-        .workspace_root
-        .clone()
-        .into_std_path_buf()
-        .join("target");
-    for target in TARGETS {
-        for root in &[&local_target, &workspace_target] {
-            let candidate = root
-                .join(target)
-                .join("release")
-                .join(format!("{wasm_name}.wasm"));
-            if candidate.exists() {
-                return Ok(candidate);
-            }
-        }
+    const PROFILE: &str = "release";
+    let target_root = meta.target_directory.as_std_path();
+    validate_wasm_output_name(wasm_name)?;
+
+    let candidate = target_root
+        .join(target)
+        .join(PROFILE)
+        .join(format!("{wasm_name}.wasm"));
+    let artifact_metadata = match fs::symlink_metadata(&candidate) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => bail!(
+            "Could not locate compiled WASM binary at `target/{target}/{PROFILE}/{wasm_name}.wasm` under configured target directory {}",
+            target_root.display()
+        ),
+        Err(error) => {
+            return Err(error).with_context(|| {
+                format!(
+                    "Failed to inspect compiled WASM binary {}",
+                    candidate.display()
+                )
+            });
+        },
+    };
+
+    if artifact_metadata.file_type().is_symlink() {
+        bail!("Compiled WASM binary is a symlink: {}", candidate.display());
     }
-    bail!(
-        "Could not locate compiled WASM binary under `target/{{wasm32-unknown-unknown,wasm32-wasip2}}/release/{wasm_name}.wasm` in {} or workspace root",
-        dir.display()
-    );
+    if !artifact_metadata.is_file() {
+        bail!(
+            "Compiled WASM binary is not a regular file: {}",
+            candidate.display()
+        );
+    }
+
+    // A regular artifact beneath a symlinked parent could still resolve
+    // outside the configured root. Canonicalize only for containment; return
+    // Cargo's path so callers retain the authoritative configured location,
+    // including when the target root itself is a legitimate symlink.
+    let resolved_target_root = fs::canonicalize(target_root).with_context(|| {
+        format!(
+            "Failed to resolve target directory {}",
+            target_root.display()
+        )
+    })?;
+    let resolved_candidate = fs::canonicalize(&candidate).with_context(|| {
+        format!(
+            "Failed to resolve compiled WASM binary {}",
+            candidate.display()
+        )
+    })?;
+    if !resolved_candidate.starts_with(&resolved_target_root) {
+        bail!(
+            "Compiled WASM binary {} escapes configured target directory {}",
+            candidate.display(),
+            target_root.display()
+        );
+    }
+
+    Ok(candidate)
 }
 
 /// Merge the developer's `Capsule.toml` with any extracted description.
@@ -368,6 +661,7 @@ fn build_manifest_content(
     wasm_name: &str,
 ) -> Result<String> {
     let capsule_description = extract_capsule_description(wasm_path);
+    let packaged_name = format!("{wasm_name}.wasm");
 
     let base_toml_path = dir.join("Capsule.toml");
     let mut toml_doc = if base_toml_path.exists() {
@@ -378,6 +672,8 @@ fn build_manifest_content(
     } else {
         create_default_manifest(crate_name, package_version, wasm_name)
     };
+
+    bind_manifest_to_packaged_wasm(&mut toml_doc, &packaged_name)?;
 
     if let Some(desc) = &capsule_description
         && let Some(pkg) = toml_doc.get_mut("package")
@@ -393,6 +689,70 @@ fn build_manifest_content(
     }
 
     Ok(toml_doc.to_string())
+}
+
+/// Bind the manifest's single WASM component to the one file the archiver
+/// writes. A hand-authored manifest can retain an old package-name filename
+/// after a `[lib] name = "..."` change; leaving that pointer untouched would
+/// produce an archive whose executable cannot be resolved at install time.
+///
+/// This builder emits exactly one cdylib, so multiple component tables are an
+/// unsafe ambiguity rather than an invitation to discard author-declared
+/// components. All other component fields (id, type, hash, links, and
+/// capabilities) remain untouched. If an author supplied both `file` and the
+/// legacy `entrypoint` alias, fail closed instead of choosing one silently.
+fn bind_manifest_to_packaged_wasm(
+    toml_doc: &mut toml_edit::DocumentMut,
+    packaged_name: &str,
+) -> Result<()> {
+    validate_wasm_output_name(packaged_name.strip_suffix(".wasm").unwrap_or(packaged_name))?;
+
+    let Some(component_item) = toml_doc.get_mut("component") else {
+        let mut component = toml_edit::Table::new();
+        let component_id = packaged_name.strip_suffix(".wasm").unwrap_or(packaged_name);
+        component.insert("id", toml_edit::value(component_id));
+        component.insert("file", toml_edit::value(packaged_name));
+        component.insert("type", toml_edit::value("executable"));
+        let mut components = toml_edit::ArrayOfTables::new();
+        components.push(component);
+        toml_doc.insert("component", toml_edit::Item::ArrayOfTables(components));
+        return Ok(());
+    };
+
+    let Some(components) = component_item.as_array_of_tables_mut() else {
+        bail!("Capsule.toml component must be an array of tables")
+    };
+    if components.len() != 1 {
+        bail!(
+            "Capsule.toml declares {} components, but this build packages exactly one cdylib",
+            components.len()
+        );
+    }
+    let component = components
+        .get_mut(0)
+        .context("Capsule.toml component array unexpectedly empty")?;
+    let has_file = component.get("file").is_some();
+    let has_entrypoint = component.get("entrypoint").is_some();
+    if has_file && has_entrypoint {
+        bail!(
+            "Capsule.toml component declares both `file` and `entrypoint`; refusing an ambiguous executable path"
+        );
+    }
+
+    let key = if has_file {
+        "file"
+    } else if has_entrypoint {
+        "entrypoint"
+    } else {
+        "file"
+    };
+    if let Some(item) = component.get(key)
+        && item.as_str().is_none()
+    {
+        bail!("Capsule.toml component `{key}` must be a string")
+    }
+    component.insert(key, toml_edit::value(packaged_name));
+    Ok(())
 }
 
 /// Resolve the output directory, creating it if necessary.
@@ -568,164 +928,5 @@ fn create_default_manifest(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn decode(encoded: &str) -> Vec<String> {
-        encoded.split(RUSTFLAGS_SEP).map(str::to_owned).collect()
-    }
-
-    #[test]
-    fn no_injection_for_non_wasm_target() {
-        assert_eq!(
-            encoded_rustflags_with_getrandom(Some("wasm32-wasip2"), &[], None, None),
-            None
-        );
-        assert_eq!(
-            encoded_rustflags_with_getrandom(None, &[], None, None),
-            None
-        );
-    }
-
-    #[test]
-    fn injects_cfg_when_capsule_declares_nothing() {
-        let encoded =
-            encoded_rustflags_with_getrandom(Some(GETRANDOM_TARGET), &[], None, None).unwrap();
-        assert_eq!(decode(&encoded), vec![GETRANDOM_CUSTOM_CFG.to_owned()]);
-    }
-
-    #[test]
-    fn does_not_duplicate_an_already_present_cfg() {
-        // The current per-capsule `.cargo/config.toml` case: the flag is
-        // already there, so injection must be a no-op (no double flag).
-        let config = vec![GETRANDOM_CUSTOM_CFG.to_owned()];
-        let encoded =
-            encoded_rustflags_with_getrandom(Some(GETRANDOM_TARGET), &config, None, None).unwrap();
-        assert_eq!(decode(&encoded), vec![GETRANDOM_CUSTOM_CFG.to_owned()]);
-    }
-
-    #[test]
-    fn preserves_other_config_rustflags() {
-        let config = vec!["-C".to_owned(), "target-feature=+simd128".to_owned()];
-        let encoded =
-            encoded_rustflags_with_getrandom(Some(GETRANDOM_TARGET), &config, None, None).unwrap();
-        assert_eq!(
-            decode(&encoded),
-            vec![
-                "-C".to_owned(),
-                "target-feature=+simd128".to_owned(),
-                GETRANDOM_CUSTOM_CFG.to_owned(),
-            ]
-        );
-    }
-
-    #[test]
-    fn preserves_repeated_flag_tokens() {
-        // Regression: de-duping individual tokens must NOT drop a repeated
-        // `-C`, which would fuse two separate flags into invalid rustc input
-        // (`-C opt-level=3` + `-C debuginfo=2` -> `-C opt-level=3 debuginfo=2`).
-        let config = vec![
-            "-C".to_owned(),
-            "opt-level=3".to_owned(),
-            "-C".to_owned(),
-            "debuginfo=2".to_owned(),
-        ];
-        let encoded =
-            encoded_rustflags_with_getrandom(Some(GETRANDOM_TARGET), &config, None, None).unwrap();
-        assert_eq!(
-            decode(&encoded),
-            vec![
-                "-C".to_owned(),
-                "opt-level=3".to_owned(),
-                "-C".to_owned(),
-                "debuginfo=2".to_owned(),
-                GETRANDOM_CUSTOM_CFG.to_owned(),
-            ]
-        );
-    }
-
-    #[test]
-    fn merges_inherited_plain_rustflags() {
-        let encoded = encoded_rustflags_with_getrandom(
-            Some(GETRANDOM_TARGET),
-            &[],
-            None,
-            Some("--cfg=foo -Cdebuginfo=2"),
-        )
-        .unwrap();
-        assert_eq!(
-            decode(&encoded),
-            vec![
-                "--cfg=foo".to_owned(),
-                "-Cdebuginfo=2".to_owned(),
-                GETRANDOM_CUSTOM_CFG.to_owned(),
-            ]
-        );
-    }
-
-    #[test]
-    fn encoded_env_takes_precedence_over_plain() {
-        // When both are set Cargo reads the encoded form; we must too.
-        let encoded = encoded_rustflags_with_getrandom(
-            Some(GETRANDOM_TARGET),
-            &[],
-            Some("--cfg=from_encoded"),
-            Some("--cfg=from_plain"),
-        )
-        .unwrap();
-        assert_eq!(
-            decode(&encoded),
-            vec![
-                "--cfg=from_encoded".to_owned(),
-                GETRANDOM_CUSTOM_CFG.to_owned(),
-            ]
-        );
-    }
-
-    #[test]
-    fn reads_target_and_rustflags_from_config() {
-        let dir = tempfile::tempdir().unwrap();
-        let cargo_dir = dir.path().join(".cargo");
-        fs::create_dir_all(&cargo_dir).unwrap();
-        fs::write(
-            cargo_dir.join("config.toml"),
-            "[build]\n\
-             target = \"wasm32-unknown-unknown\"\n\n\
-             [target.wasm32-unknown-unknown]\n\
-             rustflags = [\"--cfg=getrandom_backend=\\\"custom\\\"\"]\n",
-        )
-        .unwrap();
-
-        let (target, flags) = cargo_config_target_and_rustflags(dir.path());
-        assert_eq!(target.as_deref(), Some(GETRANDOM_TARGET));
-        assert_eq!(flags, vec![GETRANDOM_CUSTOM_CFG.to_owned()]);
-    }
-
-    #[test]
-    fn reads_string_form_rustflags_from_config() {
-        // Cargo allows `rustflags` as a single space-separated string, not
-        // just an array — parse both forms.
-        let dir = tempfile::tempdir().unwrap();
-        let cargo_dir = dir.path().join(".cargo");
-        fs::create_dir_all(&cargo_dir).unwrap();
-        fs::write(
-            cargo_dir.join("config.toml"),
-            "[build]\n\
-             target = \"wasm32-unknown-unknown\"\n\
-             rustflags = \"-C opt-level=3\"\n",
-        )
-        .unwrap();
-
-        let (target, flags) = cargo_config_target_and_rustflags(dir.path());
-        assert_eq!(target.as_deref(), Some(GETRANDOM_TARGET));
-        assert_eq!(flags, vec!["-C".to_owned(), "opt-level=3".to_owned()]);
-    }
-
-    #[test]
-    fn missing_config_yields_no_target_or_flags() {
-        let dir = tempfile::tempdir().unwrap();
-        let (target, flags) = cargo_config_target_and_rustflags(dir.path());
-        assert_eq!(target, None);
-        assert!(flags.is_empty());
-    }
-}
+#[path = "rust_tests.rs"]
+mod tests;

--- a/crates/astrid-build/src/rust/config.rs
+++ b/crates/astrid-build/src/rust/config.rs
@@ -435,6 +435,13 @@ pub(super) fn resolve_cargo_home(dir: &Path, home: PathBuf) -> PathBuf {
     if home.is_absolute() {
         home
     } else {
+        // `cargo_home_from_env` may receive a relative working directory.
+        // Anchor the result here so Cargo's loader cannot resolve it again.
+        let dir = if dir.is_absolute() {
+            dir.to_path_buf()
+        } else {
+            std::env::current_dir().map_or_else(|_| dir.to_path_buf(), |current| current.join(dir))
+        };
         dir.join(home)
     }
 }

--- a/crates/astrid-build/src/rust/config.rs
+++ b/crates/astrid-build/src/rust/config.rs
@@ -22,14 +22,14 @@ pub(super) fn cargo_config_has_matching_target_rustflags_with_home(
     Ok(cargo_config_rustflags_for_target_with_home(dir, cargo_home, selected_target)?.1)
 }
 
-pub(super) fn cargo_config_rustflags_for_target(
-    dir: &Path,
-    selected_target: &str,
-) -> Result<(Vec<String>, bool)> {
-    let cargo_home = cargo_home_from_env(dir);
-    cargo_config_rustflags_for_target_with_home(dir, cargo_home.as_deref(), selected_target)
+#[derive(Debug, Default)]
+pub(super) struct EffectiveCargoRustflags {
+    pub(super) flags: Vec<String>,
+    pub(super) has_matching_target: bool,
+    pub(super) flags_are_array: bool,
 }
 
+#[cfg(test)]
 pub(super) fn cargo_config_rustflags_for_target_with_home(
     dir: &Path,
     cargo_home: Option<&Path>,
@@ -37,6 +37,19 @@ pub(super) fn cargo_config_rustflags_for_target_with_home(
 ) -> Result<(Vec<String>, bool)> {
     let config = load_cargo_config(dir, cargo_home, Some(selected_target))?;
     Ok((config.rustflags, config.has_matching_target_rustflags))
+}
+
+pub(super) fn cargo_config_effective_rustflags_for_target(
+    dir: &Path,
+    selected_target: &str,
+) -> Result<EffectiveCargoRustflags> {
+    let cargo_home = cargo_home_from_env(dir);
+    let config = load_cargo_config(dir, cargo_home.as_deref(), Some(selected_target))?;
+    Ok(EffectiveCargoRustflags {
+        flags: config.rustflags,
+        has_matching_target: config.has_matching_target_rustflags,
+        flags_are_array: config.rustflags_is_array,
+    })
 }
 
 pub(super) fn cargo_config_target_and_rustflags_with_home(
@@ -58,6 +71,7 @@ pub(super) fn cargo_config_target_and_rustflags_for_target_with_home(
 struct CargoConfig {
     target: Option<String>,
     rustflags: Vec<String>,
+    rustflags_is_array: bool,
     has_matching_target_rustflags: bool,
 }
 
@@ -90,13 +104,19 @@ fn load_cargo_config(
     let flags_target = selected_target.or(state.target.as_deref());
     let (target_flags, has_matching_target_rustflags) =
         matching_target_rustflags(flags_target, state.target_entries)?;
-    let rustflags = target_flags
-        .map(|flags| flags.flags)
-        .or_else(|| state.build_flags.map(|flags| flags.flags))
+    let effective_rustflags = match target_flags {
+        // An empty matching entry is still a matching entry, but it supplies no
+        // effective flags. Keep the caller's build-level flags and form.
+        Some(flags) if !flags.flags.is_empty() => Some(flags),
+        _ => state.build_flags,
+    };
+    let (rustflags, rustflags_is_array) = effective_rustflags
+        .map(|flags| (flags.flags, flags.is_array))
         .unwrap_or_default();
     Ok(CargoConfig {
         target: state.target,
         rustflags,
+        rustflags_is_array,
         has_matching_target_rustflags,
     })
 }

--- a/crates/astrid-build/src/rust/config.rs
+++ b/crates/astrid-build/src/rust/config.rs
@@ -1,0 +1,440 @@
+use anyhow::{Context, Result, bail};
+use cargo_metadata::cargo_platform::{Cfg, Platform};
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::str::FromStr;
+
+pub(super) fn cargo_config_target_and_rustflags(
+    dir: &Path,
+) -> Result<(Option<String>, Vec<String>)> {
+    let cargo_home = cargo_home_from_env(dir);
+    cargo_config_target_and_rustflags_with_home(dir, cargo_home.as_deref())
+}
+
+#[cfg(test)]
+pub(super) fn cargo_config_has_matching_target_rustflags_with_home(
+    dir: &Path,
+    cargo_home: Option<&Path>,
+    selected_target: &str,
+) -> Result<bool> {
+    Ok(cargo_config_rustflags_for_target_with_home(dir, cargo_home, selected_target)?.1)
+}
+
+pub(super) fn cargo_config_rustflags_for_target(
+    dir: &Path,
+    selected_target: &str,
+) -> Result<(Vec<String>, bool)> {
+    let cargo_home = cargo_home_from_env(dir);
+    cargo_config_rustflags_for_target_with_home(dir, cargo_home.as_deref(), selected_target)
+}
+
+pub(super) fn cargo_config_rustflags_for_target_with_home(
+    dir: &Path,
+    cargo_home: Option<&Path>,
+    selected_target: &str,
+) -> Result<(Vec<String>, bool)> {
+    let config = load_cargo_config(dir, cargo_home, Some(selected_target))?;
+    Ok((config.rustflags, config.has_matching_target_rustflags))
+}
+
+pub(super) fn cargo_config_target_and_rustflags_with_home(
+    dir: &Path,
+    cargo_home: Option<&Path>,
+) -> Result<(Option<String>, Vec<String>)> {
+    cargo_config_target_and_rustflags_for_target_with_home(dir, cargo_home, None)
+}
+
+pub(super) fn cargo_config_target_and_rustflags_for_target_with_home(
+    dir: &Path,
+    cargo_home: Option<&Path>,
+    selected_target: Option<&str>,
+) -> Result<(Option<String>, Vec<String>)> {
+    let config = load_cargo_config(dir, cargo_home, selected_target)?;
+    Ok((config.target, config.rustflags))
+}
+
+struct CargoConfig {
+    target: Option<String>,
+    rustflags: Vec<String>,
+    has_matching_target_rustflags: bool,
+}
+
+fn load_cargo_config(
+    dir: &Path,
+    cargo_home: Option<&Path>,
+    selected_target: Option<&str>,
+) -> Result<CargoConfig> {
+    let mut state = CargoConfigState::default();
+    let mut loader = CargoConfigLoader::default();
+    let mut config_paths = Vec::new();
+    let cargo_home = cargo_home.map(|home| resolve_cargo_home(dir, home.to_path_buf()));
+    if let Some(cargo_home) = cargo_home.as_deref() {
+        push_config_path(&mut config_paths, cargo_home);
+    }
+
+    let resolved_dir = dir.canonicalize().unwrap_or_else(|_| dir.to_path_buf());
+    let mut ancestors = resolved_dir
+        .ancestors()
+        .map(Path::to_path_buf)
+        .collect::<Vec<_>>();
+    ancestors.reverse();
+    for ancestor in ancestors {
+        push_config_path(&mut config_paths, &ancestor.join(".cargo"));
+    }
+    for path in config_paths {
+        loader.load(&path, &mut state)?;
+    }
+
+    let flags_target = selected_target.or(state.target.as_deref());
+    let (target_flags, has_matching_target_rustflags) =
+        matching_target_rustflags(flags_target, state.target_entries)?;
+    let rustflags = target_flags
+        .map(|flags| flags.flags)
+        .or_else(|| state.build_flags.map(|flags| flags.flags))
+        .unwrap_or_default();
+    Ok(CargoConfig {
+        target: state.target,
+        rustflags,
+        has_matching_target_rustflags,
+    })
+}
+
+#[derive(Default)]
+struct CargoConfigState {
+    target: Option<String>,
+    build_flags: Option<ParsedRustflags>,
+    target_entries: Vec<(String, ParsedRustflags)>,
+}
+
+#[derive(Default)]
+struct CargoConfigLoader {
+    active: HashSet<PathBuf>,
+}
+
+impl CargoConfigLoader {
+    fn load(&mut self, path: &Path, state: &mut CargoConfigState) -> Result<()> {
+        let Some(content) = read_optional_config(path)? else {
+            return Ok(());
+        };
+        let canonical = path
+            .canonicalize()
+            .with_context(|| format!("Failed to resolve Cargo configuration {}", path.display()))?;
+        if !self.active.insert(canonical.clone()) {
+            bail!(
+                "Cargo configuration include cycle detected at {}",
+                canonical.display()
+            );
+        }
+
+        let result = self.load_content(&content, &canonical, state);
+        self.active.remove(&canonical);
+        result
+    }
+
+    fn load_content(
+        &mut self,
+        content: &str,
+        path: &Path,
+        state: &mut CargoConfigState,
+    ) -> Result<()> {
+        let doc = content
+            .parse::<toml_edit::DocumentMut>()
+            .with_context(|| format!("Failed to parse Cargo configuration {}", path.display()))?;
+
+        for include in cargo_config_includes(&doc, path)?.into_iter().flatten() {
+            self.load(&include, state)?;
+        }
+        state.absorb_document(&doc, path)
+    }
+}
+
+impl CargoConfigState {
+    fn absorb_document(&mut self, doc: &toml_edit::DocumentMut, path: &Path) -> Result<()> {
+        if let Some(item) = doc.get("build").and_then(|build| build.get("target")) {
+            if let Some(value) = item.as_str() {
+                self.target = Some(value.to_owned());
+            } else if item.as_array().is_some() {
+                // Cargo supports a target array for multi-target builds. This
+                // packager has one executable slot, so it must not guess.
+                self.target = None;
+            } else {
+                bail!(
+                    "Cargo build.target must be a string or array in {}",
+                    path.display()
+                );
+            }
+        }
+
+        if let Some(item) = doc.get("build").and_then(|build| build.get("rustflags")) {
+            merge_rustflags(&mut self.build_flags, parse_rustflags(item, path)?);
+        }
+        if let Some(targets) = doc.get("target").and_then(toml_edit::Item::as_table_like) {
+            for (platform, item) in targets.iter() {
+                let Some(rustflags) = item
+                    .as_table_like()
+                    .and_then(|target| target.get("rustflags"))
+                else {
+                    continue;
+                };
+                self.target_entries
+                    .push((platform.to_owned(), parse_rustflags(rustflags, path)?));
+            }
+        }
+        Ok(())
+    }
+}
+
+fn cargo_config_includes(
+    doc: &toml_edit::DocumentMut,
+    path: &Path,
+) -> Result<Vec<Option<PathBuf>>> {
+    let Some(item) = doc.get("include") else {
+        return Ok(Vec::new());
+    };
+
+    if let Some(value) = item.as_str() {
+        return Ok(vec![resolve_cargo_config_include(path, value, false)?]);
+    }
+    if let Some(array) = item.as_array() {
+        return array
+            .iter()
+            .map(|value| {
+                if let Some(include) = value.as_str() {
+                    Ok(resolve_cargo_config_include(path, include, false)?)
+                } else if let Some(table) = value.as_inline_table() {
+                    let include = table
+                        .get("path")
+                        .and_then(toml_edit::Value::as_str)
+                        .ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "Cargo include table must contain a string path in {}",
+                                path.display()
+                            )
+                        })?;
+                    let optional = match table.get("optional") {
+                        None => false,
+                        Some(value) => value.as_bool().ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "Cargo include optional must be a boolean in {}",
+                                path.display()
+                            )
+                        })?,
+                    };
+                    Ok(resolve_cargo_config_include(path, include, optional)?)
+                } else {
+                    bail!(
+                        "Cargo include array contains a non-string or non-table value in {}",
+                        path.display()
+                    )
+                }
+            })
+            .collect();
+    }
+    if let Some(table) = item.as_table_like() {
+        let include = table
+            .get("path")
+            .and_then(toml_edit::Item::as_str)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Cargo include table must contain a string path in {}",
+                    path.display()
+                )
+            })?;
+        let optional = match table.get("optional") {
+            None => false,
+            Some(value) => value.as_bool().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Cargo include optional must be a boolean in {}",
+                    path.display()
+                )
+            })?,
+        };
+        return Ok(vec![resolve_cargo_config_include(path, include, optional)?]);
+    }
+    bail!(
+        "Cargo include must be a string, array, or table in {}",
+        path.display()
+    )
+}
+
+fn resolve_cargo_config_include(
+    including_file: &Path,
+    include: &str,
+    optional: bool,
+) -> Result<Option<PathBuf>> {
+    if include.is_empty() {
+        bail!("Cargo include path cannot be empty");
+    }
+    let parent = including_file
+        .parent()
+        .context("Cargo configuration file has no parent directory")?;
+    let candidate = parent.join(include);
+    let resolved = match candidate.canonicalize() {
+        Ok(path) => path,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound && optional => {
+            return Ok(None);
+        },
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            bail!(
+                "Required Cargo configuration include {} does not exist",
+                candidate.display()
+            );
+        },
+        Err(error) => {
+            return Err(error).with_context(|| {
+                format!(
+                    "Failed to resolve Cargo configuration include {}",
+                    candidate.display()
+                )
+            });
+        },
+    };
+    Ok(Some(resolved))
+}
+
+fn matching_target_rustflags(
+    selected_target: Option<&str>,
+    target_entries: Vec<(String, ParsedRustflags)>,
+) -> Result<(Option<ParsedRustflags>, bool)> {
+    let Some(selected_target) = selected_target else {
+        return Ok((None, false));
+    };
+
+    let mut target_cfgs = None;
+    let mut matching = None;
+    let mut found = false;
+    for (platform, flags) in target_entries {
+        if target_platform_matches(&platform, selected_target, &mut target_cfgs)? {
+            found = true;
+            merge_rustflags(&mut matching, flags);
+        }
+    }
+    Ok((matching, found))
+}
+
+fn target_platform_matches(
+    platform: &str,
+    selected_target: &str,
+    target_cfgs: &mut Option<Vec<Cfg>>,
+) -> Result<bool> {
+    let platform = Platform::from_str(platform)
+        .with_context(|| format!("Invalid Cargo target platform `{platform}`"))?;
+    if !matches!(platform, Platform::Cfg(_)) {
+        return Ok(platform.matches(selected_target, &[]));
+    }
+
+    if target_cfgs.is_none() {
+        *target_cfgs = Some(target_cfgs_for(selected_target)?);
+    }
+    Ok(platform.matches(selected_target, target_cfgs.as_deref().unwrap_or_default()))
+}
+
+fn target_cfgs_for(target: &str) -> Result<Vec<Cfg>> {
+    let output = Command::new("rustc")
+        .args(["--print", "cfg", "--target", target])
+        .output()
+        .with_context(|| format!("Failed to inspect Cargo target cfg for `{target}`"))?;
+    if !output.status.success() {
+        bail!(
+            "rustc could not report cfg values for Cargo target `{target}` (status {})",
+            output.status
+        );
+    }
+    std::str::from_utf8(&output.stdout)
+        .with_context(|| format!("rustc emitted invalid cfg output for `{target}`"))?
+        .lines()
+        .map(|line| {
+            Cfg::from_str(line)
+                .with_context(|| format!("rustc emitted invalid cfg `{line}` for `{target}`"))
+        })
+        .collect()
+}
+
+fn push_config_path(paths: &mut Vec<PathBuf>, cargo_dir: &Path) {
+    let toml = cargo_dir.join("config.toml");
+    let legacy = cargo_dir.join("config");
+    // Cargo prefers the extensionless file when both names exist.
+    if legacy.is_file() {
+        paths.push(legacy);
+    } else if toml.is_file() {
+        paths.push(toml);
+    }
+}
+
+fn read_optional_config(path: &Path) -> Result<Option<String>> {
+    match fs::read_to_string(path) {
+        Ok(content) => Ok(Some(content)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error)
+            .with_context(|| format!("Failed to read Cargo configuration {}", path.display())),
+    }
+}
+
+struct ParsedRustflags {
+    flags: Vec<String>,
+    is_array: bool,
+}
+
+fn parse_rustflags(item: &toml_edit::Item, path: &Path) -> Result<ParsedRustflags> {
+    if let Some(array) = item.as_array() {
+        let flags = array
+            .iter()
+            .map(|value| {
+                value.as_str().map(str::to_owned).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "Cargo rustflags array contains a non-string value in {}",
+                        path.display()
+                    )
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        return Ok(ParsedRustflags {
+            flags,
+            is_array: true,
+        });
+    }
+    if let Some(value) = item.as_str() {
+        return Ok(ParsedRustflags {
+            flags: value.split_whitespace().map(str::to_owned).collect(),
+            is_array: false,
+        });
+    }
+    bail!(
+        "Cargo rustflags must be a string or array in {}",
+        path.display()
+    )
+}
+
+fn merge_rustflags(slot: &mut Option<ParsedRustflags>, incoming: ParsedRustflags) {
+    if let Some(existing) = slot
+        && existing.is_array
+        && incoming.is_array
+    {
+        existing.flags.extend(incoming.flags);
+    } else {
+        *slot = Some(incoming);
+    }
+}
+
+pub(super) fn cargo_home_from_env(dir: &Path) -> Option<PathBuf> {
+    if let Some(home) = std::env::var_os("CARGO_HOME")
+        && !home.is_empty()
+    {
+        return Some(resolve_cargo_home(dir, PathBuf::from(home)));
+    }
+    #[cfg(windows)]
+    let home = std::env::var_os("USERPROFILE");
+    #[cfg(not(windows))]
+    let home = std::env::var_os("HOME");
+    home.map(|home| resolve_cargo_home(dir, PathBuf::from(home).join(".cargo")))
+}
+
+pub(super) fn resolve_cargo_home(dir: &Path, home: PathBuf) -> PathBuf {
+    if home.is_absolute() {
+        home
+    } else {
+        dir.join(home)
+    }
+}

--- a/crates/astrid-build/src/rust_tests.rs
+++ b/crates/astrid-build/src/rust_tests.rs
@@ -2,6 +2,7 @@ use super::*;
 use serde_json::json;
 use std::fs::{self, File};
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 #[test]
 fn getrandom_injection_is_wasm_only() {
@@ -856,6 +857,42 @@ fn relative_cargo_home_is_resolved_from_child_current_dir() {
     let (target, _) =
         cargo_config_target_and_rustflags_with_home(&capsule, Some(relative_home)).unwrap();
     assert_eq!(target.as_deref(), Some(GETRANDOM_TARGET));
+}
+
+#[test]
+fn relative_cargo_home_env_is_resolved_from_relative_project_dir() {
+    const MODE_ENV: &str = "ASTRID_RELATIVE_CARGO_HOME_TEST";
+    const TEST_NAME: &str = "relative_cargo_home_env_is_resolved_from_relative_project_dir";
+
+    if std::env::var_os(MODE_ENV).is_some() {
+        let (target, _) = cargo_config_target_and_rustflags(Path::new("project")).unwrap();
+        assert_eq!(target.as_deref(), Some(GETRANDOM_TARGET));
+        return;
+    }
+
+    let root = tempfile::tempdir().unwrap();
+    let relative_home = Path::new("relative-cargo-home");
+    fs::create_dir_all(root.path().join("project").join(relative_home)).unwrap();
+    fs::write(
+        root.path()
+            .join("project")
+            .join(relative_home)
+            .join("config.toml"),
+        "[build]\ntarget = \"wasm32-unknown-unknown\"\n",
+    )
+    .unwrap();
+
+    // Environment state is process-global, so execute the normal env-backed
+    // loader in a child harness whose working directory is the project parent.
+    let status = Command::new(std::env::current_exe().unwrap())
+        .current_dir(root.path())
+        .env("CARGO_HOME", relative_home)
+        .env(MODE_ENV, "1")
+        .args(["--exact", TEST_NAME, "--nocapture"])
+        .status()
+        .unwrap();
+    assert!(status.success());
+    assert!(!root.path().join("project/project").exists());
 }
 
 #[test]

--- a/crates/astrid-build/src/rust_tests.rs
+++ b/crates/astrid-build/src/rust_tests.rs
@@ -199,9 +199,8 @@ fn build_config_rustflags_reach_path_dependency_with_getrandom_backend() {
     )
     .unwrap();
 
-    let (config_flags, has_matching_target_rustflags) =
-        cargo_config_rustflags_for_target_with_home(project.path(), None, GETRANDOM_TARGET)
-            .unwrap();
+    let config_rustflags =
+        cargo_config_effective_rustflags_for_target(project.path(), GETRANDOM_TARGET).unwrap();
 
     let (meta, _crate_name, _version, wasm_name, package_id) =
         resolve_package_metadata(project.path()).unwrap();
@@ -210,19 +209,19 @@ fn build_config_rustflags_reach_path_dependency_with_getrandom_backend() {
         &package_id,
         &wasm_name,
         GETRANDOM_TARGET.to_owned(),
-        &config_flags,
-        has_matching_target_rustflags,
+        &config_rustflags,
         &RustflagsEnvironment::default(),
     )
     .unwrap();
     assert_eq!(
-        config_flags,
+        config_rustflags.flags,
         vec![
             "--check-cfg=cfg(caller_cfg)".to_owned(),
             "--cfg=caller_cfg".to_owned(),
         ]
     );
-    assert!(!has_matching_target_rustflags);
+    assert!(!config_rustflags.has_matching_target);
+    assert!(config_rustflags.flags_are_array);
     assert_eq!(compiled.target, GETRANDOM_TARGET);
     let expected = locate_wasm_binary(&meta, GETRANDOM_TARGET, &wasm_name).unwrap();
     assert_eq!(compiled.path, expected);
@@ -510,9 +509,8 @@ fn include_only_rustflags_reach_path_dependency_with_getrandom_backend() {
     )
     .unwrap();
 
-    let (config_flags, has_matching_target_rustflags) =
-        cargo_config_rustflags_for_target_with_home(project.path(), None, GETRANDOM_TARGET)
-            .unwrap();
+    let config_rustflags =
+        cargo_config_effective_rustflags_for_target(project.path(), GETRANDOM_TARGET).unwrap();
 
     let (meta, _crate_name, _version, wasm_name, package_id) =
         resolve_package_metadata(project.path()).unwrap();
@@ -521,19 +519,19 @@ fn include_only_rustflags_reach_path_dependency_with_getrandom_backend() {
         &package_id,
         &wasm_name,
         GETRANDOM_TARGET.to_owned(),
-        &config_flags,
-        has_matching_target_rustflags,
+        &config_rustflags,
         &RustflagsEnvironment::default(),
     )
     .unwrap();
     assert_eq!(
-        config_flags,
+        config_rustflags.flags,
         vec![
             "--check-cfg=cfg(caller_cfg)".to_owned(),
             "--cfg=caller_cfg".to_owned(),
         ]
     );
-    assert!(!has_matching_target_rustflags);
+    assert!(!config_rustflags.has_matching_target);
+    assert!(config_rustflags.flags_are_array);
     assert_eq!(compiled.target, GETRANDOM_TARGET);
     let expected = locate_wasm_binary(&meta, GETRANDOM_TARGET, &wasm_name).unwrap();
     assert_eq!(compiled.path, expected);
@@ -594,8 +592,7 @@ fn build_env_and_getrandom_cfg_reach_dependency_without_target_flags() {
         &package_id,
         &wasm_name,
         GETRANDOM_TARGET.to_owned(),
-        &[],
-        false,
+        &EffectiveCargoRustflags::default(),
         &RustflagsEnvironment {
             build: Some("--check-cfg=cfg(caller_cfg) --cfg=caller_cfg".to_owned()),
             ..RustflagsEnvironment::default()
@@ -627,6 +624,102 @@ fn exact_target_rustflags_entry_is_detected_for_getrandom_merge() {
         )
         .unwrap()
     );
+}
+
+#[test]
+fn string_form_matching_target_rustflags_survive_getrandom_merge() {
+    if !rust_target_is_installed(GETRANDOM_TARGET) {
+        eprintln!(
+            "skipping string-form rustflags dependency build falsifier: {GETRANDOM_TARGET} target is not installed"
+        );
+        return;
+    }
+
+    let project = tempfile::tempdir().unwrap();
+    fs::create_dir_all(project.path().join(".cargo")).unwrap();
+    fs::create_dir_all(project.path().join("src")).unwrap();
+    fs::create_dir_all(project.path().join("control-dep/src")).unwrap();
+    fs::write(
+        project.path().join("Cargo.toml"),
+        "[package]\nname = \"string-rustflags-getrandom\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n[lib]\ncrate-type = [\"cdylib\"]\n\n[dependencies]\ncontrol-dep = { path = \"control-dep\" }\ngetrandom = \"0.4\"\n",
+    )
+    .unwrap();
+    fs::write(
+        project.path().join("control-dep/Cargo.toml"),
+        "[package]\nname = \"control-dep\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+    )
+    .unwrap();
+    fs::write(
+        project.path().join("control-dep/src/lib.rs"),
+        "#[cfg(not(control_cfg))]\ncompile_error!(\"string rustflags were rejected before this dependency\");\n\npub fn assert_cfg() {}\n",
+    )
+    .unwrap();
+    fs::write(
+        project.path().join(".cargo/config.toml"),
+        "[build]\ntarget = \"wasm32-unknown-unknown\"\n\n[target.'cfg(all(target_arch = \"wasm32\", target_os = \"unknown\", target_env = \"\", target_pointer_width = \"32\", target_vendor = \"unknown\", target_family = \"wasm\"))']\nrustflags = \"--check-cfg=cfg(control_cfg) --cfg=control_cfg\"\n",
+    )
+    .unwrap();
+    fs::write(
+        project.path().join("src/lib.rs"),
+        "pub fn random() -> [u8; 1] {\n    control_dep::assert_cfg();\n    let mut out = [0; 1];\n    getrandom::fill(&mut out).unwrap();\n    out\n}\n\n#[unsafe(no_mangle)]\npub unsafe extern \"Rust\" fn __getrandom_v03_custom(_dest: *mut u8, _len: usize) -> Result<(), getrandom::Error> {\n    Err(getrandom::Error::UNSUPPORTED)\n}\n",
+    )
+    .unwrap();
+
+    let (meta, _crate_name, _version, wasm_name, package_id) =
+        resolve_package_metadata(project.path()).unwrap();
+    let compiled = compile_wasm(project.path(), &package_id, &wasm_name).unwrap();
+    assert_eq!(compiled.target, GETRANDOM_TARGET);
+    let expected = locate_wasm_binary(&meta, GETRANDOM_TARGET, &wasm_name).unwrap();
+    assert_eq!(compiled.path, expected);
+    assert!(compiled.path.is_file());
+}
+
+#[test]
+fn matching_empty_target_rustflags_preserve_build_config_for_dependencies() {
+    if !rust_target_is_installed(GETRANDOM_TARGET) {
+        eprintln!(
+            "skipping empty matching rustflags dependency build falsifier: {GETRANDOM_TARGET} target is not installed"
+        );
+        return;
+    }
+
+    let project = tempfile::tempdir().unwrap();
+    fs::create_dir_all(project.path().join(".cargo")).unwrap();
+    fs::create_dir_all(project.path().join("src")).unwrap();
+    fs::create_dir_all(project.path().join("control-dep/src")).unwrap();
+    fs::write(
+        project.path().join("Cargo.toml"),
+        "[package]\nname = \"empty-target-rustflags\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n[lib]\ncrate-type = [\"cdylib\"]\n\n[dependencies]\ncontrol-dep = { path = \"control-dep\" }\ngetrandom = \"0.4\"\n",
+    )
+    .unwrap();
+    fs::write(
+        project.path().join("control-dep/Cargo.toml"),
+        "[package]\nname = \"control-dep\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+    )
+    .unwrap();
+    fs::write(
+        project.path().join("control-dep/src/lib.rs"),
+        "#[cfg(not(caller_cfg))]\ncompile_error!(\"matching empty rustflags dropped [build] rustflags\");\n\npub fn assert_cfg() {}\n",
+    )
+    .unwrap();
+    fs::write(
+        project.path().join(".cargo/config.toml"),
+        "[build]\ntarget = \"wasm32-unknown-unknown\"\nrustflags = [\"--check-cfg=cfg(caller_cfg)\", \"--cfg=caller_cfg\"]\n\n[target.wasm32-unknown-unknown]\nrustflags = []\n",
+    )
+    .unwrap();
+    fs::write(
+        project.path().join("src/lib.rs"),
+        "pub fn random() -> [u8; 1] {\n    control_dep::assert_cfg();\n    let mut out = [0; 1];\n    getrandom::fill(&mut out).unwrap();\n    out\n}\n\n#[unsafe(no_mangle)]\npub unsafe extern \"Rust\" fn __getrandom_v03_custom(_dest: *mut u8, _len: usize) -> Result<(), getrandom::Error> {\n    Err(getrandom::Error::UNSUPPORTED)\n}\n",
+    )
+    .unwrap();
+
+    let (meta, _crate_name, _version, wasm_name, package_id) =
+        resolve_package_metadata(project.path()).unwrap();
+    let compiled = compile_wasm(project.path(), &package_id, &wasm_name).unwrap();
+    assert_eq!(compiled.target, GETRANDOM_TARGET);
+    let expected = locate_wasm_binary(&meta, GETRANDOM_TARGET, &wasm_name).unwrap();
+    assert_eq!(compiled.path, expected);
+    assert!(compiled.path.is_file());
 }
 
 #[test]

--- a/crates/astrid-build/src/rust_tests.rs
+++ b/crates/astrid-build/src/rust_tests.rs
@@ -1,0 +1,1147 @@
+use super::*;
+use serde_json::json;
+use std::fs::{self, File};
+use std::path::{Path, PathBuf};
+
+#[test]
+fn getrandom_injection_is_wasm_only() {
+    assert!(inject_getrandom_for_target(GETRANDOM_TARGET));
+    assert!(!inject_getrandom_for_target("wasm32-wasip2"));
+    assert!(!inject_getrandom_for_target("aarch64-apple-darwin"));
+    assert_eq!(
+        getrandom_rustflags_override(
+            "wasm32-wasip2",
+            &["--cfg=from-config".to_owned()],
+            None,
+            None,
+            None,
+            None,
+        ),
+        None
+    );
+}
+
+#[test]
+fn inherited_rustflags_and_environment_precedence_are_preserved() {
+    let config = vec!["--cfg=from-config".to_owned()];
+    let (key, value) = getrandom_rustflags_override(
+        GETRANDOM_TARGET,
+        &config,
+        Some("--cfg=from-encoded"),
+        Some("--cfg=from-plain"),
+        Some("--cfg=from-target-env"),
+        Some("--cfg=from-build-env"),
+    )
+    .unwrap();
+    assert_eq!(key, "CARGO_ENCODED_RUSTFLAGS");
+    assert_eq!(
+        value,
+        format!("--cfg=from-encoded{RUSTFLAGS_SEP}{GETRANDOM_CUSTOM_CFG}")
+    );
+
+    let (key, value) = getrandom_rustflags_override(
+        GETRANDOM_TARGET,
+        &config,
+        None,
+        Some("--cfg=from-plain"),
+        Some("--cfg=from-target-env"),
+        Some("--cfg=from-build-env"),
+    )
+    .unwrap();
+    assert_eq!(key, "RUSTFLAGS");
+    assert_eq!(value, format!("--cfg=from-plain {GETRANDOM_CUSTOM_CFG}"));
+
+    let target_key = cargo_target_rustflags_env_key(GETRANDOM_TARGET);
+    let (key, value) = getrandom_rustflags_override(
+        GETRANDOM_TARGET,
+        &config,
+        None,
+        None,
+        Some("--cfg=from-target-env"),
+        Some("--cfg=from-build-env"),
+    )
+    .unwrap();
+    assert_eq!(key, target_key);
+    assert_eq!(
+        value,
+        format!("--cfg=from-target-env {GETRANDOM_CUSTOM_CFG}")
+    );
+
+    let (key, value) =
+        getrandom_rustflags_override(GETRANDOM_TARGET, &config, None, None, None, None).unwrap();
+    assert_eq!(key, "CARGO_ENCODED_RUSTFLAGS");
+    assert_eq!(
+        value,
+        format!("--cfg=from-config{RUSTFLAGS_SEP}{GETRANDOM_CUSTOM_CFG}")
+    );
+
+    let (key, value) = getrandom_rustflags_override(
+        GETRANDOM_TARGET,
+        &config,
+        None,
+        None,
+        None,
+        Some("--cfg=from-build-env"),
+    )
+    .unwrap();
+    assert_eq!(key, "CARGO_BUILD_RUSTFLAGS");
+    assert_eq!(
+        value,
+        format!("--cfg=from-build-env {GETRANDOM_CUSTOM_CFG}")
+    );
+
+    let repeated = vec![
+        "-C".to_owned(),
+        "opt-level=3".to_owned(),
+        "-C".to_owned(),
+        "debuginfo=2".to_owned(),
+        GETRANDOM_CUSTOM_CFG.to_owned(),
+    ];
+    let (key, value) =
+        getrandom_rustflags_override(GETRANDOM_TARGET, &repeated, None, None, None, None).unwrap();
+    assert_eq!(key, "CARGO_ENCODED_RUSTFLAGS");
+    assert_eq!(value, repeated.join(RUSTFLAGS_SEP));
+}
+
+#[test]
+fn missing_getrandom_config_still_builds_dependency_with_injected_backend() {
+    if !rust_target_is_installed(GETRANDOM_TARGET) {
+        eprintln!(
+            "skipping dependency build falsifier: {GETRANDOM_TARGET} target is not installed"
+        );
+        return;
+    }
+
+    let project = tempfile::tempdir().unwrap();
+    fs::create_dir_all(project.path().join(".cargo")).unwrap();
+    fs::create_dir_all(project.path().join("src")).unwrap();
+    fs::create_dir_all(project.path().join("control-dep/src")).unwrap();
+    fs::write(
+        project.path().join("Cargo.toml"),
+        "[package]\nname = \"missing-getrandom-config\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n[lib]\ncrate-type = [\"cdylib\"]\n\n[dependencies]\ncontrol-dep = { path = \"control-dep\" }\ngetrandom = \"0.4\"\n",
+    )
+    .unwrap();
+    fs::write(
+        project.path().join("control-dep/Cargo.toml"),
+        "[package]\nname = \"control-dep\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+    )
+    .unwrap();
+    fs::write(
+        project.path().join("control-dep/src/lib.rs"),
+        "#[cfg(not(control_cfg))]\ncompile_error!(\"Cargo cfg-expression rustflags were dropped before this dependency\");\n\npub fn assert_cfg() {}\n",
+    )
+    .unwrap();
+    fs::write(
+        project.path().join(".cargo/config.toml"),
+        "[build]\ntarget = \"wasm32-unknown-unknown\"\n\n[target.'cfg(target_arch = \"wasm32\")']\nrustflags = [\"--check-cfg=cfg(control_cfg)\", \"--cfg=control_cfg\"]\n",
+    )
+    .unwrap();
+    assert!(
+        cargo_config_has_matching_target_rustflags_with_home(
+            project.path(),
+            None,
+            GETRANDOM_TARGET,
+        )
+        .unwrap()
+    );
+    fs::write(
+        project.path().join("src/lib.rs"),
+        "pub fn random() -> [u8; 1] {\n    control_dep::assert_cfg();\n    let mut out = [0; 1];\n    getrandom::fill(&mut out).unwrap();\n    out\n}\n\n#[unsafe(no_mangle)]\npub unsafe extern \"Rust\" fn __getrandom_v03_custom(_dest: *mut u8, _len: usize) -> Result<(), getrandom::Error> {\n    Err(getrandom::Error::UNSUPPORTED)\n}\n",
+    )
+    .unwrap();
+
+    let (meta, _crate_name, _version, wasm_name, package_id) =
+        resolve_package_metadata(project.path()).unwrap();
+    let compiled = compile_wasm(project.path(), &package_id, &wasm_name).unwrap();
+    assert_eq!(compiled.target, GETRANDOM_TARGET);
+    let expected = locate_wasm_binary(&meta, GETRANDOM_TARGET, &wasm_name).unwrap();
+    assert_eq!(compiled.path, expected);
+    assert!(compiled.path.is_file());
+}
+
+#[test]
+fn build_config_rustflags_reach_path_dependency_with_getrandom_backend() {
+    if !rust_target_is_installed(GETRANDOM_TARGET) {
+        eprintln!(
+            "skipping [build].rustflags dependency build falsifier: {GETRANDOM_TARGET} target is not installed"
+        );
+        return;
+    }
+
+    let project = tempfile::tempdir().unwrap();
+    fs::create_dir_all(project.path().join(".cargo")).unwrap();
+    fs::create_dir_all(project.path().join("src")).unwrap();
+    fs::create_dir_all(project.path().join("control-dep/src")).unwrap();
+    fs::write(
+        project.path().join("Cargo.toml"),
+        "[package]\nname = \"build-config-getrandom\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n[lib]\ncrate-type = [\"cdylib\"]\n\n[dependencies]\ncontrol-dep = { path = \"control-dep\" }\ngetrandom = \"0.4\"\n",
+    )
+    .unwrap();
+    fs::write(
+        project.path().join("control-dep/Cargo.toml"),
+        "[package]\nname = \"control-dep\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+    )
+    .unwrap();
+    fs::write(
+        project.path().join("control-dep/src/lib.rs"),
+        "#[cfg(not(caller_cfg))]\ncompile_error!(\"[build].rustflags were dropped before this dependency\");\n\npub fn assert_cfg() {}\n",
+    )
+    .unwrap();
+    fs::write(
+        project.path().join(".cargo/config.toml"),
+        "[build]\ntarget = \"wasm32-unknown-unknown\"\nrustflags = [\"--check-cfg=cfg(caller_cfg)\", \"--cfg=caller_cfg\"]\n",
+    )
+    .unwrap();
+    fs::write(
+        project.path().join("src/lib.rs"),
+        "pub fn random() -> [u8; 1] {\n    control_dep::assert_cfg();\n    let mut out = [0; 1];\n    getrandom::fill(&mut out).unwrap();\n    out\n}\n\n#[unsafe(no_mangle)]\npub unsafe extern \"Rust\" fn __getrandom_v03_custom(_dest: *mut u8, _len: usize) -> Result<(), getrandom::Error> {\n    Err(getrandom::Error::UNSUPPORTED)\n}\n",
+    )
+    .unwrap();
+
+    let (config_flags, has_matching_target_rustflags) =
+        cargo_config_rustflags_for_target_with_home(project.path(), None, GETRANDOM_TARGET)
+            .unwrap();
+
+    let (meta, _crate_name, _version, wasm_name, package_id) =
+        resolve_package_metadata(project.path()).unwrap();
+    let compiled = compile_wasm_with_target(
+        project.path(),
+        &package_id,
+        &wasm_name,
+        GETRANDOM_TARGET.to_owned(),
+        &config_flags,
+        has_matching_target_rustflags,
+        &RustflagsEnvironment::default(),
+    )
+    .unwrap();
+    assert_eq!(
+        config_flags,
+        vec![
+            "--check-cfg=cfg(caller_cfg)".to_owned(),
+            "--cfg=caller_cfg".to_owned(),
+        ]
+    );
+    assert!(!has_matching_target_rustflags);
+    assert_eq!(compiled.target, GETRANDOM_TARGET);
+    let expected = locate_wasm_binary(&meta, GETRANDOM_TARGET, &wasm_name).unwrap();
+    assert_eq!(compiled.path, expected);
+    assert!(compiled.path.is_file());
+}
+
+#[test]
+fn included_config_rustflags_precede_including_config() {
+    let project = tempfile::tempdir().unwrap();
+    let cargo_home = project.path().join("cargo-home");
+    fs::create_dir_all(project.path().join(".cargo")).unwrap();
+    fs::create_dir_all(&cargo_home).unwrap();
+    fs::write(
+        project.path().join(".cargo/included.toml"),
+        "[build]\nrustflags = [\"--cfg=included\"]\n",
+    )
+    .unwrap();
+    fs::write(
+        project.path().join(".cargo/config.toml"),
+        "include = [\"included.toml\"]\n\n[build]\nrustflags = [\"--cfg=includer\"]\n",
+    )
+    .unwrap();
+
+    let (flags, has_matching_target_rustflags) = cargo_config_rustflags_for_target_with_home(
+        project.path(),
+        Some(&cargo_home),
+        GETRANDOM_TARGET,
+    )
+    .unwrap();
+    assert_eq!(
+        flags,
+        vec!["--cfg=included".to_owned(), "--cfg=includer".to_owned()]
+    );
+    assert!(!has_matching_target_rustflags);
+}
+
+#[test]
+fn nested_included_configs_follow_include_order() {
+    let project = tempfile::tempdir().unwrap();
+    let cargo_home = project.path().join("cargo-home");
+    fs::create_dir_all(project.path().join(".cargo")).unwrap();
+    fs::create_dir_all(&cargo_home).unwrap();
+    fs::write(
+        project.path().join(".cargo/first.toml"),
+        "include = [\"second.toml\"]\n\n[build]\nrustflags = [\"--cfg=first\"]\n",
+    )
+    .unwrap();
+    fs::write(
+        project.path().join(".cargo/second.toml"),
+        "[build]\nrustflags = [\"--cfg=second\"]\n",
+    )
+    .unwrap();
+    fs::write(
+        project.path().join(".cargo/config.toml"),
+        "include = [\"first.toml\"]\n\n[build]\nrustflags = [\"--cfg=root\"]\n",
+    )
+    .unwrap();
+
+    let (flags, _) = cargo_config_rustflags_for_target_with_home(
+        project.path(),
+        Some(&cargo_home),
+        GETRANDOM_TARGET,
+    )
+    .unwrap();
+    assert_eq!(
+        flags,
+        vec![
+            "--cfg=second".to_owned(),
+            "--cfg=first".to_owned(),
+            "--cfg=root".to_owned(),
+        ]
+    );
+}
+
+#[test]
+fn self_including_cargo_config_fails_closed() {
+    let project = tempfile::tempdir().unwrap();
+    let cargo_home = project.path().join("cargo-home");
+    fs::create_dir_all(project.path().join(".cargo")).unwrap();
+    fs::create_dir_all(&cargo_home).unwrap();
+    fs::write(
+        project.path().join(".cargo/config.toml"),
+        "include = [\"config.toml\"]\n",
+    )
+    .unwrap();
+
+    let error = cargo_config_rustflags_for_target_with_home(
+        project.path(),
+        Some(&cargo_home),
+        GETRANDOM_TARGET,
+    )
+    .unwrap_err();
+    assert!(error.to_string().contains("include cycle"));
+}
+
+#[test]
+fn required_cargo_config_include_missing_fails() {
+    let project = tempfile::tempdir().unwrap();
+    let cargo_home = project.path().join("cargo-home");
+    fs::create_dir_all(project.path().join(".cargo")).unwrap();
+    fs::create_dir_all(&cargo_home).unwrap();
+    fs::write(
+        project.path().join(".cargo/config.toml"),
+        "include = [\"missing.toml\"]\n",
+    )
+    .unwrap();
+
+    let error = cargo_config_rustflags_for_target_with_home(
+        project.path(),
+        Some(&cargo_home),
+        GETRANDOM_TARGET,
+    )
+    .unwrap_err();
+    assert!(error.to_string().contains("does not exist"));
+}
+
+#[test]
+fn optional_missing_cargo_config_include_is_allowed() {
+    let project = tempfile::tempdir().unwrap();
+    let cargo_home = project.path().join("cargo-home");
+    fs::create_dir_all(project.path().join(".cargo")).unwrap();
+    fs::create_dir_all(&cargo_home).unwrap();
+    fs::write(
+        project.path().join(".cargo/config.toml"),
+        "include = [{ path = \"missing.toml\", optional = true }]\n\n[build]\nrustflags = [\"--cfg=root\"]\n",
+    )
+    .unwrap();
+
+    let (flags, _) = cargo_config_rustflags_for_target_with_home(
+        project.path(),
+        Some(&cargo_home),
+        GETRANDOM_TARGET,
+    )
+    .unwrap();
+    assert_eq!(flags, vec!["--cfg=root".to_owned()]);
+}
+
+#[test]
+fn dotted_relative_cargo_config_includes_are_supported() {
+    let project = tempfile::tempdir().unwrap();
+    let cargo_home = project.path().join("cargo-home");
+    fs::create_dir_all(project.path().join(".cargo/sub")).unwrap();
+    fs::create_dir_all(&cargo_home).unwrap();
+    fs::write(
+        project.path().join(".cargo/included.toml"),
+        "[build]\nrustflags = [\"--cfg=included\"]\n",
+    )
+    .unwrap();
+    fs::write(
+        project.path().join(".cargo/config.toml"),
+        "include = [\"./sub/../included.toml\"]\n\n[build]\nrustflags = [\"--cfg=includer\"]\n",
+    )
+    .unwrap();
+
+    let (flags, _) = cargo_config_rustflags_for_target_with_home(
+        project.path(),
+        Some(&cargo_home),
+        GETRANDOM_TARGET,
+    )
+    .unwrap();
+    assert_eq!(
+        flags,
+        vec!["--cfg=included".to_owned(), "--cfg=includer".to_owned()]
+    );
+}
+
+#[test]
+fn absolute_cargo_config_includes_are_supported() {
+    let project = tempfile::tempdir().unwrap();
+    let cargo_home = project.path().join("cargo-home");
+    fs::create_dir_all(project.path().join(".cargo")).unwrap();
+    fs::create_dir_all(&cargo_home).unwrap();
+    let included = project.path().join(".cargo/included.toml");
+    fs::write(&included, "[build]\nrustflags = [\"--cfg=included\"]\n").unwrap();
+    let absolute_include = included.canonicalize().unwrap();
+    fs::write(
+        project.path().join(".cargo/config.toml"),
+        format!(
+            "include = [{}]\n\n[build]\nrustflags = [\"--cfg=includer\"]\n",
+            toml_edit::Value::from(absolute_include.to_string_lossy().as_ref())
+        ),
+    )
+    .unwrap();
+
+    let (flags, _) = cargo_config_rustflags_for_target_with_home(
+        project.path(),
+        Some(&cargo_home),
+        GETRANDOM_TARGET,
+    )
+    .unwrap();
+    assert_eq!(
+        flags,
+        vec!["--cfg=included".to_owned(), "--cfg=includer".to_owned()]
+    );
+}
+
+#[test]
+fn mutually_including_cargo_configs_fail_closed() {
+    let project = tempfile::tempdir().unwrap();
+    let cargo_home = project.path().join("cargo-home");
+    fs::create_dir_all(project.path().join(".cargo")).unwrap();
+    fs::create_dir_all(&cargo_home).unwrap();
+    fs::write(
+        project.path().join(".cargo/first.toml"),
+        "include = [\"second.toml\"]\n",
+    )
+    .unwrap();
+    fs::write(
+        project.path().join(".cargo/second.toml"),
+        "include = [\"config.toml\"]\n",
+    )
+    .unwrap();
+    fs::write(
+        project.path().join(".cargo/config.toml"),
+        "include = [\"first.toml\"]\n",
+    )
+    .unwrap();
+
+    let error = cargo_config_rustflags_for_target_with_home(
+        project.path(),
+        Some(&cargo_home),
+        GETRANDOM_TARGET,
+    )
+    .unwrap_err();
+    assert!(error.to_string().contains("include cycle"));
+}
+
+#[test]
+fn malformed_cargo_includes_fail() {
+    let project = tempfile::tempdir().unwrap();
+    let cargo_home = project.path().join("cargo-home");
+    fs::create_dir_all(project.path().join(".cargo")).unwrap();
+    fs::create_dir_all(&cargo_home).unwrap();
+    fs::write(project.path().join(".cargo/config.toml"), "include = [1]\n").unwrap();
+    let error = cargo_config_rustflags_for_target_with_home(
+        project.path(),
+        Some(&cargo_home),
+        GETRANDOM_TARGET,
+    )
+    .unwrap_err();
+    assert!(error.to_string().contains("non-string or non-table"));
+}
+
+#[test]
+fn include_only_rustflags_reach_path_dependency_with_getrandom_backend() {
+    if !rust_target_is_installed(GETRANDOM_TARGET) {
+        eprintln!(
+            "skipping included rustflags dependency build falsifier: {GETRANDOM_TARGET} target is not installed"
+        );
+        return;
+    }
+
+    let project = tempfile::tempdir().unwrap();
+    fs::create_dir_all(project.path().join(".cargo")).unwrap();
+    fs::create_dir_all(project.path().join("src")).unwrap();
+    fs::create_dir_all(project.path().join("control-dep/src")).unwrap();
+    fs::write(
+        project.path().join("Cargo.toml"),
+        "[package]\nname = \"include-getrandom\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n[lib]\ncrate-type = [\"cdylib\"]\n\n[dependencies]\ncontrol-dep = { path = \"control-dep\" }\ngetrandom = \"0.4\"\n",
+    )
+    .unwrap();
+    fs::write(
+        project.path().join("control-dep/Cargo.toml"),
+        "[package]\nname = \"control-dep\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+    )
+    .unwrap();
+    fs::write(
+        project.path().join("control-dep/src/lib.rs"),
+        "#[cfg(not(caller_cfg))]\ncompile_error!(\"included [build].rustflags were dropped before this dependency\");\n\npub fn assert_cfg() {}\n",
+    )
+    .unwrap();
+    fs::write(
+        project.path().join(".cargo/included.toml"),
+        "[build]\nrustflags = [\"--check-cfg=cfg(caller_cfg)\", \"--cfg=caller_cfg\"]\n",
+    )
+    .unwrap();
+    fs::write(
+        project.path().join(".cargo/config.toml"),
+        "include = [\"included.toml\"]\n\n[build]\ntarget = \"wasm32-unknown-unknown\"\n",
+    )
+    .unwrap();
+    fs::write(
+        project.path().join("src/lib.rs"),
+        "pub fn random() -> [u8; 1] {\n    control_dep::assert_cfg();\n    let mut out = [0; 1];\n    getrandom::fill(&mut out).unwrap();\n    out\n}\n\n#[unsafe(no_mangle)]\npub unsafe extern \"Rust\" fn __getrandom_v03_custom(_dest: *mut u8, _len: usize) -> Result<(), getrandom::Error> {\n    Err(getrandom::Error::UNSUPPORTED)\n}\n",
+    )
+    .unwrap();
+
+    let (config_flags, has_matching_target_rustflags) =
+        cargo_config_rustflags_for_target_with_home(project.path(), None, GETRANDOM_TARGET)
+            .unwrap();
+
+    let (meta, _crate_name, _version, wasm_name, package_id) =
+        resolve_package_metadata(project.path()).unwrap();
+    let compiled = compile_wasm_with_target(
+        project.path(),
+        &package_id,
+        &wasm_name,
+        GETRANDOM_TARGET.to_owned(),
+        &config_flags,
+        has_matching_target_rustflags,
+        &RustflagsEnvironment::default(),
+    )
+    .unwrap();
+    assert_eq!(
+        config_flags,
+        vec![
+            "--check-cfg=cfg(caller_cfg)".to_owned(),
+            "--cfg=caller_cfg".to_owned(),
+        ]
+    );
+    assert!(!has_matching_target_rustflags);
+    assert_eq!(compiled.target, GETRANDOM_TARGET);
+    let expected = locate_wasm_binary(&meta, GETRANDOM_TARGET, &wasm_name).unwrap();
+    assert_eq!(compiled.path, expected);
+    assert!(compiled.path.is_file());
+}
+
+#[test]
+fn build_env_and_getrandom_cfg_reach_dependency_without_target_flags() {
+    if !rust_target_is_installed(GETRANDOM_TARGET) {
+        eprintln!(
+            "skipping CARGO_BUILD_RUSTFLAGS regression: {GETRANDOM_TARGET} target is not installed"
+        );
+        return;
+    }
+
+    let project = tempfile::tempdir().unwrap();
+    fs::create_dir_all(project.path().join(".cargo")).unwrap();
+    fs::create_dir_all(project.path().join("src")).unwrap();
+    fs::create_dir_all(project.path().join("control-dep/src")).unwrap();
+    fs::write(
+        project.path().join("Cargo.toml"),
+        "[package]\nname = \"build-env-getrandom\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n[lib]\ncrate-type = [\"cdylib\"]\n\n[dependencies]\ncontrol-dep = { path = \"control-dep\" }\ngetrandom = \"0.4\"\n",
+    )
+    .unwrap();
+    fs::write(
+        project.path().join("control-dep/Cargo.toml"),
+        "[package]\nname = \"control-dep\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+    )
+    .unwrap();
+    fs::write(
+        project.path().join("control-dep/src/lib.rs"),
+        "#[cfg(not(caller_cfg))]\ncompile_error!(\"CARGO_BUILD_RUSTFLAGS did not reach this dependency\");\n\npub fn assert_cfg() {}\n",
+    )
+    .unwrap();
+    fs::write(
+        project.path().join(".cargo/config.toml"),
+        "[build]\ntarget = \"wasm32-unknown-unknown\"\n",
+    )
+    .unwrap();
+    fs::write(
+        project.path().join("src/lib.rs"),
+        "pub fn random() -> [u8; 1] {\n    control_dep::assert_cfg();\n    let mut out = [0; 1];\n    getrandom::fill(&mut out).unwrap();\n    out\n}\n\n#[unsafe(no_mangle)]\npub unsafe extern \"Rust\" fn __getrandom_v03_custom(_dest: *mut u8, _len: usize) -> Result<(), getrandom::Error> {\n    Err(getrandom::Error::UNSUPPORTED)\n}\n",
+    )
+    .unwrap();
+
+    assert!(
+        !cargo_config_has_matching_target_rustflags_with_home(
+            project.path(),
+            None,
+            GETRANDOM_TARGET,
+        )
+        .unwrap()
+    );
+    let (meta, _crate_name, _version, wasm_name, package_id) =
+        resolve_package_metadata(project.path()).unwrap();
+    let compiled = compile_wasm_with_target(
+        project.path(),
+        &package_id,
+        &wasm_name,
+        GETRANDOM_TARGET.to_owned(),
+        &[],
+        false,
+        &RustflagsEnvironment {
+            build: Some("--check-cfg=cfg(caller_cfg) --cfg=caller_cfg".to_owned()),
+            ..RustflagsEnvironment::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(compiled.target, GETRANDOM_TARGET);
+    let expected = locate_wasm_binary(&meta, GETRANDOM_TARGET, &wasm_name).unwrap();
+    assert_eq!(compiled.path, expected);
+    assert!(compiled.path.is_file());
+}
+
+#[test]
+fn exact_target_rustflags_entry_is_detected_for_getrandom_merge() {
+    let project = tempfile::tempdir().unwrap();
+    let cargo_dir = project.path().join(".cargo");
+    fs::create_dir_all(&cargo_dir).unwrap();
+    fs::write(
+        cargo_dir.join("config.toml"),
+        "[build]\ntarget = \"wasm32-unknown-unknown\"\n\n[target.wasm32-unknown-unknown]\nrustflags = []\n",
+    )
+    .unwrap();
+
+    assert!(
+        cargo_config_has_matching_target_rustflags_with_home(
+            project.path(),
+            None,
+            GETRANDOM_TARGET,
+        )
+        .unwrap()
+    );
+}
+
+#[test]
+fn nonmatching_target_cfg_is_not_detected_for_getrandom_merge() {
+    let project = tempfile::tempdir().unwrap();
+    let cargo_dir = project.path().join(".cargo");
+    fs::create_dir_all(&cargo_dir).unwrap();
+    fs::write(
+        cargo_dir.join("config.toml"),
+        "[build]\ntarget = \"wasm32-unknown-unknown\"\n\n[target.'cfg(target_os = \"linux\")']\nrustflags = [\"--cfg=linux_only\"]\n",
+    )
+    .unwrap();
+
+    assert!(
+        !cargo_config_has_matching_target_rustflags_with_home(
+            project.path(),
+            None,
+            GETRANDOM_TARGET,
+        )
+        .unwrap()
+    );
+}
+
+fn rust_target_is_installed(target: &str) -> bool {
+    let Ok(output) = std::process::Command::new("rustc")
+        .args(["--print", "target-libdir", "--target", target])
+        .output()
+    else {
+        return false;
+    };
+    if !output.status.success() {
+        return false;
+    }
+    let Ok(libdir) = std::str::from_utf8(&output.stdout) else {
+        return false;
+    };
+    fs::read_dir(libdir.trim()).is_ok_and(|entries| {
+        entries
+            .flatten()
+            .any(|entry| entry.file_name().to_string_lossy().starts_with("libcore-"))
+    })
+}
+
+#[test]
+fn unavailable_target_is_detected_without_installing_toolchains() {
+    assert!(!rust_target_is_installed(
+        "astrid-test-target-that-does-not-exist"
+    ));
+}
+
+#[test]
+fn local_config_target_and_rustflags_are_read() {
+    let dir = tempfile::tempdir().unwrap();
+    let cargo_dir = dir.path().join(".cargo");
+    fs::create_dir_all(&cargo_dir).unwrap();
+    fs::write(
+        cargo_dir.join("config.toml"),
+        "[build]\n\
+             target = \"wasm32-unknown-unknown\"\n\n\
+             [target.wasm32-unknown-unknown]\n\
+             rustflags = [\"--cfg=getrandom_backend=\\\"custom\\\"\"]\n",
+    )
+    .unwrap();
+
+    let (target, flags) = cargo_config_target_and_rustflags_with_home(dir.path(), None).unwrap();
+    assert_eq!(target.as_deref(), Some(GETRANDOM_TARGET));
+    assert_eq!(flags, vec![GETRANDOM_CUSTOM_CFG.to_owned()]);
+}
+
+#[test]
+fn string_form_rustflags_are_preserved() {
+    let dir = tempfile::tempdir().unwrap();
+    let cargo_dir = dir.path().join(".cargo");
+    fs::create_dir_all(&cargo_dir).unwrap();
+    fs::write(
+        cargo_dir.join("config.toml"),
+        "[build]\ntarget = \"wasm32-unknown-unknown\"\nrustflags = \"-C opt-level=3\"\n",
+    )
+    .unwrap();
+
+    let (target, flags) = cargo_config_target_and_rustflags_with_home(dir.path(), None).unwrap();
+    assert_eq!(target.as_deref(), Some(GETRANDOM_TARGET));
+    assert_eq!(flags, vec!["-C".to_owned(), "opt-level=3".to_owned()]);
+}
+
+#[test]
+fn ancestor_and_cargo_home_config_hierarchy_is_preserved() {
+    let root = tempfile::tempdir().unwrap();
+    let cargo_home = root.path().join("cargo-home");
+    let ancestor = root.path().join("ancestor");
+    let capsule = ancestor.join("workspace").join("capsule");
+    fs::create_dir_all(capsule.join(".cargo")).unwrap();
+    fs::create_dir_all(ancestor.join(".cargo")).unwrap();
+    fs::create_dir_all(&cargo_home).unwrap();
+
+    fs::write(
+        cargo_home.join("config.toml"),
+        "[build]\ntarget = \"wasm32-wasip2\"\nrustflags = [\"--cfg=from-cargo-home\"]\n",
+    )
+    .unwrap();
+    fs::write(
+        ancestor.join(".cargo/config.toml"),
+        "[build]\ntarget = \"wasm32-unknown-unknown\"\n\n[target.wasm32-unknown-unknown]\nrustflags = [\"--cfg=from-ancestor\"]\n",
+    )
+    .unwrap();
+
+    let (target, flags) =
+        cargo_config_target_and_rustflags_with_home(&capsule, Some(&cargo_home)).unwrap();
+    assert_eq!(target.as_deref(), Some(GETRANDOM_TARGET));
+    assert_eq!(flags, vec!["--cfg=from-ancestor".to_owned()]);
+
+    fs::remove_file(ancestor.join(".cargo/config.toml")).unwrap();
+    let (target, flags) =
+        cargo_config_target_and_rustflags_with_home(&capsule, Some(&cargo_home)).unwrap();
+    assert_eq!(target.as_deref(), Some("wasm32-wasip2"));
+    assert_eq!(flags, vec!["--cfg=from-cargo-home".to_owned()]);
+}
+
+#[test]
+fn nearest_config_overrides_parent_without_erasing_unrelated_values() {
+    let root = tempfile::tempdir().unwrap();
+    let ancestor = root.path().join("ancestor");
+    let capsule = ancestor.join("capsule");
+    fs::create_dir_all(capsule.join(".cargo")).unwrap();
+    fs::create_dir_all(ancestor.join(".cargo")).unwrap();
+    fs::write(
+        ancestor.join(".cargo/config.toml"),
+        "[build]\ntarget = \"wasm32-wasip2\"\nrustflags = [\"--cfg=parent\"]\n",
+    )
+    .unwrap();
+    fs::write(
+        capsule.join(".cargo/config.toml"),
+        "[target.wasm32-unknown-unknown]\nrustflags = [\"--cfg=child-target\"]\n",
+    )
+    .unwrap();
+
+    let (target, flags) = cargo_config_target_and_rustflags_with_home(&capsule, None).unwrap();
+    assert_eq!(target.as_deref(), Some("wasm32-wasip2"));
+    assert_eq!(flags, vec!["--cfg=parent".to_owned()]);
+}
+
+#[test]
+fn array_rustflags_are_joined_across_config_hierarchy() {
+    let root = tempfile::tempdir().unwrap();
+    let ancestor = root.path().join("ancestor");
+    let capsule = ancestor.join("capsule");
+    fs::create_dir_all(capsule.join(".cargo")).unwrap();
+    fs::create_dir_all(ancestor.join(".cargo")).unwrap();
+    fs::write(
+        ancestor.join(".cargo/config.toml"),
+        "[build]\ntarget = \"wasm32-unknown-unknown\"\n\n[target.wasm32-unknown-unknown]\nrustflags = [\"--cfg=parent\"]\n",
+    )
+    .unwrap();
+    fs::write(
+        capsule.join(".cargo/config.toml"),
+        "[target.wasm32-unknown-unknown]\nrustflags = [\"--cfg=child\"]\n",
+    )
+    .unwrap();
+
+    let (target, flags) = cargo_config_target_and_rustflags_with_home(&capsule, None).unwrap();
+    assert_eq!(target.as_deref(), Some(GETRANDOM_TARGET));
+    assert_eq!(
+        flags,
+        vec!["--cfg=parent".to_owned(), "--cfg=child".to_owned()]
+    );
+}
+
+#[test]
+fn extensionless_cargo_config_wins_when_both_names_exist() {
+    let dir = tempfile::tempdir().unwrap();
+    let cargo_dir = dir.path().join(".cargo");
+    fs::create_dir_all(&cargo_dir).unwrap();
+    fs::write(
+        cargo_dir.join("config.toml"),
+        "[build]\ntarget = \"wasm32-wasip2\"\n",
+    )
+    .unwrap();
+    fs::write(
+        cargo_dir.join("config"),
+        "[build]\ntarget = \"wasm32-unknown-unknown\"\n",
+    )
+    .unwrap();
+
+    let (target, _) = cargo_config_target_and_rustflags_with_home(dir.path(), None).unwrap();
+    assert_eq!(target.as_deref(), Some(GETRANDOM_TARGET));
+}
+
+#[test]
+fn environment_target_selects_matching_config_rustflags() {
+    let dir = tempfile::tempdir().unwrap();
+    let cargo_dir = dir.path().join(".cargo");
+    fs::create_dir_all(&cargo_dir).unwrap();
+    fs::write(
+        cargo_dir.join("config.toml"),
+        "[build]\ntarget = \"wasm32-wasip2\"\nrustflags = [\"--cfg=build\"]\n\n[target.wasm32-unknown-unknown]\nrustflags = [\"--cfg=target\"]\n",
+    )
+    .unwrap();
+
+    let (config_target, _) = cargo_config_target_and_rustflags_with_home(dir.path(), None).unwrap();
+    assert_eq!(config_target.as_deref(), Some("wasm32-wasip2"));
+    let (_, flags) = cargo_config_target_and_rustflags_for_target_with_home(
+        dir.path(),
+        None,
+        Some(GETRANDOM_TARGET),
+    )
+    .unwrap();
+    assert_eq!(flags, vec!["--cfg=target".to_owned()]);
+}
+
+#[test]
+fn relative_cargo_home_is_resolved_from_child_current_dir() {
+    let root = tempfile::tempdir().unwrap();
+    let capsule = root.path().join("workspace").join("capsule");
+    let relative_home = Path::new("relative-cargo-home");
+    fs::create_dir_all(capsule.join(".cargo")).unwrap();
+    let resolved_home = resolve_cargo_home(&capsule, relative_home.to_path_buf());
+    fs::create_dir_all(&resolved_home).unwrap();
+    fs::write(
+        resolved_home.join("config.toml"),
+        "[build]\ntarget = \"wasm32-unknown-unknown\"\n",
+    )
+    .unwrap();
+
+    assert_eq!(
+        resolve_cargo_home(&capsule, relative_home.to_path_buf()),
+        capsule.join(relative_home)
+    );
+    let (target, _) =
+        cargo_config_target_and_rustflags_with_home(&capsule, Some(relative_home)).unwrap();
+    assert_eq!(target.as_deref(), Some(GETRANDOM_TARGET));
+}
+
+#[test]
+fn multi_target_config_does_not_guess_a_single_target() {
+    let project = tempfile::tempdir().unwrap();
+    let cargo_dir = project.path().join(".cargo");
+    fs::create_dir_all(&cargo_dir).unwrap();
+    fs::write(
+        cargo_dir.join("config.toml"),
+        "[build]\ntarget = [\"wasm32-unknown-unknown\", \"wasm32-wasip2\"]\n",
+    )
+    .unwrap();
+
+    let (target, flags) =
+        cargo_config_target_and_rustflags_with_home(project.path(), None).unwrap();
+    assert_eq!(target, None);
+    assert!(flags.is_empty());
+}
+
+#[test]
+fn missing_config_yields_no_target_or_flags() {
+    let dir = tempfile::tempdir().unwrap();
+    let (target, flags) = cargo_config_target_and_rustflags_with_home(dir.path(), None).unwrap();
+    assert_eq!(target, None);
+    assert!(flags.is_empty());
+}
+
+#[test]
+fn environment_target_overrides_capsule_config_target() {
+    let target = resolve_build_target(
+        Some(GETRANDOM_TARGET.to_owned()),
+        Some("wasm32-wasip2".to_owned()),
+    )
+    .unwrap();
+    assert_eq!(target, "wasm32-wasip2");
+}
+
+#[test]
+fn missing_target_is_rejected_instead_of_building_host_cdylib() {
+    let error = resolve_build_target(None, None).unwrap_err();
+    assert!(error.to_string().contains("No Cargo build target selected"));
+
+    let error = resolve_build_target(Some(String::new()), None).unwrap_err();
+    assert!(error.to_string().contains("No Cargo build target selected"));
+
+    let error = resolve_build_target(None, Some(" ".to_owned())).unwrap_err();
+    assert!(error.to_string().contains("No Cargo build target selected"));
+}
+
+fn metadata_for(capsule_dir: &Path, target_directory: &Path) -> cargo_metadata::Metadata {
+    serde_json::from_value(json!({
+        "packages": [],
+        "workspace_members": [],
+        "resolve": null,
+        "workspace_root": capsule_dir,
+        "target_directory": target_directory,
+        "version": 15,
+    }))
+    .unwrap()
+}
+
+fn create_artifact(target_root: &Path, target: &str, wasm_name: &str) -> anyhow::Result<PathBuf> {
+    let artifact = target_root
+        .join(target)
+        .join("release")
+        .join(format!("{wasm_name}.wasm"));
+    fs::create_dir_all(artifact.parent().unwrap())?;
+    fs::write(&artifact, b"\0asm")?;
+    Ok(artifact)
+}
+
+#[test]
+fn locates_exact_artifact_from_external_target_root() {
+    let capsule = tempfile::tempdir().unwrap();
+    let external_root = tempfile::tempdir().unwrap();
+    let expected = create_artifact(external_root.path(), GETRANDOM_TARGET, "capsule_cli").unwrap();
+
+    create_artifact(
+        &capsule.path().join("target"),
+        GETRANDOM_TARGET,
+        "capsule_cli",
+    )
+    .unwrap();
+    create_artifact(
+        &capsule.path().join("workspace-target"),
+        GETRANDOM_TARGET,
+        "capsule_cli",
+    )
+    .unwrap();
+
+    let meta = metadata_for(capsule.path(), external_root.path());
+    let actual = locate_wasm_binary(&meta, GETRANDOM_TARGET, "capsule_cli").unwrap();
+
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn selects_exact_cross_target_artifact() {
+    let capsule = tempfile::tempdir().unwrap();
+    let target_root = tempfile::tempdir().unwrap();
+    create_artifact(target_root.path(), GETRANDOM_TARGET, "capsule").unwrap();
+    let expected = create_artifact(target_root.path(), "wasm32-wasip2", "capsule").unwrap();
+
+    let meta = metadata_for(capsule.path(), target_root.path());
+    let actual = locate_wasm_binary(&meta, "wasm32-wasip2", "capsule").unwrap();
+
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn missing_artifact_is_rejected_without_fallback() {
+    let capsule = tempfile::tempdir().unwrap();
+    let target_root = tempfile::tempdir().unwrap();
+    let meta = metadata_for(capsule.path(), target_root.path());
+
+    let error = locate_wasm_binary(&meta, GETRANDOM_TARGET, "missing_capsule").unwrap_err();
+
+    assert!(error.to_string().contains("Could not locate compiled WASM"));
+}
+
+#[test]
+fn directory_artifact_is_rejected() {
+    let capsule = tempfile::tempdir().unwrap();
+    let target_root = tempfile::tempdir().unwrap();
+    fs::create_dir_all(
+        target_root
+            .path()
+            .join(GETRANDOM_TARGET)
+            .join("release")
+            .join("capsule.wasm"),
+    )
+    .unwrap();
+    let meta = metadata_for(capsule.path(), target_root.path());
+
+    let error = locate_wasm_binary(&meta, GETRANDOM_TARGET, "capsule").unwrap_err();
+
+    assert!(error.to_string().contains("not a regular file"));
+}
+
+#[cfg(unix)]
+#[test]
+fn symlinked_artifact_is_rejected() {
+    let capsule = tempfile::tempdir().unwrap();
+    let target_root = tempfile::tempdir().unwrap();
+    let real_artifact = create_artifact(target_root.path(), GETRANDOM_TARGET, "capsule").unwrap();
+    let release = target_root.path().join(GETRANDOM_TARGET).join("release");
+    let symlink = release.join("symlink.wasm");
+    std::os::unix::fs::symlink(real_artifact, &symlink).unwrap();
+    let meta = metadata_for(capsule.path(), target_root.path());
+
+    let error = locate_wasm_binary(&meta, GETRANDOM_TARGET, "symlink").unwrap_err();
+
+    assert!(error.to_string().contains("is a symlink"));
+}
+
+#[cfg(unix)]
+#[test]
+fn artifact_escaping_target_root_is_rejected() {
+    let capsule = tempfile::tempdir().unwrap();
+    let target_root = tempfile::tempdir().unwrap();
+    let outside = tempfile::tempdir().unwrap();
+    create_artifact(outside.path(), GETRANDOM_TARGET, "escaped").unwrap();
+    fs::create_dir_all(target_root.path().join(GETRANDOM_TARGET)).unwrap();
+    std::os::unix::fs::symlink(
+        outside.path().join(GETRANDOM_TARGET).join("release"),
+        target_root.path().join(GETRANDOM_TARGET).join("release"),
+    )
+    .unwrap();
+    let meta = metadata_for(capsule.path(), target_root.path());
+
+    let error = locate_wasm_binary(&meta, GETRANDOM_TARGET, "escaped").unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("escapes configured target directory")
+    );
+}
+
+#[test]
+fn rejects_escaping_artifact_name() {
+    let error = validate_wasm_output_name("../stale.wasm").unwrap_err();
+    assert!(error.to_string().contains("Unsafe WASM artifact name"));
+}
+
+#[test]
+fn uses_explicit_cdylib_output_name() {
+    let output_name = resolve_wasm_output_name_from_targets(["custom_capsule".to_owned()]).unwrap();
+    assert_eq!(output_name, "custom_capsule");
+}
+
+#[test]
+fn rejects_ambiguous_cdylib_outputs() {
+    let error = resolve_wasm_output_name_from_targets(["first".to_owned(), "second".to_owned()])
+        .unwrap_err();
+
+    assert!(error.to_string().contains("ambiguous WASM artifact"));
+}
+
+#[test]
+fn rejects_missing_cdylib_output() {
+    let error = resolve_wasm_output_name_from_targets(std::iter::empty()).unwrap_err();
+
+    assert!(error.to_string().contains("no cdylib target"));
+}
+
+#[cfg(unix)]
+#[test]
+fn rejects_target_path_escaping_target_root() {
+    let capsule = tempfile::tempdir().unwrap();
+    let parent = tempfile::tempdir().unwrap();
+    let target_root = parent.path().join("target");
+    fs::create_dir_all(&target_root).unwrap();
+    create_artifact(parent.path(), "", "escaped").unwrap();
+
+    let meta = metadata_for(capsule.path(), &target_root);
+    let error = locate_wasm_binary(&meta, "../", "escaped").unwrap_err();
+
+    assert!(
+        error
+            .to_string()
+            .contains("escapes configured target directory")
+    );
+}
+
+#[test]
+fn existing_manifest_is_bound_to_renamed_cdylib_in_archive() {
+    let source = tempfile::tempdir().unwrap();
+    let wasm_path = source.path().join("renamed_capsule.wasm");
+    fs::write(&wasm_path, b"\0asm\x01\0\0\0").unwrap();
+    fs::write(
+        source.path().join("Capsule.toml"),
+        "[package]\nname = \"original-package\"\nversion = \"1.0.0\"\n\n[[component]]\nid = \"main\"\nfile = \"original_package.wasm\"\ntype = \"executable\"\n\n[capabilities]\nnet_connect = false\n",
+    )
+    .unwrap();
+
+    let manifest = build_manifest_content(
+        source.path(),
+        &wasm_path,
+        "original-package",
+        "1.0.0",
+        "renamed_capsule",
+    )
+    .unwrap();
+    let parsed = manifest.parse::<toml_edit::DocumentMut>().unwrap();
+    let file = parsed
+        .get("component")
+        .and_then(toml_edit::Item::as_array_of_tables)
+        .and_then(|components| components.get(0))
+        .and_then(|component| component.get("file"))
+        .and_then(toml_edit::Item::as_str);
+    assert_eq!(file, Some("renamed_capsule.wasm"));
+    assert!(manifest.contains("net_connect = false"));
+
+    let archive_path = source.path().join("renamed.capsule");
+    pack_capsule_archive(
+        &archive_path,
+        &manifest,
+        Some(&wasm_path),
+        source.path(),
+        &[],
+        None,
+    )
+    .unwrap();
+    let decoder = flate2::read::GzDecoder::new(File::open(&archive_path).unwrap());
+    let mut archive = tar::Archive::new(decoder);
+    let entries = archive
+        .entries()
+        .unwrap()
+        .map(|entry| entry.unwrap().path().unwrap().into_owned())
+        .collect::<Vec<_>>();
+    assert!(entries.contains(&PathBuf::from("renamed_capsule.wasm")));
+    assert!(entries.contains(&PathBuf::from(file.unwrap())));
+}
+
+#[test]
+fn existing_manifest_with_multiple_components_fails_closed() {
+    let source = tempfile::tempdir().unwrap();
+    let wasm_path = source.path().join("capsule.wasm");
+    fs::write(&wasm_path, b"\0asm\x01\0\0\0").unwrap();
+    fs::write(
+        source.path().join("Capsule.toml"),
+        "[package]\nname = \"capsule\"\nversion = \"1.0.0\"\n\n[[component]]\nfile = \"one.wasm\"\n\n[[component]]\nfile = \"two.wasm\"\n",
+    )
+    .unwrap();
+
+    let error = build_manifest_content(source.path(), &wasm_path, "capsule", "1.0.0", "capsule")
+        .unwrap_err();
+    assert!(error.to_string().contains("exactly one cdylib"));
+}


### PR DESCRIPTION
## Linked Issue

Closes #1807.

## Summary

Resolve capsule outputs from Cargo metadata and Cargo effective configuration without replacing flags Cargo applies to dependencies.

## Changes

- Honor workspace, ancestor, relative CARGO_HOME, environment, target-specific, build, and matching target-cfg configuration.
- Preserve CARGO_BUILD_RUSTFLAGS when no matching target-specific source exists; merge through Cargo config only when the selected target or matching cfg table supplies rustflags.
- Resolve target-cfg matching with Cargo platform semantics and fail closed if the rustc cfg probe or parser fails.
- Resolve the exact cdylib artifact from Cargo JSON output and reject missing, ambiguous, symlinked, non-regular, or escaping artifacts.
- Fail closed when Capsule.toml does not name the selected WASM executable after a lib rename.
- Keep production files below the 1000-line source cap with Cargo config discovery in a focused module.

## Verification

- cargo fmt --all -- --check
- cargo clippy -p astrid-build --all-targets --locked -- -D warnings
- cargo test -p astrid-build --lib --locked (52 passed)
- Executable dependency builds for CARGO_BUILD_RUSTFLAGS-only and matching target-cfg rustflags, both retaining getrandom injection
- Relative CARGO_HOME resolution regression
- Capability-aware missing-target regression for generic CI hosts
- Renamed-manifest archive resolver and path-safety regressions
- git diff --check

## AI / Tool Assistance

Assisted-by: Codex:gpt-5.6-luna

Codex implemented the bounded successor. The exact commit, signature, DCO, ownership, source limits, and local gates were independently verified before publication.

## Checklist

- [x] The linked issue describes the intended outcome.
- [x] The change is scoped to that outcome.
- [x] Regression tests cover the changed behavior.
- [x] Formatting, linting, and focused tests pass.
- [x] The commit is signed and includes DCO sign-off.

