### PR TITLE
docs(changelog): structure 2026.9.0 as unreleased version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ## [Unreleased]
 
+## [2026.9.0] - Unreleased
+
 ### Fixed
 
 - **`astrid status` and `astrid mcp serve` no longer treat an unlinked
@@ -1939,6 +1941,7 @@ Initial tracked release. See the [repository history](https://github.com/astrid-
 for changes included in this version.
 
 [Unreleased]: https://github.com/astrid-runtime/astrid/compare/v0.10.4...HEAD
+[2026.9.0]: https://github.com/astrid-runtime/astrid/compare/v0.10.4...HEAD
 [0.10.4]: https://github.com/astrid-runtime/astrid/compare/v0.10.3...v0.10.4
 [0.10.3]: https://github.com/astrid-runtime/astrid/compare/v0.10.2...v0.10.3
 [0.10.2]: https://github.com/astrid-runtime/astrid/compare/v0.10.1...v0.10.2

--- a/scripts/changelog.py
+++ b/scripts/changelog.py
@@ -133,22 +133,24 @@ def _section_heading(line: str) -> str | None:
     return line[4:].strip()
 
 
-def parse_unreleased_sections(body: str) -> OrderedDict[str, str]:
-    sections: OrderedDict[str, str] = OrderedDict()
+def _parse_unreleased_chunks(body: str) -> list[tuple[str, str]]:
+    chunks: list[tuple[str, str]] = []
     current: str | None = None
-    chunks: list[str] = []
+    lines: list[str] = []
 
     def flush() -> None:
-        nonlocal current, chunks
+        nonlocal current, lines
         if current is None:
-            if "".join(chunks).strip():
+            if "".join(lines).strip():
                 raise ValueError(
                     "unreleased text before the first ### heading is not a Keep a Changelog section"
                 )
-            chunks = []
+            lines = []
             return
-        sections[current] = "".join(chunks)
-        chunks = []
+        body = "".join(lines)
+        if body.strip():
+            chunks.append((current, body))
+        lines = []
 
     for line in body.splitlines(keepends=True):
         heading = _section_heading(line.rstrip("\n"))
@@ -156,14 +158,26 @@ def parse_unreleased_sections(body: str) -> OrderedDict[str, str]:
             flush()
             current = heading
             continue
-        chunks.append(line)
+        lines.append(line)
     flush()
-    return sections
+    return chunks
 
 
-def render_sections(sections: OrderedDict[str, str]) -> str:
+def _append_entry(chunks: list[tuple[str, str]], heading: str, entry: str) -> None:
+    for index, (existing_heading, body) in enumerate(chunks):
+        if existing_heading != heading:
+            continue
+        if not body.strip():
+            chunks[index] = (heading, "\n" + entry)
+        else:
+            chunks[index] = (heading, body.rstrip() + "\n\n" + entry)
+        return
+    chunks.append((heading, "\n" + entry))
+
+
+def _render_unreleased_chunks(chunks: list[tuple[str, str]]) -> str:
     parts: list[str] = []
-    for heading, body in sections.items():
+    for heading, body in chunks:
         if not body.strip():
             continue
         parts.append(f"### {heading}\n")
@@ -174,6 +188,26 @@ def render_sections(sections: OrderedDict[str, str]) -> str:
         if not text.endswith("\n\n"):
             parts.append("\n")
     return "".join(parts)
+
+
+def _merge_unreleased_section_chunks(
+    bodies: Sequence[str], fragments: Sequence[tuple[Path, str, str]]
+) -> list[tuple[str, str]]:
+    chunks = [
+        chunk
+        for body in bodies
+        for chunk in _parse_unreleased_chunks(body)
+    ]
+    kind_rank = {kind: index for index, kind in enumerate(KINDS)}
+    for _path, kind, body in sorted(
+        fragments, key=lambda item: (kind_rank[item[1]], item[0].name)
+    ):
+        _append_entry(chunks, KIND_HEADING[kind], entry_from_fragment(body))
+    return chunks
+
+
+def render_sections(sections: OrderedDict[str, str]) -> str:
+    return _render_unreleased_chunks(list(sections.items()))
 
 
 def split_changelog(text: str) -> tuple[str, str, str]:
@@ -198,6 +232,26 @@ def split_changelog(text: str) -> tuple[str, str, str]:
     return preamble, unreleased, rest
 
 
+def _version_header_line(line: str, version: str) -> str | None:
+    match = re.fullmatch(rf"## \[{re.escape(version)}\] - (.+)", line.rstrip("\n"))
+    return match.group(1) if match else None
+
+
+def _split_header_body(
+    lines: list[str], header_at: int
+) -> tuple[list[str], list[str]]:
+    body_at = header_at + 1
+    end_at = next(
+        (
+            index
+            for index, line in enumerate(lines[body_at:], start=body_at)
+            if line.startswith(VERSION_HEADER_PREFIX)
+        ),
+        len(lines),
+    )
+    return lines[body_at:end_at], lines[end_at:]
+
+
 def load_fragments(changes_dir: Path) -> list[tuple[Path, str, str]]:
     loaded: list[tuple[Path, str, str]] = []
     for path in pending_fragment_paths(changes_dir):
@@ -211,20 +265,9 @@ def load_fragments(changes_dir: Path) -> list[tuple[Path, str, str]]:
 def merge_fragments(
     unreleased_body: str, fragments: Sequence[tuple[Path, str, str]]
 ) -> OrderedDict[str, str]:
-    sections = parse_unreleased_sections(unreleased_body)
-    kind_rank = {kind: index for index, kind in enumerate(KINDS)}
-    for _path, kind, body in sorted(
-        fragments, key=lambda item: (kind_rank[item[1]], item[0].name)
-    ):
-        heading = KIND_HEADING[kind]
-        entry = entry_from_fragment(body)
-        current = sections.get(heading, "")
-        if current.strip():
-            current = current.rstrip() + "\n\n" + entry
-        else:
-            current = "\n" + entry
-        sections[heading] = current if current.endswith("\n") else current + "\n"
-    return sections
+    return OrderedDict(
+        _merge_unreleased_section_chunks([unreleased_body], fragments)
+    )
 
 
 def roll_changelog(
@@ -235,6 +278,52 @@ def roll_changelog(
     fragments: Sequence[tuple[Path, str, str]],
 ) -> str:
     preamble, unreleased, rest = split_changelog(text)
+    rest_lines = rest.splitlines(keepends=True)
+    version_headers = [
+        (index, _version_header_line(line, version))
+        for index, line in enumerate(rest_lines)
+    ]
+    version_headers = [
+        (index, suffix) for index, suffix in version_headers if suffix is not None
+    ]
+    if len(version_headers) > 1:
+        suffixes = [suffix for _, suffix in version_headers]
+        if "Unreleased" in suffixes and any(
+            suffix != "Unreleased" for suffix in suffixes
+        ):
+            raise ValueError(
+                f"staged and dated [{version}] sections are ambiguous"
+            )
+        raise ValueError(f"duplicate [{version}] changelog headings")
+
+    if version_headers:
+        staged_at, suffix = version_headers[0]
+        if suffix != "Unreleased":
+            raise ValueError(
+                f"[{version}] is already dated; staged and dated sections are ambiguous"
+            )
+        staged_body, rest_after = _split_header_body(rest_lines, staged_at)
+        rendered = _render_unreleased_chunks(
+            _merge_unreleased_section_chunks(
+                [unreleased, "".join(staged_body)], fragments
+            )
+        )
+        rolled = preamble
+        if rolled and not rolled.endswith("\n"):
+            rolled += "\n"
+        rolled += f"{UNRELEASED_HEADER}\n\n"
+        rolled += f"## [{version}] - {date}\n"
+        if rendered:
+            rolled += "\n" + rendered
+            if not rolled.endswith("\n"):
+                rolled += "\n"
+            if not rolled.endswith("\n\n"):
+                rolled += "\n"
+        else:
+            rolled += "\n"
+        rolled += "".join(rest_after)
+        return rolled
+
     rendered = render_sections(merge_fragments(unreleased, fragments))
     rolled = preamble
     if rolled and not rolled.endswith("\n"):

--- a/scripts/test_changelog.py
+++ b/scripts/test_changelog.py
@@ -36,6 +36,31 @@ SAMPLE = """# Changelog
 - **Historical.** Must not change.
 """
 
+STAGED = """# Changelog
+
+## [Unreleased]
+
+## [2026.9.0] - Unreleased
+
+### Fixed
+
+- **Distinctive staged fix.** Refs #2026.
+
+### Added
+
+- **Staged add.**
+
+### Fixed
+
+- **Repeated staged fix.** Refs #2027.
+
+## [0.10.4] - 2026-08-01
+
+### Fixed
+
+- **Historical.** Must not change.
+"""
+
 
 class CheckPrTests(unittest.TestCase):
     def test_parse_labels_accepts_github_escaped_newline(self):
@@ -182,6 +207,54 @@ class RollNotesTests(unittest.TestCase):
         self.assertIn("## [0.1.0] - 2026-01-01", rest)
         self.assertEqual(rest.count("**Historical.** Must not change."), 1)
         self.assertNotIn("**Historical.** Must not change.", rolled[: rolled.index("## [0.1.0]")])
+
+    def test_roll_finalizes_matching_staged_version_in_place(self):
+        fragments = [
+            (
+                Path("changes/9.added.md"),
+                "added",
+                "**Fragment add.**\nCloses #9.\n",
+            )
+        ]
+        rolled = roll_changelog(
+            STAGED,
+            version="2026.9.0",
+            date="2026-09-05",
+            fragments=fragments,
+        )
+        self.assertEqual(rolled.count("## [2026.9.0] - 2026-09-05"), 1)
+        self.assertNotIn("## [2026.9.0] - Unreleased", rolled)
+        self.assertIn("- **Distinctive staged fix.** Refs #2026.", rolled)
+        self.assertIn("- **Repeated staged fix.** Refs #2027.", rolled)
+        self.assertIn("- **Fragment add.**\n  Closes #9.", rolled)
+        self.assertLess(
+            rolled.index("**Distinctive staged fix.**"),
+            rolled.index("**Fragment add.**"),
+        )
+        self.assertLess(
+            rolled.index("**Fragment add.**"),
+            rolled.index("**Repeated staged fix.**"),
+        )
+        self.assertEqual(extract_notes(rolled, "2026.9.0").count("2026.9.0"), 0)
+        self.assertIn("### Fixed", extract_notes(rolled, "2026.9.0"))
+
+    def test_roll_rejects_duplicate_version_headings(self):
+        duplicate = STAGED.replace(
+            "## [2026.9.0] - Unreleased",
+            "## [2026.9.0] - Unreleased\n\n## [2026.9.0] - Unreleased",
+            1,
+        )
+        with self.assertRaisesRegex(ValueError, "duplicate"):
+            roll_changelog(duplicate, version="2026.9.0", date="2026-09-05", fragments=[])
+
+    def test_roll_rejects_staged_and_dated_version_headings(self):
+        ambiguous = STAGED.replace(
+            "## [2026.9.0] - Unreleased",
+            "## [2026.9.0] - Unreleased\n\n## [2026.9.0] - 2026-09-04",
+            1,
+        )
+        with self.assertRaisesRegex(ValueError, "staged and dated"):
+            roll_changelog(ambiguous, version="2026.9.0", date="2026-09-05", fragments=[])
 
     def test_notes_match_awk_style_section_body(self):
         rolled = roll_changelog(SAMPLE, version="0.2.0", date="2026-08-20", fragments=[])


### PR DESCRIPTION
## Linked Issue

Related to #1817. This PR does not close the release tracking issue.

This is a docs/release traceability exception: changelog structure and roll tooling only, no new product issue, and no `Closes` keyword because #1817 remains the open 2026.9.0 tracking issue until the actual tag exists.

## Summary

Cumulative contract for the 2026.9.0 changelog vehicle:

1. Stage the already-written 2026.9.0 body under `## [2026.9.0] - Unreleased` while keeping the rolling `## [Unreleased]` heading required by the changelog gate.
2. Make `scripts/changelog.py roll --version 2026.9.0` finalize that staged heading **in place**. It must not prepend an empty dated `## [2026.9.0] - <date>` and leave the staged body behind.

This is documentation/tooling only. It does not tag, publish, date, or claim that `v2026.9.0` exists. Historical Windows/WinFsp adapter notes remain product-history text; they are not a Windows runtime-archive publication claim.

## Changes

- Keep `## [Unreleased]`.
- Keep `## [2026.9.0] - Unreleased` immediately below it, with the staged 2026.9.0 body unchanged until roll.
- Footer: `[2026.9.0]` compare `v0.10.4...HEAD`. `[Unreleased]` stays `v0.10.4...HEAD`. No invented `v2026.9.0` compare URL and no ship date.
- `roll --version V` finalizes exactly one matching staged `## [V] - Unreleased` heading in place, merges ordinary unreleased fragments into that same section, and preserves source heading/bullet order including repeated `###` headings.
- Ordinary rolling is unchanged when no matching staged heading exists.
- Ambiguous duplicates fail closed: two `## [V]` headings, two staged unreleased headings for `V`, or staged `V` plus an already-dated `V`.

Unique versus `origin/main`: `CHANGELOG.md`, `scripts/changelog.py`, `scripts/test_changelog.py`.
Unique versus frozen parent `6b407bb8`: `scripts/changelog.py`, `scripts/test_changelog.py`.

## Verification

- Exact head `1119ec4cd1db699e8a7df341df40e1836c7c76c4`. Sole parent `6b407bb8503c0623b66d6e67979b02cacb714085`. `origin/main` `3de333f1b39d41bacfb535b49d83198212bf2403`.
- Commit GPG Good [full] EDDSA key `7CD32E7697286B11593246B9FA53358CB4127512` with matching DCO.
- Local successor proof: parent roll produced an empty dated header plus leftover staged heading and 1-byte notes; successor produces one dated `## [2026.9.0] - 2026-09-05` section, preserves all 104 staged bullets in source order, and extracts the staged body.
- `python3 scripts/test_changelog.py` and `git diff --check` pass on the successor. Source 488/1000, tests 321/2000.

Independent exact-head review is required; this PR is not merge-ready on author evidence. Do not resolve Copilot thread `r3939246992` until review proves in-place finalize.

## AI / Tool Assistance

Assisted-by: Codex:glm-5.3-flash: staged `## [2026.9.0] - Unreleased` on parent `3de333f1`, then repaired `roll` to finalize that heading in place on parent `6b407bb8`.

I reviewed the unique diff, ancestry, GPG, DCO, and changelog tests. Independent exact-head review is required.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/{issue}.{kind}.md` (docs/CI-only may skip; this PR edits `CHANGELOG.md` directly and uses `skip-changelog`)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
