### PR TITLE
fix(uplink): make admin response timeout configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -947,6 +947,7 @@ name = "astrid-uplink"
 version = "2026.9.0"
 dependencies = [
  "anyhow",
+ "astrid-config",
  "astrid-core",
  "astrid-crypto",
  "astrid-events",

--- a/changes/1872.fixed.md
+++ b/changes/1872.fixed.md
@@ -1,1 +1,1 @@
-Allow admin IPC clients to configure their response deadline with `ASTRID_ADMIN_TIMEOUT_SECS` for slower package installation operations. Valid values are 1–600 seconds; missing, invalid, and out-of-range values retain the 15-second default.
+Allow admin IPC clients to configure their response deadline with `admin_timeout_secs` in the pre-mount client configuration, falling back to `ASTRID_ADMIN_TIMEOUT_SECS` and then 15 seconds. Valid values are 1–600 seconds; invalid file values report an error, while invalid environment values retain the default.

--- a/changes/1872.fixed.md
+++ b/changes/1872.fixed.md
@@ -1,0 +1,1 @@
+Allow admin IPC clients to configure their response deadline with `ASTRID_ADMIN_TIMEOUT_SECS` for slower package installation operations. Valid values are 1–600 seconds; missing, invalid, and out-of-range values retain the 15-second default.

--- a/crates/astrid-config/README.md
+++ b/crates/astrid-config/README.md
@@ -64,6 +64,26 @@ Post-merge validation checks: budget invariants (per-action cannot exceed sessio
 
 ## Development
 
+### Pre-mount client timeouts
+
+Client deadlines are separate from daemon/runtime policy and remain available
+when the runtime is stopped. The existing private client file is
+`~/.aos/etc/astrid/client.toml`, or an absolute path selected with
+`ASTRID_CLIENT_CONFIG_PATH`:
+
+```toml
+run_idle_secs = 120
+admin_timeout_secs = 60
+```
+
+`admin_timeout_secs` accepts 1–600 seconds. An explicit file value wins;
+`ASTRID_ADMIN_TIMEOUT_SECS` supplies a fallback when the key is absent, then
+the default is 15 seconds. Invalid environment values use the default; invalid
+file values report an error. Existing files containing only `run_idle_secs`
+continue to work. The uplink's explicit `with_timeout` API can override the
+resolved deadline. This changes how long the client waits, not the daemon's
+execution budget. The setting is not part of layered runtime `config show`.
+
 ```bash
 cargo test -p astrid-config
 ```

--- a/crates/astrid-config/src/client.rs
+++ b/crates/astrid-config/src/client.rs
@@ -16,10 +16,16 @@ pub const DEFAULT_RUN_IDLE_TIMEOUT_SECS: u64 = 120;
 /// The only timeout ceiling shared by the client parser and CLI argument parser.
 pub const MAX_RUN_IDLE_TIMEOUT_SECS: u64 = 86_400;
 
+/// Historical admin response deadline when neither file nor environment sets it.
+pub const DEFAULT_ADMIN_TIMEOUT_SECS: u64 = 15;
+
+/// Bounded client wait; this does not change the daemon's operation budget.
+pub const MAX_ADMIN_TIMEOUT_SECS: u64 = 600;
+
 /// Explicit client-file override selected by the operator or launcher.
 const CLIENT_CONFIG_PATH_VAR: &str = "ASTRID_CLIENT_CONFIG_PATH";
 
-/// Bound the narrow file even though it can contain only one key.
+/// Bound the narrow client-only configuration file.
 const MAX_CLIENT_CONFIG_FILE_SIZE: u64 = 1024 * 1024;
 
 /// Pre-mount behavior for Astrid CLI clients.
@@ -28,12 +34,16 @@ const MAX_CLIENT_CONFIG_FILE_SIZE: u64 = 1024 * 1024;
 pub struct ClientConfig {
     /// Seconds `astrid run` may wait for its next active-run message.
     pub run_idle_secs: u64,
+    /// Admin response deadline. When absent, `ASTRID_ADMIN_TIMEOUT_SECS` is
+    /// a fallback, followed by the historical 15-second default.
+    pub admin_timeout_secs: Option<u64>,
 }
 
 impl Default for ClientConfig {
     fn default() -> Self {
         Self {
             run_idle_secs: DEFAULT_RUN_IDLE_TIMEOUT_SECS,
+            admin_timeout_secs: None,
         }
     }
 }
@@ -150,7 +160,56 @@ pub fn load_client_config(path: &Path) -> ConfigResult<ClientConfig> {
             source: error,
         })?;
     validate_run_idle_secs(config.run_idle_secs)?;
+    if let Some(seconds) = config.admin_timeout_secs {
+        validate_admin_timeout_secs(seconds)?;
+    }
     Ok(config)
+}
+
+/// Resolve an admin response deadline from client configuration, then environment.
+///
+/// Invalid environment values retain the historical default. Explicit file values
+/// take precedence and fail validation rather than silently being ignored.
+/// Runtime configuration is never read, so this works before mounting storage.
+///
+/// # Errors
+/// Returns an error if the selected client file is missing, unsafe, or invalid.
+pub fn resolve_admin_timeout(
+    client_path: Option<&Path>,
+    environment: Option<&str>,
+) -> ConfigResult<u64> {
+    if let Some(path) = client_path
+        && let Some(seconds) = load_client_config(path)?.admin_timeout_secs
+    {
+        return Ok(seconds);
+    }
+    Ok(environment
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|seconds| (1..=MAX_ADMIN_TIMEOUT_SECS).contains(seconds))
+        .unwrap_or(DEFAULT_ADMIN_TIMEOUT_SECS))
+}
+
+/// Resolve the production admin deadline using the same pre-mount client file
+/// as `astrid run`, with `ASTRID_ADMIN_TIMEOUT_SECS` as a fallback.
+///
+/// # Errors
+/// See [`production_client_config_path`] and [`resolve_admin_timeout`].
+pub fn production_admin_timeout() -> ConfigResult<u64> {
+    let path = production_client_config_path()?;
+    resolve_admin_timeout(
+        path.as_deref(),
+        std::env::var("ASTRID_ADMIN_TIMEOUT_SECS").ok().as_deref(),
+    )
+}
+
+fn validate_admin_timeout_secs(seconds: u64) -> ConfigResult<()> {
+    if !(1..=MAX_ADMIN_TIMEOUT_SECS).contains(&seconds) {
+        return Err(ConfigError::ValidationError {
+            field: "admin_timeout_secs".to_owned(),
+            message: format!("must be between 1 and {MAX_ADMIN_TIMEOUT_SECS} seconds"),
+        });
+    }
+    Ok(())
 }
 
 /// Load the run idle timeout from one client file.

--- a/crates/astrid-config/src/client_tests.rs
+++ b/crates/astrid-config/src/client_tests.rs
@@ -107,3 +107,66 @@ fn resolution_preserves_cli_precedence_and_absent_file_default() {
     );
     assert_eq!(resolve_run_idle_timeout(None, None).unwrap(), 120);
 }
+
+#[test]
+fn admin_timeout_environment_bounds_and_default() {
+    for seconds in [1, 15, 60, 600] {
+        assert_eq!(
+            resolve_admin_timeout(None, Some(&seconds.to_string())).unwrap(),
+            seconds
+        );
+    }
+    for value in [
+        None,
+        Some(""),
+        Some("0"),
+        Some("601"),
+        Some("-1"),
+        Some("1.5"),
+        Some("invalid"),
+        Some("18446744073709551616"),
+    ] {
+        assert_eq!(resolve_admin_timeout(None, value).unwrap(), 15, "{value:?}");
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn admin_timeout_file_precedes_environment_and_missing_key_falls_back() {
+    let root = tempdir().unwrap();
+    let path = root.path().join("client.toml");
+    write_private_client_config(&path, "run_idle_secs = 45\nadmin_timeout_secs = 90\n");
+    assert_eq!(resolve_admin_timeout(Some(&path), Some("60")).unwrap(), 90);
+    assert_eq!(
+        resolve_admin_timeout(Some(&path), Some("invalid")).unwrap(),
+        90
+    );
+    assert_eq!(load_run_idle_timeout(&path).unwrap(), 45);
+    write_private_client_config(&path, "run_idle_secs = 45\n");
+    assert_eq!(resolve_admin_timeout(Some(&path), Some("60")).unwrap(), 60);
+    assert_eq!(resolve_admin_timeout(Some(&path), None).unwrap(), 15);
+}
+
+#[cfg(unix)]
+#[test]
+fn admin_timeout_invalid_file_is_not_masked_by_environment() {
+    let root = tempdir().unwrap();
+    let path = root.path().join("client.toml");
+    assert!(resolve_admin_timeout(Some(&path), Some("60")).is_err());
+    for contents in [
+        "admin_timeout_secs = 0",
+        "admin_timeout_secs = 601",
+        "admin_timeout_secs = -1",
+        "admin_timeout_secs = '60'",
+    ] {
+        write_private_client_config(&path, contents);
+        assert!(
+            resolve_admin_timeout(Some(&path), Some("60")).is_err(),
+            "{contents}"
+        );
+    }
+    for seconds in [1, 600] {
+        write_private_client_config(&path, &format!("admin_timeout_secs = {seconds}"));
+        assert_eq!(resolve_admin_timeout(Some(&path), None).unwrap(), seconds);
+    }
+}

--- a/crates/astrid-uplink/Cargo.toml
+++ b/crates/astrid-uplink/Cargo.toml
@@ -14,6 +14,7 @@ test-support = []
 
 [dependencies]
 anyhow = { workspace = true }
+astrid-config = { workspace = true }
 astrid-core = { workspace = true }
 astrid-crypto = { workspace = true }
 astrid-events = { workspace = true }

--- a/crates/astrid-uplink/src/admin_client.rs
+++ b/crates/astrid-uplink/src/admin_client.rs
@@ -33,24 +33,6 @@ use uuid::Uuid;
 
 use crate::socket_client::SocketClient;
 
-/// Fallback timeout for the response read loop. Generous because admin
-/// writes can block on the kernel write lock.
-const DEFAULT_TIMEOUT_SECS: u64 = 15;
-
-/// Response timeout honoring `ASTRID_ADMIN_TIMEOUT_SECS`. Slower libc
-/// targets (musl) and heavily loaded kernels can exceed a fixed 15s on
-/// env writes; operators and CI may raise the ceiling without patching.
-fn admin_timeout() -> Duration {
-    admin_timeout_from_value(std::env::var("ASTRID_ADMIN_TIMEOUT_SECS").ok().as_deref())
-}
-
-fn admin_timeout_from_value(value: Option<&str>) -> Duration {
-    let configured = value
-        .and_then(|value| value.parse::<u64>().ok())
-        .filter(|seconds| (1..=600).contains(seconds));
-    Duration::from_secs(configured.unwrap_or(DEFAULT_TIMEOUT_SECS))
-}
-
 /// Stable wire-name suffix for an [`AdminRequestKind`].
 ///
 /// Mirrors `admin_request_method` on the kernel side — the suffix is
@@ -130,8 +112,9 @@ impl AdminClient {
     ///
     /// # Errors
     /// Returns an error if the socket file is missing (no daemon),
-    /// connection fails, or the handshake is rejected.
+    /// connection fails, the handshake is rejected, or client configuration is invalid.
     pub async fn connect(caller: PrincipalId) -> Result<Self> {
+        let timeout = Duration::from_secs(astrid_config::client::production_admin_timeout()?);
         let session_id = astrid_core::SessionId::from_uuid(Uuid::new_v4());
         let inner = SocketClient::connect(session_id, caller.clone())
             .await
@@ -139,7 +122,7 @@ impl AdminClient {
         Ok(Self {
             inner,
             caller,
-            timeout: admin_timeout(),
+            timeout,
         })
     }
 
@@ -311,36 +294,6 @@ pub fn into_result(body: AdminResponseBody) -> Result<AdminResponseBody> {
 mod tests {
     use super::*;
     use astrid_core::PrincipalId;
-
-    #[test]
-    fn admin_timeout_accepts_configured_seconds_including_boundaries() {
-        for seconds in [1, 15, 60, 600] {
-            assert_eq!(
-                admin_timeout_from_value(Some(&seconds.to_string())),
-                Duration::from_secs(seconds)
-            );
-        }
-    }
-
-    #[test]
-    fn admin_timeout_defaults_for_missing_invalid_and_out_of_range_values() {
-        for value in [
-            None,
-            Some(""),
-            Some("0"),
-            Some("601"),
-            Some("-1"),
-            Some("1.5"),
-            Some("invalid"),
-            Some("18446744073709551616"),
-        ] {
-            assert_eq!(
-                admin_timeout_from_value(value),
-                Duration::from_secs(DEFAULT_TIMEOUT_SECS),
-                "unexpected timeout for {value:?}"
-            );
-        }
-    }
 
     #[test]
     fn topic_suffixes_match_kernel_constants() {

--- a/crates/astrid-uplink/src/admin_client.rs
+++ b/crates/astrid-uplink/src/admin_client.rs
@@ -33,9 +33,23 @@ use uuid::Uuid;
 
 use crate::socket_client::SocketClient;
 
-/// Default timeout for the response read loop. Generous because admin
+/// Fallback timeout for the response read loop. Generous because admin
 /// writes can block on the kernel write lock.
-const DEFAULT_TIMEOUT: Duration = Duration::from_secs(15);
+const DEFAULT_TIMEOUT_SECS: u64 = 15;
+
+/// Response timeout honoring `ASTRID_ADMIN_TIMEOUT_SECS`. Slower libc
+/// targets (musl) and heavily loaded kernels can exceed a fixed 15s on
+/// env writes; operators and CI may raise the ceiling without patching.
+fn admin_timeout() -> Duration {
+    admin_timeout_from_value(std::env::var("ASTRID_ADMIN_TIMEOUT_SECS").ok().as_deref())
+}
+
+fn admin_timeout_from_value(value: Option<&str>) -> Duration {
+    let configured = value
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|seconds| (1..=600).contains(seconds));
+    Duration::from_secs(configured.unwrap_or(DEFAULT_TIMEOUT_SECS))
+}
 
 /// Stable wire-name suffix for an [`AdminRequestKind`].
 ///
@@ -125,7 +139,7 @@ impl AdminClient {
         Ok(Self {
             inner,
             caller,
-            timeout: DEFAULT_TIMEOUT,
+            timeout: admin_timeout(),
         })
     }
 
@@ -297,6 +311,36 @@ pub fn into_result(body: AdminResponseBody) -> Result<AdminResponseBody> {
 mod tests {
     use super::*;
     use astrid_core::PrincipalId;
+
+    #[test]
+    fn admin_timeout_accepts_configured_seconds_including_boundaries() {
+        for seconds in [1, 15, 60, 600] {
+            assert_eq!(
+                admin_timeout_from_value(Some(&seconds.to_string())),
+                Duration::from_secs(seconds)
+            );
+        }
+    }
+
+    #[test]
+    fn admin_timeout_defaults_for_missing_invalid_and_out_of_range_values() {
+        for value in [
+            None,
+            Some(""),
+            Some("0"),
+            Some("601"),
+            Some("-1"),
+            Some("1.5"),
+            Some("invalid"),
+            Some("18446744073709551616"),
+        ] {
+            assert_eq!(
+                admin_timeout_from_value(value),
+                Duration::from_secs(DEFAULT_TIMEOUT_SECS),
+                "unexpected timeout for {value:?}"
+            );
+        }
+    }
 
     #[test]
     fn topic_suffixes_match_kernel_constants() {


### PR DESCRIPTION
## Linked Issue

Closes #1872

## Summary

Allow a longer admin response deadline for packaged musl installation, where the second installation pass repeatedly exceeded the existing 15-second deadline waiting for `env.set`.

## Changes

- Resolve `admin_timeout_secs` from the existing pre-mount client file in `astrid-config`, falling back to `ASTRID_ADMIN_TIMEOUT_SECS`, then 15 seconds. Accept 1–600 seconds; reject invalid file values while retaining fallback behavior for invalid environment values.
- Use the existing `ASTRID_CLIENT_CONFIG_PATH` or canonical `~/.aos/etc/astrid/client.toml`. Do not read runtime configuration to resolve a client deadline.
- Preserve the explicit `with_timeout` override and existing response correlation logic.
- Cover valid boundaries, missing values, malformed values, overflow, and out-of-range fallback without mutating process environment in tests.

## Verification

- `cargo test -p astrid-config -p astrid-uplink --lib`: 121 config tests and 44 uplink tests passed. Coverage includes file/environment precedence, legacy client files, invalid files, bounds, malformed environment values, and missing files.
- `cargo clippy -p astrid-config -p astrid-uplink --lib --tests -- -D warnings`: passed.
- `cargo fmt --all -- --check` and `git diff --check`: passed.
- Predecessor executable CI passed across GNU, musl, Darwin, and Windows; the updated head must complete its own required checks.
- The complete packaged musl journey has not yet been demonstrated with this change. Increasing the deadline is not itself proof that installation completes, and the reason for the slower response remains unconfirmed.

## Test Plan

Run the packaged aarch64 musl installation with a 60-second admin deadline, then verify restart and the FUSE read/write/sync/unmount journey. Repeat for x86_64 musl. Retain the existing GNU and Darwin evidence for unchanged behavior.

## AI / Tool Assistance

Assisted-by: Codex:GLM-5.3

Assisted-by: Codex:GPT-6-Astra

Tool assistance implemented the timeout override and focused tests. The diff, bounds, fallback behavior, and test results were inspected directly.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/{issue}.{kind}.md`
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
