### PR TITLE
fix(release): use UUID request_id in musl archive certification

### DIFF
--- a/scripts/certify_musl_release_archive.sh
+++ b/scripts/certify_musl_release_archive.sh
@@ -252,11 +252,23 @@ python3 "$repo_root/scripts/check_static_elf.py" --architecture "$architecture" 
 timeout 180s "$bin/astrid" --principal default start
 timeout 30s "$bin/astrid" --principal default status
 
-request=$(python3 - <<-'PY'
+[[ -x /usr/bin/uuidgen ]] || fail "musl certification requires /usr/bin/uuidgen"
+request_id="$(/usr/bin/uuidgen)"
+if ! REQUEST_ID="$request_id" python3 - <<-'PY'
+import os
+import uuid
+
+uuid.UUID(os.environ["REQUEST_ID"])
+PY
+then
+  fail "provider request_id is not a UUID: $request_id"
+fi
+request=$(REQUEST_ID="$request_id" python3 - <<-'PY'
 import json
+import os
 print(json.dumps({
     "protocol_version": 1,
-    "request_id": "musl-release-certification",
+    "request_id": os.environ["REQUEST_ID"],
     "acting_principal_hint": "default",
     "operation": {
         "operation": "status",

--- a/scripts/test_certify_musl_release_archive_contract.sh
+++ b/scripts/test_certify_musl_release_archive_contract.sh
@@ -11,6 +11,7 @@ import subprocess
 import sys
 import tarfile
 import tempfile
+import uuid
 
 
 repo = pathlib.Path(sys.argv[1])
@@ -97,6 +98,8 @@ for fragment in (
     "b3sum_digest",
     "tarfile.open",
     "ASTRID_HOME=",
+    "/usr/bin/uuidgen",
+    "uuid.UUID",
     "--principal default start",
     "--principal default status",
     "storage mount",
@@ -123,6 +126,24 @@ for forbidden in ("class " + "Blake3", "blake3" + "_bytes", "hashlib", "import h
         fail(f"homemade or Python hashing remains in cert executable: {forbidden}")
 if "sha256sum_bin=$(command -v sha256sum)" not in script:
     fail("system sha256sum is not the production digest authority")
+if '"request_id": "musl-release-certification"' in script:
+    fail("literal non-UUID request_id remains")
+if "os.environ[\"REQUEST_ID\"]" not in script and "os.environ['REQUEST_ID']" not in script:
+    fail("provider request_id is not taken from generated UUID environment")
+try:
+    uuid.UUID("musl-release-certification")
+except ValueError:
+    pass
+else:
+    fail("uuid decoder unexpectedly accepted the failed-run request_id literal")
+generated = subprocess.run(
+    ["/usr/bin/uuidgen"],
+    check=True,
+    text=True,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+).stdout.strip()
+uuid.UUID(generated)
 for rejected in ("apple", "windows", "fskit"):
     if rejected not in script:
         fail(f"cert executable does not reject {rejected} companions")

--- a/scripts/test_certify_musl_release_archive_contract.sh
+++ b/scripts/test_certify_musl_release_archive_contract.sh
@@ -126,7 +126,9 @@ for forbidden in ("class " + "Blake3", "blake3" + "_bytes", "hashlib", "import h
         fail(f"homemade or Python hashing remains in cert executable: {forbidden}")
 if "sha256sum_bin=$(command -v sha256sum)" not in script:
     fail("system sha256sum is not the production digest authority")
-if '"request_id": "musl-release-certification"' in script:
+if "musl-release-certification" in script:
+    fail("failed-run request_id literal remains")
+if '"request_id": "musl-release-certification"' in script or '"request_id":"musl-release-certification"' in script:
     fail("literal non-UUID request_id remains")
 if "os.environ[\"REQUEST_ID\"]" not in script and "os.environ['REQUEST_ID']" not in script:
     fail("provider request_id is not taken from generated UUID environment")


### PR DESCRIPTION
## Linked Issue

Related to #1817. This PR does not close the release tracking issue or
parked Windows issue #1818.

## Summary

Prepare-only musl archive certification on landed `1897e086` failed after
successful builds because the packaged FUSE provider UUID-decodes
`request_id`. The cert script sent the literal
`musl-release-certification` and both musl cert jobs exited 2.

This successor generates a real UUID with pinned `/usr/bin/uuidgen`,
fail-closes unless Python `uuid.UUID` accepts it, and rejects that
failed-run literal in the contract independently of JSON spacing or
quoting. Stage-only packaging checks are unchanged. This does not rerun
prepare-only, dispatch Darwin, bump versions, tag, or publish.

## Changes

- `scripts/certify_musl_release_archive.sh` requires `/usr/bin/uuidgen`,
  generates `request_id` from it, UUID-decodes before the stdio probe,
  and passes that value into the provider JSON.
- `scripts/test_certify_musl_release_archive_contract.sh` fail-closes if
  the failed-run literal remains anywhere in the cert executable,
  including compact JSON (`"request_id":"..."`), requires the pinned
  generator plus `uuid.UUID`, and executes a real decoder against both
  the literal (must fail) and `/usr/bin/uuidgen` output (must parse).

## Verification

- Exact head `9070bada1934a11590ebf26236db08ab8cef8cb8`.
- Sole parent `7c5d317c02fc9ad8450ab2c90aa72fadb09ed9ad`.
- `origin/main` `1897e086549ac447c6b6cc47ad264a500ebe9fcb` remains an
  ancestor.
- Unique files versus `origin/main`:
  - `scripts/certify_musl_release_archive.sh`
  - `scripts/test_certify_musl_release_archive_contract.sh`
- Unique versus parent: `scripts/test_certify_musl_release_archive_contract.sh`
  only. Production cert script is unchanged from the parent.
- GPG Good [full] EDDSA key `7CD32E7697286B11593246B9FA53358CB4127512`
  with matching DCO.
- `bash -n` on both files; `git diff --check` clean.
- `scripts/test_certify_musl_release_archive_contract.sh` PASS.
- `scripts/ci/test-release-contracts.sh` PASS.

Independent exact-head review is required; predecessor review of
`7c5d317c` does not transfer. This PR is not merge-ready on author
evidence. Do not dispatch prepare-only until this lands.

## Residuals and claim limits

- Failed run `33947544507` artifacts are unsigned build evidence only,
  not certified musl, not inventory 20.
- Does not change FSKit companion identity-probe semantics.
- Does not dispatch Darwin or musl prepare-only.
- Does not bump, tag, publish, or close #1817 / #1818.
- `ASTRID_HOME` ownership warning from the failed run is out of scope.

## AI / Tool Assistance

Assisted-by: Codex:grok-oauth/grok-4.6

The UUID request_id repair and the serialization-independent literal
check were authored in an isolated worktree. Exact SHA, unique file set,
ancestry, signature, DCO, and local contract tests were independently
verified. Independent exact-head review is required.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment skipped for this release-guard-only change; PR
is labeled `skip-changelog`
- [x] I understand every change in this PR and can explain its design,
risks, and validation.
- [x] I reviewed and tested the meaningful tool-generated output
included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by`
trailer.
