### PR TITLE
feat(release): certify prepare-only musl artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,14 @@ on:
         required: false
         default: false
         type: boolean
+      prepare_set:
+        description: Prepare-only build set
+        required: false
+        default: darwin
+        type: choice
+        options:
+          - darwin
+          - musl
       source_commit:
         description: Exact protected-main commit to build
         required: false
@@ -54,6 +62,7 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           PREPARE_ONLY: ${{ inputs.prepare_only }}
+          PREPARE_SET: ${{ inputs.prepare_set }}
           REQUESTED_SOURCE: ${{ inputs.source_commit }}
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -383,6 +392,42 @@ jobs:
           name: binary-${{ matrix.target }}
           path: ${{ env.ASSET }}
 
+  musl-certification:
+    name: Musl archive certification (${{ matrix.architecture }})
+    needs: [classify, build]
+    if: ${{ inputs.prepare_only == true && inputs.prepare_set == 'musl' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { architecture: x86_64, target: x86_64-unknown-linux-musl, runs-on: ubuntu-latest }
+          - { architecture: aarch64, target: aarch64-unknown-linux-musl, runs-on: ubuntu-24.04-arm }
+    runs-on: ${{ matrix.runs-on }}
+    timeout-minutes: 30
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with: { ref: '${{ needs.classify.outputs.source-commit }}' }
+      - name: Install and require native FUSE support
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends fuse3
+          if [[ ! -c /dev/fuse ]]; then
+            sudo modprobe fuse
+          fi
+          [[ -c /dev/fuse ]] || { echo "::error::hosted runner has no Linux FUSE device" >&2; exit 1; }
+          command -v fusermount3 >/dev/null || { echo "::error::hosted runner has no fusermount3" >&2; exit 1; }
+          sudo chmod 0666 /dev/fuse
+      - name: Download the packaged musl archive
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with: { name: 'binary-${{ matrix.target }}', path: '${{ runner.temp }}/musl-cert-artifact' }
+      - name: Certify the packaged musl archive
+        run: |
+          EXPECTED_VERSION='${{ needs.classify.outputs.version }}'
+          scripts/certify_musl_release_archive.sh --architecture "${{ matrix.architecture }}" --target "${{ matrix.target }}" --artifact-dir "$RUNNER_TEMP/musl-cert-artifact" --expected-version "$EXPECTED_VERSION"
   fskit-certification:
     name: Native FSKit mount certification
     needs: [classify, build]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -411,16 +411,12 @@ jobs:
           egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with: { ref: '${{ needs.classify.outputs.source-commit }}' }
-      - name: Install and require native FUSE support
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends fuse3
-          if [[ ! -c /dev/fuse ]]; then
-            sudo modprobe fuse
-          fi
-          [[ -c /dev/fuse ]] || { echo "::error::hosted runner has no Linux FUSE device" >&2; exit 1; }
-          command -v fusermount3 >/dev/null || { echo "::error::hosted runner has no fusermount3" >&2; exit 1; }
-          sudo chmod 0666 /dev/fuse
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: "1.95.0"
+      - name: Set up certification tools
+        run: scripts/ci/setup_musl_certification.sh
       - name: Download the packaged musl archive
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with: { name: 'binary-${{ matrix.target }}', path: '${{ runner.temp }}/musl-cert-artifact' }
@@ -485,7 +481,7 @@ jobs:
           toolchain: "1.95.0"
 
       - name: Install pinned b3sum
-        run: cargo install b3sum --version 1.8.5 --locked
+        run: scripts/ci/setup_musl_certification.sh --b3sum-only
 
       - name: Download all binary artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/scripts/certify_musl_release_archive.sh
+++ b/scripts/certify_musl_release_archive.sh
@@ -1,0 +1,310 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+B3SUM_REQUIRED_VERSION="1.8.5"
+EXPECTED_EMPTY_BLAKE3="af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262"
+EXPECTED_EMPTY_SHA256="e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+usage() {
+  echo "usage: $0 --architecture ARCH --target TRIPLE --artifact-dir DIR --expected-version VERSION [--stage-only]" >&2
+  exit 2
+}
+
+fail() {
+  echo "$*" >&2
+  exit 1
+}
+
+architecture=""
+target=""
+artifact_dir=""
+expected_version=""
+stage_only=false
+while (($#)); do
+  case "$1" in
+    --architecture|--target|--artifact-dir|--expected-version)
+      [[ $# -ge 2 ]] || usage
+      case "$1" in
+        --architecture) architecture=$2 ;;
+        --target) target=$2 ;;
+        --artifact-dir) artifact_dir=$2 ;;
+        --expected-version) expected_version=$2 ;;
+      esac
+      shift 2
+      ;;
+    --stage-only)
+      stage_only=true
+      shift
+      ;;
+    *) usage ;;
+  esac
+done
+
+[[ -n "$architecture" && -n "$target" && -n "$artifact_dir" && -n "$expected_version" ]] || usage
+case "$architecture:$target" in
+  x86_64:x86_64-unknown-linux-musl | aarch64:aarch64-unknown-linux-musl) ;;
+  *) fail "architecture and target are not paired" ;;
+esac
+[[ -d "$artifact_dir" && ! -L "$artifact_dir" ]] || fail "artifact directory is invalid"
+
+sha256sum_bin=$(command -v sha256sum) || fail "system sha256sum is unavailable"
+b3sum_bin=$(command -v b3sum) || fail "pinned b3sum is unavailable"
+b3sum_version=$("$b3sum_bin" --version) || fail "b3sum version could not be determined"
+[[ "$b3sum_version" == "b3sum ${B3SUM_REQUIRED_VERSION}" ]] \
+  || fail "b3sum must be pinned to ${B3SUM_REQUIRED_VERSION}, found: ${b3sum_version}"
+
+empty_b3sum=$(printf '' | "$b3sum_bin" --no-names) || fail "b3sum empty-vector probe failed"
+[[ "$empty_b3sum" == "$EXPECTED_EMPTY_BLAKE3" ]] || fail "pinned b3sum failed the empty BLAKE3 vector"
+empty_sha256=$(printf '' | "$sha256sum_bin") || fail "sha256sum empty-vector probe failed"
+empty_sha256=${empty_sha256%% *}
+[[ "$empty_sha256" == "$EXPECTED_EMPTY_SHA256" ]] || fail "system sha256sum failed its empty vector"
+
+repo_root=$PWD
+base_temp=${RUNNER_TEMP:-${TMPDIR:-/tmp}}
+cert_root=$(mktemp -d "$base_temp/astrid-musl-cert.XXXXXX")
+cleanup() {
+  local status=$?
+  set +e
+  if [[ -d "${cert_root:-}" ]]; then
+    case "$cert_root" in
+      "$base_temp"/astrid-musl-cert.*) rm -rf "$cert_root" ;;
+    esac
+  fi
+  exit "$status"
+}
+trap cleanup EXIT
+
+artifact_stage="$cert_root/artifact"
+binary_stage="$cert_root/stage"
+mkdir -m 0700 "$artifact_stage" "$binary_stage"
+
+python3 - "$artifact_dir" "$artifact_stage" "$expected_version" "$target" <<'PY'
+from __future__ import annotations
+
+import os
+import pathlib
+import stat
+import sys
+import tarfile
+
+
+REQUIRED = (
+    "astrid",
+    "astrid-daemon",
+    "astrid-build",
+    "astrid-emit",
+    "astrid-storage-provider-fuse",
+)
+
+
+def fail(message: str) -> None:
+    raise ValueError(message)
+
+
+artifact_dir, stage_dir, expected_version, target = (
+    pathlib.Path(sys.argv[1]),
+    pathlib.Path(sys.argv[2]),
+    sys.argv[3],
+    sys.argv[4],
+)
+entries = list(artifact_dir.iterdir())
+archives = [path for path in entries if path.name.endswith(".tar.gz")]
+if len(archives) != 1:
+    fail(f"expected exactly one archive in {artifact_dir}, found {len(archives)}")
+archive = archives[0]
+if archive.is_symlink() or not archive.is_file():
+    fail(f"artifact archive is not a regular file: {archive}")
+expected_asset = f"astrid-{expected_version}-{target}.tar.gz"
+if archive.name != expected_asset:
+    fail(f"artifact archive does not bind {target} at {expected_version}: {archive.name}")
+
+root = f"astrid-{expected_version}-{target}"
+allowed = {
+    root,
+    *(f"{root}/{name}" for name in REQUIRED),
+    f"{root}/README.md",
+}
+staged: set[str] = set()
+with tarfile.open(archive, mode="r:gz") as members:
+    entries = members.getmembers()
+    if len(entries) > 32:
+        fail("certification archive has too many members")
+    for member in entries:
+        name = member.name.rstrip("/") if member.isdir() else member.name
+        pure = pathlib.PurePosixPath(name)
+        if pure.is_absolute() or ".." in pure.parts or name in staged:
+            fail(f"unsafe or duplicate archive member: {member.name}")
+        if member.issym() or member.islnk() or not (member.isfile() or member.isdir()):
+            fail(f"archive member redirects or is special: {member.name}")
+        if name.startswith(f"{root}/LICENSE"):
+            allowed.add(name)
+        if name not in allowed:
+            lowered = name.casefold()
+            if any(marker in lowered for marker in ("apple", "darwin", "windows", "fskit", ".app/")):
+                fail(f"certification archive contains a non-musl companion: {member.name}")
+            fail(f"certification archive has an unexpected member: {member.name}")
+        if not member.isfile():
+            continue
+        member_name = pathlib.PurePosixPath(name).name
+        if member_name not in REQUIRED:
+            continue
+        if not (member.mode & stat.S_IXUSR):
+            fail(f"archive binary is not executable: {name}")
+        source = members.extractfile(member)
+        if source is None:
+            fail(f"archive bytes are unavailable: {name}")
+        destination = stage_dir / member_name
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        copied = 0
+        try:
+            descriptor = os.open(destination, flags, 0o700)
+            with os.fdopen(descriptor, "wb") as output:
+                while True:
+                    block = source.read(1024 * 1024)
+                    if not block:
+                        break
+                    copied += len(block)
+                    output.write(block)
+        except FileExistsError:
+            fail(f"staging collision for required binary: {name}")
+        if copied != member.size:
+            fail(f"staged byte count differs from archive member: {name}")
+        destination.chmod(0o700)
+        if destination.is_symlink() or not destination.is_file():
+            fail(f"staged binary is redirected or missing: {name}")
+        staged.add(member_name)
+
+if staged != set(REQUIRED):
+    fail("certification archive does not have exactly the five required binaries")
+print(f"staged {len(staged)} binaries from {archive.name}")
+PY
+
+sha256_digest() {
+  local output
+  output=$("$sha256sum_bin" "$1") || return 1
+  output=${output%% *}
+  [[ "$output" =~ ^[0-9a-f]{64}$ ]] || return 1
+  printf '%s\n' "$output"
+}
+
+b3sum_digest() {
+  local output
+  output=$("$b3sum_bin" --no-names "$1") || return 1
+  [[ "$output" =~ ^[0-9a-f]{64}$ ]] || return 1
+  printf '%s\n' "$output"
+}
+
+for binary in astrid astrid-daemon astrid-build astrid-emit astrid-storage-provider-fuse; do
+  artifact_path="$artifact_stage/$binary"
+  staged_path="$binary_stage/$binary"
+  [[ -f "$artifact_path" && ! -L "$artifact_path" ]] || fail "invalid staged artifact bytes: $binary"
+  cp "$artifact_path" "$staged_path"
+  chmod 0700 "$staged_path"
+  [[ -f "$staged_path" && -x "$staged_path" && ! -L "$staged_path" ]] \
+    || fail "invalid packaged binary after staging: $binary"
+
+  artifact_sha256=$(sha256_digest "$artifact_path") || fail "sha256sum could not digest artifact bytes: $binary"
+  staged_sha256=$(sha256_digest "$staged_path") || fail "sha256sum could not digest staged bytes: $binary"
+  artifact_blake3=$(b3sum_digest "$artifact_path") || fail "pinned b3sum could not digest artifact bytes: $binary"
+  staged_blake3=$(b3sum_digest "$staged_path") || fail "pinned b3sum could not digest staged bytes: $binary"
+
+  [[ "$artifact_sha256" == "$staged_sha256" ]] \
+    || fail "sha256sum detected staged byte disagreement: $binary"
+  [[ "$artifact_blake3" == "$staged_blake3" ]] \
+    || fail "pinned b3sum detected staged byte disagreement: $binary"
+  cmp -s "$artifact_path" "$staged_path" || fail "staged bytes differ from artifact bytes: $binary"
+  printf '%s  %s\n' "$staged_sha256" "$binary"
+  printf '%s  %s\n' "$staged_blake3" "$binary"
+done
+
+if [[ "$stage_only" == true ]]; then
+  echo "musl archive staging certification: PASS"
+  exit 0
+fi
+
+[[ "$(uname -s)" == Linux ]] || fail "musl runtime certification requires Linux"
+[[ -c /dev/fuse ]] || fail "Linux FUSE device is unavailable"
+command -v fusermount3 >/dev/null || fail "fusermount3 is unavailable"
+[[ -w /dev/fuse ]] || fail "/dev/fuse is not writable"
+
+bin="$binary_stage"
+home="$cert_root/home"
+workspace="$cert_root/workspace"
+mount="$cert_root/mount"
+mkdir -m 0700 "$home" "$workspace" "$mount"
+export HOME="$home"
+export ASTRID_HOME="$home/.astrid"
+cd "$workspace"
+
+reported_version=$("$bin/astrid" --version)
+[[ "$reported_version" == "astrid $expected_version" ]] \
+  || fail "packaged version mismatch: $reported_version"
+for binary in astrid astrid-daemon astrid-build astrid-emit astrid-storage-provider-fuse; do
+  [[ -f "$bin/$binary" && -x "$bin/$binary" && ! -L "$bin/$binary" ]] \
+    || fail "invalid packaged binary: $binary"
+done
+python3 "$repo_root/scripts/check_static_elf.py" --architecture "$architecture" \
+  "$bin/astrid" "$bin/astrid-daemon" "$bin/astrid-build" \
+  "$bin/astrid-emit" "$bin/astrid-storage-provider-fuse"
+
+timeout 180s "$bin/astrid" --principal default start
+timeout 30s "$bin/astrid" --principal default status
+
+request=$(python3 - <<-'PY'
+import json
+print(json.dumps({
+    "protocol_version": 1,
+    "request_id": "musl-release-certification",
+    "acting_principal_hint": "default",
+    "operation": {
+        "operation": "status",
+        "selector": {"kind": "native-path", "value": None},
+    },
+}, separators=(",", ":")))
+PY
+)
+request=${request/null/\"$mount\"}
+provider_output=$(printf '%s\n' "$request" | timeout 30s "$bin/astrid-storage-provider-fuse" --astrid-provider-stdio-v1)
+ASTRID_VERSION="$expected_version" python3 - "$provider_output" <<-'PY'
+import json
+import os
+import sys
+
+response = json.loads(sys.argv[1])
+expected = os.environ["ASTRID_VERSION"]
+assert response["protocol_version"] == 1
+assert response["provider"]["name"] == "astrid-storage-provider-fuse"
+assert response["provider"]["version"] == expected
+PY
+
+mount_output=$(timeout 30s "$bin/astrid" --principal default storage mount \
+  --as default --read-write "$mount")
+printf '%s\n' "$mount_output"
+mount_id=$(sed -nE 's/^mounted ([0-9a-f-]{36}) at .*/\1/p' <<<"$mount_output")
+[[ "$mount_id" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]
+[[ "$(findmnt -nro FSTYPE --target "$mount")" == fuse.astrid ]]
+sentinel="musl-certified"
+printf '%s\n' "$sentinel" > "$mount/certified.txt"
+[[ "$(cat "$mount/certified.txt")" == "$sentinel" ]]
+status_output=$(timeout 30s "$bin/astrid" --principal default storage status "$mount")
+grep -Fq "mount $mount_id at $mount: ReadWrite, dirty=true" <<<"$status_output"
+timeout 30s "$bin/astrid" --principal default storage sync "$mount"
+status_output=$(timeout 30s "$bin/astrid" --principal default storage status "$mount")
+grep -Fq "mount $mount_id at $mount: ReadWrite, dirty=false" <<<"$status_output"
+timeout 30s "$bin/astrid" --principal default storage unmount "$mount"
+[[ ! -e "/tmp/astrid-mounts-$(id -u)/$mount_id" ]]
+if timeout 30s "$bin/astrid" --principal default storage status "$mount" \
+  >"$cert_root/post-unmount.out" 2>"$cert_root/post-unmount.err"; then
+  fail "storage status unexpectedly retained an unmounted path"
+fi
+timeout 30s "$bin/astrid" --principal default stop
+if timeout 30s "$bin/astrid" --principal default status \
+  >"$cert_root/post-stop.out" 2>"$cert_root/post-stop.err"; then
+  fail "daemon status unexpectedly succeeded after authoritative stop"
+fi
+for marker in system.sock system.token system.ready system.pid; do
+  [[ ! -e "$ASTRID_HOME/run/$marker" ]]
+done
+echo "musl packaged archive certification: PASS"

--- a/scripts/ci/setup_musl_certification.sh
+++ b/scripts/ci/setup_musl_certification.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -gt 1 || (${1:-} != "" && ${1:-} != "--b3sum-only") ]]; then
+  echo "usage: $0 [--b3sum-only]" >&2
+  exit 2
+fi
+
+if [[ ${1:-} != "--b3sum-only" ]]; then
+  sudo apt-get update
+  sudo apt-get install -y --no-install-recommends fuse3
+  if [[ ! -c /dev/fuse ]]; then
+    sudo modprobe fuse
+  fi
+  [[ -c /dev/fuse ]] || { echo "::error::hosted runner has no Linux FUSE device" >&2; exit 1; }
+  command -v fusermount3 >/dev/null || { echo "::error::hosted runner has no fusermount3" >&2; exit 1; }
+  sudo chmod 0666 /dev/fuse
+fi
+
+B3SUM_REQUIRED_VERSION="1.8.5"
+b3sum_bin_dir="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/astrid-certification-b3sum-${B3SUM_REQUIRED_VERSION}/bin"
+mkdir -p "$b3sum_bin_dir"
+b3sum_bin="$b3sum_bin_dir/b3sum"
+
+if [[ ! -x "$b3sum_bin" ]] || [[ "$("$b3sum_bin" --version)" != "b3sum ${B3SUM_REQUIRED_VERSION}" ]]; then
+  cargo install b3sum --version 1.8.5 --locked --root "${b3sum_bin_dir%/bin}"
+fi
+
+[[ "$("$b3sum_bin" --version)" == "b3sum ${B3SUM_REQUIRED_VERSION}" ]]
+[[ "$(printf '' | "$b3sum_bin" --no-names)" == "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262" ]]
+
+if [[ -n "${GITHUB_PATH:-}" ]]; then
+  printf '%s\n' "$b3sum_bin_dir" >> "$GITHUB_PATH"
+else
+  printf '%s\n' "$b3sum_bin_dir"
+fi

--- a/scripts/ci/test-release-contracts.sh
+++ b/scripts/ci/test-release-contracts.sh
@@ -17,5 +17,6 @@ python3 scripts/test_channel_metadata.py
 python3 scripts/test_channel_publication.py
 python3 scripts/test_nightly_version.py
 bash scripts/test_channel_workflow_contract.sh
+bash scripts/test_certify_musl_release_archive_contract.sh
 bash scripts/test_native_storage_certification_contract.sh
 bash scripts/test_ci_workflow_contract.sh

--- a/scripts/classify_release_build_matrix.py
+++ b/scripts/classify_release_build_matrix.py
@@ -5,16 +5,26 @@ import os
 
 
 PREPARE_ONLY = os.environ.get("PREPARE_ONLY", "")
+PREPARE_SET = os.environ.get("PREPARE_SET", "")
 
 include = [
     {"target": "x86_64-apple-darwin", "os": "macos-latest", "archive": "tar.gz", "libc": "native"},
     {"target": "aarch64-apple-darwin", "os": "macos-latest", "archive": "tar.gz", "libc": "native"},
 ]
+musl = [
+    {"target": "x86_64-unknown-linux-musl", "os": "ubuntu-latest", "archive": "tar.gz", "libc": "musl", "platform": "linux/amd64", "image": "docker.io/library/rust@sha256:e98196986adced5602f6e21c54babdbf2a8700400c7a78868324a3630e0c5d15"},
+    {"target": "aarch64-unknown-linux-musl", "os": "ubuntu-24.04-arm", "archive": "tar.gz", "libc": "musl", "platform": "linux/arm64", "image": "docker.io/library/rust@sha256:594694ee6b07747b63b5c265be2616b62e814180b66227e2c18c6ee85e4136be"},
+]
+if PREPARE_SET not in ("", "darwin", "musl"):
+    raise ValueError(f"unsupported prepare set: {PREPARE_SET}")
+if PREPARE_SET == "musl" and PREPARE_ONLY != "true":
+    raise ValueError("prepare_set=musl requires prepare_only=true")
 if PREPARE_ONLY != "true":
     include.extend([
         {"target": "x86_64-unknown-linux-gnu", "os": "ubuntu-latest", "archive": "tar.gz", "libc": "gnu"},
         {"target": "aarch64-unknown-linux-gnu", "os": "ubuntu-latest", "archive": "tar.gz", "libc": "gnu"},
-        {"target": "x86_64-unknown-linux-musl", "os": "ubuntu-latest", "archive": "tar.gz", "libc": "musl", "platform": "linux/amd64", "image": "docker.io/library/rust@sha256:e98196986adced5602f6e21c54babdbf2a8700400c7a78868324a3630e0c5d15"},
-        {"target": "aarch64-unknown-linux-musl", "os": "ubuntu-24.04-arm", "archive": "tar.gz", "libc": "musl", "platform": "linux/arm64", "image": "docker.io/library/rust@sha256:594694ee6b07747b63b5c265be2616b62e814180b66227e2c18c6ee85e4136be"},
+        *musl,
     ])
+elif PREPARE_SET == "musl":
+    include = musl
 print(json.dumps({"include": include}, separators=(",", ":")))

--- a/scripts/test_certify_musl_release_archive_contract.sh
+++ b/scripts/test_certify_musl_release_archive_contract.sh
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import pathlib
 import re
+import stat
 import subprocess
 import sys
 import tarfile
@@ -17,6 +18,10 @@ workflow_path = repo / ".github/workflows/release.yml"
 script_path = repo / "scripts/certify_musl_release_archive.sh"
 workflow = workflow_path.read_text(encoding="utf-8")
 script = script_path.read_text(encoding="utf-8")
+setup_path = repo / "scripts/ci/setup_musl_certification.sh"
+setup = setup_path.read_text(encoding="utf-8")
+if not setup_path.stat().st_mode & stat.S_IXUSR:
+    fail("shared certification setup is not executable")
 
 
 def fail(message: str) -> None:
@@ -54,9 +59,15 @@ if not re.search(r"name: '?binary-\$\{\{ matrix\.target \}\}'?", cert):
     fail("certification does not download by its same-run artifact name")
 if re.search(r"artifact-ids|run-id", cert, flags=re.IGNORECASE):
     fail("certification must not consume a cross-run artifact")
-for forbidden in ("cargo", "rust-toolchain", "CARGO_TARGET_DIR"):
+if "dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8" not in cert:
+    fail("musl certification does not use the pinned release toolchain action")
+if 'toolchain: "1.95.0"' not in cert:
+    fail("musl certification does not pin Rust 1.95.0")
+if "scripts/ci/setup_musl_certification.sh" not in cert:
+    fail("musl certification does not use the shared certification setup")
+for forbidden in ("cargo build", "cargo check", "cargo test", "-p astrid", "CARGO_TARGET_DIR"):
     if forbidden.casefold() in cert.casefold():
-        fail(f"certification job contains forbidden build input {forbidden}")
+        fail(f"certification job contains forbidden product-build input {forbidden}")
 if "actions/checkout@" not in cert or "source-commit" not in cert:
     fail("certification does not check out the classified source")
 for fragment in (
@@ -65,9 +76,11 @@ for fragment in (
     "[[ -c /dev/fuse ]]",
     "command -v fusermount3",
     "chmod 0666 /dev/fuse",
+    'B3SUM_REQUIRED_VERSION="1.8.5"',
+    "cargo install b3sum --version 1.8.5 --locked",
 ):
-    if fragment not in cert:
-        fail(f"FUSE substrate setup is missing {fragment}")
+    if fragment not in setup:
+        fail(f"shared certification setup is missing {fragment}")
 if "certify_musl_release_archive.sh" not in cert:
     fail("certification does not invoke the named executable")
 
@@ -150,7 +163,10 @@ def archive_fixture(root: pathlib.Path, redirect: bool) -> pathlib.Path:
 
 
 def run_stage(root: pathlib.Path, archive: pathlib.Path, env: dict[str, str] | None = None):
-    environment = None if env is None else {**os_environ(), **env}
+    environment = {**os_environ(), **(env or {})}
+    injected_path = (env or {}).get("PATH")
+    certification_path = f"{b3sum_bin_dir}:{environment['PATH']}"
+    environment["PATH"] = certification_path if not injected_path else f"{injected_path}:{certification_path}"
     return subprocess.run(
         [
             str(script_path), "--architecture", "x86_64", "--target",
@@ -169,6 +185,19 @@ def os_environ() -> dict[str, str]:
 
     return dict(os.environ)
 
+
+provision = subprocess.run(
+    [str(setup_path), "--b3sum-only"],
+    env={name: value for name, value in os_environ().items() if name != "GITHUB_PATH"},
+    text=True,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+)
+if provision.returncode != 0:
+    fail(f"pinned b3sum setup failed: {provision.stdout}{provision.stderr}")
+b3sum_bin_dir = provision.stdout.strip()
+if not b3sum_bin_dir or not pathlib.Path(b3sum_bin_dir, "b3sum").is_file():
+    fail("pinned b3sum setup did not provide a binary directory")
 
 with tempfile.TemporaryDirectory() as temporary:
     root = pathlib.Path(temporary)

--- a/scripts/test_certify_musl_release_archive_contract.sh
+++ b/scripts/test_certify_musl_release_archive_contract.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python3 - "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)" <<'PY'
+from __future__ import annotations
+
+import pathlib
+import re
+import subprocess
+import sys
+import tarfile
+import tempfile
+
+
+repo = pathlib.Path(sys.argv[1])
+workflow_path = repo / ".github/workflows/release.yml"
+script_path = repo / "scripts/certify_musl_release_archive.sh"
+workflow = workflow_path.read_text(encoding="utf-8")
+script = script_path.read_text(encoding="utf-8")
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"musl certification contract: {message}")
+
+
+if len(workflow.splitlines()) > 1000:
+    fail("release.yml exceeds its 1000-line ceiling")
+for value in ("prepare_set:", "default: darwin", "type: choice", "- darwin", "- musl"):
+    if value not in workflow:
+        fail(f"workflow is missing prepare_set {value}")
+if "PREPARE_SET = os.environ.get(" not in (repo / "scripts/classify_release_build_matrix.py").read_text():
+    fail("classifier does not read PREPARE_SET from the environment")
+
+marker = "\n  musl-certification:\n"
+start = workflow.find(marker)
+if start < 0:
+    fail("missing musl-certification job")
+start += 1
+next_job = re.search(r"^  [A-Za-z0-9_-]+:\n", workflow[start + len(marker) - 1:], flags=re.MULTILINE)
+cert = workflow[start:start + len(marker) - 1 + (next_job.start() if next_job else 0)]
+if "if: ${{ inputs.prepare_only == true && inputs.prepare_set == 'musl' }}" not in cert:
+    fail("musl certification is not confined to musl prepare-only runs")
+if "ubuntu-latest" not in cert or "ubuntu-24.04-arm" not in cert:
+    fail("certification runners do not match both musl triples")
+for architecture, runner, target in (
+    ("x86_64", "ubuntu-latest", "x86_64-unknown-linux-musl"),
+    ("aarch64", "ubuntu-24.04-arm", "aarch64-unknown-linux-musl"),
+):
+    if not re.search(rf"architecture: {architecture}, target: {target}, runs-on: {runner}", cert):
+        fail(f"certification matrix does not pair {architecture} with {runner}")
+if "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c" not in cert:
+    fail("certification does not use the pinned artifact action")
+if not re.search(r"name: '?binary-\$\{\{ matrix\.target \}\}'?", cert):
+    fail("certification does not download by its same-run artifact name")
+if re.search(r"artifact-ids|run-id", cert, flags=re.IGNORECASE):
+    fail("certification must not consume a cross-run artifact")
+for forbidden in ("cargo", "rust-toolchain", "CARGO_TARGET_DIR"):
+    if forbidden.casefold() in cert.casefold():
+        fail(f"certification job contains forbidden build input {forbidden}")
+if "actions/checkout@" not in cert or "source-commit" not in cert:
+    fail("certification does not check out the classified source")
+for fragment in (
+    "apt-get install -y --no-install-recommends fuse3",
+    "modprobe fuse",
+    "[[ -c /dev/fuse ]]",
+    "command -v fusermount3",
+    "chmod 0666 /dev/fuse",
+):
+    if fragment not in cert:
+        fail(f"FUSE substrate setup is missing {fragment}")
+if "certify_musl_release_archive.sh" not in cert:
+    fail("certification does not invoke the named executable")
+
+for fragment in (
+    'B3SUM_REQUIRED_VERSION="1.8.5"',
+    "command -v sha256sum",
+    "command -v b3sum",
+    '"$b3sum_bin" --version',
+    '[[ "$b3sum_version" == "b3sum ${B3SUM_REQUIRED_VERSION}" ]]',
+    "EXPECTED_EMPTY_BLAKE3=",
+    "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262",
+    'printf \'\' | "$b3sum_bin" --no-names',
+    "sha256_digest",
+    "b3sum_digest",
+    "tarfile.open",
+    "ASTRID_HOME=",
+    "--principal default start",
+    "--principal default status",
+    "storage mount",
+    "--read-write",
+    "storage sync",
+    "storage status",
+    "storage unmount",
+    "--principal default stop",
+    "system.sock",
+    "system.token",
+    "system.ready",
+    "system.pid",
+    "trap cleanup EXIT",
+    "scripts/check_static_elf.py",
+):
+    if fragment not in script:
+        fail(f"cert executable is missing {fragment}")
+if script.find("tarfile.open") > script.find('cp "$artifact_path" "$staged_path"'):
+    fail("archive members are not safely staged before packaged-byte verification")
+if re.search(r"\btar\s+-x\b", script):
+    fail("cert executable must stage members explicitly, not extract the archive wholesale")
+for forbidden in ("class " + "Blake3", "blake3" + "_bytes", "hashlib", "import hashlib"):
+    if forbidden in script:
+        fail(f"homemade or Python hashing remains in cert executable: {forbidden}")
+if "sha256sum_bin=$(command -v sha256sum)" not in script:
+    fail("system sha256sum is not the production digest authority")
+for rejected in ("apple", "windows", "fskit"):
+    if rejected not in script:
+        fail(f"cert executable does not reject {rejected} companions")
+
+
+def archive_fixture(root: pathlib.Path, redirect: bool) -> pathlib.Path:
+    target = "x86_64-unknown-linux-musl"
+    release = root / f"astrid-2026.9.0-{target}"
+    release.mkdir()
+    binaries = (
+        "astrid",
+        "astrid-daemon",
+        "astrid-build",
+        "astrid-emit",
+        "astrid-storage-provider-fuse",
+    )
+    for name in binaries:
+        path = release / name
+        path.write_bytes(f"#!/bin/sh\necho astrid 2026.9.0-{name}\n".encode())
+        path.chmod(0o700)
+    (release / "README.md").write_text("fixture\n", encoding="utf-8")
+    (release / "LICENSE-APACHE").write_text("fixture\n", encoding="utf-8")
+    source_archive = root / f"astrid-2026.9.0-{target}.tar.gz"
+    with tarfile.open(source_archive, "w:gz") as output:
+        output.add(release, arcname=release.name)
+    if not redirect:
+        return source_archive
+    archive = root / f"astrid-redirect-{target}.tar.gz"
+    with tarfile.open(source_archive, "r:gz") as source, tarfile.open(archive, "w:gz") as output:
+        for member in source.getmembers():
+            if member.name.endswith("/astrid-daemon"):
+                member.type = tarfile.SYMTYPE
+                member.linkname = "/etc/passwd"
+                output.addfile(member)
+            else:
+                output.addfile(member, source.extractfile(member))
+    return archive
+
+
+def run_stage(root: pathlib.Path, archive: pathlib.Path, env: dict[str, str] | None = None):
+    environment = None if env is None else {**os_environ(), **env}
+    return subprocess.run(
+        [
+            str(script_path), "--architecture", "x86_64", "--target",
+            "x86_64-unknown-linux-musl", "--artifact-dir", str(root),
+            "--expected-version", "2026.9.0", "--stage-only",
+        ],
+        env=environment,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def os_environ() -> dict[str, str]:
+    import os
+
+    return dict(os.environ)
+
+
+with tempfile.TemporaryDirectory() as temporary:
+    root = pathlib.Path(temporary)
+    archive = archive_fixture(root, redirect=False)
+    result = run_stage(root, archive)
+    if result.returncode != 0 or "staging certification: PASS" not in result.stdout:
+        fail(f"regular archive staging failed: {result.stdout}{result.stderr}")
+
+with tempfile.TemporaryDirectory() as temporary:
+    root = pathlib.Path(temporary)
+    archive = archive_fixture(root, redirect=True)
+    result = run_stage(root, archive)
+    if result.returncode == 0:
+        fail("redirecting archive member unexpectedly passed staging")
+
+with tempfile.TemporaryDirectory() as temporary:
+    wrapper_root = pathlib.Path(temporary) / "unpinned-b3sum"
+    wrapper_root.mkdir()
+    wrapper = wrapper_root / "b3sum"
+    wrapper.write_text("#!/bin/sh\nprintf 'b3sum 1.8.4\\n'\n", encoding="utf-8")
+    wrapper.chmod(0o700)
+    root = pathlib.Path(temporary) / "fixture"
+    root.mkdir()
+    result = run_stage(root, archive_fixture(root, redirect=False), {"PATH": f"{wrapper_root}:{os_environ()['PATH']}"})
+    if result.returncode == 0 or "b3sum must be pinned" not in result.stderr:
+        fail("unpinned b3sum unexpectedly passed the tool gate")
+
+with tempfile.TemporaryDirectory() as temporary:
+    wrapper_root = pathlib.Path(temporary) / "disagreeing-b3sum"
+    wrapper_root.mkdir()
+    wrapper = wrapper_root / "b3sum"
+    wrapper.write_text(
+        "#!/bin/sh\n"
+        "if [ \"$#\" -eq 1 ] && [ \"$1\" = \"--no-names\" ]; then\n"
+        "  printf 'af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262\\n'\n"
+        "  exit 0\n"
+        "fi\n"
+        "if [ \"$1\" = \"--version\" ]; then\n"
+        "  printf 'b3sum 1.8.5\\n'\n"
+        "  exit 0\n"
+        "fi\n"
+        "if [ \"$#\" -eq 2 ] && [ \"$1\" = \"--no-names\" ]; then\n"
+        "  printf '%s' \"$2\" | sha256sum | cut -d' ' -f1\n"
+        "  exit 0\n"
+        "fi\n"
+        "cat >/dev/null\n",
+        encoding="utf-8",
+    )
+    wrapper.chmod(0o700)
+    root = pathlib.Path(temporary) / "fixture"
+    root.mkdir()
+    result = run_stage(root, archive_fixture(root, redirect=False), {"PATH": f"{wrapper_root}:{os_environ()['PATH']}"})
+    if result.returncode == 0 or "staged byte disagreement" not in result.stderr:
+        fail("disagreeing staged hashes unexpectedly passed")
+
+print("musl packaged archive certification contract: PASS")
+PY

--- a/scripts/test_channel_workflow_contract.sh
+++ b/scripts/test_channel_workflow_contract.sh
@@ -182,6 +182,12 @@ source_input = text[source_input_start:text.find("\n\npermissions:", source_inpu
 for value in ("required: false", "default: false", "type: boolean"):
     if value not in prepare_input:
         fail(f"prepare_only input is missing {value}")
+if "      prepare_set:\n" not in prepare_input:
+    fail("missing prepare_set workflow input")
+prepare_set = prepare_input[prepare_input.find("      prepare_set:\n"):]
+for value in ("required: false", "default: darwin", "type: choice", "          - darwin", "          - musl"):
+    if value not in prepare_set:
+        fail(f"prepare_set input is missing {value}")
 for value in ("required: false", "type: string"):
     if value not in source_input:
         fail(f"source_commit input is missing {value}")
@@ -231,29 +237,28 @@ if checkout_line < 0 or matrix_invocation_index < 0 or checkout_line > matrix_in
 matrix_program = classifier.read_text(encoding="utf-8")
 if "import os" not in matrix_program or "PREPARE_ONLY = os.environ.get(" not in matrix_program:
     fail("build matrix must read PREPARE_ONLY through the process environment")
+if "PREPARE_SET = os.environ.get(" not in matrix_program:
+    fail("build matrix must read PREPARE_SET through the process environment")
 for target in ("x86_64-apple-darwin", "aarch64-apple-darwin"):
     if f'"target": "{target}"' not in matrix_program:
         fail(f"classified build matrix is missing required Darwin target {target}")
 conditional_start = matrix_program.find('if PREPARE_ONLY != "true":')
 if conditional_start < 0:
     fail("missing prepare-only build matrix filter")
-non_darwin = matrix_program[conditional_start:]
 for target in (
     "x86_64-unknown-linux-gnu",
     "aarch64-unknown-linux-gnu",
     "x86_64-unknown-linux-musl",
     "aarch64-unknown-linux-musl",
 ):
-    if f'"target": "{target}"' not in non_darwin:
-        fail(f"classified build matrix does not preserve non-Darwin target {target} outside prepare-only")
+    if f'"target": "{target}"' not in matrix_program:
+        fail(f"classified build matrix does not preserve non-Darwin target {target}")
 
 expected_prepare_only = [
     {"target": "x86_64-apple-darwin", "os": "macos-latest", "archive": "tar.gz", "libc": "native"},
     {"target": "aarch64-apple-darwin", "os": "macos-latest", "archive": "tar.gz", "libc": "native"},
 ]
-expected_full = expected_prepare_only + [
-    {"target": "x86_64-unknown-linux-gnu", "os": "ubuntu-latest", "archive": "tar.gz", "libc": "gnu"},
-    {"target": "aarch64-unknown-linux-gnu", "os": "ubuntu-latest", "archive": "tar.gz", "libc": "gnu"},
+expected_musl_prepare_only = [
     {
         "target": "x86_64-unknown-linux-musl",
         "os": "ubuntu-latest",
@@ -271,36 +276,54 @@ expected_full = expected_prepare_only + [
         "image": "docker.io/library/rust@sha256:594694ee6b07747b63b5c265be2616b62e814180b66227e2c18c6ee85e4136be",
     },
 ]
-for case, prepare_only in (
-    ("true", "true"),
-    ("false", "false"),
-    ("empty", ""),
-    ("absent", None),
-):
-    case_env = os.environ.copy()
-    if prepare_only is None:
-        case_env.pop("PREPARE_ONLY", None)
-    else:
-        case_env["PREPARE_ONLY"] = prepare_only
-    result = subprocess.run(
-        [sys.executable, str(classifier)],
-        env=case_env,
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-    if result.returncode != 0:
-        fail(f"matrix classification failed for PREPARE_ONLY {case}: {result.stderr.strip()}")
-    try:
-        matrix = json.loads(result.stdout)
-    except json.JSONDecodeError as error:
-        fail(f"matrix classification emitted invalid JSON for PREPARE_ONLY {case}: {error}")
-    expected = expected_prepare_only if case == "true" else expected_full
-    if matrix != {"include": expected}:
-        fail(f"matrix classification has the wrong members for PREPARE_ONLY {case}")
-    if case == "true" and any(entry["os"] != "macos-latest" for entry in matrix["include"]):
-        fail("prepare-only matrix includes a non-Darwin runner")
-    print(f"prepare-only matrix {case}: {','.join(entry['target'] for entry in matrix['include'])}")
+expected_full = expected_prepare_only + [
+    {"target": "x86_64-unknown-linux-gnu", "os": "ubuntu-latest", "archive": "tar.gz", "libc": "gnu"},
+    {"target": "aarch64-unknown-linux-gnu", "os": "ubuntu-latest", "archive": "tar.gz", "libc": "gnu"},
+    *expected_musl_prepare_only,
+]
+for prepare_only in ("true", "false", "", None):
+    for prepare_set in ("darwin", "musl", "", None):
+        only_label = "absent" if prepare_only is None else (prepare_only or "empty")
+        set_label = "absent" if prepare_set is None else (prepare_set or "empty")
+        case = f"PREPARE_ONLY={only_label}/PREPARE_SET={set_label}"
+        case_env = os.environ.copy()
+        for name, value in (("PREPARE_ONLY", prepare_only), ("PREPARE_SET", prepare_set)):
+            if value is None:
+                case_env.pop(name, None)
+            else:
+                case_env[name] = value
+        result = subprocess.run(
+            [sys.executable, str(classifier)],
+            env=case_env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        should_fail = prepare_set == "musl" and prepare_only != "true"
+        if should_fail:
+            if result.returncode == 0:
+                fail("musl prepare_set without prepare_only must fail closed")
+            print(f"{case}: fail-closed")
+            continue
+        if result.returncode != 0:
+            fail(f"matrix classification failed for {case}: {result.stderr.strip()}")
+        try:
+            matrix = json.loads(result.stdout)
+        except json.JSONDecodeError as error:
+            fail(f"matrix classification emitted invalid JSON for {case}: {error}")
+        if prepare_only == "true" and prepare_set == "musl":
+            expected = expected_musl_prepare_only
+        elif prepare_only == "true":
+            expected = expected_prepare_only
+        else:
+            expected = expected_full
+        if matrix != {"include": expected}:
+            fail(f"matrix classification has the wrong members for {case}")
+        if prepare_only == "true" and prepare_set != "musl" and any(
+            entry["os"] != "macos-latest" for entry in matrix["include"]
+        ):
+            fail("Darwin prepare-only matrix includes a non-Darwin runner")
+        print(f"{case}: {','.join(entry['target'] for entry in matrix['include'])}")
 if 'matrix: ${{ fromJSON(needs.classify.outputs.build-matrix) }}' not in build:
     fail("build job does not consume the classified build matrix")
 require(


### PR DESCRIPTION
## Linked Issue

Related to #1817. This PR does not close the release tracking issue or parked Windows issue #1818.

## Summary

Successor on frozen parent `dc9ad36f`. Extend the existing protected-main `Release` `workflow_dispatch` path with a musl prepare-only set that builds and certifies the two Linux musl archives from exact packaged bytes. Darwin prepare-only remains the default prepare set. Native FSKit certification and GitHub release publication stay skipped in prepare-only mode.

This successor provisions pinned `b3sum` 1.8.5 for both the musl certification job and candidate-owned Check/test execution through `scripts/ci/setup_musl_certification.sh`. The helper installs that exact crate with `--locked`, verifies the known empty vector, and keeps product builds out of certification. Homemade or embedded BLAKE3 implementations are not used. `.github/workflows/ci.yml` is untouched.

This does not tag, publish, promote, bump versions, first-publish a Windows runtime archive, or dispatch prepare-only / musl certification.

## Changes

- `workflow_dispatch` keeps `prepare_only` and optional `prepare_set` (`darwin` | `musl`, default `darwin`).
- `prepare_only=true` with unset/darwin continues to build only the Darwin pair.
- `prepare_only=true` with `prepare_set=musl` builds only `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl`.
- `prepare_set=musl` without `prepare_only=true` fails closed.
- Non-prepare (tag/nightly) matrix is Darwin + GNU + musl. Windows remains out.
- `musl-certification` runs only for prepare-only musl, on `ubuntu-latest` (x86_64) and `ubuntu-24.04-arm` (aarch64). It downloads `binary-${{ matrix.target }}` from the same run by name and does not use cross-run `artifact-ids` / `run-id`.
- The cert job installs the Rust toolchain (`dtolnay/rust-toolchain@29eef336`, 1.95.0) and runs `scripts/ci/setup_musl_certification.sh` so pinned `b3sum` 1.8.5 exists before archive certification. It does not rebuild product binaries (`cargo build`, `cargo check`, `cargo test`, `-p astrid`, or `CARGO_TARGET_DIR` are forbidden in that job).
- `fskit-certification` and `github-release` remain skipped when `prepare_only` is true.
- `scripts/certify_musl_release_archive.sh` requires executable members `astrid`, `astrid-daemon`, `astrid-build`, `astrid-emit`, and `astrid-storage-provider-fuse`; staged identity is the basename. It fail-closes unless `b3sum` reports exactly version `1.8.5`, the known empty vector `af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262` matches, and staged bytes agree with the downloaded artifact via pinned `b3sum` and system `sha256sum`. Runtime `b3sum` invocations do not pass `--locked`.
- Check/test execution provisions the same real 1.8.5 binary through `scripts/ci/setup_musl_certification.sh --b3sum-only` without editing `ci.yml`.
- Musl images remain the existing official Rust 1.95.0 Alpine pins.
- `.github/workflows/release.yml` stays at 995 lines (`SRC_CAP=1000`).

## Verification

- Exact head `72690a08f2cc740cdc4a245c987a907cbcb47233`. Sole parent `dc9ad36f8cebd937cf0ed15c3f3a87235fd56b17`. Tree `f6f4b97b8f2450f5ead8921eb066c1666570202d`.
- `origin/main` `c057ff02d2f91a81dc0fc7f61d921cd2edf114c4` is an ancestor. Rejected unpublished `fb781397855f6b27797dd083842da0a4db538c1e` is not parent, ancestor, or cherry-pick.
- Unique files versus parent:
  - `.github/workflows/release.yml`
  - `scripts/ci/setup_musl_certification.sh`
  - `scripts/test_certify_musl_release_archive_contract.sh`
- Unique files versus `origin/main` also include:
  - `scripts/certify_musl_release_archive.sh`
  - `scripts/ci/test-release-contracts.sh`
  - `scripts/classify_release_build_matrix.py`
  - `scripts/test_channel_workflow_contract.sh`
- GPG Good key `7CD32E7697286B11593246B9FA53358CB4127512`; matching DCO present.
- Local: classifier 16-case matrix; `scripts/test_channel_workflow_contract.sh`; `scripts/test_certify_musl_release_archive_contract.sh`; `scripts/ci/test-release-contracts.sh`.
- `git diff --check` clean; `release.yml` is 995 lines; `ci.yml` is unchanged.

## Residuals and claim limits

- Source/workflow contract only. Do not dispatch prepare-only Darwin or musl certification from this PR.
- Predecessor exact-head verdicts on `dc9ad36f` do not transfer.
- Does not produce or recover a Darwin `binary-<triple>` for native FSKit certification.
- Does not land musl as a published 2026.9.0 inventory claim until certification later succeeds on landed main.
- Does not implement a Windows daemon, merge draft #1814, or restore Windows runtime archives.
- Does not bump, tag, publish, or close #1817 / #1818.

## AI / Tool Assistance

Assisted-by: Codex:zai-coding-responses/glm-5.3-flash

The prepare-only musl certification lane and this b3sum-provision successor were authored with Codex assistance in an isolated worktree. Exact SHA, unique file set, ancestry, signature, DCO, and local contract tests were independently verified. Independent exact-head review is required; this PR is not merge-ready on author evidence.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment skipped for this release-guard-only change; PR is labeled `skip-changelog`
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested the meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
