### PR TITLE
fix(kernel): provision Windows migration fixtures

### DIFF
--- a/changes/1863.fixed.md
+++ b/changes/1863.fixed.md
@@ -1,0 +1,3 @@
+Windows kernel test fixtures now provision the private migration-ledger
+directory before writing the canonical completion receipt, keeping storage-mount
+native tests isolated and deterministic on fresh homes. Closes #1863

--- a/crates/astrid-kernel/src/lib.rs
+++ b/crates/astrid-kernel/src/lib.rs
@@ -4043,6 +4043,8 @@ fn seed_test_migration_ledger(home: &astrid_core::dirs::AstridHome) {
     };
     let mut bytes = serde_json::to_vec(&ledger).expect("test kernel: encode migration ledger");
     bytes.push(b'\n');
+    astrid_core::platform_fs::ensure_private_directory(&home.migrations_dir())
+        .expect("test kernel: create migration ledger directory");
     astrid_core::platform_fs::atomic_write_private_file(
         &home.migrations_dir().join("layout-v2-components.complete"),
         &bytes,


### PR DESCRIPTION
## Linked Issue

Closes #1863

## Summary

Makes the `storage_mount` migration-ledger fixture establish the same trusted migrations-directory authority required by Windows before its unchanged atomic write.

## Changes

- Ensure the temporary home's migrations directory is private before seeding the test migration ledger.
- Keep the production migration write path and atomic-write behavior unchanged.
- Add the required changelog fragment.

## Verification

- Focused `storage_mount` tests: 20 passed, 0 failed.
- `cargo test -p astrid-kernel --lib -- --test-threads=1`: 495 passed, 0 failed.
- Host `cargo check` and Clippy with `-D warnings` pass.
- `cargo fmt --all -- --check` and diff checks pass.
- Windows cross-target compilation was attempted but the local macOS toolchain lacks the Windows SDK C header `stdlib.h`; native x86 Windows CI is therefore required evidence.
- Validation used an isolated, campaign-owned Cargo target directory; no shared target was cleaned.

Claim limit: this repairs test-fixture setup only. It does not change production storage semantics and does not claim Windows publication or release support.

## AI / Tool Assistance

Assisted-by: OpenAI Codex: GPT-5.6 and GPT-5.6 Luna

Codex assisted with CI diagnosis, the fixture-only implementation, regression validation, and independent exact-head review. Joshua J. Bouw reviewed the complete change, authorized and created the signed commit, and the result was validated with the commands above.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/{issue}.{kind}.md` (docs/CI-only may skip; release PRs roll fragments into the version section instead of adding one)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
