### PR TITLE
test(capsule): use an unsatisfiable astrid-version fixture

### DIFF
--- a/crates/astrid-capsule/src/discovery.rs
+++ b/crates/astrid-capsule/src/discovery.rs
@@ -773,11 +773,11 @@ version = "0.1.0"
 
     #[test]
     fn load_manifest_rejects_unsatisfied_astrid_version() {
-        let toml = "[package]\nname = \"test\"\nversion = \"0.1.0\"\nastrid-version = \">=99.0.0\"";
+        let toml = "[package]\nname = \"test\"\nversion = \"0.1.0\"\nastrid-version = \"<0.0.0\"";
         let err = load_from_toml(toml).unwrap_err();
         let msg = err.to_string();
         assert!(
-            msg.contains("astrid-version") && msg.contains("99.0.0"),
+            msg.contains("astrid-version") && msg.contains("<0.0.0"),
             "expected astrid-version rejection, got: {msg}"
         );
     }


### PR DESCRIPTION
## Linked Issue

Closes #1848.

## Summary

The capsule discovery test `load_manifest_rejects_unsatisfied_astrid_version` used `astrid-version = ">=99.0.0"` as a supposed future floor. Cargo `semver` treats `2026.9.0` as satisfying that constraint, so the test unwraps `Ok` once the workspace uses CalVer.

This change keeps the production matcher unchanged and replaces only the fixture with a structurally unsatisfiable requirement, `astrid-version = "<0.0.0"`, while retaining the same rejection assertion.

## Changes

- `crates/astrid-capsule/src/discovery.rs`: test fixture and assertion now use `<0.0.0`.
- Production `VersionReq` parsing and `CARGO_PKG_VERSION` matching are unchanged.
- Workspace identity remains `0.10.4`.

## Verification

- Exact head `334f70aa0606c9ff0797bc5e9c17c174a37f2bc3`. Sole parent `df36816edb71d643780bb50e220a78fbdf7ca763` (`origin/main`).
- Unique files versus parent: `crates/astrid-capsule/src/discovery.rs`.
- GPG Good [full] key `7CD32E7697286B11593246B9FA53358CB4127512`; DCO present.
- Local: `cargo test --locked -p astrid-capsule discovery::tests::load_manifest_rejects_unsatisfied_astrid_version -- --exact` plus the three sibling astrid-version tests.
- Independent exact-head full GLM Max plus Luna Max review is required on this SHA.

## AI / Tool Assistance

Assisted-by: GPT-5.6-Luna: bounded test-only discovery fixture replacement and named-test execution.

I reviewed the unique one-file diff, ancestry, GPG/DCO, and the four named discovery tests. Independent exact-head review is required; this PR is not merge-ready on author evidence.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/{issue}.{kind}.md` (docs/CI-only may skip; release PRs roll fragments into the version section instead of adding one)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
