### PR TITLE
fix(release): keep Windows runtime archives out of v2026.9.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,28 +230,6 @@ jobs:
         if: matrix.libc == 'native'
         run: echo "BINARY_ROOT=target/${{ matrix.target }}/release" >> "$GITHUB_ENV"
 
-      - name: Build the Windows WinFsp provider
-        if: matrix.target == 'x86_64-pc-windows-msvc'
-        run: cargo build --release --target ${{ matrix.target }} -p astrid-storage-provider-winfsp --locked
-
-      - name: Stage the pinned Windows WinFsp runtime
-        if: matrix.target == 'x86_64-pc-windows-msvc'
-        shell: pwsh
-        run: |
-          $msi = Join-Path $env:RUNNER_TEMP "winfsp-2.1.25156.msi"
-          Invoke-WebRequest -Uri "https://github.com/winfsp/winfsp/releases/download/v2.1/winfsp-2.1.25156.msi" -OutFile $msi
-          $hash = (Get-FileHash -LiteralPath $msi -Algorithm SHA256).Hash
-          if ($hash -ne "073A70E00F77423E34BED98B86E600DEF93393BA5822204FAC57A29324DB9F7A") {
-            throw "WinFsp MSI digest mismatch: $hash"
-          }
-          $exitCode = (Start-Process -FilePath "msiexec.exe" -ArgumentList @("/i", "`"$msi`"", "/qn", "/norestart") -Wait -PassThru).ExitCode
-          if ($exitCode -ne 0 -and $exitCode -ne 3010) {
-            throw "WinFsp installation failed with exit code $exitCode"
-          }
-          $installRoot = (Get-ItemProperty -Path "HKLM:\SOFTWARE\WOW6432Node\WinFsp").InstallDir
-          "WINFSP_MSI=$msi" | Add-Content -Encoding ascii -Path $env:GITHUB_ENV
-          "WINFSP_ROOT=$installRoot" | Add-Content -Encoding ascii -Path $env:GITHUB_ENV
-
       - name: Build Linux binaries against the glibc 2.31 baseline
         if: matrix.libc == 'gnu'
         env:
@@ -364,13 +342,6 @@ jobs:
           DIR="astrid-${VERSION}-${{ matrix.target }}"
           mkdir "$DIR"
           EXE=""
-          if [[ "$TARGET" == x86_64-pc-windows-msvc ]]; then
-            EXE=".exe"
-            cp "$BINARY_ROOT/astrid-storage-provider-winfsp.exe" "$DIR/"
-            cp "$WINFSP_ROOT/bin/winfsp-x64.dll" "$DIR/"
-            cp "$WINFSP_MSI" "$DIR/winfsp-2.1.25156.msi"
-            cp scripts/install-windows.ps1 scripts/uninstall-windows.ps1 "$DIR/"
-          fi
           cp "$BINARY_ROOT/astrid$EXE" "$DIR/"
           cp "$BINARY_ROOT/astrid-daemon$EXE" "$DIR/"
           cp "$BINARY_ROOT/astrid-build$EXE" "$DIR/"
@@ -541,14 +512,6 @@ jobs:
           astrid-*/macos/manage-macos-fskit.sh enable
           ```
 
-          **Windows pre-built archive (PowerShell):**
-          ```powershell
-          tar -xzf astrid-*-x86_64-pc-windows-msvc.tar.gz
-          $release = Get-ChildItem -Directory "astrid-*-x86_64-pc-windows-msvc" |
-            Select-Object -First 1
-          & (Join-Path $release.FullName "install-windows.ps1")
-          ```
-
           Astrid Runtime does not bundle a product distro. To compose it with a
           distro you trust, run:
           ```
@@ -600,6 +563,13 @@ jobs:
           VERSION="${GITHUB_REF_NAME#v}"
           CARGO_VERSION=$(sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -n1)
           test "$VERSION" = "$CARGO_VERSION"
+          if compgen -G "artifacts/*x86_64-pc-windows-msvc*" >/dev/null || \
+            compgen -G "artifacts/astrid-*-windows-release.toml*" >/dev/null || \
+            grep -Eq 'x86_64-pc-windows-msvc' \
+              artifacts/BLAKE3SUMS.txt artifacts/SHA256SUMS.txt; then
+            echo "stable release rejects Windows archives and Windows metadata" >&2
+            exit 1
+          fi
           SOURCE_COMMIT=$(git rev-parse "${GITHUB_REF_NAME}^{commit}")
           CONTRACTS_COMMIT=$(git -C wit rev-parse HEAD)
           python3 scripts/release_manifest.py generate \
@@ -619,15 +589,6 @@ jobs:
             --output "artifacts/astrid-${VERSION}-musl-release.toml"
           python3 scripts/musl_release_manifest.py validate \
             "artifacts/astrid-${VERSION}-musl-release.toml" \
-            --legacy-manifest "artifacts/astrid-${VERSION}-release.toml" \
-            --artifacts artifacts \
-            --verify-artifacts
-          python3 scripts/windows_release_manifest.py generate \
-            --artifacts artifacts \
-            --legacy-manifest "artifacts/astrid-${VERSION}-release.toml" \
-            --output "artifacts/astrid-${VERSION}-windows-release.toml"
-          python3 scripts/windows_release_manifest.py validate \
-            "artifacts/astrid-${VERSION}-windows-release.toml" \
             --legacy-manifest "artifacts/astrid-${VERSION}-release.toml" \
             --artifacts artifacts \
             --verify-artifacts

--- a/scripts/classify_release_build_matrix.py
+++ b/scripts/classify_release_build_matrix.py
@@ -12,7 +12,6 @@ include = [
 ]
 if PREPARE_ONLY != "true":
     include.extend([
-        {"target": "x86_64-pc-windows-msvc", "os": "windows-latest", "archive": "tar.gz", "libc": "native"},
         {"target": "x86_64-unknown-linux-gnu", "os": "ubuntu-latest", "archive": "tar.gz", "libc": "gnu"},
         {"target": "aarch64-unknown-linux-gnu", "os": "ubuntu-latest", "archive": "tar.gz", "libc": "gnu"},
         {"target": "x86_64-unknown-linux-musl", "os": "ubuntu-latest", "archive": "tar.gz", "libc": "musl", "platform": "linux/amd64", "image": "docker.io/library/rust@sha256:e98196986adced5602f6e21c54babdbf2a8700400c7a78868324a3630e0c5d15"},

--- a/scripts/release_manifest.py
+++ b/scripts/release_manifest.py
@@ -27,7 +27,8 @@ MUSL_TARGETS = (
     "x86_64-unknown-linux-musl",
 )
 WINDOWS_TARGETS = ("x86_64-pc-windows-msvc",)
-EXTENSION_TARGETS = (*MUSL_TARGETS, *WINDOWS_TARGETS)
+EXTENSION_TARGETS = MUSL_TARGETS
+PARKED_WINDOWS_TARGETS = WINDOWS_TARGETS
 ROOT_KEYS = {
     "schema-version",
     "kind",
@@ -112,13 +113,15 @@ def expected_asset(version: str, target: str) -> str:
 
 
 def validate_release_checksum_names(entries: dict[str, str], version: str, label: str) -> None:
-    """Keep the fixed-platform manifest compatible with combined checksums."""
+    """Keep fixed and musl manifests compatible with parked combined checksums."""
     legacy = {expected_asset(version, target) for target in TARGETS}
-    combined = legacy | {expected_asset(version, target) for target in EXTENSION_TARGETS}
-    if set(entries) not in (legacy, combined):
+    musl = legacy | {expected_asset(version, target) for target in EXTENSION_TARGETS}
+    parked = musl | {expected_asset(version, target) for target in PARKED_WINDOWS_TARGETS}
+    if set(entries) not in (legacy, musl, parked):
         fail(
             f"{label} must contain exactly the four fixed release archives, "
-            "optionally plus all three extension archives"
+            "optionally plus both musl extension archives, or the parked "
+            "seven-archive Windows shape"
         )
 
 

--- a/scripts/release_publication.py
+++ b/scripts/release_publication.py
@@ -11,7 +11,6 @@ from pathlib import Path
 
 import release_manifest
 import musl_release_manifest
-import windows_release_manifest
 
 
 FIXED_PAYLOADS = ("BLAKE3SUMS.txt", "SHA256SUMS.txt")
@@ -68,12 +67,15 @@ def validate_release_assets(
         "release manifest contracts commit does not match the tagged submodule",
     )
 
-    archives = {target["asset"] for target in metadata["targets"]}
-    payloads = archives | set(FIXED_PAYLOADS) | {metadata_name}
-    extension_contracts = (
-        (musl_release_manifest, release_manifest.MUSL_TARGETS),
-        (windows_release_manifest, release_manifest.WINDOWS_TARGETS),
-    )
+    windows_assets = {
+        release_manifest.expected_asset(version, target)
+        for target in release_manifest.WINDOWS_TARGETS
+    }
+    windows_markers = {
+        f"astrid-{version}-windows-release.toml",
+        *windows_assets,
+    }
+    windows_markers |= {f"{name}.sigstore.json" for name in windows_markers}
     checksum_assets = set(
         release_manifest.read_checksums(
             directory / "BLAKE3SUMS.txt", "BLAKE3"
@@ -83,8 +85,19 @@ def validate_release_assets(
             directory / "SHA256SUMS.txt", "SHA-256"
         )
     )
-    extension_metadata = []
     entry_names = {path.name for path in entries}
+    forbidden_windows = sorted((entry_names | checksum_assets) & windows_markers)
+    require(
+        not forbidden_windows,
+        f"stable publication rejects Windows release assets: {forbidden_windows}",
+    )
+
+    archives = {target["asset"] for target in metadata["targets"]}
+    payloads = archives | set(FIXED_PAYLOADS) | {metadata_name}
+    extension_contracts = (
+        (musl_release_manifest, release_manifest.MUSL_TARGETS),
+    )
+    extension_metadata = []
     for module, extension_targets in extension_contracts:
         extension_name = module.metadata_name(version)
         extension_archives = {

--- a/scripts/test_channel_workflow_contract.sh
+++ b/scripts/test_channel_workflow_contract.sh
@@ -239,7 +239,6 @@ if conditional_start < 0:
     fail("missing prepare-only build matrix filter")
 non_darwin = matrix_program[conditional_start:]
 for target in (
-    "x86_64-pc-windows-msvc",
     "x86_64-unknown-linux-gnu",
     "aarch64-unknown-linux-gnu",
     "x86_64-unknown-linux-musl",
@@ -253,7 +252,6 @@ expected_prepare_only = [
     {"target": "aarch64-apple-darwin", "os": "macos-latest", "archive": "tar.gz", "libc": "native"},
 ]
 expected_full = expected_prepare_only + [
-    {"target": "x86_64-pc-windows-msvc", "os": "windows-latest", "archive": "tar.gz", "libc": "native"},
     {"target": "x86_64-unknown-linux-gnu", "os": "ubuntu-latest", "archive": "tar.gz", "libc": "gnu"},
     {"target": "aarch64-unknown-linux-gnu", "os": "ubuntu-latest", "archive": "tar.gz", "libc": "gnu"},
     {

--- a/scripts/test_release_publication.py
+++ b/scripts/test_release_publication.py
@@ -14,7 +14,6 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 import release_manifest
 import release_publication
 import musl_release_manifest
-import windows_release_manifest
 
 
 VERSION = "0.10.0"
@@ -62,14 +61,14 @@ class ReleasePublicationTests(unittest.TestCase):
             (root / f"{payload}.sigstore.json").write_text("{}\n")
         return metadata
 
-    def add_extensions(self, root: Path) -> None:
+    def add_musl_extension(self, root: Path) -> None:
         legacy_path = root / f"astrid-{VERSION}-release.toml"
-        for target in release_manifest.EXTENSION_TARGETS:
+        for target in release_manifest.MUSL_TARGETS:
             name = release_manifest.expected_asset(VERSION, target)
             (root / name).write_bytes(f"archive:{target}".encode())
         sha_lines = []
         blake_lines = []
-        for target in (*release_manifest.TARGETS, *release_manifest.EXTENSION_TARGETS):
+        for target in (*release_manifest.TARGETS, *release_manifest.MUSL_TARGETS):
             name = release_manifest.expected_asset(VERSION, target)
             value = (root / name).read_bytes()
             sha_lines.append(f"{hashlib.sha256(value).hexdigest()}  {name}")
@@ -92,20 +91,15 @@ class ReleasePublicationTests(unittest.TestCase):
             asset = release_manifest.expected_asset(VERSION, target)
             (root / f"{asset}.sigstore.json").write_text("{}\n")
         (root / f"{musl_path.name}.sigstore.json").write_text("{}\n")
-        with mock.patch.object(
-            release_manifest,
-            "blake3_file",
-            side_effect=lambda path: hashlib.sha256(
-                b"blake3:" + path.read_bytes()
-            ).hexdigest(),
-        ):
-            windows = windows_release_manifest.build_manifest(root, legacy_path)
-        windows_path = root / windows_release_manifest.metadata_name(VERSION)
-        windows_path.write_text(windows_release_manifest.render_manifest(windows))
-        for target in release_manifest.WINDOWS_TARGETS:
-            asset = release_manifest.expected_asset(VERSION, target)
-            (root / f"{asset}.sigstore.json").write_text("{}\n")
-        (root / f"{windows_path.name}.sigstore.json").write_text("{}\n")
+
+    def add_windows_checksums(self, root: Path) -> None:
+        asset = release_manifest.expected_asset(
+            VERSION, release_manifest.WINDOWS_TARGETS[0]
+        )
+        for checksum_name in ("BLAKE3SUMS.txt", "SHA256SUMS.txt"):
+            path = root / checksum_name
+            with path.open("a") as output:
+                output.write(f"{'f' * 64}  {asset}\n")
 
     def validate(self, root: Path) -> list[str]:
         with mock.patch.object(
@@ -130,14 +124,14 @@ class ReleasePublicationTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)
             self.fixture(root)
-            self.add_extensions(root)
-            self.assertEqual(len(self.validate(root)), 12)
+            self.add_musl_extension(root)
+            self.assertEqual(len(self.validate(root)), 10)
 
     def test_rejects_every_partial_musl_extension_inventory(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)
             self.fixture(root)
-            self.add_extensions(root)
+            self.add_musl_extension(root)
             removals = [
                 musl_release_manifest.metadata_name(VERSION),
                 f"{musl_release_manifest.metadata_name(VERSION)}.sigstore.json",
@@ -157,27 +151,63 @@ class ReleasePublicationTests(unittest.TestCase):
                         self.validate(root)
                     (root / name).write_bytes(saved)
 
-    def test_rejects_every_partial_windows_extension_inventory(self) -> None:
+    def test_rejects_a_windows_archive_instead_of_treating_it_as_optional(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)
             self.fixture(root)
-            self.add_extensions(root)
             windows_asset = release_manifest.expected_asset(
                 VERSION, release_manifest.WINDOWS_TARGETS[0]
             )
-            removals = [
-                windows_release_manifest.metadata_name(VERSION),
-                f"{windows_release_manifest.metadata_name(VERSION)}.sigstore.json",
-                windows_asset,
-                f"{windows_asset}.sigstore.json",
-            ]
-            for name in removals:
-                with self.subTest(name=name):
-                    saved = (root / name).read_bytes()
-                    (root / name).unlink()
-                    with self.assertRaises((ValueError, OSError)):
-                        self.validate(root)
-                    (root / name).write_bytes(saved)
+            (root / windows_asset).write_bytes(b"archive:windows")
+            (root / f"{windows_asset}.sigstore.json").write_text("{}\n")
+            with self.assertRaisesRegex(
+                ValueError, "stable publication rejects Windows release assets"
+            ):
+                self.validate(root)
+
+    def test_rejects_a_windows_manifest_instead_of_treating_it_as_optional(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            self.fixture(root)
+            (root / f"astrid-{VERSION}-windows-release.toml").write_text(
+                "schema-version = 1\n"
+            )
+            (root / f"astrid-{VERSION}-windows-release.toml.sigstore.json").write_text(
+                "{}\n"
+            )
+            with self.assertRaisesRegex(
+                ValueError, "stable publication rejects Windows release assets"
+            ):
+                self.validate(root)
+
+    def test_rejects_windows_checksum_advertisement(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            self.fixture(root)
+            self.add_windows_checksums(root)
+            with self.assertRaisesRegex(
+                ValueError, "stable publication rejects Windows release assets"
+            ):
+                self.validate(root)
+
+    def test_rejects_a_complete_windows_extension_inventory(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            self.fixture(root)
+            self.add_musl_extension(root)
+            windows_asset = release_manifest.expected_asset(
+                VERSION, release_manifest.WINDOWS_TARGETS[0]
+            )
+            windows_metadata = f"astrid-{VERSION}-windows-release.toml"
+            (root / windows_asset).write_bytes(b"archive:windows")
+            (root / windows_metadata).write_text("schema-version = 1\n")
+            for name in (windows_asset, windows_metadata):
+                (root / f"{name}.sigstore.json").write_text("{}\n")
+            self.add_windows_checksums(root)
+            with self.assertRaisesRegex(
+                ValueError, "stable publication rejects Windows release assets"
+            ):
+                self.validate(root)
 
     def test_rejects_musl_checksums_without_extension_assets(self) -> None:
         with tempfile.TemporaryDirectory() as temp:

--- a/scripts/test_windows_release_manifest.py
+++ b/scripts/test_windows_release_manifest.py
@@ -29,7 +29,11 @@ class WindowsReleaseManifestTests(unittest.TestCase):
         self.artifacts = pathlib.Path(self.temp.name)
         b3_lines = []
         sha_lines = []
-        for target in (*release_manifest.TARGETS, *release_manifest.EXTENSION_TARGETS):
+        for target in (
+            *release_manifest.TARGETS,
+            *release_manifest.MUSL_TARGETS,
+            *release_manifest.WINDOWS_TARGETS,
+        ):
             name = release_manifest.expected_asset(VERSION, target)
             path = self.artifacts / name
             path.write_bytes(f"archive:{target}".encode())

--- a/scripts/windows_release_manifest.py
+++ b/scripts/windows_release_manifest.py
@@ -14,6 +14,10 @@ import release_manifest
 
 
 KIND = "astrid-release-windows-extension"
+PARKED_EXTENSION_TARGETS = (
+    *release_manifest.MUSL_TARGETS,
+    *release_manifest.WINDOWS_TARGETS,
+)
 ROOT_KEYS = {
     "schema-version",
     "kind",
@@ -74,7 +78,7 @@ def build_manifest(
     )
     expected_all = {
         release_manifest.expected_asset(version, target)
-        for target in (*release_manifest.TARGETS, *release_manifest.EXTENSION_TARGETS)
+        for target in (*release_manifest.TARGETS, *PARKED_EXTENSION_TARGETS)
     }
     if set(blake3) != expected_all or set(sha256) != expected_all:
         fail("Windows metadata requires checksums for exactly all seven release archives")


### PR DESCRIPTION
## Linked Issue

Related to #1817 and parked Windows runtime outcome #1818. This PR does not close either issue.

This is a release-train publication-membership change, not a new product issue. Labels include `no-issue` and `release`.

## Summary

Keep Windows runtime archives out of the v2026.9.0 stable cut. Live `v0.10.4` never shipped a Windows archive; current-main Windows release targets were prospective first-publication only. A stable tag, attestation, GitHub release, or publication path must not build, sign, advertise, or upload `x86_64-pc-windows-msvc` runtime assets.

Windows component compilation and tests remain supporting evidence. The parked Windows generator is preserved as non-product #1818 compatibility and is not invoked from github-release.

## Changes

- Drop `x86_64-pc-windows-msvc` from the non-prepare Release matrix; prepare-only remains Darwin-only.
- Remove WinFsp staging, Windows archive packaging, Windows release-note install instructions, and `windows_release_manifest.py` generation from `release.yml`.
- Fail closed before attestation if a Windows archive, `windows-release.toml`, Sigstore marker, or checksum reference is present.
- Stable publication membership is musl-only as the current extension set. Parked seven-archive Windows checksums remain valid only for the parked generator/tests.
- Publication rejects every Windows archive, `windows-release.toml`, checksum advertisement, and Sigstore marker.

## Exact head

- SHA: `ad8f49cf386fcedf9ba7f64ac57950ec68a67b92`
- Parent / `origin/main`: `3de333f1b39d41bacfb535b49d83198212bf2403`
- Unique files:
  - `.github/workflows/release.yml`
  - `scripts/classify_release_build_matrix.py`
  - `scripts/release_manifest.py`
  - `scripts/release_publication.py`
  - `scripts/test_channel_workflow_contract.sh`
  - `scripts/test_release_publication.py`
  - `scripts/windows_release_manifest.py`
  - `scripts/test_windows_release_manifest.py`

## Verification

- GPG Good [full] (`7CD32E7697286B11593246B9FA53358CB4127512`) and matching DCO
- Classifier: `PREPARE_ONLY=true` Darwin pair; false/empty/absent Darwin + GNU + musl; no Windows
- `bash scripts/ci/test-release-contracts.sh`
- `python3 scripts/test_release_manifest.py`
- `python3 scripts/test_release_publication.py`
- `git diff --check`
- `release.yml` is 954 lines

## Residuals and claim limits

- Does not implement a Windows daemon or merge draft #1814.
- Does not certify musl archives; musl remains in the build matrix pending a later cert vehicle.
- Does not bump, tag, or publish.
- Does not change `windows-filesystem-native` or `windows-local-transport` component CI.
- Does not close #1818.

## AI / Tool Assistance

Assisted-by: Codex:zai-coding-responses/glm-5.3-flash

The publication-membership split and fail-closed Windows rejection were authored with Codex assistance in an isolated worktree. The exact SHA, unique file set, signature, DCO, and focused contract tests were independently verified before this PR was opened.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment skipped for this release-guard-only change; PR is labeled `skip-changelog`
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested the meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
