### PR TITLE
fix(core): make layout receipt decoding portable

### DIFF
--- a/changes/1858.fixed.md
+++ b/changes/1858.fixed.md
@@ -1,0 +1,3 @@
+Decode persisted layout receipt paths without compiling Unix-only APIs on
+Windows or WebAssembly. Unix retains byte-exact path decoding; other targets
+reject encodings they cannot represent losslessly. Closes #1858

--- a/crates/astrid-core/src/dirs_layout.rs
+++ b/crates/astrid-core/src/dirs_layout.rs
@@ -1,6 +1,8 @@
 //! Versioned Astrid-home layout migration.
 
-use std::fs::{File, OpenOptions};
+use std::fs::File;
+#[cfg(unix)]
+use std::fs::OpenOptions;
 use std::io;
 use std::io::Read as _;
 #[cfg(unix)]
@@ -18,6 +20,13 @@ use records::{
     admit_or_write_canonical, inventory_regular_file, inventory_tree, read_canonical_record,
     verify_receipt_destination_authority, verify_receipt_destination_is_live_path,
 };
+
+#[cfg(test)]
+pub(super) fn decode_layout_receipt_path_for_test(
+    bytes: Vec<u8>,
+) -> io::Result<std::ffi::OsString> {
+    records::encoded_bytes_to_os_string(bytes)
+}
 use retirement::{
     retire_legacy_source_tree as retire_legacy_source_tree_impl,
     validate_legacy_retirement_candidate,

--- a/crates/astrid-core/src/dirs_layout_records.rs
+++ b/crates/astrid-core/src/dirs_layout_records.rs
@@ -1,5 +1,6 @@
 //! Canonical records and content identities for home-layout migration.
 
+use std::ffi::OsString;
 use std::fs::OpenOptions;
 use std::io::{self, Read as _};
 use std::path::{Path, PathBuf};
@@ -219,8 +220,38 @@ pub(super) fn verify_receipt_destination_is_live_path(
 fn physical_path(destination: &LayoutTreeIdentityV1) -> io::Result<PathBuf> {
     let bytes = hex::decode(&destination.physical_path_hex)
         .map_err(|error| io::Error::other(format!("decode layout destination path: {error}")))?;
-    let os_bytes = <std::ffi::OsString as std::os::unix::ffi::OsStringExt>::from_vec(bytes);
-    Ok(PathBuf::from(os_bytes))
+    encoded_bytes_to_os_string(bytes).map(PathBuf::from)
+}
+
+#[cfg(unix)]
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "the cross-platform receipt decoder has one fallible signature"
+)]
+pub(super) fn encoded_bytes_to_os_string(bytes: Vec<u8>) -> io::Result<OsString> {
+    use std::os::unix::ffi::OsStringExt as _;
+
+    // Unix receipts commit to the raw OsStr byte sequence, including paths
+    // that are not UTF-8. Decoding must therefore preserve every byte.
+    Ok(OsString::from_vec(bytes))
+}
+
+#[cfg(not(unix))]
+pub(super) fn encoded_bytes_to_os_string(bytes: Vec<u8>) -> io::Result<OsString> {
+    let text = String::from_utf8(bytes).map_err(|error| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("layout destination path is not portable UTF-8: {error}"),
+        )
+    })?;
+    let path = OsString::from(&text);
+    if path.as_encoded_bytes() != text.as_bytes() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "layout destination path cannot be represented losslessly on this platform",
+        ));
+    }
+    Ok(path)
 }
 
 pub(super) fn inventory_tree(path: &Path) -> io::Result<LayoutTreeIdentityV1> {

--- a/crates/astrid-core/src/dirs_tests.rs
+++ b/crates/astrid-core/src/dirs_tests.rs
@@ -7,6 +7,37 @@ fn migration_target() -> LayoutMigrationTarget {
     LayoutMigrationTarget::new("test-store/3;state-owner-codec/2", "test-binary/1").unwrap()
 }
 
+#[test]
+fn receipt_path_decoder_round_trips_portable_bytes() {
+    let encoded = b"/tmp/astrid.volume".to_vec();
+
+    let decoded = dirs_layout::decode_layout_receipt_path_for_test(encoded.clone())
+        .expect("portable path bytes must decode");
+
+    assert_eq!(decoded.as_encoded_bytes(), encoded);
+}
+
+#[cfg(unix)]
+#[test]
+fn receipt_path_decoder_preserves_non_utf8_unix_bytes() {
+    let encoded = b"/tmp/astrid-\xff.volume".to_vec();
+
+    let decoded = dirs_layout::decode_layout_receipt_path_for_test(encoded.clone())
+        .expect("Unix path bytes must decode without normalization");
+
+    assert_eq!(decoded.as_encoded_bytes(), encoded);
+}
+
+#[cfg(not(unix))]
+#[test]
+fn receipt_path_decoder_rejects_nonportable_bytes() {
+    let error = dirs_layout::decode_layout_receipt_path_for_test(vec![0xff])
+        .expect_err("non-UTF-8 receipt bytes must fail closed");
+
+    assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+    assert!(error.to_string().contains("not portable UTF-8"));
+}
+
 #[cfg(not(windows))]
 fn write_released_legacy_store(home: &AstridHome, bytes: &[u8]) -> PathBuf {
     let manifest = home.state_db_path().join("manifest");


### PR DESCRIPTION
## Linked Issue

Closes #1858

## Summary

Make persisted layout receipt path decoding compile and fail closed across Unix, Windows, and WebAssembly without changing Unix byte semantics.

## Changes

- preserve byte-exact `OsStr` decoding on Unix
- accept only losslessly representable UTF-8 receipt paths on non-Unix targets
- run the portable-path regressions through the existing Windows-native `dirs::tests` filter
- keep Unix-only file options out of non-Unix builds

## Verification

- `cargo test -p astrid-core dirs::tests --locked -- --nocapture`
- `cargo check -p astrid-core --target wasm32-unknown-unknown`
- `cargo clippy -p astrid-core --all-targets --all-features --locked --target x86_64-pc-windows-msvc --no-deps -- -D warnings`
- `cargo clippy -p astrid-core --all-targets --all-features --locked --target aarch64-pc-windows-msvc --no-deps -- -D warnings`
- `cargo fmt --all -- --check`

Windows publication remains outside the 2026.9 release scope. Exact-head CI must execute the native Windows regression and prove Wasm portability.

## AI / Tool Assistance

Assisted-by: Codex:gpt-5.6-sol

Codex implemented and tested the bounded portability repair. I reviewed the exact four-file diff, verified the signed commit and DCO trailer, and reproduced the targeted native and cross-target checks.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/{issue}.{kind}.md`
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
