### PR TITLE
fix(ci): recognize escaped changelog labels

### DIFF
--- a/scripts/changelog.py
+++ b/scripts/changelog.py
@@ -29,7 +29,10 @@ def is_code_path(path: str) -> bool:
 
 
 def parse_labels(raw: str) -> list[str]:
-    return [part.strip() for part in re.split(r"[\s,]+", raw) if part.strip()]
+    # GitHub expressions pass join(labels, '\n') as the two literal
+    # characters ``\\n``. Treat that separator like a real newline while
+    # retaining whitespace and comma delimiters used by other callers.
+    return [part.strip() for part in re.split(r"(?:\\n|[\s,]+)", raw) if part.strip()]
 
 
 def has_skip_changelog(labels: Iterable[str]) -> bool:

--- a/scripts/test_changelog.py
+++ b/scripts/test_changelog.py
@@ -6,7 +6,14 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent))
 
 import changelog
-from changelog import check_pr, entry_from_fragment, extract_notes, fragment_body_errors, roll_changelog
+from changelog import (
+    check_pr,
+    entry_from_fragment,
+    extract_notes,
+    fragment_body_errors,
+    parse_labels,
+    roll_changelog,
+)
 
 
 SAMPLE = """# Changelog
@@ -31,6 +38,32 @@ SAMPLE = """# Changelog
 
 
 class CheckPrTests(unittest.TestCase):
+    def test_parse_labels_accepts_github_escaped_newline(self):
+        self.assertEqual(
+            parse_labels(r"skip-changelog\nlarge-file-ok"),
+            ["skip-changelog", "large-file-ok"],
+        )
+
+    def test_escaped_newline_does_not_create_partial_label_matches(self):
+        raw = r"not-skip-changelog\nlarge-file-ok"
+        self.assertEqual(parse_labels(raw), ["not-skip-changelog", "large-file-ok"])
+        errors = check_pr(
+            labels=parse_labels(raw),
+            changed_paths=["crates/astrid-kernel/src/lib.rs"],
+            added_paths=[],
+        )
+        self.assertTrue(errors)
+
+    def test_github_multilabel_payload_skips_changelog_check(self):
+        self.assertEqual(
+            check_pr(
+                labels=parse_labels(r"skip-changelog\nlarge-file-ok"),
+                changed_paths=["crates/astrid-kernel/src/lib.rs"],
+                added_paths=[],
+            ),
+            [],
+        )
+
     def test_code_without_fragment_fails(self):
         errors = check_pr(
             labels=[],


### PR DESCRIPTION
## Linked Issue

Closes #1846

## Summary

Restore escaped multi-label parsing on `main` so the changelog gate recognizes `skip-changelog` when GitHub supplies labels separated by literal `\\n` characters.

## Changes

- treat GitHub's literal escaped-newline separator like a real label separator
- preserve existing whitespace and comma separators
- cover the actual multi-label payload and partial-label refusal

## Verification

- `python3 scripts/test_changelog.py`
- executable `scripts/changelog.py check` with `skip-changelog\\nrelease\\nno-issue`
- `git diff --check`

## AI / Tool Assistance

Assisted-by: Codex:gpt-5.6-sol

Codex restored the previously reviewed #1651 behavior onto current `main`, added the regressions, and ran the targeted checks. I reviewed the complete two-file diff and verified the signed commit.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment not required for this CI-only correction
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
