### PR TITLE
fix(windows): preserve private runtime identity lifecycle

### DIFF
--- a/changes/1862.fixed.md
+++ b/changes/1862.fixed.md
@@ -1,0 +1,1 @@
+Provision the fresh Windows runtime-signing key directory through Astrid's private-directory boundary before key generation, so inherited ACLs cannot make capsule signing fail on a new home. Closes #1862

--- a/changes/1862.fixed.md
+++ b/changes/1862.fixed.md
@@ -1,1 +1,1 @@
-Provision the fresh Windows runtime-signing key directory through Astrid's private-directory boundary before key generation, so inherited ACLs cannot make capsule signing fail on a new home. Closes #1862
+Provision the fresh Windows runtime-signing key directory through Astrid's private-directory boundary before key generation, and narrowly admit that pre-volume bootstrap for repeated signing and first open. Closes #1862

--- a/changes/1867.fixed.md
+++ b/changes/1867.fixed.md
@@ -1,0 +1,1 @@
+- Provision capsule inspection's Windows runtime identity through the private filesystem boundary before key generation. Closes #1867.

--- a/crates/astrid-build/src/artifact.rs
+++ b/crates/astrid-build/src/artifact.rs
@@ -127,6 +127,9 @@ fn sign_archive_with_runtime_key_in_home(
     home: &AstridHome,
 ) -> anyhow::Result<VerifiedProvenance> {
     #[cfg(windows)]
+    home.validate_runtime_identity_provisioning()
+        .context("failed to provision private Astrid home for capsule signing")?;
+    #[cfg(windows)]
     home.ensure()
         .context("failed to provision private Astrid home for capsule signing")?;
     #[cfg(windows)]
@@ -644,6 +647,56 @@ mod tests {
             !home.runtime_key_path().exists(),
             "fail-closed provisioning must not generate a key"
         );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn runtime_signing_rejects_stopped_volume_without_sidecars() {
+        let dir = tempfile::tempdir().unwrap();
+        let archive = dir.path().join("test.capsule");
+        unsigned_archive(
+            &archive,
+            b"[package]\nname='test'\nversion='1.0.0'\n",
+            b"wasm",
+        );
+        let fresh = FreshWindowsHome::new();
+        let home = AstridHome::from_path(&fresh.path);
+        astrid_core::platform_fs::ensure_private_directory(home.root()).unwrap();
+        let volume_bytes = b"stopped-volume";
+        std::fs::write(home.storage_volume_path(), volume_bytes).unwrap();
+        astrid_core::platform_fs::restrict_private_file(&home.storage_volume_path()).unwrap();
+        let volume_before = std::fs::read(home.storage_volume_path()).unwrap();
+        let entries_before = home
+            .root()
+            .read_dir()
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .collect::<Vec<_>>();
+
+        let error = sign_archive_with_runtime_key_in_home(&archive, &home)
+            .expect_err("runtime signing must not revive a stopped durable root");
+
+        assert!(
+            format!("{error:#}")
+                .contains("stopped Astrid durable root cannot provision runtime identity sidecars"),
+            "unexpected error: {error:#}"
+        );
+        assert_eq!(
+            std::fs::read(home.storage_volume_path()).unwrap(),
+            volume_before
+        );
+        assert!(!home.keys_dir().exists(), "signing must not create keys/");
+        assert!(
+            !home.runtime_key_path().exists(),
+            "signing must not create runtime.key"
+        );
+        let entries_after = home
+            .root()
+            .read_dir()
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .collect::<Vec<_>>();
+        assert_eq!(entries_after, entries_before);
     }
 
     #[test]

--- a/crates/astrid-build/src/artifact.rs
+++ b/crates/astrid-build/src/artifact.rs
@@ -129,6 +129,9 @@ fn sign_archive_with_runtime_key_in_home(
     #[cfg(windows)]
     home.ensure()
         .context("failed to provision private Astrid home for capsule signing")?;
+    #[cfg(windows)]
+    astrid_core::platform_fs::ensure_private_directory(&home.keys_dir())
+        .context("failed to provision private runtime-signing key directory")?;
 
     let key_path = home.runtime_key_path();
     let keypair = astrid_crypto::load_or_generate_keypair(&key_path)

--- a/crates/astrid-build/src/artifact.rs
+++ b/crates/astrid-build/src/artifact.rs
@@ -594,8 +594,20 @@ mod tests {
         let fresh = FreshWindowsHome::new();
         let home = AstridHome::from_path(&fresh.path);
 
-        sign_archive_with_runtime_key_in_home(&archive, &home)
+        let first = sign_archive_with_runtime_key_in_home(&archive, &home)
             .expect("runtime signing should provision its private home");
+
+        home.ensure()
+            .expect("runtime signing bootstrap must remain admitted");
+        let second_archive = dir.path().join("second.capsule");
+        unsigned_archive(
+            &second_archive,
+            b"[package]\nname='second'\nversion='1.0.0'\n",
+            b"wasm",
+        );
+        let second = sign_archive_with_runtime_key_in_home(&second_archive, &home)
+            .expect("repeated runtime signing should reuse the admitted private key");
+        assert_eq!(second.signer, first.signer);
 
         for path in [home.root(), home.keys_dir().as_path()] {
             astrid_core::platform_fs::ensure_private_directory(path)

--- a/crates/astrid-capsule-install/src/authority.rs
+++ b/crates/astrid-capsule-install/src/authority.rs
@@ -20,8 +20,9 @@ use astrid_storage::RuntimePrincipalStore;
 use serde::{Deserialize, Serialize};
 
 use crate::paths::resolve_target_dir_for_in_workspace;
-
 mod leftover;
+#[cfg(windows)]
+mod runtime_identity;
 mod status;
 pub(crate) use leftover::{
     parse_legacy_authority_receipt, quarantine_legacy_authority_receipt,
@@ -848,8 +849,7 @@ fn inspect_manifest(
     workspace_layout: &WorkspaceLayout,
 ) -> anyhow::Result<InstallInspection> {
     #[cfg(windows)]
-    home.ensure()
-        .context("failed to provision private Astrid home for capsule inspection")?;
+    runtime_identity::prepare(home)?;
 
     let key_path = home.runtime_key_path();
     let keypair = astrid_crypto::load_or_generate_keypair(&key_path)

--- a/crates/astrid-capsule-install/src/authority/runtime_identity.rs
+++ b/crates/astrid-capsule-install/src/authority/runtime_identity.rs
@@ -1,0 +1,10 @@
+use anyhow::Context as _;
+use astrid_core::dirs::AstridHome;
+
+pub(super) fn prepare(home: &AstridHome) -> anyhow::Result<()> {
+    astrid_core::platform_fs::ensure_private_directory(home.root())
+        .context("failed to validate private Astrid home for capsule inspection")?;
+    astrid_core::platform_fs::ensure_private_directory(&home.keys_dir())
+        .context("failed to provision private runtime identity directory")?;
+    Ok(())
+}

--- a/crates/astrid-capsule-install/src/authority/runtime_identity.rs
+++ b/crates/astrid-capsule-install/src/authority/runtime_identity.rs
@@ -2,6 +2,8 @@ use anyhow::Context as _;
 use astrid_core::dirs::AstridHome;
 
 pub(super) fn prepare(home: &AstridHome) -> anyhow::Result<()> {
+    home.validate_runtime_identity_provisioning()
+        .context("runtime identity provisioning is not admitted for capsule inspection")?;
     astrid_core::platform_fs::ensure_private_directory(home.root())
         .context("failed to validate private Astrid home for capsule inspection")?;
     astrid_core::platform_fs::ensure_private_directory(&home.keys_dir())

--- a/crates/astrid-capsule-install/tests/install.rs
+++ b/crates/astrid-capsule-install/tests/install.rs
@@ -236,6 +236,62 @@ fn inspected_user_install_uses_initialized_fresh_private_windows_home() {
     );
 }
 
+#[cfg(windows)]
+#[test]
+fn capsule_inspection_rejects_stopped_volume_without_sidecars() {
+    let capsule_dir = tempfile::tempdir().unwrap();
+    write_minimal_capsule(capsule_dir.path(), "stopped-volume-test", "1.0.0");
+    let fresh = FreshWindowsHome::new();
+    let home = AstridHome::from_path(&fresh.path);
+    astrid_core::platform_fs::ensure_private_directory(home.root()).unwrap();
+    let volume_bytes = b"stopped-volume";
+    std::fs::write(home.storage_volume_path(), volume_bytes).unwrap();
+    astrid_core::platform_fs::restrict_private_file(&home.storage_volume_path()).unwrap();
+    let volume_before = std::fs::read(home.storage_volume_path()).unwrap();
+    let entries_before = home
+        .root()
+        .read_dir()
+        .unwrap()
+        .map(|entry| entry.unwrap().file_name())
+        .collect::<Vec<_>>();
+
+    let error = inspect_directory_for_principal_in_workspace(
+        capsule_dir.path(),
+        &home,
+        &PrincipalId::default(),
+        false,
+        None,
+        &WorkspaceLayout::default(),
+    )
+    .expect_err("capsule inspection must not revive a stopped durable root");
+
+    assert!(
+        error
+            .to_string()
+            .contains("runtime identity provisioning is not admitted"),
+        "unexpected error: {error:#}"
+    );
+    assert_eq!(
+        std::fs::read(home.storage_volume_path()).unwrap(),
+        volume_before
+    );
+    assert!(
+        !home.keys_dir().exists(),
+        "inspection must not create keys/"
+    );
+    assert!(
+        !home.runtime_key_path().exists(),
+        "inspection must not create runtime.key"
+    );
+    let entries_after = home
+        .root()
+        .read_dir()
+        .unwrap()
+        .map(|entry| entry.unwrap().file_name())
+        .collect::<Vec<_>>();
+    assert_eq!(entries_after, entries_before);
+}
+
 #[test]
 fn install_preserves_node_modules() {
     let capsule_dir = tempfile::tempdir().unwrap();

--- a/crates/astrid-capsule-install/tests/install.rs
+++ b/crates/astrid-capsule-install/tests/install.rs
@@ -201,6 +201,8 @@ fn inspected_user_install_uses_initialized_fresh_private_windows_home() {
         &layout,
     )
     .expect("inspection should use the private runtime identity");
+    let runtime_identity = std::fs::read(home.runtime_key_path())
+        .expect("inspection should persist the private runtime identity");
     let decision = AuthorityDecision::ExplicitApproval {
         content_digest: inspection.content_digest,
     };
@@ -214,6 +216,15 @@ fn inspected_user_install_uses_initialized_fresh_private_windows_home() {
         &layout,
     )
     .expect("authorized install should scan and provision the private principal home");
+
+    assert_eq!(
+        std::fs::read(home.runtime_key_path()).unwrap(),
+        runtime_identity,
+        "the authorized reinspection must reuse the first runtime identity"
+    );
+    astrid_core::platform_fs::validate_private_directory(home.root()).unwrap();
+    astrid_core::platform_fs::validate_private_directory(&home.keys_dir()).unwrap();
+    astrid_core::platform_fs::validate_private_file(&home.runtime_key_path()).unwrap();
 
     assert!(output.target_dir.join("Capsule.toml").is_file());
     assert_eq!(

--- a/crates/astrid-capsule-install/tests/install.rs
+++ b/crates/astrid-capsule-install/tests/install.rs
@@ -238,7 +238,7 @@ fn inspected_user_install_uses_initialized_fresh_private_windows_home() {
 
 #[cfg(windows)]
 #[test]
-fn capsule_inspection_rejects_stopped_volume_without_sidecars() {
+fn fresh_private_windows_home_capsule_inspection_rejects_stopped_volume_without_sidecars() {
     let capsule_dir = tempfile::tempdir().unwrap();
     write_minimal_capsule(capsule_dir.path(), "stopped-volume-test", "1.0.0");
     let fresh = FreshWindowsHome::new();

--- a/crates/astrid-core/src/dirs.rs
+++ b/crates/astrid-core/src/dirs.rs
@@ -247,6 +247,13 @@ pub struct AstridHome {
     root: PathBuf,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum UnsentinelledRootState {
+    Empty,
+    RuntimeKeyBootstrap,
+    StoppedVolume,
+}
+
 impl AstridHome {
     /// Resolve the home directory.
     ///
@@ -375,7 +382,9 @@ impl AstridHome {
         }
 
         match existing_layout.as_deref() {
-            None => self.validate_fresh_root_entries()?,
+            None => {
+                self.validate_fresh_root_entries()?;
+            },
             Some(LEGACY_LAYOUT_VERSION) => {},
             Some(LAYOUT_VERSION) => {
                 // Before the singleton-owned migration barrier, v2 boot only
@@ -412,12 +421,62 @@ impl AstridHome {
         Ok(())
     }
 
-    fn validate_fresh_root_entries(&self) -> io::Result<()> {
+    /// Validate that this home may provision or reuse a runtime identity.
+    ///
+    /// A sentinel-free root containing only `astrid.volume` is the canonical
+    /// stopped representation. Creating `keys/runtime.key` beside that volume
+    /// would turn the stopped root into an inadmissible mixed state, so callers
+    /// must pass this read-only preflight before creating either sidecar.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for unsupported layouts, unsafe fresh-root entries, or
+    /// the stopped volume-only representation.
+    pub fn validate_runtime_identity_provisioning(&self) -> io::Result<()> {
+        match self.layout_version()?.as_deref() {
+            Some(LEGACY_LAYOUT_VERSION | LAYOUT_VERSION) => return Ok(()),
+            Some(version) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("unsupported Astrid home layout version {version:?}"),
+                ));
+            },
+            None => {},
+        }
+
+        match std::fs::symlink_metadata(self.root()) {
+            Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "Astrid home without a layout sentinel is redirected or not a directory: {}",
+                        self.root().display()
+                    ),
+                ));
+            },
+            Ok(_) => {},
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => return Err(error),
+        }
+        crate::platform_fs::validate_private_directory(self.root())?;
+
+        if self.validate_fresh_root_entries()? == UnsentinelledRootState::StoppedVolume {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "stopped Astrid durable root cannot provision runtime identity sidecars",
+            ));
+        }
+        Ok(())
+    }
+
+    fn validate_fresh_root_entries(&self) -> io::Result<UnsentinelledRootState> {
         let mut entries = self.root().read_dir()?.collect::<Result<Vec<_>, _>>()?;
         entries.sort_by_key(std::fs::DirEntry::file_name);
         if entries.len() == 1 && entries[0].file_name() == std::ffi::OsStr::new("keys") {
-            return self.validate_runtime_key_bootstrap(&entries[0].path());
+            self.validate_runtime_key_bootstrap(&entries[0].path())?;
+            return Ok(UnsentinelledRootState::RuntimeKeyBootstrap);
         }
+        let mut state = UnsentinelledRootState::Empty;
         for entry in entries {
             let path = entry.path();
             if entry.file_name() != std::ffi::OsStr::new("astrid.volume") {
@@ -440,8 +499,9 @@ impl AstridHome {
                 ));
             }
             crate::platform_fs::validate_private_file(&path)?;
+            state = UnsentinelledRootState::StoppedVolume;
         }
-        Ok(())
+        Ok(state)
     }
 
     fn validate_runtime_key_bootstrap(&self, keys_dir: &Path) -> io::Result<()> {

--- a/crates/astrid-core/src/dirs.rs
+++ b/crates/astrid-core/src/dirs.rs
@@ -3,9 +3,11 @@
 //! Two key directory structures:
 //!
 //! - [`AstridHome`]: Global durable root at `~/.astrid/` (or `$ASTRID_HOME`).
-//!   Stopped state is exactly the private `astrid.volume` media file. While a
-//!   daemon runs, volume-backed files are projected at their historical paths;
-//!   transients use `ASTRID_RUN_DIR` or a disposable runtime directory.
+//!   Stopped state is exactly the private `astrid.volume` media file. Before
+//!   that volume exists, capsule signing may leave only the private runtime-key
+//!   bootstrap that storage ingests on first open. While a daemon runs,
+//!   volume-backed files are projected at their historical paths; transients
+//!   use `ASTRID_RUN_DIR` or a disposable runtime directory.
 //!
 //! - [`WorkspaceDir`]: Selected per-project state directory.
 //!   Holds project configuration, capsules, hooks, and instructions.
@@ -315,10 +317,12 @@ impl AstridHome {
     /// Validate the durable root without creating a parallel state tree.
     ///
     /// Fresh initialization leaves only the private root for the storage layer
-    /// to fill with `astrid.volume`. Released homes retain their historical
-    /// directories and sentinel as one-time migration inputs until verified
-    /// cutover. Running projections are created later from mounted volume
-    /// state, never by this admission boundary.
+    /// to fill with `astrid.volume`. The sole pre-volume exception is the
+    /// private runtime-key bootstrap that storage ingests on first open.
+    /// Released homes retain their historical directories and sentinel as
+    /// one-time migration inputs until verified cutover. Running projections
+    /// are created later from mounted volume state, never by this admission
+    /// boundary.
     ///
     /// # Errors
     ///
@@ -411,6 +415,9 @@ impl AstridHome {
     fn validate_fresh_root_entries(&self) -> io::Result<()> {
         let mut entries = self.root().read_dir()?.collect::<Result<Vec<_>, _>>()?;
         entries.sort_by_key(std::fs::DirEntry::file_name);
+        if entries.len() == 1 && entries[0].file_name() == std::ffi::OsStr::new("keys") {
+            return self.validate_runtime_key_bootstrap(&entries[0].path());
+        }
         for entry in entries {
             let path = entry.path();
             if entry.file_name() != std::ffi::OsStr::new("astrid.volume") {
@@ -428,6 +435,26 @@ impl AstridHome {
                     io::ErrorKind::InvalidData,
                     format!(
                         "Astrid durable media is redirected or not a regular file: {}",
+                        path.display()
+                    ),
+                ));
+            }
+            crate::platform_fs::validate_private_file(&path)?;
+        }
+        Ok(())
+    }
+
+    fn validate_runtime_key_bootstrap(&self, keys_dir: &Path) -> io::Result<()> {
+        crate::platform_fs::validate_private_directory(keys_dir)?;
+        let mut entries = keys_dir.read_dir()?.collect::<Result<Vec<_>, _>>()?;
+        entries.sort_by_key(std::fs::DirEntry::file_name);
+        for entry in entries {
+            let path = entry.path();
+            if path != self.runtime_key_path() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "unadmitted entry in the fresh runtime-key bootstrap: {}",
                         path.display()
                     ),
                 ));

--- a/crates/astrid-core/src/dirs_tests.rs
+++ b/crates/astrid-core/src/dirs_tests.rs
@@ -218,6 +218,86 @@ fn test_astrid_home_ensure_idempotent() {
 }
 
 #[test]
+fn pre_volume_runtime_key_bootstrap_admits_repeated_ensure() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(test_home_root(&dir));
+    home.ensure().unwrap();
+    crate::platform_fs::ensure_private_directory(&home.keys_dir()).unwrap();
+
+    home.ensure().unwrap();
+    std::fs::write(home.runtime_key_path(), b"bootstrap-key").unwrap();
+    crate::platform_fs::restrict_private_file(&home.runtime_key_path()).unwrap();
+    home.ensure().unwrap();
+
+    assert!(!home.storage_volume_path().exists());
+    assert_eq!(
+        std::fs::read(home.runtime_key_path()).unwrap(),
+        b"bootstrap-key"
+    );
+}
+
+#[test]
+fn pre_volume_runtime_key_bootstrap_rejects_extra_entry() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(test_home_root(&dir));
+    home.ensure().unwrap();
+    crate::platform_fs::ensure_private_directory(&home.keys_dir()).unwrap();
+    let extra = home.keys_dir().join("operator.pub");
+    std::fs::write(&extra, b"unadmitted").unwrap();
+    crate::platform_fs::restrict_private_file(&extra).unwrap();
+
+    let error = home.ensure().unwrap_err();
+
+    assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+    assert!(error.to_string().contains("fresh runtime-key bootstrap"));
+    assert_eq!(std::fs::read(extra).unwrap(), b"unadmitted");
+}
+
+#[test]
+fn stopped_volume_rejects_runtime_key_sidecar() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(test_home_root(&dir));
+    home.ensure().unwrap();
+    std::fs::write(home.storage_volume_path(), b"stopped-volume").unwrap();
+    crate::platform_fs::restrict_private_file(&home.storage_volume_path()).unwrap();
+    crate::platform_fs::ensure_private_directory(&home.keys_dir()).unwrap();
+
+    let error = home.ensure().unwrap_err();
+
+    assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+    assert!(home.storage_volume_path().exists());
+    assert!(home.keys_dir().exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn pre_volume_runtime_key_bootstrap_rejects_unsafe_permissions() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(test_home_root(&dir));
+    home.ensure().unwrap();
+    crate::platform_fs::ensure_private_directory(&home.keys_dir()).unwrap();
+    std::fs::set_permissions(home.keys_dir(), std::fs::Permissions::from_mode(0o755)).unwrap();
+    assert_eq!(
+        home.ensure().unwrap_err().kind(),
+        io::ErrorKind::PermissionDenied
+    );
+
+    crate::platform_fs::ensure_private_directory(&home.keys_dir()).unwrap();
+    std::fs::write(home.runtime_key_path(), b"bootstrap-key").unwrap();
+    std::fs::set_permissions(
+        home.runtime_key_path(),
+        std::fs::Permissions::from_mode(0o644),
+    )
+    .unwrap();
+    assert_eq!(
+        home.ensure().unwrap_err().kind(),
+        io::ErrorKind::PermissionDenied
+    );
+}
+
+#[test]
 fn test_fresh_home_restart_does_not_recreate_legacy_secret_dir() {
     let dir = tempfile::tempdir().unwrap();
     let home = AstridHome::from_path(test_home_root(&dir));


### PR DESCRIPTION
## Linked Issue

Closes #1862
Closes #1867

## Summary

Preserve one private Windows runtime identity across pre-volume signing bootstrap, storage ingestion, and repeated capsule inspection without replaying whole-home startup admission while the runtime is active.

## Changes

- Provision `keys/` through Astrid's private-directory authority before runtime-signing key generation.
- Admit only a sole pre-volume private `keys/` directory that is empty or contains exactly the private `runtime.key` file.
- Reject a stopped, sentinel-free volume-only root before either signing or capsule inspection can create `keys/` or `runtime.key` sidecars.
- Keep extra children, unsafe permissions, redirects, non-regular entries, and unsupported layouts fail-closed.
- During capsule inspection, validate/provision only the private Astrid root and `keys/` boundary before loading the identity; retain the guarded key-file restriction.
- Prove repeated signing and inspect-then-authorized-install reuse the same identity bytes and exact private ACL contracts.
- Prove both real callers leave stopped-root entries and `astrid.volume` bytes unchanged on rejection.

## Verification

- `cargo test -p astrid-core -p astrid-build --lib -- --test-threads=1`: 376 core and 65 build tests passed on the host.
- `cargo test --locked -p astrid-capsule-install`: 88 unit and 14 integration tests passed on the host.
- Host check and Clippy with `--all-targets --all-features -D warnings` pass for the affected crates.
- `x86_64-pc-windows-msvc` all-target cross-check passes for `astrid-core`; full local Windows consumer cross-compilation is blocked before project code by missing Windows C SDK headers in transitive C dependencies.
- `cargo fmt --all -- --check` and diff checks pass.
- Independent precommit review accepted the stopped-root amendment. The final signed head requires fresh exact-head review and native x86_64/ARM CI.

Claim limit: the pre-volume exception exists only before `astrid.volume` and only for the runtime key storage already ingests on first open. A stopped volume-only root cannot acquire identity sidecars. Capsule inspection binds only its active-operation identity boundary; startup admission remains unchanged. The preflight is check-before-create rather than an atomic filesystem transaction. Host and cross-target checks are not native ACL proof. This PR does not claim Windows publication or general release support.

## AI / Tool Assistance

Assisted-by: OpenAI Codex: GPT-5.6 and GPT-5.6 Luna

Codex assisted with CI diagnosis, the bounded runtime-identity repairs, regression tests, validation, and independent review. Joshua J. Bouw reviewed the complete changes and authorized the signed DCO commits.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/{issue}.{kind}.md` (docs/CI-only may skip; release PRs roll fragments into the version section instead of adding one)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
