### PR TITLE
fix(capsule): provision private Windows runtime identity

### DIFF
--- a/changes/1867.fixed.md
+++ b/changes/1867.fixed.md
@@ -1,0 +1,1 @@
+- Provision capsule inspection's Windows runtime identity through the private filesystem boundary before key generation. Closes #1867.

--- a/crates/astrid-capsule-install/src/authority.rs
+++ b/crates/astrid-capsule-install/src/authority.rs
@@ -20,8 +20,9 @@ use astrid_storage::RuntimePrincipalStore;
 use serde::{Deserialize, Serialize};
 
 use crate::paths::resolve_target_dir_for_in_workspace;
-
 mod leftover;
+#[cfg(windows)]
+mod runtime_identity;
 mod status;
 pub(crate) use leftover::{
     parse_legacy_authority_receipt, quarantine_legacy_authority_receipt,
@@ -848,8 +849,7 @@ fn inspect_manifest(
     workspace_layout: &WorkspaceLayout,
 ) -> anyhow::Result<InstallInspection> {
     #[cfg(windows)]
-    home.ensure()
-        .context("failed to provision private Astrid home for capsule inspection")?;
+    runtime_identity::prepare(home)?;
 
     let key_path = home.runtime_key_path();
     let keypair = astrid_crypto::load_or_generate_keypair(&key_path)

--- a/crates/astrid-capsule-install/src/authority/runtime_identity.rs
+++ b/crates/astrid-capsule-install/src/authority/runtime_identity.rs
@@ -1,0 +1,10 @@
+use anyhow::Context as _;
+use astrid_core::dirs::AstridHome;
+
+pub(super) fn prepare(home: &AstridHome) -> anyhow::Result<()> {
+    astrid_core::platform_fs::ensure_private_directory(home.root())
+        .context("failed to validate private Astrid home for capsule inspection")?;
+    astrid_core::platform_fs::ensure_private_directory(&home.keys_dir())
+        .context("failed to provision private runtime identity directory")?;
+    Ok(())
+}

--- a/crates/astrid-capsule-install/tests/install.rs
+++ b/crates/astrid-capsule-install/tests/install.rs
@@ -201,6 +201,8 @@ fn inspected_user_install_uses_initialized_fresh_private_windows_home() {
         &layout,
     )
     .expect("inspection should use the private runtime identity");
+    let runtime_identity = std::fs::read(home.runtime_key_path())
+        .expect("inspection should persist the private runtime identity");
     let decision = AuthorityDecision::ExplicitApproval {
         content_digest: inspection.content_digest,
     };
@@ -214,6 +216,15 @@ fn inspected_user_install_uses_initialized_fresh_private_windows_home() {
         &layout,
     )
     .expect("authorized install should scan and provision the private principal home");
+
+    assert_eq!(
+        std::fs::read(home.runtime_key_path()).unwrap(),
+        runtime_identity,
+        "the authorized reinspection must reuse the first runtime identity"
+    );
+    astrid_core::platform_fs::validate_private_directory(home.root()).unwrap();
+    astrid_core::platform_fs::validate_private_directory(&home.keys_dir()).unwrap();
+    astrid_core::platform_fs::validate_private_file(&home.runtime_key_path()).unwrap();
 
     assert!(output.target_dir.join("Capsule.toml").is_file());
     assert_eq!(


### PR DESCRIPTION
## Linked Issue

Closes #1867

## Summary

Prepare the Windows runtime identity at the filesystem boundary owned by capsule inspection instead of replaying whole-home startup admission after storage is active.

## Changes

- Validate/provision the Astrid root and `keys/` directory with the private Windows directory API before loading or generating `runtime.key`.
- Keep the existing private key-file restriction and all redirect/DACL checks intact.
- Extend the native Windows regression to prove inspect-then-authorized-install reuses the same runtime identity and preserves the exact private root, directory, and file contracts.

## Verification

- `cargo test --locked -p astrid-capsule-install` (88 unit + 14 integration tests passed on macOS host)
- `cargo check --locked -p astrid-capsule-install --all-targets --all-features`
- `cargo clippy --locked -p astrid-capsule-install --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- Native Windows x86_64 and ARM verification is intentionally left to hosted CI. A macOS cross-target test build was attempted but cannot compile the C-backed Windows dependencies without Windows SDK headers, so it is not counted as Windows evidence.

Claim limit: this repairs capsule inspection's runtime-identity provisioning only. It does not change startup admission, clean-stop volume policy, Windows publication, or general Windows release support.

## AI / Tool Assistance

Assisted-by: OpenAI:Codex

Codex helped diagnose the native Windows CI failure, prepare the bounded implementation and regression, and run local verification. Joshua reviewed the exact patch and retains authorship, signing, DCO, and merge authority.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/{issue}.{kind}.md` (docs/CI-only may skip; release PRs roll fragments into the version section instead of adding one)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
