### PR TITLE
feat(release): set Astrid workspace version to 2026.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,7 +233,7 @@ dependencies = [
 
 [[package]]
 name = "astrid"
-version = "0.10.4"
+version = "2026.9.0"
 dependencies = [
  "anyhow",
  "arboard",
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-approval"
-version = "0.10.4"
+version = "2026.9.0"
 dependencies = [
  "astrid-audit",
  "astrid-capabilities",
@@ -318,7 +318,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-audit"
-version = "0.10.4"
+version = "2026.9.0"
 dependencies = [
  "astrid-capabilities",
  "astrid-core",
@@ -338,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-build"
-version = "0.10.4"
+version = "2026.9.0"
 dependencies = [
  "anyhow",
  "astrid-core",
@@ -360,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-capabilities"
-version = "0.10.4"
+version = "2026.9.0"
 dependencies = [
  "astrid-core",
  "astrid-crypto",
@@ -378,7 +378,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-capsule"
-version = "0.10.4"
+version = "2026.9.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -431,7 +431,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-capsule-install"
-version = "0.10.4"
+version = "2026.9.0"
 dependencies = [
  "anyhow",
  "astrid-build",
@@ -459,7 +459,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-capsule-types"
-version = "0.10.4"
+version = "2026.9.0"
 dependencies = [
  "astrid-core",
  "dashmap",
@@ -475,7 +475,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-config"
-version = "0.10.4"
+version = "2026.9.0"
 dependencies = [
  "astrid-core",
  "directories",
@@ -489,7 +489,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-core"
-version = "0.10.4"
+version = "2026.9.0"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -514,7 +514,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-crypto"
-version = "0.10.4"
+version = "2026.9.0"
 dependencies = [
  "base64 0.23.1",
  "blake3",
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-daemon"
-version = "0.10.4"
+version = "2026.9.0"
 dependencies = [
  "anyhow",
  "astrid-capsule",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-emit"
-version = "0.10.4"
+version = "2026.9.0"
 dependencies = [
  "anyhow",
  "astrid-core",
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-events"
-version = "0.10.4"
+version = "2026.9.0"
 dependencies = [
  "astrid-core",
  "astrid-runtime",
@@ -589,7 +589,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-gateway"
-version = "0.10.4"
+version = "2026.9.0"
 dependencies = [
  "anyhow",
  "astrid-audit",
@@ -637,7 +637,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-hooks"
-version = "0.10.4"
+version = "2026.9.0"
 dependencies = [
  "astrid-capabilities",
  "astrid-capsule",
@@ -665,7 +665,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-integration-tests"
-version = "0.10.4"
+version = "2026.9.0"
 dependencies = [
  "arc-swap",
  "astrid-approval",
@@ -702,7 +702,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-kernel"
-version = "0.10.4"
+version = "2026.9.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -746,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-mcp"
-version = "0.10.4"
+version = "2026.9.0"
 dependencies = [
  "astrid-audit",
  "astrid-capabilities",
@@ -770,7 +770,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-prelude"
-version = "0.10.4"
+version = "2026.9.0"
 dependencies = [
  "astrid-audit",
  "astrid-capabilities",
@@ -785,7 +785,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-runtime"
-version = "0.10.4"
+version = "2026.9.0"
 dependencies = [
  "futures",
  "tokio",
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-storage"
-version = "0.10.4"
+version = "2026.9.0"
 dependencies = [
  "arc-swap",
  "astrid-core",
@@ -833,7 +833,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-storage-chunker-evidence"
-version = "0.10.4"
+version = "2026.9.0"
 dependencies = [
  "anyhow",
  "astrid-storage",
@@ -850,7 +850,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-storage-provider-fskit"
-version = "0.10.4"
+version = "2026.9.0"
 dependencies = [
  "anyhow",
  "astrid-core",
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-storage-provider-fuse"
-version = "0.10.4"
+version = "2026.9.0"
 dependencies = [
  "anyhow",
  "astrid-core",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-storage-provider-winfsp"
-version = "0.10.4"
+version = "2026.9.0"
 dependencies = [
  "anyhow",
  "astrid-core",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-telemetry"
-version = "0.10.4"
+version = "2026.9.0"
 dependencies = [
  "astrid-config",
  "chrono",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-test"
-version = "0.10.4"
+version = "2026.9.0"
 dependencies = [
  "astrid-core",
  "chrono",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-types"
-version = "0.10.4"
+version = "2026.9.0"
 dependencies = [
  "chrono",
  "getrandom 0.4.3",
@@ -944,7 +944,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-uplink"
-version = "0.10.4"
+version = "2026.9.0"
 dependencies = [
  "anyhow",
  "astrid-core",
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-vfs"
-version = "0.10.4"
+version = "2026.9.0"
 dependencies = [
  "astrid-capabilities",
  "astrid-core",
@@ -982,7 +982,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-workspace"
-version = "0.10.4"
+version = "2026.9.0"
 dependencies = [
  "astrid-core",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.10.4"
+version = "2026.9.0"
 edition = "2024"
 authors = ["Joshua J. Bouw <dev@joshuajbouw.com>", "Unicity Labs <info@unicity-labs.com>"]
 license = "MIT OR Apache-2.0"
@@ -44,33 +44,33 @@ repository = "https://github.com/astrid-runtime/astrid"
 rust-version = "1.95"
 
 [workspace.dependencies]
-astrid-approval = { path = "crates/astrid-approval", version = "0.10.4" }
-astrid-audit = { path = "crates/astrid-audit", version = "0.10.4" }
-astrid-capabilities = { path = "crates/astrid-capabilities", version = "0.10.4" }
-astrid-build = { path = "crates/astrid-build", version = "0.10.4" }
-astrid-capsule = { path = "crates/astrid-capsule", version = "0.10.4" }
-astrid-capsule-install = { path = "crates/astrid-capsule-install", version = "0.10.4" }
-astrid-capsule-types = { path = "crates/astrid-capsule-types", version = "0.10.4" }
-astrid-config = { path = "crates/astrid-config", version = "0.10.4" }
-astrid-daemon = { path = "crates/astrid-daemon", version = "0.10.4" }
-astrid-core = { path = "crates/astrid-core", version = "0.10.4" }
-astrid-crypto = { path = "crates/astrid-crypto", version = "0.10.4" }
-astrid-emit = { path = "crates/astrid-emit", version = "0.10.4" }
-astrid-events = { path = "crates/astrid-events", version = "0.10.4" }
-astrid-hooks = { path = "crates/astrid-hooks", version = "0.10.4" }
-astrid-kernel = { path = "crates/astrid-kernel", version = "0.10.4" }
-astrid-mcp = { path = "crates/astrid-mcp", version = "0.10.4" }
-astrid-prelude = { path = "crates/astrid-prelude", version = "0.10.4" }
-astrid-runtime = { path = "crates/astrid-runtime", version = "0.10.4" }
-astrid-storage = { path = "crates/astrid-storage", version = "0.10.4" }
-astrid-storage-provider-winfsp = { path = "crates/astrid-storage-provider-winfsp", version = "0.10.4" }
-astrid-telemetry = { path = "crates/astrid-telemetry", version = "0.10.4" }
+astrid-approval = { path = "crates/astrid-approval", version = "2026.9.0" }
+astrid-audit = { path = "crates/astrid-audit", version = "2026.9.0" }
+astrid-capabilities = { path = "crates/astrid-capabilities", version = "2026.9.0" }
+astrid-build = { path = "crates/astrid-build", version = "2026.9.0" }
+astrid-capsule = { path = "crates/astrid-capsule", version = "2026.9.0" }
+astrid-capsule-install = { path = "crates/astrid-capsule-install", version = "2026.9.0" }
+astrid-capsule-types = { path = "crates/astrid-capsule-types", version = "2026.9.0" }
+astrid-config = { path = "crates/astrid-config", version = "2026.9.0" }
+astrid-daemon = { path = "crates/astrid-daemon", version = "2026.9.0" }
+astrid-core = { path = "crates/astrid-core", version = "2026.9.0" }
+astrid-crypto = { path = "crates/astrid-crypto", version = "2026.9.0" }
+astrid-emit = { path = "crates/astrid-emit", version = "2026.9.0" }
+astrid-events = { path = "crates/astrid-events", version = "2026.9.0" }
+astrid-hooks = { path = "crates/astrid-hooks", version = "2026.9.0" }
+astrid-kernel = { path = "crates/astrid-kernel", version = "2026.9.0" }
+astrid-mcp = { path = "crates/astrid-mcp", version = "2026.9.0" }
+astrid-prelude = { path = "crates/astrid-prelude", version = "2026.9.0" }
+astrid-runtime = { path = "crates/astrid-runtime", version = "2026.9.0" }
+astrid-storage = { path = "crates/astrid-storage", version = "2026.9.0" }
+astrid-storage-provider-winfsp = { path = "crates/astrid-storage-provider-winfsp", version = "2026.9.0" }
+astrid-telemetry = { path = "crates/astrid-telemetry", version = "2026.9.0" }
 astrid-test = { path = "crates/astrid-test" }
-astrid-types = { path = "crates/astrid-types", version = "0.10.4", features = ["clock"] }
-astrid-uplink = { path = "crates/astrid-uplink", version = "0.10.4" }
-astrid-gateway = { path = "crates/astrid-gateway", version = "0.10.4" }
-astrid-vfs = { path = "crates/astrid-vfs", version = "0.10.4" }
-astrid-workspace = { path = "crates/astrid-workspace", version = "0.10.4" }
+astrid-types = { path = "crates/astrid-types", version = "2026.9.0", features = ["clock"] }
+astrid-uplink = { path = "crates/astrid-uplink", version = "2026.9.0" }
+astrid-gateway = { path = "crates/astrid-gateway", version = "2026.9.0" }
+astrid-vfs = { path = "crates/astrid-vfs", version = "2026.9.0" }
+astrid-workspace = { path = "crates/astrid-workspace", version = "2026.9.0" }
 anyhow = "1.0"
 arboard = "3"
 arc-swap = "1.7"

--- a/release/nightly.toml
+++ b/release/nightly.toml
@@ -1,2 +1,2 @@
 schema-version = 1
-base-version = "0.11.0"
+base-version = "2026.10.0"

--- a/scripts/check-macos-fskit.sh
+++ b/scripts/check-macos-fskit.sh
@@ -65,8 +65,6 @@ if [[ "${ASTRID_FSKIT_VALIDATE_PROJECT:-0}" == 1 ]]; then
   DERIVED_DATA="${ASTRID_FSKIT_DERIVED_DATA:-${RUNNER_TEMP:-/tmp}/astrid-fskit-derived}"
   ASTRID_VERSION="$(sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -n 1)"
   SOURCE_DATE_EPOCH="$(git log -1 --format=%ct)" \
-    CURRENT_PROJECT_VERSION="$(git rev-list --count HEAD)" \
-    MARKETING_VERSION="$ASTRID_VERSION" \
   xcodebuild \
     -project native/macos/AstridFSKit/AstridFS.xcodeproj \
     -scheme AstridFS \
@@ -75,6 +73,8 @@ if [[ "${ASTRID_FSKIT_VALIDATE_PROJECT:-0}" == 1 ]]; then
     ARCHS="$ARCHS" \
     ONLY_ACTIVE_ARCH=NO \
     CODE_SIGNING_ALLOWED=NO \
+    CURRENT_PROJECT_VERSION="$(git rev-list --count HEAD)" \
+    MARKETING_VERSION="$ASTRID_VERSION" \
     build
   APP="$DERIVED_DATA/Build/Products/Debug/AstridFS.app"
   EXTENSION="$APP/Contents/Extensions/AstridFSAppEx.appex"

--- a/scripts/test_check_macos_fskit.sh
+++ b/scripts/test_check_macos_fskit.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CHECK_SCRIPT="$REPO_ROOT/scripts/check-macos-fskit.sh"
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+CAPTURE_FILE="$SANDBOX/xcodebuild.env"
+export CAPTURE_FILE
+
+cat > "$SANDBOX/xcodebuild" <<'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+
+current_arg=""
+marketing_arg=""
+derived_data=""
+building=false
+
+while (($#)); do
+  case "$1" in
+    CURRENT_PROJECT_VERSION=*)
+      current_arg="${1#*=}"
+      ;;
+    MARKETING_VERSION=*)
+      marketing_arg="${1#*=}"
+      ;;
+    -derivedDataPath)
+      shift
+      derived_data="$1"
+      ;;
+    build)
+      building=true
+      ;;
+  esac
+  shift
+done
+
+[[ "$building" == true ]]
+
+{
+  printf 'CURRENT_PROJECT_VERSION_ARG=%q\n' "$current_arg"
+  printf 'MARKETING_VERSION_ARG=%q\n' "$marketing_arg"
+  printf 'CURRENT_PROJECT_VERSION_ENV=%q\n' "${CURRENT_PROJECT_VERSION-}"
+  printf 'MARKETING_VERSION_ENV=%q\n' "${MARKETING_VERSION-}"
+  printf 'SOURCE_DATE_EPOCH_ENV=%q\n' "${SOURCE_DATE_EPOCH-}"
+  printf 'SOURCE_DATE_EPOCH_ARG=%q\n' "$(printf '%s\n' "$@" | grep -F 'SOURCE_DATE_EPOCH=' || true)"
+} > "$CAPTURE_FILE"
+
+if [[ -z "$marketing_arg" ]]; then
+  marketing_arg="${MARKETING_VERSION-}"
+fi
+if [[ -z "$current_arg" ]]; then
+  current_arg="${CURRENT_PROJECT_VERSION-}"
+fi
+
+[[ -n "$derived_data" ]]
+[[ -n "$current_arg" ]]
+[[ -n "$marketing_arg" ]]
+
+app_dir="$derived_data/Build/Products/Debug/AstridFS.app"
+extension_dir="$app_dir/Contents/Extensions/AstridFSAppEx.appex"
+mkdir -p "$app_dir/Contents/Extensions"
+
+for plist in "$app_dir/Contents/Info.plist" "$extension_dir/Contents/Info.plist"; do
+  mkdir -p "$(dirname "$plist")"
+  cat > "$plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleShortVersionString</key>
+  <string>$marketing_arg</string>
+  <key>LSUIElement</key>
+  <true/>
+</dict>
+</plist>
+PLIST
+done
+MOCK
+chmod +x "$SANDBOX/xcodebuild"
+
+validation_block="$(awk '/^if \[\[ "\$\{ASTRID_FSKIT_VALIDATE_PROJECT:-0\}" == 1 \]\]; then$/,/^fi$/' "$CHECK_SCRIPT")"
+[[ -n "$validation_block" ]]
+
+run_validation() {
+  local block="$1"
+  (
+    export PATH="$SANDBOX:$PATH"
+    export ASTRID_FSKIT_VALIDATE_PROJECT=1
+    export ASTRID_FSKIT_DERIVED_DATA="$SANDBOX/project-derived"
+    unset RUNNER_TEMP
+    ARCHS="$(uname -m)"
+    cd "$REPO_ROOT"
+    eval "$block"
+  )
+}
+
+settings_are_xcodebuild_args() {
+  local capture
+  capture="$(cat "$CAPTURE_FILE")"
+  eval "$capture"
+
+  [[ -n "$CURRENT_PROJECT_VERSION_ARG" ]]
+  [[ -n "$MARKETING_VERSION_ARG" ]]
+  [[ -z "$CURRENT_PROJECT_VERSION_ENV" ]]
+  [[ -z "$MARKETING_VERSION_ENV" ]]
+  [[ -n "$SOURCE_DATE_EPOCH_ENV" ]]
+  [[ -z "$SOURCE_DATE_EPOCH_ARG" ]]
+}
+
+run_validation "$validation_block"
+settings_are_xcodebuild_args
+
+[[ "$(sed -n 's/^version = "\([^"]*\)"/\1/p' "$REPO_ROOT/Cargo.toml" | head -n 1)" == "2026.9.0" ]]
+[[ "$(plutil -extract CFBundleShortVersionString raw -expect string \
+  "$SANDBOX/project-derived/Build/Products/Debug/AstridFS.app/Contents/Info.plist")" == "2026.9.0" ]]
+[[ "$(plutil -extract CFBundleShortVersionString raw -expect string \
+  "$SANDBOX/project-derived/Build/Products/Debug/AstridFS.app/Contents/Extensions/AstridFSAppEx.appex/Contents/Info.plist")" == "2026.9.0" ]]
+
+env_only_block="$(printf '%s\n' "$validation_block" |
+  perl -0pe 's/^[ \t]+CURRENT_PROJECT_VERSION=.*\\\n//mg;
+             s/^[ \t]+MARKETING_VERSION=.*\\\n//mg;
+             s/^([ \t]+)xcodebuild \\\n/$1CURRENT_PROJECT_VERSION="$(git rev-list --count HEAD)" \\\n$1MARKETING_VERSION="$ASTRID_VERSION" \\\n$1xcodebuild \\\n/mg')"
+[[ "$env_only_block" != "$validation_block" ]]
+
+if run_validation "$env_only_block" && settings_are_xcodebuild_args; then
+  echo "regression failed: env-only build settings were accepted" >&2
+  exit 1
+fi
+
+echo "check-macos-fskit build-settings regression passed"

--- a/scripts/test_nightly_version.py
+++ b/scripts/test_nightly_version.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pathlib
+import re
 import tempfile
 import unittest
 
@@ -11,6 +12,8 @@ import nightly_version
 
 COMMIT = "0123456789abcdef0123456789abcdef01234567"
 VERSION = f"0.10.0-nightly.20260717.g{COMMIT}"
+LIVE_BASE_VERSION = "2026.10.0"
+LIVE_SOURCE_VERSION = "2026.9.0"
 
 
 class NightlyVersionTests(unittest.TestCase):
@@ -83,6 +86,26 @@ class NightlyVersionTests(unittest.TestCase):
         lock.write_text(lock.read_text().replace('name = "astrid-one"\nversion = "0.9.4"', 'name = "astrid-one"\nversion = "0.9.4"\nsource = "registry+https://example.invalid"'), encoding="utf-8")
         with self.assertRaisesRegex(ValueError, "missing source-less"):
             nightly_version.stage(self.root, VERSION)
+
+    def test_rejects_stale_base_for_live_source_version(self) -> None:
+        (self.root / "release/nightly.toml").write_text(
+            'schema-version = 1\nbase-version = "0.11.0"\n', encoding="utf-8"
+        )
+        cargo = self.root / "Cargo.toml"
+        cargo.write_text(cargo.read_text().replace('version = "0.9.4"', f'version = "{LIVE_SOURCE_VERSION}"'), encoding="utf-8")
+        with self.assertRaisesRegex(
+            ValueError,
+            re.escape("nightly base-version must be newer than the workspace source version"),
+        ):
+            nightly_version.base_version(self.root)
+
+    def test_live_repository_does_not_alias_stable_source_version(self) -> None:
+        self.assertEqual(nightly_version.source_version(nightly_version.ROOT), LIVE_SOURCE_VERSION)
+        base = nightly_version.base_version(nightly_version.ROOT)
+        self.assertEqual(base, LIVE_BASE_VERSION)
+        identity = nightly_version.derive(base, "20260905", COMMIT)
+        self.assertEqual(identity, f"{LIVE_BASE_VERSION}-nightly.20260905.g{COMMIT}")
+        self.assertNotEqual(identity, LIVE_SOURCE_VERSION)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Linked Issue

Related to #1817. This PR does not close the release tracking issue.

## Summary

Set the Astrid Cargo workspace identity from `0.10.4` to canonical CalVer `2026.9.0` (never `2026.09.0`), pass FSKit `CURRENT_PROJECT_VERSION` / `MARKETING_VERSION` as `xcodebuild` settings rather than process environment, and advance the enabled nightly train to `base-version = "2026.10.0"` so nightly derivation stays newer than the stable source.

This is a source-version, nightly-train, and check-script claim only. It does not tag, publish, promote a GitHub release, change `release.yml`, first-publish a Windows runtime archive, or dispatch prepare-only/native certification.

## Changes

- `Cargo.toml`: workspace package version and in-tree path requirements `0.10.4` -> `2026.9.0`.
- `Cargo.lock`: matching `astrid*` package versions.
- `scripts/check-macos-fskit.sh`: pass `CURRENT_PROJECT_VERSION` and `MARKETING_VERSION` as `xcodebuild` arguments; keep `SOURCE_DATE_EPOCH` as environment.
- `scripts/test_check_macos_fskit.sh`: mocked-argv regression that rejects env-only settings and asserts app+appex short version `2026.9.0`.
- `release/nightly.toml`: `base-version` `0.11.0` -> `2026.10.0`; schema-version remains 1; nightly stays enabled.
- `scripts/test_nightly_version.py`: live-combination regression that stale `0.11.0` fails against workspace `2026.9.0`, and derived `2026.10.0-nightly.<date>.g<40-hex>` does not alias stable `2026.9.0`.

`scripts/build-macos-fskit.sh`, manager scripts, `native/macos/**`, `scripts/publish_crates_io.sh`, and `scripts/test_channel_workflow_contract.sh` are unchanged.

## Verification

- Exact head `3d835f96fc3a8fdbb9ae1103a2bc8d9b7488514a`. Parent `9dc293621695f7a63bcd9d5a212beebfe51ecdd8`. Base/main `313c6eb7dc67e4788edca46afa585b506bd22667`.
- Unique files versus origin/main: `Cargo.toml`, `Cargo.lock`, `release/nightly.toml`, `scripts/check-macos-fskit.sh`, `scripts/test_check_macos_fskit.sh`, `scripts/test_nightly_version.py`.
- Unique versus frozen parent `9dc29362`: only `release/nightly.toml` and `scripts/test_nightly_version.py`.
- Combined tree `dd62fe50a74f683b7c5121dd5d6d9f60dc605734`.
- Successor commit GPG Good [full] key `7CD32E7697286B11593246B9FA53358CB4127512` with matching DCO.
- Workspace lock identity: 32 `astrid*` packages at `2026.9.0`, 29 publishable. No `2026.09.0`.
- `python3 -m unittest discover -s scripts -p test_nightly_version.py -v`: 7/7 passed.
- Live derive: `2026.10.0-nightly.20260905.g9dc293621695f7a63bcd9d5a212beebfe51ecdd8`.
- Independent exact-head review of `3d835f96` is required; predecessor ACCEPT/AMEND does not transfer. This PR is not merge-ready on author evidence.
- Source-version review cannot ACCEPT a signed-artifact, certification-execution, or publication claim.

## AI / Tool Assistance

Assisted-by: Codex:glm-5.3-flash: nightly `base-version` 2026.10.0 and live-combination regression on frozen parent `9dc29362`.

I reviewed the unique diff, ancestry, GPG, DCO, and nightly derive output. Independent exact-head review is required; this PR is not merge-ready on author evidence.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/{issue}.{kind}.md` (docs/CI-only may skip; release PRs roll fragments into the version section instead of adding one)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
