### PR TITLE
fix(test): provision private Windows run directory

### DIFF
--- a/changes/1869.fixed.md
+++ b/changes/1869.fixed.md
@@ -1,0 +1,3 @@
+Windows named-pipe handshake tests now provision the runtime directory through
+the production private-filesystem boundary before writing the session token.
+Closes #1869

--- a/crates/astrid-capsule/tests/windows_named_pipe_handshake.rs
+++ b/crates/astrid-capsule/tests/windows_named_pipe_handshake.rs
@@ -38,7 +38,10 @@ async fn native_windows_preread_replays_full_signed_handshake() {
     std::fs::write(&key_path, keypair.secret_key_bytes()).expect("write principal key");
 
     let token = SessionToken::generate();
-    std::fs::create_dir_all(home.run_dir()).expect("create run directory");
+    astrid_core::platform_fs::ensure_private_directory(&home.run_dir())
+        .expect("create private run directory");
+    astrid_core::platform_fs::validate_private_directory(&home.run_dir())
+        .expect("run directory must satisfy the private-access contract");
     token
         .write_to_file(&home.token_path())
         .expect("write session token");


### PR DESCRIPTION
## Linked Issue

Closes #1869

## Summary

Provision the Windows named-pipe handshake fixture's runtime directory through Astrid's private-filesystem boundary before writing the session token.

## Changes

- Replace generic `run/` directory creation with `ensure_private_directory`.
- Assert the resulting fixture directory satisfies the exact private-access contract.
- Keep production `SessionToken` and ACL enforcement unchanged.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- Independent source review confirms the exact two-file test-only scope and fail-closed boundary.
- Native Windows x86_64 and ARM named-pipe handshake execution is intentionally left to hosted CI.

Claim limit: this repairs test fixture provisioning only. It does not weaken production token validation or claim Windows publication/general release support.

## AI / Tool Assistance

Assisted-by: OpenAI:Codex

Codex helped isolate the native CI fixture failure, prepare the bounded test-only patch, and run independent review. Joshua reviewed the exact change and authorized the signed DCO commit.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/{issue}.{kind}.md` (docs/CI-only may skip; release PRs roll fragments into the version section instead of adding one)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
