### PR TITLE
fix(storage): expose Linux FUSE volume metadata

### DIFF
--- a/changes/1875.fixed.md
+++ b/changes/1875.fixed.md
@@ -1,0 +1,1 @@
+Linux FUSE mounts now use the configured volume name and authenticated backing-volume capacity and root timestamps instead of a hardcoded name and default zero filesystem statistics.

--- a/crates/astrid-storage-provider-fuse/src/filesystem.rs
+++ b/crates/astrid-storage-provider-fuse/src/filesystem.rs
@@ -15,11 +15,14 @@ use astrid_core::storage_provider::StorageProviderAccessV1;
 use fuser::{
     Config, Errno, FileAttr, FileHandle, FileType, Filesystem, FopenFlags, Generation, INodeNo,
     MountOption, OpenFlags, RenameFlags, ReplyAttr, ReplyData, ReplyDirectory, ReplyEmpty,
-    ReplyEntry, ReplyOpen, ReplyWrite, Request, Session, SessionACL,
+    ReplyEntry, ReplyOpen, ReplyStatfs, ReplyWrite, Request, Session, SessionACL,
 };
 
 use crate::callback::{CALLBACK_CHUNK_BYTES, CallbackClient, callback_errno};
 use crate::mountpoint::owner_ids;
+
+mod volume_info;
+use volume_info::VolumeInfo;
 
 // Astrid is the authority and may be changed through another principal view or
 // native client. Do not let the kernel serve stale lengths or bytes from an
@@ -36,13 +39,15 @@ pub(crate) fn start_session(
 ) -> Result<FuseBackgroundSession> {
     let access = lease.access;
     let filesystem = AstridFuseFilesystem::new(lease);
+    let info = VolumeInfo::read(&filesystem.callback)
+        .map_err(|error| anyhow::anyhow!("read FUSE volume metadata: {error:?}"))?;
     let mount_option = match access {
         StorageProviderAccessV1::ReadOnly => MountOption::RO,
         StorageProviderAccessV1::ReadWrite => MountOption::RW,
     };
     let mut config = Config::default();
     config.mount_options = vec![
-        MountOption::FSName("astrid".to_owned()),
+        MountOption::FSName(info.volume_name),
         MountOption::Subtype("astrid".to_owned()),
         mount_option,
         MountOption::DefaultPermissions,
@@ -114,7 +119,15 @@ impl AstridFuseFilesystem {
 
     fn attributes_for(&self, path: &str, ino: INodeNo) -> Result<FileAttr, Errno> {
         let entry = self.stat_path(path)?;
-        Ok(self.attributes(ino, &entry))
+        let mut attributes = self.attributes(ino, &entry);
+        if path.is_empty() {
+            let volume = VolumeInfo::read(&self.callback)?;
+            attributes.crtime = volume.created()?;
+            attributes.mtime = volume.modified()?;
+            attributes.ctime = attributes.mtime;
+            attributes.atime = attributes.mtime;
+        }
+        Ok(attributes)
     }
 
     fn attributes(&self, ino: INodeNo, entry: &StorageFilesystemEntryV1) -> FileAttr {
@@ -261,6 +274,24 @@ impl AstridFuseFilesystem {
 }
 
 impl Filesystem for AstridFuseFilesystem {
+    fn statfs(&self, _req: &Request, _ino: INodeNo, reply: ReplyStatfs) {
+        match VolumeInfo::read(&self.callback) {
+            Ok(info) => reply.statfs(
+                info.total_blocks,
+                info.free_blocks,
+                info.available_blocks,
+                // The callback does not expose inode accounting. Zero means
+                // unavailable; do not invent a fixed inode quota.
+                0,
+                0,
+                info.block_size,
+                255,
+                info.block_size,
+            ),
+            Err(error) => reply.error(error),
+        }
+    }
+
     fn open(&self, _req: &Request, _ino: INodeNo, _flags: OpenFlags, reply: ReplyOpen) {
         reply.opened(FileHandle(0), FopenFlags::FOPEN_DIRECT_IO);
     }

--- a/crates/astrid-storage-provider-fuse/src/filesystem/tests.rs
+++ b/crates/astrid-storage-provider-fuse/src/filesystem/tests.rs
@@ -491,7 +491,7 @@ fn linux_native_fuse_mount_supports_all_required_operations() {
     let mut fake = FakeFilesystem::default();
     fake.directories.insert(String::new());
     let (state, telemetry) = spawn_fake_callback(&callback_path, fake);
-    let mountpoint = temporary.path().join("native-mount");
+    let mountpoint = temporary.path().join("native mount");
     std::fs::create_dir(&mountpoint).unwrap();
     std::fs::set_permissions(&mountpoint, std::fs::Permissions::from_mode(0o700)).unwrap();
     let lease = test_lease(&callback_path, StorageProviderAccessV1::ReadWrite);
@@ -509,7 +509,9 @@ fn linux_native_fuse_mount_supports_all_required_operations() {
     );
     let mountinfo = std::fs::read_to_string("/proc/self/mountinfo").unwrap();
     assert!(mountinfo.lines().any(|line| {
-            line.contains(mountpoint.to_str().unwrap())
+            line.as_bytes().split(|byte| *byte == b' ').nth(4).is_some_and(|field| {
+                crate::mountpoint::unescape_mountinfo(field) == mountpoint.to_str().unwrap().as_bytes()
+            })
                 && line.split_once(" - ").is_some_and(|(_, details)| {
                     let mut fields = details.split_whitespace();
                     matches!(fields.next(), Some("fuse" | "fuse.astrid"))

--- a/crates/astrid-storage-provider-fuse/src/filesystem/tests.rs
+++ b/crates/astrid-storage-provider-fuse/src/filesystem/tests.rs
@@ -75,7 +75,13 @@ fn fake_operation(
     operation: StorageFilesystemOperationV1,
 ) -> Result<StorageFilesystemSuccessV1, StorageFilesystemFailureV1> {
     let result = match operation {
-        StorageFilesystemOperationV1::VolumeInfo => Err(failure_detail("unsupported", "fixture has no backing device")),
+        StorageFilesystemOperationV1::VolumeInfo => Ok(StorageFilesystemSuccessV1::Data(
+            serde_json::json!({
+                "volume_name": "AOS", "block_size": 4096,
+                "total_blocks": 100, "free_blocks": 80, "available_blocks": 70,
+                "created_secs": 1000, "modified_secs": 2000
+            }).to_string().into_bytes(),
+        )),
         StorageFilesystemOperationV1::Stat { path } => {
             if let Some(data) = state.files.get(&path) {
                 Ok(StorageFilesystemSuccessV1::Entry(entry(
@@ -492,6 +498,24 @@ fn linux_native_fuse_mount_supports_all_required_operations() {
     let session = start_session(lease, &mountpoint).expect("mount real Linux FUSE filesystem");
 
     assert!(crate::mountpoint::mountinfo_contains(&mountpoint).unwrap());
+    let capacity = nix::sys::statvfs::statvfs(&mountpoint).unwrap();
+    assert_eq!(capacity.blocks(), 100);
+    assert_eq!(capacity.blocks_free(), 80);
+    assert_eq!(capacity.blocks_available(), 70);
+    assert_eq!(capacity.fragment_size(), 4096);
+    assert_eq!(
+        std::fs::metadata(&mountpoint).unwrap().modified().unwrap(),
+        std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(2000),
+    );
+    let mountinfo = std::fs::read_to_string("/proc/self/mountinfo").unwrap();
+    assert!(mountinfo.lines().any(|line| {
+            line.contains(mountpoint.to_str().unwrap())
+                && line.split_once(" - ").is_some_and(|(_, details)| {
+                    let mut fields = details.split_whitespace();
+                    matches!(fields.next(), Some("fuse" | "fuse.astrid"))
+                        && fields.next() == Some("AOS")
+                })
+    }), "configured source label missing from mountinfo: {mountinfo}");
     std::fs::write(mountpoint.join("hello.txt"), b"Astrid FUSE").unwrap();
     assert_eq!(
         std::fs::read(mountpoint.join("hello.txt")).unwrap(),

--- a/crates/astrid-storage-provider-fuse/src/filesystem/volume_info.rs
+++ b/crates/astrid-storage-provider-fuse/src/filesystem/volume_info.rs
@@ -1,0 +1,112 @@
+//! Presentation metadata from the authenticated kernel, never synthetic capacity.
+
+use std::time::{Duration, SystemTime};
+
+use astrid_core::storage_filesystem::{StorageFilesystemOperationV1, StorageFilesystemSuccessV1};
+use fuser::Errno;
+use serde::Deserialize;
+
+use crate::callback::{CallbackClient, callback_errno};
+
+#[derive(Debug, Deserialize)]
+pub(super) struct VolumeInfo {
+    pub(super) volume_name: String,
+    pub(super) block_size: u32,
+    pub(super) total_blocks: u64,
+    pub(super) free_blocks: u64,
+    pub(super) available_blocks: u64,
+    created_secs: Option<u64>,
+    modified_secs: Option<u64>,
+}
+
+impl VolumeInfo {
+    pub(super) fn read(callback: &CallbackClient) -> Result<Self, Errno> {
+        match callback
+            .call(StorageFilesystemOperationV1::VolumeInfo)
+            .map_err(callback_errno)?
+        {
+            StorageFilesystemSuccessV1::Data(bytes) => Self::parse(&bytes),
+            _ => Err(Errno::EIO),
+        }
+    }
+
+    fn parse(bytes: &[u8]) -> Result<Self, Errno> {
+        let info: Self = serde_json::from_slice(bytes).map_err(|_| Errno::EIO)?;
+        if info.block_size == 0
+            || info.available_blocks > info.free_blocks
+            || info.free_blocks > info.total_blocks
+            || info.volume_name.trim().is_empty()
+            || info.volume_name.chars().any(char::is_control)
+        {
+            return Err(Errno::EIO);
+        }
+        Ok(info)
+    }
+
+    pub(super) fn created(&self) -> Result<SystemTime, Errno> {
+        timestamp(self.created_secs)
+    }
+
+    pub(super) fn modified(&self) -> Result<SystemTime, Errno> {
+        timestamp(self.modified_secs)
+    }
+}
+
+fn timestamp(seconds: Option<u64>) -> Result<SystemTime, Errno> {
+    // An unavailable backing timestamp stays unknown, rather than changing on
+    // every getattr and appearing to be a freshly modified file.
+    SystemTime::UNIX_EPOCH
+        .checked_add(Duration::from_secs(seconds.unwrap_or_default()))
+        .ok_or(Errno::EIO)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn fixture() -> serde_json::Value {
+        serde_json::json!({
+            "volume_name": "AOS", "block_size": 4096,
+            "total_blocks": 100, "free_blocks": 80, "available_blocks": 70,
+            "created_secs": 1000, "modified_secs": 2000
+        })
+    }
+
+    #[test]
+    fn preserves_backing_counts_name_and_dates() {
+        let info = VolumeInfo::parse(fixture().to_string().as_bytes()).unwrap();
+        assert_eq!(info.volume_name, "AOS");
+        assert_eq!(info.block_size, 4096);
+        assert_eq!((info.total_blocks, info.free_blocks, info.available_blocks), (100, 80, 70));
+        assert_eq!(info.created().unwrap(), SystemTime::UNIX_EPOCH + Duration::from_secs(1000));
+        assert_eq!(info.modified().unwrap(), SystemTime::UNIX_EPOCH + Duration::from_secs(2000));
+    }
+
+    #[test]
+    fn refuses_malformed_or_inconsistent_capacity() {
+        for (key, value) in [
+            ("block_size", serde_json::json!(0)),
+            ("block_size", serde_json::json!(u64::MAX)),
+            ("available_blocks", serde_json::json!(81)),
+            ("free_blocks", serde_json::json!(101)),
+            ("volume_name", serde_json::json!("\n")),
+        ] {
+            let mut data = fixture();
+            data[key] = value;
+            assert!(VolumeInfo::parse(data.to_string().as_bytes()).is_err(), "{key}");
+        }
+        assert!(VolumeInfo::parse(b"{}").is_err());
+        assert!(VolumeInfo::parse(b"not json").is_err());
+    }
+
+    #[test]
+    fn missing_dates_remain_unknown() {
+        let mut data = fixture();
+        data["created_secs"] = serde_json::Value::Null;
+        data["modified_secs"] = serde_json::Value::Null;
+        let info = VolumeInfo::parse(data.to_string().as_bytes()).unwrap();
+        assert_eq!(info.created().unwrap(), SystemTime::UNIX_EPOCH);
+        assert_eq!(info.modified().unwrap(), SystemTime::UNIX_EPOCH);
+    }
+}

--- a/crates/astrid-storage-provider-fuse/src/mountpoint.rs
+++ b/crates/astrid-storage-provider-fuse/src/mountpoint.rs
@@ -101,7 +101,7 @@ pub(crate) fn mountinfo_contains(mountpoint: &Path) -> Result<bool> {
         }))
 }
 
-fn unescape_mountinfo(value: &[u8]) -> Vec<u8> {
+pub(crate) fn unescape_mountinfo(value: &[u8]) -> Vec<u8> {
     let mut result = Vec::with_capacity(value.len());
     let mut index = 0;
     while index < value.len() {


### PR DESCRIPTION
## Linked Issue

Closes #1875

## Summary

Expose the configured volume name, backing capacity, and root timestamps through Linux FUSE, using the authenticated VolumeInfo callback introduced with the macOS mount fixes.

## Changes

- Replace the hardcoded mount source name with the configured volume name (AOS for AOS).
- Implement statfs using kernel-reported block size, total, free, and available blocks. These describe the shared growable backing container, not a reserved capacity or per-principal quota. Inode counts remain unavailable.
- Use backing-volume timestamps for the mount root; unavailable dates remain unknown. This does not add durable per-file timestamps.
- Reject malformed metadata instead of inventing capacity, and extend the real FUSE mount test to verify kernel-visible capacity, root modification time, and the AOS source name.

## Verification

- Linux aarch64 GNU and Alpine/MUSL: provider tests including the native /dev/fuse test, and strict Clippy for all targets.
- `cargo fmt --all --check` and `git diff --check`.
- Follow-up `d09ea5cf`: decode the exact mountinfo mountpoint field before matching; Debian GNU tests (20/20 including the native mount at a path containing a space) and strict Clippy pass.
- The native test exercises real Linux mount/statvfs/getattr/write/read/rename/sync/unmount and read-only refusal, with the existing authenticated callback fixture. It is not a new packaged AOS/Oracle release certification.
- No Windows or macOS frontend changes. x86_64 remains covered by CI rather than a new local execution claim.

## Test Plan

On Linux with /dev/fuse available:

```sh
ASTRID_FUSE_E2E=1 cargo test --locked -p astrid-storage-provider-fuse -- --include-ignored
cargo clippy --locked -p astrid-storage-provider-fuse --all-targets -- -D warnings
```

The same commands were exercised in Debian GNU and Alpine MUSL containers using Rust 1.95.0. The MUSL run explicitly selected `--target aarch64-unknown-linux-musl`.

## AI / Tool Assistance

Assisted-by: Codex:GPT-6-Astra

Assisted with implementation and tests. Reviewed the metadata mapping, callback error propagation, integer conversions, and claim limits; exercised the real Linux mount path and strict Rust checks.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/1875.fixed.md`
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
