### PR TITLE
fix(storage): allow mounted files beyond the callback payload limit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ on:
       - 'scripts/test_channel_publication.py'
       - 'scripts/test_channel_workflow_contract.sh'
       - 'scripts/test_ci_workflow_contract.sh'
+      - 'scripts/test_gnu_build_packages.py'
       - 'scripts/nightly_version.py'
       - 'scripts/test_nightly_version.py'
       - 'release/nightly.toml'
@@ -57,62 +58,8 @@ on:
       - '.github/workflows/ci.yml'
       - '.github/workflows/native-storage-certification.yml'
       - '.github/workflows/release.yml'
+  # Required build/test checks must also run for stacked and docs-only PRs.
   pull_request:
-    branches: [main]
-    paths:
-      - '**.rs'
-      - 'scripts/install-windows.ps1'
-      - 'scripts/uninstall-windows.ps1'
-      - 'scripts/windows_release_manifest.py'
-      - 'scripts/test_windows_release_manifest.py'
-      - 'scripts/release_manifest.py'
-      - 'scripts/test_release_manifest.py'
-      - 'scripts/musl_release_manifest.py'
-      - 'scripts/test_musl_release_manifest.py'
-      - 'scripts/package_release_archive.py'
-      - 'scripts/test_validate_release_archive.py'
-      - 'scripts/validate_release_archive.py'
-      - 'scripts/build-macos-fskit.sh'
-      - 'scripts/check-macos-fskit.sh'
-      - 'scripts/manage-macos-fskit.sh'
-      - 'scripts/test_manage_macos_fskit.sh'
-      - 'scripts/validate-macos-fskit.sh'
-      - 'scripts/validate_macos_release.py'
-      - 'scripts/test_macos_release_packaging.py'
-      - 'scripts/test_v0104_linux_upgrade.sh'
-      - 'scripts/test_v0104_macos_upgrade.sh'
-      - 'scripts/ci/**'
-      - 'scripts/fixtures/windows-release-extension.toml'
-      - 'scripts/check_glibc.py'
-      - 'scripts/test_check_glibc.py'
-      - 'scripts/check_dco.py'
-      - 'scripts/test_check_dco.py'
-      - 'scripts/changelog.py'
-      - 'scripts/test_changelog.py'
-      - 'scripts/check_static_elf.py'
-      - 'scripts/test_check_static_elf.py'
-      - 'scripts/release_publication.py'
-      - 'scripts/test_release_publication.py'
-      - 'scripts/release_draft_recovery.py'
-      - 'scripts/test_release_draft_recovery.py'
-      - 'scripts/crate_publication.py'
-      - 'scripts/test_crate_publication.py'
-      - 'scripts/channel_metadata.py'
-      - 'scripts/test_channel_metadata.py'
-      - 'scripts/channel_publication.py'
-      - 'scripts/test_channel_publication.py'
-      - 'scripts/test_channel_workflow_contract.sh'
-      - 'scripts/test_ci_workflow_contract.sh'
-      - 'scripts/nightly_version.py'
-      - 'scripts/test_nightly_version.py'
-      - 'release/nightly.toml'
-      - 'crates/astrid-storage-provider-fskit/**'
-      - 'native/macos/**'
-      - '**/Cargo.toml'
-      - '**/Cargo.lock'
-      - '.github/workflows/ci.yml'
-      - '.github/workflows/native-storage-certification.yml'
-      - '.github/workflows/release.yml'
 permissions:
   contents: read
 
@@ -183,8 +130,7 @@ jobs:
                 packages+=(gcc-aarch64-linux-gnu libc6-dev-arm64-cross)
                 export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
               fi
-              apt-get update
-              apt-get install -y --no-install-recommends "${packages[@]}"
+              bash scripts/ci/install_gnu_build_packages.sh "${packages[@]}"
               git config --global --add safe.directory /workspace
               [[ "$(git rev-parse --short=12 HEAD)" == "$SOURCE_SHA" ]]
               cargo build \

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -2,7 +2,6 @@ name: PR Checks
 
 on:
   pull_request:
-    branches: [main]
     types: [opened, edited, reopened, labeled, unlabeled, synchronize]
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -261,8 +261,7 @@ jobs:
                 packages+=(gcc-aarch64-linux-gnu libc6-dev-arm64-cross)
                 export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
               fi
-              apt-get update
-              apt-get install -y --no-install-recommends "${packages[@]}"
+              bash scripts/ci/install_gnu_build_packages.sh "${packages[@]}"
               git config --global --add safe.directory /workspace
               [[ "$(git rev-parse --short=12 HEAD)" == "$SOURCE_SHA" ]]
               cargo build \

--- a/changes/1878.fixed.md
+++ b/changes/1878.fixed.md
@@ -1,1 +1,5 @@
 Mounted files can grow beyond the filesystem callback's 4 MiB per-request limit. Range writes and resizing stream replacement content instead of allocating a whole-file buffer, preserving zero-filled gaps and atomic publication.
+
+Until sparse extensions are supported, a single resize or write may synthesize
+at most 4 MiB of gap bytes; larger gaps fail before publication without limiting
+the total size of files grown through ordinary writes.

--- a/changes/1878.fixed.md
+++ b/changes/1878.fixed.md
@@ -1,0 +1,1 @@
+Mounted files can grow beyond the filesystem callback's 4 MiB per-request limit. Range writes and resizing stream replacement content instead of allocating a whole-file buffer, preserving zero-filled gaps and atomic publication.

--- a/changes/1890.fixed.md
+++ b/changes/1890.fixed.md
@@ -1,0 +1,2 @@
+Run CI and contribution checks for stacked pull requests, and restore GNU
+compatibility builds using signed, dated Bullseye package snapshots.

--- a/crates/astrid-kernel/src/storage_mount/filesystem.rs
+++ b/crates/astrid-kernel/src/storage_mount/filesystem.rs
@@ -1,4 +1,7 @@
 use super::*;
+use std::io::Read;
+
+mod range;
 
 pub(super) trait CallbackFilesystem {
     fn stat(&self, path: &FilesystemPath) -> Result<FilesystemEntry, FilesystemError>;
@@ -10,6 +13,11 @@ pub(super) trait CallbackFilesystem {
         length: u64,
     ) -> Result<Vec<u8>, FilesystemError>;
     fn write(&self, path: &FilesystemPath, bytes: &[u8]) -> Result<(), FilesystemError>;
+    fn write_streaming(
+        &self,
+        path: &FilesystemPath,
+        source: impl Read,
+    ) -> Result<(), FilesystemError>;
     fn create_dir(&self, path: &FilesystemPath) -> Result<(), FilesystemError>;
     fn remove(&self, path: &FilesystemPath) -> Result<(), FilesystemError>;
     fn rename(
@@ -45,6 +53,14 @@ where
 
     fn write(&self, path: &FilesystemPath, bytes: &[u8]) -> Result<(), FilesystemError> {
         AstridFilesystem::write(self, path, bytes)
+    }
+
+    fn write_streaming(
+        &self,
+        path: &FilesystemPath,
+        source: impl Read,
+    ) -> Result<(), FilesystemError> {
+        AstridFilesystem::write_streaming(self, path, source)
     }
 
     fn create_dir(&self, path: &FilesystemPath) -> Result<(), FilesystemError> {
@@ -99,6 +115,15 @@ where
         self.write(path, bytes).map_err(map_workspace_error)
     }
 
+    fn write_streaming(
+        &self,
+        path: &FilesystemPath,
+        source: impl Read,
+    ) -> Result<(), FilesystemError> {
+        self.write_streaming(path, source)
+            .map_err(map_workspace_error)
+    }
+
     fn create_dir(&self, path: &FilesystemPath) -> Result<(), FilesystemError> {
         self.create_dir(path).map_err(map_workspace_error)
     }
@@ -150,6 +175,14 @@ where
 
     fn write(&self, path: &FilesystemPath, bytes: &[u8]) -> Result<(), FilesystemError> {
         OwnerSubtreeFilesystem::write(self, path, bytes)
+    }
+
+    fn write_streaming(
+        &self,
+        path: &FilesystemPath,
+        source: impl Read,
+    ) -> Result<(), FilesystemError> {
+        OwnerSubtreeFilesystem::write_streaming(self, path, source)
     }
 
     fn create_dir(&self, path: &FilesystemPath) -> Result<(), FilesystemError> {
@@ -219,6 +252,14 @@ impl<F: CallbackFilesystem> CallbackFilesystem for PrefixedFilesystem<F> {
         self.inner.write(&self.path(path)?, bytes)
     }
 
+    fn write_streaming(
+        &self,
+        path: &FilesystemPath,
+        source: impl Read,
+    ) -> Result<(), FilesystemError> {
+        self.inner.write_streaming(&self.path(path)?, source)
+    }
+
     fn create_dir(&self, path: &FilesystemPath) -> Result<(), FilesystemError> {
         self.inner.create_dir(&self.path(path)?)
     }
@@ -282,22 +323,15 @@ pub(super) fn execute_blocking(
             write_range(filesystem, path, offset, &data)
         },
         StorageFilesystemOperationV1::SetLength { path, length } => {
-            if length > STORAGE_FILESYSTEM_MAX_IO_BYTES {
+            if length > i64::MAX as u64 {
                 return Err(FilesystemError::InvalidPath(path));
             }
             let path = FilesystemPath::new(path)?;
             let current_length = require_file(filesystem, &path)?;
-            if current_length > STORAGE_FILESYSTEM_MAX_IO_BYTES {
-                return Err(FilesystemError::InvalidPath(path.as_str().to_owned()));
-            }
             if current_length == length {
                 return Ok(StorageFilesystemSuccessV1::Written(length));
             }
-            let mut bytes = filesystem.read(&path, 0, current_length)?;
-            let target = usize::try_from(length)
-                .map_err(|_| FilesystemError::InvalidPath(path.as_str().to_owned()))?;
-            bytes.resize(target, 0);
-            filesystem.write(&path, &bytes)?;
+            range::replace(filesystem, &path, current_length, length, length, &[])?;
             Ok(StorageFilesystemSuccessV1::Written(length))
         },
         StorageFilesystemOperationV1::Create { path, kind } => {
@@ -350,20 +384,17 @@ fn write_range(
     let end_offset = offset
         .checked_add(data_length)
         .ok_or_else(|| FilesystemError::InvalidPath(path.as_str().to_owned()))?;
-    if current_length.max(end_offset) > STORAGE_FILESYSTEM_MAX_IO_BYTES {
+    if current_length.max(end_offset) > i64::MAX as u64 {
         return Err(FilesystemError::InvalidPath(path.as_str().to_owned()));
     }
-    let mut bytes = filesystem.read(&path, 0, current_length)?;
-    let start = usize::try_from(offset)
-        .map_err(|_| FilesystemError::InvalidPath(path.as_str().to_owned()))?;
-    let end = start
-        .checked_add(data.len())
-        .ok_or_else(|| FilesystemError::InvalidPath(path.as_str().to_owned()))?;
-    if end > bytes.len() {
-        bytes.resize(end, 0);
-    }
-    bytes[start..end].copy_from_slice(data);
-    filesystem.write(&path, &bytes)?;
+    range::replace(
+        filesystem,
+        &path,
+        current_length,
+        current_length.max(end_offset),
+        offset,
+        data,
+    )?;
     Ok(StorageFilesystemSuccessV1::Written(
         current_length.max(end_offset),
     ))

--- a/crates/astrid-kernel/src/storage_mount/filesystem/range.rs
+++ b/crates/astrid-kernel/src/storage_mount/filesystem/range.rs
@@ -1,0 +1,146 @@
+//! Stream replacement bytes without treating the RPC payload ceiling as a file limit.
+use super::*;
+
+pub(super) fn replace(
+    filesystem: &impl CallbackFilesystem,
+    path: &FilesystemPath,
+    old_length: u64,
+    new_length: u64,
+    offset: u64,
+    data: &[u8],
+) -> Result<(), FilesystemError> {
+    // Publication happens only after the reader finishes, so reads still see the
+    // original file. The mount callback serializes its mutations.
+    filesystem.write_streaming(
+        path,
+        Replacement {
+            filesystem,
+            path,
+            old_length,
+            new_length,
+            offset,
+            data,
+            position: 0,
+        },
+    )
+}
+
+struct Replacement<'a, F> {
+    filesystem: &'a F,
+    path: &'a FilesystemPath,
+    old_length: u64,
+    new_length: u64,
+    offset: u64,
+    data: &'a [u8],
+    position: u64,
+}
+
+impl<F: CallbackFilesystem> Read for Replacement<'_, F> {
+    fn read(&mut self, output: &mut [u8]) -> std::io::Result<usize> {
+        let remaining = self.new_length.saturating_sub(self.position);
+        let count = usize::try_from(remaining.min(STORAGE_FILESYSTEM_MAX_IO_BYTES))
+            .unwrap_or(usize::MAX)
+            .min(output.len());
+        if count == 0 {
+            return Ok(0);
+        }
+        let patch_end = self.offset.strict_add(self.data.len() as u64);
+        let count = if self.position >= self.offset && self.position < patch_end {
+            let count = count
+                .min(usize::try_from(patch_end.strict_sub(self.position)).unwrap_or(usize::MAX));
+            let start = usize::try_from(self.position.strict_sub(self.offset))
+                .map_err(|_| std::io::Error::other("patch offset exceeds address space"))?;
+            output[..count].copy_from_slice(&self.data[start..start.strict_add(count)]);
+            count
+        } else {
+            let boundary = if self.position < self.offset {
+                self.offset
+            } else {
+                self.new_length
+            };
+            let count = count
+                .min(usize::try_from(boundary.strict_sub(self.position)).unwrap_or(usize::MAX));
+            if self.position < self.old_length {
+                let count = count.min(
+                    usize::try_from(self.old_length.strict_sub(self.position))
+                        .unwrap_or(usize::MAX),
+                );
+                let bytes = self
+                    .filesystem
+                    .read(self.path, self.position, count as u64)
+                    .map_err(|error| std::io::Error::other(error.to_string()))?;
+                if bytes.len() != count {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::UnexpectedEof,
+                        "mounted file changed during replacement",
+                    ));
+                }
+                output[..count].copy_from_slice(&bytes);
+                count
+            } else {
+                output[..count].fill(0);
+                count
+            }
+        };
+        self.position = self.position.strict_add(count as u64);
+        Ok(count)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn mounted_large_file_range_writes_resize_and_sync() {
+        let temporary = tempfile::tempdir().unwrap();
+        let home = astrid_core::dirs::AstridHome::from_path(temporary.path().join(".astrid"));
+        let kernel = crate::test_kernel_with_home(home).await;
+        let store = kernel.principal_store.clone().unwrap();
+        let fs = AstridFilesystem::new(
+            store.content(),
+            StateOwner::Principal(astrid_core::PrincipalUid::from_bytes([0xB8; 32])),
+        );
+        let path = FilesystemPath::new("large.bin").unwrap();
+        fs.write(&path, b"seed").unwrap();
+        let offset = STORAGE_FILESYSTEM_MAX_IO_BYTES + 1;
+        execute_blocking(
+            &fs,
+            StorageFilesystemOperationV1::Write {
+                path: path.as_str().into(),
+                offset,
+                data: b"tail".to_vec(),
+            },
+        )
+        .unwrap();
+        assert_eq!(fs.stat(&path).unwrap().logical_bytes(), offset + 4);
+        assert_eq!(fs.read(&path, 0, 4).unwrap(), b"seed");
+        assert_eq!(fs.read(&path, offset - 1, 5).unwrap(), b"\0tail");
+        execute_blocking(
+            &fs,
+            StorageFilesystemOperationV1::Write {
+                path: path.as_str().into(),
+                offset: 1,
+                data: b"XY".to_vec(),
+            },
+        )
+        .unwrap();
+        assert_eq!(fs.read(&path, 0, 4).unwrap(), b"sXYd");
+        assert_eq!(fs.read(&path, offset, 4).unwrap(), b"tail");
+        for length in [offset + 8, offset + 2, 0] {
+            execute_blocking(
+                &fs,
+                StorageFilesystemOperationV1::SetLength {
+                    path: path.as_str().into(),
+                    length,
+                },
+            )
+            .unwrap();
+            assert_eq!(fs.stat(&path).unwrap().logical_bytes(), length);
+            if length == offset + 8 {
+                assert_eq!(fs.read(&path, offset, 8).unwrap(), b"tail\0\0\0\0");
+            }
+        }
+        execute_blocking(&fs, StorageFilesystemOperationV1::Sync).unwrap();
+    }
+}

--- a/crates/astrid-kernel/src/storage_mount/filesystem/range.rs
+++ b/crates/astrid-kernel/src/storage_mount/filesystem/range.rs
@@ -9,6 +9,13 @@ pub(super) fn replace(
     offset: u64,
     data: &[u8],
 ) -> Result<(), FilesystemError> {
+    // Gaps are currently materialized, not sparse. Bound generated zeros by the
+    // per-callback byte budget: a tiny resize must not hold the shared mutation
+    // lock while generating unbounded bytes. This is not a total file-size cap.
+    let zero_fill = offset.min(new_length).saturating_sub(old_length);
+    if zero_fill > STORAGE_FILESYSTEM_MAX_IO_BYTES {
+        return Err(FilesystemError::InvalidPath(path.as_str().to_owned()));
+    }
     // Publication happens only after the reader finishes, so reads still see the
     // original file. The mount callback serializes its mutations.
     filesystem.write_streaming(
@@ -90,6 +97,52 @@ impl<F: CallbackFilesystem> Read for Replacement<'_, F> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn mounted_materialized_gaps_reject_before_publication() {
+        let temporary = tempfile::tempdir().unwrap();
+        let home = astrid_core::dirs::AstridHome::from_path(temporary.path().join(".astrid"));
+        let kernel = crate::test_kernel_with_home(home).await;
+        let store = kernel.principal_store.clone().unwrap();
+        let fs = AstridFilesystem::new(
+            store.content(),
+            StateOwner::Principal(astrid_core::PrincipalUid::from_bytes([0xB9; 32])),
+        );
+        let path = FilesystemPath::new("gap.bin").unwrap();
+        fs.write(&path, b"seed").unwrap();
+        for length in [4 + STORAGE_FILESYSTEM_MAX_IO_BYTES + 1, i64::MAX as u64] {
+            for operation in [
+                StorageFilesystemOperationV1::SetLength {
+                    path: path.as_str().into(),
+                    length,
+                },
+                StorageFilesystemOperationV1::Write {
+                    path: path.as_str().into(),
+                    offset: length,
+                    data: vec![1],
+                },
+            ] {
+                assert!(matches!(
+                    execute_blocking(&fs, operation),
+                    Err(FilesystemError::InvalidPath(_))
+                ));
+                assert_eq!(fs.stat(&path).unwrap().logical_bytes(), 4);
+                assert_eq!(fs.read(&path, 0, 4).unwrap(), b"seed");
+            }
+        }
+        // Exact budget is allowed even when total length exceeds the ceiling.
+        for length in [4 + STORAGE_FILESYSTEM_MAX_IO_BYTES, 0] {
+            execute_blocking(
+                &fs,
+                StorageFilesystemOperationV1::SetLength {
+                    path: path.as_str().into(),
+                    length,
+                },
+            )
+            .unwrap();
+            assert_eq!(fs.stat(&path).unwrap().logical_bytes(), length);
+        }
+    }
 
     #[tokio::test]
     async fn mounted_large_file_range_writes_resize_and_sync() {

--- a/crates/astrid-kernel/src/storage_mount/tests.rs
+++ b/crates/astrid-kernel/src/storage_mount/tests.rs
@@ -179,6 +179,15 @@ impl<F: CallbackFilesystem> CallbackFilesystem for ReadBoundarySpy<F> {
         self.inner.create_dir(path)
     }
 
+    fn write_streaming(
+        &self,
+        path: &FilesystemPath,
+        source: impl std::io::Read,
+    ) -> Result<(), FilesystemError> {
+        self.writes.fetch_add(1, Ordering::AcqRel);
+        self.inner.write_streaming(path, source)
+    }
+
     fn remove(&self, path: &FilesystemPath) -> Result<(), FilesystemError> {
         self.inner.remove(path)
     }
@@ -231,7 +240,7 @@ async fn oversized_set_length_and_random_write_preflight_before_full_read() {
         &spy,
         StorageFilesystemOperationV1::SetLength {
             path: "probe.bin".to_owned(),
-            length: STORAGE_FILESYSTEM_MAX_IO_BYTES.saturating_add(1),
+            length: (i64::MAX as u64) + 1,
         },
     );
     let set_length_preflighted =
@@ -243,7 +252,7 @@ async fn oversized_set_length_and_random_write_preflight_before_full_read() {
         &spy,
         StorageFilesystemOperationV1::Write {
             path: "probe.bin".to_owned(),
-            offset: STORAGE_FILESYSTEM_MAX_IO_BYTES,
+            offset: i64::MAX as u64,
             data: vec![0x5A],
         },
     );
@@ -254,7 +263,7 @@ async fn oversized_set_length_and_random_write_preflight_before_full_read() {
 
     assert!(
         set_length_preflighted,
-        "SetLength above the callback/quota ceiling must fail during preflight"
+        "SetLength outside the native offset domain must fail during preflight"
     );
     assert_eq!(
         set_length_reads, 0,
@@ -285,8 +294,8 @@ async fn oversized_set_length_and_random_write_preflight_before_full_read() {
         },
     );
     assert!(
-        matches!(truncation, Err(FilesystemError::InvalidPath(path)) if path == "oversized.bin"),
-        "truncating an already oversized file must fail before rebuilding its contents"
+        truncation.is_ok(),
+        "truncating a large file must succeed without reading its old contents"
     );
     assert_eq!(
         reads.load(Ordering::Acquire),
@@ -295,8 +304,8 @@ async fn oversized_set_length_and_random_write_preflight_before_full_read() {
     );
     assert_eq!(
         writes.load(Ordering::Acquire),
-        0,
-        "oversized truncation must not publish replacement bytes"
+        1,
+        "truncation publishes the empty replacement"
     );
 }
 

--- a/crates/astrid-storage/src/content/store/workspace/filesystem.rs
+++ b/crates/astrid-storage/src/content/store/workspace/filesystem.rs
@@ -143,6 +143,20 @@ where
             .write(&self.owner, self.branch, &path.file_name()?, bytes)
     }
 
+    /// Atomically publish streamed bytes into this branch, preserving quota checks.
+    pub fn write_streaming<R: std::io::Read>(
+        &self,
+        path: &FilesystemPath,
+        source: R,
+    ) -> Result<(), WorkspaceBranchError> {
+        self.require_parent(path)?;
+        if self.directory_exists(path)? {
+            return Err(FilesystemError::IsDirectory(path.clone()).into());
+        }
+        self.branches
+            .write_streaming(&self.owner, self.branch, &path.file_name()?, source)
+    }
+
     /// Create an explicit empty directory marker.
     pub fn create_dir(&self, path: &FilesystemPath) -> Result<(), WorkspaceBranchError> {
         if path.as_str().is_empty() {

--- a/crates/astrid-storage/src/content/store/workspace/operations.rs
+++ b/crates/astrid-storage/src/content/store/workspace/operations.rs
@@ -533,6 +533,50 @@ where
         })
     }
 
+    /// Publish streamed bytes after branch quota authorization.
+    ///
+    /// # Errors
+    ///
+    /// Returns source, content, quota, or branch publication errors.
+    pub fn write_streaming<R: std::io::Read>(
+        &self,
+        owner: &P,
+        id: WorkspaceUid,
+        name: &ContentName,
+        source: R,
+    ) -> Result<(), WorkspaceBranchError> {
+        // Defer admission until the existing branch transaction checks quota.
+        let profile = crate::content_dag::ChunkingProfile::ASTRID_V1;
+        let (verified, staged) =
+            if let Some((bound, limit)) = self.content.quota_staging_bound(owner)? {
+                self.content
+                    .stage_deferred_bounded(source, profile, bound, limit)?
+            } else {
+                self.content.stage_deferred(source, profile)?
+            };
+        let descriptor = verified.descriptor();
+        self.mutate_catalog(owner, id, None, |root, records| {
+            let mutation = super::insert(
+                root,
+                name,
+                super::CatalogValue {
+                    file: descriptor.file(),
+                    logical_bytes: descriptor.logical_bytes(),
+                },
+                &mut |object| self.content.load_required_for(owner, object),
+                &|record| self.content.engine.identify_object(record),
+            )?;
+            records.extend(
+                staged
+                    .iter()
+                    .cloned()
+                    .map(|record| (self.content.engine.identify_object(&record), record)),
+            );
+            records.extend(mutation.records);
+            Ok(mutation.root)
+        })
+    }
+
     /// Remove one named file from a branch.  Directory markers are treated as
     /// ordinary named values by this lower-level API; the filesystem wrapper
     /// enforces directory semantics.

--- a/crates/astrid-storage/src/content/store/workspace/tests.rs
+++ b/crates/astrid-storage/src/content/store/workspace/tests.rs
@@ -29,6 +29,53 @@ fn content_with_engine() -> (Arc<TestContent>, Arc<TestEngine>) {
 }
 
 #[test]
+fn workspace_streaming_preserves_base_and_failed_source_does_not_publish() {
+    use std::io::{self, Read};
+    struct Failing;
+    impl Read for Failing {
+        fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
+            Err(io::Error::other("injected source failure"))
+        }
+    }
+    let content = content();
+    let branches = WorkspaceBranchStore::new(Arc::clone(&content));
+    let owner = owner();
+    let name = ContentName::new("large").unwrap();
+    content.put(&owner, &name, b"base").unwrap();
+    let id = WorkspaceUid::from_bytes([83; 16]);
+    branches.begin_with_uid(&owner, id).unwrap();
+    let fs = branches.filesystem(owner, id);
+    let path = FilesystemPath::new("large").unwrap();
+    let size = 4 * 1024 * 1024 + 1;
+    fs.write_streaming(&path, io::repeat(0x5a).take(size))
+        .unwrap();
+    assert_eq!(fs.stat(&path).unwrap().logical_bytes(), size);
+    assert_eq!(fs.read(&path, size - 4, 4).unwrap(), [0x5a; 4]);
+    assert_eq!(content.read(&owner, &name).unwrap().unwrap(), b"base");
+    assert!(fs.write_streaming(&path, Failing).is_err());
+    assert_eq!(fs.stat(&path).unwrap().logical_bytes(), size);
+    assert_eq!(fs.read(&path, size - 4, 4).unwrap(), [0x5a; 4]);
+}
+
+#[test]
+fn workspace_streaming_refuses_quota_without_replacing_the_file() {
+    use std::io::Read;
+    let content = content_with_quota(64);
+    let branches = WorkspaceBranchStore::new(Arc::clone(&content));
+    let owner = owner();
+    let id = WorkspaceUid::from_bytes([84; 16]);
+    branches.begin_with_uid(&owner, id).unwrap();
+    let fs = branches.filesystem(owner, id);
+    let path = FilesystemPath::new("note").unwrap();
+    fs.write(&path, b"original").unwrap();
+    assert!(
+        fs.write_streaming(&path, std::io::repeat(0).take(65))
+            .is_err()
+    );
+    assert_eq!(fs.read(&path, 0, 8).unwrap(), b"original");
+}
+
+#[test]
 fn fork_shares_root_and_divergent_write_isolated() {
     let content = content();
     let branches = WorkspaceBranchStore::new(Arc::clone(&content));

--- a/scripts/ci/install_gnu_build_packages.sh
+++ b/scripts/ci/install_gnu_build_packages.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Bullseye supplies the glibc 2.31 build baseline, but LTS ended 2026-08-31.
+# Freeze its final package sources rather than raising the binary ABI floor.
+# Only these immutable snapshots waive freshness; APT still verifies Debian
+# signatures and package hashes. Do not apply this policy to live repositories.
+sources=$(mktemp)
+trap 'rm -f "$sources"' EXIT
+printf '%s\n' \
+  'deb [check-valid-until=no] https://snapshot.debian.org/archive/debian/20260901T000000Z/ bullseye main' \
+  'deb [check-valid-until=no] https://snapshot.debian.org/archive/debian-security/20260901T000000Z/ bullseye-security main' \
+  > "$sources"
+options=(-o "Dir::Etc::sourcelist=$sources" -o Dir::Etc::sourceparts=-)
+apt-get "${options[@]}" update
+apt-get "${options[@]}" install -y --no-install-recommends "$@"

--- a/scripts/ci/test-release-contracts.sh
+++ b/scripts/ci/test-release-contracts.sh
@@ -20,3 +20,4 @@ bash scripts/test_channel_workflow_contract.sh
 bash scripts/test_certify_musl_release_archive_contract.sh
 bash scripts/test_native_storage_certification_contract.sh
 bash scripts/test_ci_workflow_contract.sh
+python3 scripts/test_gnu_build_packages.py

--- a/scripts/test_ci_workflow_contract.sh
+++ b/scripts/test_ci_workflow_contract.sh
@@ -37,16 +37,30 @@ unless concurrency["cancel-in-progress"] == expected_cancel
   fail("cancel-in-progress must be enabled only for first-attempt pull_request events")
 end
 
-# Keep this contract wired to both CI trigger classes. Parse the trigger map so
+# Keep this contract wired to filtered pushes and unconditional PRs. Parse so
 # comments or similarly named text cannot make an absent path entry pass.
 triggers = workflow["on"] || workflow[true]
 fail("missing workflow trigger map") unless triggers.is_a?(Hash)
-%w[push pull_request].each do |event_name|
+%w[push].each do |event_name|
   event = triggers.fetch(event_name) { fail("missing #{event_name} trigger") }
   paths = event.fetch("paths") { fail("missing #{event_name}.paths filter") }
   unless paths.is_a?(Array) && paths.count("scripts/test_ci_workflow_contract.sh") == 1
     fail("contract test must appear exactly once in #{event_name}.paths")
   end
+end
+
+# Required checks cannot depend on the base branch or changed file paths.
+# A YAML null pull_request value is the intended unconditional event.
+fail("missing pull_request trigger") unless triggers.key?("pull_request")
+fail("pull_request must be unconditional") unless triggers["pull_request"].nil?
+pr_checks_path = File.join(File.dirname(workflow_path), "pr-checks.yml")
+pr_checks = YAML.safe_load(File.read(pr_checks_path), aliases: false)
+pr_events = (pr_checks["on"] || pr_checks[true]).fetch("pull_request")
+fail("PR Checks must allow stacked bases") if pr_events.key?("branches") || pr_events.key?("branches-ignore")
+
+%w[ci.yml release.yml].each do |name|
+  text = File.read(File.join(File.dirname(workflow_path), name))
+  fail("#{name} must use shared GNU package setup") unless text.include?('bash scripts/ci/install_gnu_build_packages.sh "${packages[@]}"')
 end
 
 def group(workflow_name, event_name, pr_number, run_id, run_attempt)

--- a/scripts/test_gnu_build_packages.py
+++ b/scripts/test_gnu_build_packages.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Exercise package-source scope, argument forwarding and update failure."""
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+SCRIPT = Path(__file__).parent / "ci/install_gnu_build_packages.sh"
+
+
+class PackageSetupTests(unittest.TestCase):
+    def run_setup(self, fail_update=False):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            log = root / "calls.jsonl"
+            apt = root / "apt-get"
+            apt.write_text(
+                "#!/usr/bin/env python3\n"
+                "import json, os, pathlib, sys\n"
+                "args = sys.argv[1:]\n"
+                "source = next(a.split('=', 1)[1] for a in args "
+                "if a.startswith('Dir::Etc::sourcelist='))\n"
+                "with open(os.environ['APT_TEST_LOG'], 'a') as log:\n"
+                " log.write(json.dumps({'args': args, 'path': source, "
+                "'sources': pathlib.Path(source).read_text()}) + '\\n')\n"
+                "if 'update' in args and os.environ['APT_TEST_FAIL'] == '1': "
+                "sys.exit(100)\n"
+            )
+            apt.chmod(0o755)
+            env = dict(os.environ, PATH=f"{root}:{os.environ['PATH']}",
+                       APT_TEST_LOG=str(log), APT_TEST_FAIL=str(int(fail_update)))
+            result = subprocess.run(
+                ["bash", str(SCRIPT), "cmake", "gcc-aarch64-linux-gnu"],
+                env=env, check=False,
+            )
+            calls = [json.loads(line) for line in log.read_text().splitlines()]
+            for call in calls:
+                self.assertFalse(Path(call["path"]).exists(), "temporary source leaked")
+            return result.returncode, calls
+
+    def test_signed_snapshot_sources_and_forwarded_packages(self):
+        code, calls = self.run_setup()
+        self.assertEqual(code, 0)
+        self.assertEqual(len(calls), 2)
+        for call in calls:
+            self.assertIn("Dir::Etc::sourceparts=-", call["args"])
+            self.assertNotIn("--allow-unauthenticated", call["args"])
+            lines = call["sources"].splitlines()
+            self.assertEqual(len(lines), 2)
+            for line in lines:
+                self.assertIn("https://snapshot.debian.org/archive/", line)
+                self.assertIn("/20260901T000000Z/", line)
+                self.assertIn("[check-valid-until=no]", line)
+                self.assertNotIn("trusted=yes", line)
+        self.assertEqual(calls[0]["sources"], calls[1]["sources"])
+        self.assertEqual(calls[1]["args"][-5:],
+                         ["install", "-y", "--no-install-recommends",
+                          "cmake", "gcc-aarch64-linux-gnu"])
+
+    def test_failed_update_never_installs(self):
+        code, calls = self.run_setup(fail_update=True)
+        self.assertEqual(code, 100)
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0]["args"][-1], "update")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Linked Issue

Closes #1878

## Summary

Fix mounted writes and resizing beyond 4 MiB. The shared kernel callback had applied the per-request payload ceiling to the resulting whole-file length, making a real FSKit fsync fail with EINVAL at 4 MiB+1 byte.

## Changes

- Keep the 4 MiB request bound; validate file lengths against the signed native offset domain instead.
- Stream old ranges, replacement bytes and zero-filled gaps into atomic content publication instead of allocating a whole-file buffer.
- Expose streaming publication through owner, subtree and workspace adapters. Workspace publication retains branch quota checks and bounded staging when a quota is configured.
- Cover large writes, overwrites, extension, truncation, source failures and quota refusal.
- Bound newly materialized gap bytes to the existing 4 MiB callback budget. Oversized resize/write gaps fail before publication; ordinary contiguous growth is not capped at 4 MiB. Sparse extensions remain unsupported.

## Verification

- `cargo test --locked -p astrid-kernel --lib storage_mount -- --test-threads=1`: 24 PASS (original candidate).
- `cargo test --locked -p astrid-storage --lib content::store::workspace -- --test-threads=1`: 24 PASS.
- `cargo clippy --locked -p astrid-kernel -p astrid-storage --all-targets -- -D warnings`: PASS.
- `cargo fmt --all --check` and `git diff --check`: PASS.
- Real macOS 26.6.2 FSKit mount, local development-signed app build 664 and optimized candidate daemon: three 32 MiB write/fsync/SHA256-read samples completed. Previously the first sample failed EINVAL.
- Separate actual-mount regression: 8 MiB+ write, overwrite crossing 4 MiB, zero-filled extension and gap, shrink above 4 MiB, sync, unmount/remount, SHA256 readback, truncate to zero: PASS.

Claim limits: this is correctness, not a random-write performance optimization. Replacement still rebuilds the content graph; workspace deferred records remain retained until publication. On the final 9661cba8 source build, mounted 32 MiB fsync took 3.63–3.93 seconds locally; all three samples and the remount regression passed. Warm OS-cache reads are not backend throughput. Linux/Windows use the shared kernel adapter, but this PR does not claim a new packaged native execution on those hosts.


Latest repair verification: `cargo test -p astrid-kernel storage_mount --lib -- --quiet`: 25 PASS; focused range tests: 2 PASS; `cargo clippy -p astrid-kernel --lib --tests -- -D warnings`, formatting and diff checks PASS. The new regression rejects both SetLength and Write gaps beyond budget, including i64::MAX, with original bytes unchanged. Exact-budget extension and shrinking remain valid. Earlier mounted measurements are retained as earlier-candidate evidence, not a rerun of this repair. CI workflow repair #1891 is included as a prerequisite until it lands.

## Test Plan

Run the commands above. On an admitted writable mount, write more than 4 MiB, fsync, patch across the boundary, extend/shrink, sync and remount, then compare complete file bytes. Verify an oversized individual RPC is still rejected and a quota/source failure preserves the prior file.

## AI / Tool Assistance

Assisted-by: Codex:GPT-6-Astra

Implemented and reviewed the adapter changes, source/publication ordering, integer bounds, quota preservation and regression coverage; exercised the real FSKit mount in a disposable AOS home.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/1878.fixed.md`
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
