### PR TITLE
fix(storage): surface bounded FUSE child stderr on launch failure

### DIFF
--- a/crates/astrid-storage-provider-fuse/src/main.rs
+++ b/crates/astrid-storage-provider-fuse/src/main.rs
@@ -269,6 +269,23 @@ async fn mount(
     if ready.pid == 0 {
         bail!("detached FUSE service returned an invalid process identity");
     }
+    let control_ready = call_control(
+        &control_path,
+        &ControlRequest::Status {
+            requested_by: launch.requested_by.clone(),
+        },
+    )
+    .and_then(|response| require_ready_control_response(response, lease.access));
+    if let Err(error) = control_ready {
+        let _ = control_unmount(&control_path, &launch.requested_by);
+        let _ = client
+            .request(AdminRequestKind::StorageMountRevoke {
+                mount_id: lease.mount_id,
+            })
+            .await;
+        cleanup_mountpoint(&mountpoint, auto_created)?;
+        return Err(error.context("detached FUSE service failed its readiness handshake"));
+    }
     let record = registry::MountRecord {
         mount_id: lease.mount_id,
         requested_by: launch.requested_by,
@@ -291,6 +308,24 @@ async fn mount(
         mount_id: lease.mount_id,
         mountpoint,
     })
+}
+
+fn require_ready_control_response(
+    response: ControlResponse,
+    expected_access: StorageProviderAccessV1,
+) -> Result<()> {
+    match response {
+        ControlResponse::Status { access } if access == expected_access => Ok(()),
+        ControlResponse::Status { access } => {
+            bail!("detached FUSE service readiness access {access:?} does not match its lease")
+        },
+        ControlResponse::Failure { code, message } => {
+            bail!("detached FUSE service readiness failed [{code}]: {message}")
+        },
+        ControlResponse::Done => {
+            bail!("detached FUSE service returned an incompatible readiness response")
+        },
+    }
 }
 
 async fn sync(
@@ -856,7 +891,10 @@ fn into_success(body: AdminResponseBody) -> Result<serde_json::Value> {
 
 #[cfg(test)]
 mod launcher_tests {
-    use super::require_service_running_after_handoff;
+    use super::{
+        ControlResponse, StorageProviderAccessV1, require_ready_control_response,
+        require_service_running_after_handoff,
+    };
     use anyhow::Result;
 
     #[tokio::test]
@@ -884,6 +922,31 @@ mod launcher_tests {
         child.kill().await?;
         let _ = child.wait().await?;
         Ok(())
+    }
+
+    #[test]
+    fn readiness_requires_a_matching_authenticated_status_response() {
+        require_ready_control_response(
+            ControlResponse::Status {
+                access: StorageProviderAccessV1::ReadWrite,
+            },
+            StorageProviderAccessV1::ReadWrite,
+        )
+        .expect("matching status must prove control readiness");
+
+        for response in [
+            ControlResponse::Status {
+                access: StorageProviderAccessV1::ReadOnly,
+            },
+            ControlResponse::Failure {
+                code: "not-ready".to_owned(),
+                message: "service rejected readiness".to_owned(),
+            },
+            ControlResponse::Done,
+        ] {
+            require_ready_control_response(response, StorageProviderAccessV1::ReadWrite)
+                .expect_err("non-matching control responses must fail closed");
+        }
     }
 }
 

--- a/crates/astrid-storage-provider-fuse/src/main.rs
+++ b/crates/astrid-storage-provider-fuse/src/main.rs
@@ -10,34 +10,75 @@ fn main() -> std::process::ExitCode {
 }
 
 #[cfg(any(target_os = "linux", test))]
-const MAX_FUSE_STDERR_CHARS: usize = 1024;
+const MAX_FUSE_STDERR_BYTES: usize = 1024;
+
+#[cfg(any(target_os = "linux", test))]
+const MAX_PROVIDER_FAILURE_BYTES: usize = 4096;
+
+#[cfg(any(target_os = "linux", test))]
+fn bounded_utf8(input: impl Iterator<Item = char>, max_bytes: usize) -> String {
+    let mut bounded = String::with_capacity(max_bytes);
+    for character in input {
+        if bounded
+            .len()
+            .checked_add(character.len_utf8())
+            .is_none_or(|length| length > max_bytes)
+        {
+            break;
+        }
+        bounded.push(character);
+    }
+    bounded
+}
 
 #[cfg(any(target_os = "linux", test))]
 fn bounded_stderr_snippet(bytes: &[u8]) -> String {
-    String::from_utf8_lossy(bytes)
-        .chars()
-        .filter(|character| !character.is_control())
-        .take(MAX_FUSE_STDERR_CHARS)
-        .collect()
+    bounded_utf8(
+        String::from_utf8_lossy(bytes)
+            .chars()
+            .filter(|character| !character.is_control()),
+        MAX_FUSE_STDERR_BYTES,
+    )
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn bounded_failure_message(message: &str) -> String {
+    bounded_utf8(message.chars(), MAX_PROVIDER_FAILURE_BYTES)
 }
 
 #[cfg(test)]
 mod stderr_tests {
-    use super::{MAX_FUSE_STDERR_CHARS, bounded_stderr_snippet};
+    use super::{
+        MAX_FUSE_STDERR_BYTES, MAX_PROVIDER_FAILURE_BYTES, bounded_failure_message,
+        bounded_stderr_snippet,
+    };
 
     #[test]
     fn bounded_stderr_snippet_is_lossy_control_free_and_secret_bounded() {
-        let secret = format!("lease-token={}", "a".repeat(MAX_FUSE_STDERR_CHARS));
+        let secret = format!("lease-token={}", "a".repeat(MAX_FUSE_STDERR_BYTES));
         let mut bytes = vec![0, 0xff, b'\n'];
         bytes.extend_from_slice(secret.as_bytes());
 
         let snippet = bounded_stderr_snippet(&bytes);
 
-        assert_eq!(snippet.chars().count(), MAX_FUSE_STDERR_CHARS);
+        assert_eq!(snippet.len(), MAX_FUSE_STDERR_BYTES);
         assert!(snippet.starts_with('\u{fffd}'));
         assert!(snippet.chars().all(|character| !character.is_control()));
         assert!(!snippet.contains(&secret));
         assert_ne!(snippet, String::from_utf8_lossy(&bytes));
+    }
+
+    #[test]
+    fn bounded_messages_respect_protocol_byte_limits_for_multibyte_text() {
+        let multibyte = "😀".repeat(MAX_PROVIDER_FAILURE_BYTES);
+
+        let snippet = bounded_stderr_snippet(multibyte.as_bytes());
+        let failure = bounded_failure_message(&multibyte);
+
+        assert_eq!(snippet.len(), MAX_FUSE_STDERR_BYTES);
+        assert_eq!(failure.len(), MAX_PROVIDER_FAILURE_BYTES);
+        assert!(snippet.is_char_boundary(snippet.len()));
+        assert!(failure.is_char_boundary(failure.len()));
     }
 }
 
@@ -128,7 +169,7 @@ async fn run_stdio() -> Result<()> {
         Ok(success) => StorageProviderOutcomeV1::Success(success),
         Err(error) => StorageProviderOutcomeV1::Failure(StorageProviderFailureV1 {
             code: "provider-operation".to_owned(),
-            message: error.to_string().chars().take(4096).collect(),
+            message: bounded_failure_message(&error.to_string()),
         }),
     };
     let response = StorageProviderResponseV1 {
@@ -386,6 +427,12 @@ async fn run_public_service() -> Result<()> {
     stdout.write_all(&startup_bytes)?;
     stdout.write_all(b"\n")?;
     stdout.flush()?;
+    let stderr_sink = std::fs::OpenOptions::new()
+        .write(true)
+        .open("/dev/null")
+        .context("open detached FUSE stderr sink")?;
+    nix::unistd::dup2_stderr(&stderr_sink).context("hand off detached FUSE stderr sink")?;
+    drop(stderr_sink);
 
     let result = service_loop(&listener, &launch, &mut session).await;
     cleanup_service_artifacts(
@@ -473,7 +520,7 @@ async fn live_control_status(
 fn failure_response(code: &str, message: &str) -> ControlResponse {
     ControlResponse::Failure {
         code: code.to_owned(),
-        message: message.chars().take(4096).collect(),
+        message: bounded_failure_message(message),
     }
 }
 
@@ -495,14 +542,14 @@ async fn launch_service(launch: &ServiceLaunch, control_path: &Path) -> Result<C
         return Err(anyhow::anyhow!("FUSE service stderr is unavailable")
             .context(format!("detached FUSE service status: {status:?}")));
     };
-    let stderr_task = tokio::spawn(async move {
-        let mut bytes = Vec::with_capacity(MAX_FUSE_STDERR_CHARS + 1);
+    let mut stderr_task = tokio::spawn(async move {
+        let mut bytes = Vec::with_capacity(MAX_FUSE_STDERR_BYTES + 1);
         let mut buffer = [0_u8; 4096];
         while let Ok(read) = stderr.read(&mut buffer).await {
             if read == 0 {
                 break;
             }
-            let remaining = (MAX_FUSE_STDERR_CHARS + 1).saturating_sub(bytes.len());
+            let remaining = (MAX_FUSE_STDERR_BYTES + 1).saturating_sub(bytes.len());
             bytes.extend_from_slice(&buffer[..read.min(remaining)]);
         }
         bytes
@@ -510,10 +557,25 @@ async fn launch_service(launch: &ServiceLaunch, control_path: &Path) -> Result<C
     let startup = read_service_startup(&mut child, launch, control_path).await;
     match startup {
         Ok(ready) => {
-            tokio::spawn(async move {
-                let _ = tokio::join!(child.wait(), stderr_task);
-            });
-            Ok(ready)
+            match tokio::time::timeout(Duration::from_secs(1), &mut stderr_task).await {
+                Ok(Ok(_)) => {
+                    drop(child);
+                    Ok(ready)
+                },
+                Ok(Err(error)) => {
+                    let _ = child.kill().await;
+                    let status = child.wait().await;
+                    Err(anyhow::anyhow!("detached FUSE stderr drain failed: {error}")
+                        .context(format!("detached FUSE service status: {status:?}")))
+                },
+                Err(_) => {
+                    stderr_task.abort();
+                    let _ = child.kill().await;
+                    let status = child.wait().await;
+                    Err(anyhow::anyhow!("detached FUSE stderr sink handoff timed out")
+                        .context(format!("detached FUSE service status: {status:?}")))
+                },
+            }
         },
         Err(error) => {
             let _ = child.kill().await;

--- a/crates/astrid-storage-provider-fuse/src/main.rs
+++ b/crates/astrid-storage-provider-fuse/src/main.rs
@@ -417,6 +417,12 @@ async fn run_public_service() -> Result<()> {
             return Err(error);
         },
     };
+    let stderr_sink = std::fs::OpenOptions::new()
+        .write(true)
+        .open("/dev/null")
+        .context("open detached FUSE stderr sink")?;
+    nix::unistd::dup2_stderr(&stderr_sink).context("hand off detached FUSE stderr sink")?;
+    drop(stderr_sink);
     let startup = ServiceStartup::Ready {
         mount_id: lease.mount_id,
         pid: std::process::id(),
@@ -427,12 +433,6 @@ async fn run_public_service() -> Result<()> {
     stdout.write_all(&startup_bytes)?;
     stdout.write_all(b"\n")?;
     stdout.flush()?;
-    let stderr_sink = std::fs::OpenOptions::new()
-        .write(true)
-        .open("/dev/null")
-        .context("open detached FUSE stderr sink")?;
-    nix::unistd::dup2_stderr(&stderr_sink).context("hand off detached FUSE stderr sink")?;
-    drop(stderr_sink);
 
     let result = service_loop(&listener, &launch, &mut session).await;
     cleanup_service_artifacts(

--- a/crates/astrid-storage-provider-fuse/src/main.rs
+++ b/crates/astrid-storage-provider-fuse/src/main.rs
@@ -545,22 +545,29 @@ async fn launch_service(launch: &ServiceLaunch, control_path: &Path) -> Result<C
     let mut stderr_task = tokio::spawn(async move {
         let mut bytes = Vec::with_capacity(MAX_FUSE_STDERR_BYTES + 1);
         let mut buffer = [0_u8; 4096];
-        while let Ok(read) = stderr.read(&mut buffer).await {
+        loop {
+            let read = stderr.read(&mut buffer).await?;
             if read == 0 {
                 break;
             }
             let remaining = (MAX_FUSE_STDERR_BYTES + 1).saturating_sub(bytes.len());
             bytes.extend_from_slice(&buffer[..read.min(remaining)]);
         }
-        bytes
+        std::io::Result::Ok(bytes)
     });
     let startup = read_service_startup(&mut child, launch, control_path).await;
     match startup {
         Ok(ready) => {
             match tokio::time::timeout(Duration::from_secs(1), &mut stderr_task).await {
-                Ok(Ok(_)) => {
-                    drop(child);
-                    Ok(ready)
+                Ok(Ok(Ok(_))) => require_service_running_after_handoff(&mut child)
+                    .await
+                    .map(|()| ready),
+                Ok(Ok(Err(error))) => {
+                    let _ = child.kill().await;
+                    let status = child.wait().await;
+                    Err(anyhow::Error::new(error)
+                        .context("read detached FUSE stderr during sink handoff")
+                        .context(format!("detached FUSE service status: {status:?}")))
                 },
                 Ok(Err(error)) => {
                     let _ = child.kill().await;
@@ -581,8 +588,8 @@ async fn launch_service(launch: &ServiceLaunch, control_path: &Path) -> Result<C
             let _ = child.kill().await;
             let status = child.wait().await;
             let stderr = match stderr_task.await {
-                Ok(bytes) => bounded_stderr_snippet(&bytes),
-                Err(_) => String::new(),
+                Ok(Ok(bytes)) => bounded_stderr_snippet(&bytes),
+                Ok(Err(_)) | Err(_) => String::new(),
             };
             let status_context = format!("detached FUSE service status: {status:?}");
             if stderr.is_empty() {
@@ -590,6 +597,22 @@ async fn launch_service(launch: &ServiceLaunch, control_path: &Path) -> Result<C
             } else {
                 Err(error.context(format!("{status_context}; stderr: {stderr}")))
             }
+        },
+    }
+}
+
+async fn require_service_running_after_handoff(
+    child: &mut tokio::process::Child,
+) -> Result<()> {
+    match child.try_wait() {
+        Ok(None) => Ok(()),
+        Ok(Some(status)) => bail!("detached FUSE service exited after readiness: {status}"),
+        Err(error) => {
+            let _ = child.kill().await;
+            let status = child.wait().await;
+            Err(anyhow::Error::new(error)
+                .context("inspect detached FUSE service after stderr sink handoff")
+                .context(format!("detached FUSE service status: {status:?}")))
         },
     }
 }
@@ -828,6 +851,39 @@ fn into_success(body: AdminResponseBody) -> Result<serde_json::Value> {
             bail!("kernel refused storage lifecycle request: {error}")
         },
         _ => bail!("kernel returned an unexpected storage lifecycle response"),
+    }
+}
+
+#[cfg(test)]
+mod launcher_tests {
+    use super::require_service_running_after_handoff;
+    use anyhow::Result;
+
+    #[tokio::test]
+    async fn stderr_handoff_rejects_a_service_that_already_exited() -> Result<()> {
+        let mut child = tokio::process::Command::new("/bin/sh")
+            .args(["-c", "exit 0"])
+            .spawn()?;
+        let status = child.wait().await?;
+        assert!(status.success());
+
+        let error = require_service_running_after_handoff(&mut child)
+            .await
+            .expect_err("an exited service must not be registered as ready");
+        assert!(error.to_string().contains("exited after readiness"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stderr_handoff_accepts_a_service_that_is_still_running() -> Result<()> {
+        let mut child = tokio::process::Command::new("/bin/sh")
+            .args(["-c", "sleep 30"])
+            .spawn()?;
+
+        require_service_running_after_handoff(&mut child).await?;
+        child.kill().await?;
+        let _ = child.wait().await?;
+        Ok(())
     }
 }
 

--- a/crates/astrid-storage-provider-fuse/src/main.rs
+++ b/crates/astrid-storage-provider-fuse/src/main.rs
@@ -9,6 +9,38 @@ fn main() -> std::process::ExitCode {
     std::process::ExitCode::from(2)
 }
 
+#[cfg(any(target_os = "linux", test))]
+const MAX_FUSE_STDERR_CHARS: usize = 1024;
+
+#[cfg(any(target_os = "linux", test))]
+fn bounded_stderr_snippet(bytes: &[u8]) -> String {
+    String::from_utf8_lossy(bytes)
+        .chars()
+        .filter(|character| !character.is_control())
+        .take(MAX_FUSE_STDERR_CHARS)
+        .collect()
+}
+
+#[cfg(test)]
+mod stderr_tests {
+    use super::{MAX_FUSE_STDERR_CHARS, bounded_stderr_snippet};
+
+    #[test]
+    fn bounded_stderr_snippet_is_lossy_control_free_and_secret_bounded() {
+        let secret = format!("lease-token={}", "a".repeat(MAX_FUSE_STDERR_CHARS));
+        let mut bytes = vec![0, 0xff, b'\n'];
+        bytes.extend_from_slice(secret.as_bytes());
+
+        let snippet = bounded_stderr_snippet(&bytes);
+
+        assert_eq!(snippet.chars().count(), MAX_FUSE_STDERR_CHARS);
+        assert!(snippet.starts_with('\u{fffd}'));
+        assert!(snippet.chars().all(|character| !character.is_control()));
+        assert!(!snippet.contains(&secret));
+        assert_ne!(snippet, String::from_utf8_lossy(&bytes));
+    }
+}
+
 #[cfg(target_os = "linux")]
 macro_rules! linux_only {
     ($($item:item)*) => {
@@ -454,21 +486,49 @@ async fn launch_service(launch: &ServiceLaunch, control_path: &Path) -> Result<C
         .arg(PUBLIC_SERVICE_ARGUMENT)
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::null());
+        .stderr(std::process::Stdio::piped());
     command.as_std_mut().process_group(0);
     let mut child = command.spawn()?;
+    let Some(mut stderr) = child.stderr.take() else {
+        let _ = child.kill().await;
+        let status = child.wait().await;
+        return Err(anyhow::anyhow!("FUSE service stderr is unavailable")
+            .context(format!("detached FUSE service status: {status:?}")));
+    };
+    let stderr_task = tokio::spawn(async move {
+        let mut bytes = Vec::with_capacity(MAX_FUSE_STDERR_CHARS + 1);
+        let mut buffer = [0_u8; 4096];
+        while let Ok(read) = stderr.read(&mut buffer).await {
+            if read == 0 {
+                break;
+            }
+            let remaining = (MAX_FUSE_STDERR_CHARS + 1).saturating_sub(bytes.len());
+            bytes.extend_from_slice(&buffer[..read.min(remaining)]);
+        }
+        bytes
+    });
     let startup = read_service_startup(&mut child, launch, control_path).await;
     match startup {
         Ok(ready) => {
             tokio::spawn(async move {
                 let _ = child.wait().await;
             });
+            drop(stderr_task);
             Ok(ready)
         },
         Err(error) => {
             let _ = child.kill().await;
             let status = child.wait().await;
-            Err(error.context(format!("detached FUSE service status: {status:?}")))
+            let stderr = match stderr_task.await {
+                Ok(bytes) => bounded_stderr_snippet(&bytes),
+                Err(_) => String::new(),
+            };
+            let status_context = format!("detached FUSE service status: {status:?}");
+            if stderr.is_empty() {
+                Err(error.context(status_context))
+            } else {
+                Err(error.context(format!("{status_context}; stderr: {stderr}")))
+            }
         },
     }
 }

--- a/crates/astrid-storage-provider-fuse/src/main.rs
+++ b/crates/astrid-storage-provider-fuse/src/main.rs
@@ -247,26 +247,16 @@ async fn mount(
     let ready = match startup {
         Ok(ready) => ready,
         Err(error) => {
-            let _ = client
-                .request(AdminRequestKind::StorageMountRevoke {
-                    mount_id: lease.mount_id,
-                })
-                .await;
-            cleanup_mountpoint(&mountpoint, auto_created)?;
+            rollback_unregistered_mount(client, &launch, &control_path).await;
             return Err(error);
         },
     };
     if ready.mount_id != lease.mount_id || ready.access != lease.access {
-        let _ = control_unmount(&control_path, &launch.requested_by);
-        let _ = client
-            .request(AdminRequestKind::StorageMountRevoke {
-                mount_id: lease.mount_id,
-            })
-            .await;
-        cleanup_mountpoint(&mountpoint, auto_created)?;
+        rollback_unregistered_mount(client, &launch, &control_path).await;
         bail!("detached FUSE service returned a mismatched lease identity");
     }
     if ready.pid == 0 {
+        rollback_unregistered_mount(client, &launch, &control_path).await;
         bail!("detached FUSE service returned an invalid process identity");
     }
     let control_ready = call_control(
@@ -277,13 +267,7 @@ async fn mount(
     )
     .and_then(|response| require_ready_control_response(response, lease.access));
     if let Err(error) = control_ready {
-        let _ = control_unmount(&control_path, &launch.requested_by);
-        let _ = client
-            .request(AdminRequestKind::StorageMountRevoke {
-                mount_id: lease.mount_id,
-            })
-            .await;
-        cleanup_mountpoint(&mountpoint, auto_created)?;
+        rollback_unregistered_mount(client, &launch, &control_path).await;
         return Err(error.context("detached FUSE service failed its readiness handshake"));
     }
     let record = registry::MountRecord {
@@ -295,19 +279,42 @@ async fn mount(
         control_path: control_path.clone(),
     };
     if let Err(error) = registry::write_record(&record) {
-        let _ = control_unmount(&control_path, &record.requested_by);
-        let _ = client
-            .request(AdminRequestKind::StorageMountRevoke {
-                mount_id: lease.mount_id,
-            })
-            .await;
-        cleanup_mountpoint(&mountpoint, auto_created)?;
+        rollback_unregistered_mount(
+            client,
+            &ServiceLaunch {
+                lease,
+                requested_by: record.requested_by.clone(),
+                mountpoint: mountpoint.clone(),
+                auto_created_mountpoint: auto_created,
+            },
+            &control_path,
+        )
+        .await;
         return Err(error);
     }
     Ok(StorageProviderSuccessV1::Mounted {
         mount_id: lease.mount_id,
         mountpoint,
     })
+}
+
+async fn rollback_unregistered_mount(
+    client: &mut AdminClient,
+    launch: &ServiceLaunch,
+    control_path: &Path,
+) {
+    let _ = control_unmount(control_path, &launch.requested_by);
+    let _ = client
+        .request(AdminRequestKind::StorageMountRevoke {
+            mount_id: launch.lease.mount_id,
+        })
+        .await;
+    let _ = mountpoint::lazy_unmount(&launch.mountpoint);
+    let _ = cleanup_service_artifacts(
+        control_path,
+        &launch.mountpoint,
+        launch.auto_created_mountpoint,
+    );
 }
 
 fn require_ready_control_response(

--- a/crates/astrid-storage-provider-fuse/src/main.rs
+++ b/crates/astrid-storage-provider-fuse/src/main.rs
@@ -247,17 +247,16 @@ async fn mount(
     let ready = match startup {
         Ok(ready) => ready,
         Err(error) => {
-            rollback_unregistered_mount(client, &launch, &control_path).await;
-            return Err(error);
+            return Err(rollback_mount_error(error, client, &launch, &control_path).await);
         },
     };
     if ready.mount_id != lease.mount_id || ready.access != lease.access {
-        rollback_unregistered_mount(client, &launch, &control_path).await;
-        bail!("detached FUSE service returned a mismatched lease identity");
+        let error = anyhow::anyhow!("detached FUSE service returned a mismatched lease identity");
+        return Err(rollback_mount_error(error, client, &launch, &control_path).await);
     }
     if ready.pid == 0 {
-        rollback_unregistered_mount(client, &launch, &control_path).await;
-        bail!("detached FUSE service returned an invalid process identity");
+        let error = anyhow::anyhow!("detached FUSE service returned an invalid process identity");
+        return Err(rollback_mount_error(error, client, &launch, &control_path).await);
     }
     let control_ready = call_control(
         &control_path,
@@ -267,30 +266,19 @@ async fn mount(
     )
     .and_then(|response| require_ready_control_response(response, lease.access));
     if let Err(error) = control_ready {
-        rollback_unregistered_mount(client, &launch, &control_path).await;
-        return Err(error.context("detached FUSE service failed its readiness handshake"));
+        let error = error.context("detached FUSE service failed its readiness handshake");
+        return Err(rollback_mount_error(error, client, &launch, &control_path).await);
     }
     let record = registry::MountRecord {
         mount_id: lease.mount_id,
-        requested_by: launch.requested_by,
+        requested_by: launch.requested_by.clone(),
         mountpoint: mountpoint.clone(),
         access: lease.access,
         auto_created_mountpoint: auto_created,
         control_path: control_path.clone(),
     };
     if let Err(error) = registry::write_record(&record) {
-        rollback_unregistered_mount(
-            client,
-            &ServiceLaunch {
-                lease,
-                requested_by: record.requested_by.clone(),
-                mountpoint: mountpoint.clone(),
-                auto_created_mountpoint: auto_created,
-            },
-            &control_path,
-        )
-        .await;
-        return Err(error);
+        return Err(rollback_mount_error(error, client, &launch, &control_path).await);
     }
     Ok(StorageProviderSuccessV1::Mounted {
         mount_id: lease.mount_id,
@@ -298,23 +286,55 @@ async fn mount(
     })
 }
 
+async fn rollback_mount_error(
+    error: anyhow::Error,
+    client: &mut AdminClient,
+    launch: &ServiceLaunch,
+    control_path: &Path,
+) -> anyhow::Error {
+    match rollback_unregistered_mount(client, launch, control_path).await {
+        Ok(()) => error,
+        Err(rollback_error) => error.context(format!(
+            "failed to fully roll back unregistered FUSE mount: {rollback_error:#}"
+        )),
+    }
+}
+
 async fn rollback_unregistered_mount(
     client: &mut AdminClient,
     launch: &ServiceLaunch,
     control_path: &Path,
-) {
-    let _ = control_unmount(control_path, &launch.requested_by);
-    let _ = client
+) -> Result<()> {
+    let mut failures = Vec::new();
+    if let Err(error) = control_unmount(control_path, &launch.requested_by) {
+        failures.push(format!("control unmount: {error:#}"));
+    }
+    if let Err(error) = client
         .request(AdminRequestKind::StorageMountRevoke {
             mount_id: launch.lease.mount_id,
         })
-        .await;
-    let _ = mountpoint::lazy_unmount(&launch.mountpoint);
-    let _ = cleanup_service_artifacts(
-        control_path,
-        &launch.mountpoint,
-        launch.auto_created_mountpoint,
-    );
+        .await
+        .and_then(into_success)
+    {
+        failures.push(format!("revoke mount lease: {error:#}"));
+    }
+    match mountpoint::lazy_unmount(&launch.mountpoint) {
+        Ok(()) => {
+            if let Err(error) = cleanup_service_artifacts(
+                control_path,
+                &launch.mountpoint,
+                launch.auto_created_mountpoint,
+            ) {
+                failures.push(format!("remove service artifacts: {error:#}"));
+            }
+        },
+        Err(error) => failures.push(format!("detach mountpoint: {error:#}")),
+    }
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        bail!("{}", failures.join("; "))
+    }
 }
 
 fn require_ready_control_response(

--- a/crates/astrid-storage-provider-fuse/src/main.rs
+++ b/crates/astrid-storage-provider-fuse/src/main.rs
@@ -294,9 +294,9 @@ async fn rollback_mount_error(
 ) -> anyhow::Error {
     match rollback_unregistered_mount(client, launch, control_path).await {
         Ok(()) => error,
-        Err(rollback_error) => error.context(format!(
-            "failed to fully roll back unregistered FUSE mount: {rollback_error:#}"
-        )),
+        Err(rollback_error) => anyhow::anyhow!(
+            "{error:#}; failed to fully roll back unregistered FUSE mount: {rollback_error:#}"
+        ),
     }
 }
 

--- a/crates/astrid-storage-provider-fuse/src/main.rs
+++ b/crates/astrid-storage-provider-fuse/src/main.rs
@@ -511,9 +511,8 @@ async fn launch_service(launch: &ServiceLaunch, control_path: &Path) -> Result<C
     match startup {
         Ok(ready) => {
             tokio::spawn(async move {
-                let _ = child.wait().await;
+                let _ = tokio::join!(child.wait(), stderr_task);
             });
-            drop(stderr_task);
             Ok(ready)
         },
         Err(error) => {

--- a/crates/astrid-storage-provider-fuse/src/main.rs
+++ b/crates/astrid-storage-provider-fuse/src/main.rs
@@ -123,6 +123,7 @@ mod control;
 mod filesystem;
 mod mountpoint;
 mod registry;
+mod rollback;
 mod service;
 
 const PROVIDER_NAME: &str = "astrid-storage-provider-fuse";
@@ -292,12 +293,10 @@ async fn rollback_mount_error(
     launch: &ServiceLaunch,
     control_path: &Path,
 ) -> anyhow::Error {
-    match rollback_unregistered_mount(client, launch, control_path).await {
-        Ok(()) => error,
-        Err(rollback_error) => anyhow::anyhow!(
-            "{error:#}; failed to fully roll back unregistered FUSE mount: {rollback_error:#}"
-        ),
-    }
+    rollback::preserve_launch_error(
+        error,
+        rollback_unregistered_mount(client, launch, control_path).await,
+    )
 }
 
 async fn rollback_unregistered_mount(
@@ -318,23 +317,17 @@ async fn rollback_unregistered_mount(
     {
         failures.push(format!("revoke mount lease: {error:#}"));
     }
-    match mountpoint::lazy_unmount(&launch.mountpoint) {
-        Ok(()) => {
-            if let Err(error) = cleanup_service_artifacts(
+    rollback::finish_cleanup(
+        failures,
+        mountpoint::lazy_unmount(&launch.mountpoint),
+        || {
+            cleanup_service_artifacts(
                 control_path,
                 &launch.mountpoint,
                 launch.auto_created_mountpoint,
-            ) {
-                failures.push(format!("remove service artifacts: {error:#}"));
-            }
+            )
         },
-        Err(error) => failures.push(format!("detach mountpoint: {error:#}")),
-    }
-    if failures.is_empty() {
-        Ok(())
-    } else {
-        bail!("{}", failures.join("; "))
-    }
+    )
 }
 
 fn require_ready_control_response(

--- a/crates/astrid-storage-provider-fuse/src/rollback.rs
+++ b/crates/astrid-storage-provider-fuse/src/rollback.rs
@@ -1,0 +1,90 @@
+//! Fail-closed completion for mounts that never reached the durable registry.
+
+use anyhow::{Result, bail};
+
+pub(crate) fn preserve_launch_error(
+    launch_error: anyhow::Error,
+    rollback: Result<()>,
+) -> anyhow::Error {
+    match rollback {
+        Ok(()) => launch_error,
+        Err(rollback_error) => anyhow::anyhow!(
+            "{launch_error:#}; failed to fully roll back unregistered FUSE mount: {rollback_error:#}"
+        ),
+    }
+}
+
+pub(crate) fn finish_cleanup(
+    mut failures: Vec<String>,
+    detach: Result<()>,
+    cleanup: impl FnOnce() -> Result<()>,
+) -> Result<()> {
+    match detach {
+        Ok(()) => {
+            if let Err(error) = cleanup() {
+                failures.push(format!("remove service artifacts: {error:#}"));
+            }
+        },
+        Err(error) => failures.push(format!("detach mountpoint: {error:#}")),
+    }
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        bail!("{}", failures.join("; "))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+
+    use super::*;
+
+    #[test]
+    fn failed_detach_retains_artifacts_and_preserves_every_failure() {
+        let cleanup_called = Cell::new(false);
+        let rollback = finish_cleanup(
+            vec![
+                "control unmount: refused".to_owned(),
+                "revoke mount lease: denied".to_owned(),
+            ],
+            Err(anyhow::anyhow!("busy")),
+            || {
+                cleanup_called.set(true);
+                Ok(())
+            },
+        );
+        assert!(!cleanup_called.get());
+
+        let failure = preserve_launch_error(
+            anyhow::anyhow!("child exited").context("start detached FUSE service"),
+            rollback,
+        );
+        let message = failure.to_string();
+        for expected in [
+            "start detached FUSE service: child exited",
+            "control unmount: refused",
+            "revoke mount lease: denied",
+            "detach mountpoint: busy",
+        ] {
+            assert!(message.contains(expected), "missing {expected:?} in {message:?}");
+        }
+    }
+
+    #[test]
+    fn successful_detach_runs_cleanup_and_reports_its_failure() {
+        let cleanup_called = Cell::new(false);
+        let error = finish_cleanup(Vec::new(), Ok(()), || {
+            cleanup_called.set(true);
+            Err(anyhow::anyhow!("socket retained"))
+        })
+        .expect_err("artifact cleanup failure must remain visible");
+
+        assert!(cleanup_called.get());
+        assert!(
+            error
+                .to_string()
+                .contains("remove service artifacts: socket retained")
+        );
+    }
+}


### PR DESCRIPTION
## Linked Issue

Closes #1856

## Summary

When the detached Linux FUSE public-service child exits before readiness, include a strictly bounded, control-stripped stderr snippet alongside the existing wait status. After readiness, hand stderr to `/dev/null`, require the startup pipe to reach EOF, and reject a child that has already exited before registration.

This is a diagnostic and launch-integrity repair so musl archive certification can name the inner mount error without registering a dead service. It does not attempt a fusermount/product fix.

Exact head: `d8f236bbd4471ec0e80d55a4533cbda44e3d4b12`
Base: `8e95ca578a8bc00960942d23c55a13ad9d22b2e4`

## Changes

- Pipe detached-child stderr instead of discarding it.
- On pre-readiness failure, attach up to 1024 sanitized bytes to the existing status context.
- Hand the detached service's stderr to `/dev/null` before announcing readiness and require the startup pipe to reach EOF.
- Propagate stderr-reader errors and refuse to register a service that exited after `Ready`.
- Require an authenticated control `Status` response with lease-matching access immediately before registry persistence; roll back the mount lease on failure.
- Route every pre-registration failure through one rollback path that attempts control unmount, lease revocation, and lazy detach; preserve the original launch failure and append every rollback failure as context.
- Remove the control socket and empty auto-created mountpoint only after lazy detach succeeds, so a failed detach cannot hide a potentially live orphan behind deleted service artifacts.
- Bound diagnostic snippets and the final protocol failure message by UTF-8 bytes while preserving character boundaries.
- Add regression coverage for multibyte limits, alive-versus-exited service registration, fail-closed control-readiness responses, full rollback diagnostics, and detach-failure artifact retention.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p astrid-storage-provider-fuse --locked -- --nocapture`
- `cargo clippy -p astrid-storage-provider-fuse --all-targets --all-features --locked -- -D warnings`
- `cargo check -p astrid-storage-provider-fuse --tests --target x86_64-unknown-linux-gnu --locked`
- Fresh exact-head independent review and hosted CI are required before landing.

## AI / Tool Assistance

Assisted-by: Codex:gpt-5.6-luna
Implementation and readiness repairs were produced in an isolated checkout and inspected for one-file scope, fail-closed behavior, bounded diagnostics, GPG/DCO, and detached-process lifetime.

## Checklist

- [x] Linked to an issue
- [ ] Changelog fragment added under `changes/{issue}.{kind}.md` (docs/CI-only may skip; release PRs roll fragments into the version section instead of adding one)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
