### PR TITLE
fix(storage): reuse verified durable map subtrees

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ on:
       - 'scripts/test_channel_publication.py'
       - 'scripts/test_channel_workflow_contract.sh'
       - 'scripts/test_ci_workflow_contract.sh'
+      - 'scripts/test_gnu_build_packages.py'
       - 'scripts/nightly_version.py'
       - 'scripts/test_nightly_version.py'
       - 'release/nightly.toml'
@@ -57,62 +58,8 @@ on:
       - '.github/workflows/ci.yml'
       - '.github/workflows/native-storage-certification.yml'
       - '.github/workflows/release.yml'
+  # Required build/test checks must also run for stacked and docs-only PRs.
   pull_request:
-    branches: [main]
-    paths:
-      - '**.rs'
-      - 'scripts/install-windows.ps1'
-      - 'scripts/uninstall-windows.ps1'
-      - 'scripts/windows_release_manifest.py'
-      - 'scripts/test_windows_release_manifest.py'
-      - 'scripts/release_manifest.py'
-      - 'scripts/test_release_manifest.py'
-      - 'scripts/musl_release_manifest.py'
-      - 'scripts/test_musl_release_manifest.py'
-      - 'scripts/package_release_archive.py'
-      - 'scripts/test_validate_release_archive.py'
-      - 'scripts/validate_release_archive.py'
-      - 'scripts/build-macos-fskit.sh'
-      - 'scripts/check-macos-fskit.sh'
-      - 'scripts/manage-macos-fskit.sh'
-      - 'scripts/test_manage_macos_fskit.sh'
-      - 'scripts/validate-macos-fskit.sh'
-      - 'scripts/validate_macos_release.py'
-      - 'scripts/test_macos_release_packaging.py'
-      - 'scripts/test_v0104_linux_upgrade.sh'
-      - 'scripts/test_v0104_macos_upgrade.sh'
-      - 'scripts/ci/**'
-      - 'scripts/fixtures/windows-release-extension.toml'
-      - 'scripts/check_glibc.py'
-      - 'scripts/test_check_glibc.py'
-      - 'scripts/check_dco.py'
-      - 'scripts/test_check_dco.py'
-      - 'scripts/changelog.py'
-      - 'scripts/test_changelog.py'
-      - 'scripts/check_static_elf.py'
-      - 'scripts/test_check_static_elf.py'
-      - 'scripts/release_publication.py'
-      - 'scripts/test_release_publication.py'
-      - 'scripts/release_draft_recovery.py'
-      - 'scripts/test_release_draft_recovery.py'
-      - 'scripts/crate_publication.py'
-      - 'scripts/test_crate_publication.py'
-      - 'scripts/channel_metadata.py'
-      - 'scripts/test_channel_metadata.py'
-      - 'scripts/channel_publication.py'
-      - 'scripts/test_channel_publication.py'
-      - 'scripts/test_channel_workflow_contract.sh'
-      - 'scripts/test_ci_workflow_contract.sh'
-      - 'scripts/nightly_version.py'
-      - 'scripts/test_nightly_version.py'
-      - 'release/nightly.toml'
-      - 'crates/astrid-storage-provider-fskit/**'
-      - 'native/macos/**'
-      - '**/Cargo.toml'
-      - '**/Cargo.lock'
-      - '.github/workflows/ci.yml'
-      - '.github/workflows/native-storage-certification.yml'
-      - '.github/workflows/release.yml'
 permissions:
   contents: read
 
@@ -183,8 +130,7 @@ jobs:
                 packages+=(gcc-aarch64-linux-gnu libc6-dev-arm64-cross)
                 export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
               fi
-              apt-get update
-              apt-get install -y --no-install-recommends "${packages[@]}"
+              bash scripts/ci/install_gnu_build_packages.sh "${packages[@]}"
               git config --global --add safe.directory /workspace
               [[ "$(git rev-parse --short=12 HEAD)" == "$SOURCE_SHA" ]]
               cargo build \

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -2,7 +2,6 @@ name: PR Checks
 
 on:
   pull_request:
-    branches: [main]
     types: [opened, edited, reopened, labeled, unlabeled, synchronize]
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -261,8 +261,7 @@ jobs:
                 packages+=(gcc-aarch64-linux-gnu libc6-dev-arm64-cross)
                 export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
               fi
-              apt-get update
-              apt-get install -y --no-install-recommends "${packages[@]}"
+              bash scripts/ci/install_gnu_build_packages.sh "${packages[@]}"
               git config --global --add safe.directory /workspace
               [[ "$(git rev-parse --short=12 HEAD)" == "$SOURCE_SHA" ]]
               cargo build \

--- a/changes/1878.fixed.md
+++ b/changes/1878.fixed.md
@@ -1,1 +1,5 @@
 Mounted files can grow beyond the filesystem callback's 4 MiB per-request limit. Range writes and resizing stream replacement content instead of allocating a whole-file buffer, preserving zero-filled gaps and atomic publication.
+
+Until sparse extensions are supported, a single resize or write may synthesize
+at most 4 MiB of gap bytes; larger gaps fail before publication without limiting
+the total size of files grown through ordinary writes.

--- a/changes/1878.fixed.md
+++ b/changes/1878.fixed.md
@@ -1,0 +1,1 @@
+Mounted files can grow beyond the filesystem callback's 4 MiB per-request limit. Range writes and resizing stream replacement content instead of allocating a whole-file buffer, preserving zero-filled gaps and atomic publication.

--- a/changes/1880.fixed.md
+++ b/changes/1880.fixed.md
@@ -1,0 +1,1 @@
+Avoid revisiting unchanged physical-map subtrees on each durable write by caching verified persisted descendant closures. Preserve missing-descendant detection, canonical metadata, and crash recovery.

--- a/changes/1890.fixed.md
+++ b/changes/1890.fixed.md
@@ -1,0 +1,2 @@
+Run CI and contribution checks for stacked pull requests, and restore GNU
+compatibility builds using signed, dated Bullseye package snapshots.

--- a/crates/astrid-kernel/src/storage_mount/filesystem.rs
+++ b/crates/astrid-kernel/src/storage_mount/filesystem.rs
@@ -1,4 +1,7 @@
 use super::*;
+use std::io::Read;
+
+mod range;
 
 pub(super) trait CallbackFilesystem {
     fn stat(&self, path: &FilesystemPath) -> Result<FilesystemEntry, FilesystemError>;
@@ -10,6 +13,11 @@ pub(super) trait CallbackFilesystem {
         length: u64,
     ) -> Result<Vec<u8>, FilesystemError>;
     fn write(&self, path: &FilesystemPath, bytes: &[u8]) -> Result<(), FilesystemError>;
+    fn write_streaming(
+        &self,
+        path: &FilesystemPath,
+        source: impl Read,
+    ) -> Result<(), FilesystemError>;
     fn create_dir(&self, path: &FilesystemPath) -> Result<(), FilesystemError>;
     fn remove(&self, path: &FilesystemPath) -> Result<(), FilesystemError>;
     fn rename(
@@ -45,6 +53,14 @@ where
 
     fn write(&self, path: &FilesystemPath, bytes: &[u8]) -> Result<(), FilesystemError> {
         AstridFilesystem::write(self, path, bytes)
+    }
+
+    fn write_streaming(
+        &self,
+        path: &FilesystemPath,
+        source: impl Read,
+    ) -> Result<(), FilesystemError> {
+        AstridFilesystem::write_streaming(self, path, source)
     }
 
     fn create_dir(&self, path: &FilesystemPath) -> Result<(), FilesystemError> {
@@ -99,6 +115,15 @@ where
         self.write(path, bytes).map_err(map_workspace_error)
     }
 
+    fn write_streaming(
+        &self,
+        path: &FilesystemPath,
+        source: impl Read,
+    ) -> Result<(), FilesystemError> {
+        self.write_streaming(path, source)
+            .map_err(map_workspace_error)
+    }
+
     fn create_dir(&self, path: &FilesystemPath) -> Result<(), FilesystemError> {
         self.create_dir(path).map_err(map_workspace_error)
     }
@@ -150,6 +175,14 @@ where
 
     fn write(&self, path: &FilesystemPath, bytes: &[u8]) -> Result<(), FilesystemError> {
         OwnerSubtreeFilesystem::write(self, path, bytes)
+    }
+
+    fn write_streaming(
+        &self,
+        path: &FilesystemPath,
+        source: impl Read,
+    ) -> Result<(), FilesystemError> {
+        OwnerSubtreeFilesystem::write_streaming(self, path, source)
     }
 
     fn create_dir(&self, path: &FilesystemPath) -> Result<(), FilesystemError> {
@@ -219,6 +252,14 @@ impl<F: CallbackFilesystem> CallbackFilesystem for PrefixedFilesystem<F> {
         self.inner.write(&self.path(path)?, bytes)
     }
 
+    fn write_streaming(
+        &self,
+        path: &FilesystemPath,
+        source: impl Read,
+    ) -> Result<(), FilesystemError> {
+        self.inner.write_streaming(&self.path(path)?, source)
+    }
+
     fn create_dir(&self, path: &FilesystemPath) -> Result<(), FilesystemError> {
         self.inner.create_dir(&self.path(path)?)
     }
@@ -282,22 +323,15 @@ pub(super) fn execute_blocking(
             write_range(filesystem, path, offset, &data)
         },
         StorageFilesystemOperationV1::SetLength { path, length } => {
-            if length > STORAGE_FILESYSTEM_MAX_IO_BYTES {
+            if length > i64::MAX as u64 {
                 return Err(FilesystemError::InvalidPath(path));
             }
             let path = FilesystemPath::new(path)?;
             let current_length = require_file(filesystem, &path)?;
-            if current_length > STORAGE_FILESYSTEM_MAX_IO_BYTES {
-                return Err(FilesystemError::InvalidPath(path.as_str().to_owned()));
-            }
             if current_length == length {
                 return Ok(StorageFilesystemSuccessV1::Written(length));
             }
-            let mut bytes = filesystem.read(&path, 0, current_length)?;
-            let target = usize::try_from(length)
-                .map_err(|_| FilesystemError::InvalidPath(path.as_str().to_owned()))?;
-            bytes.resize(target, 0);
-            filesystem.write(&path, &bytes)?;
+            range::replace(filesystem, &path, current_length, length, length, &[])?;
             Ok(StorageFilesystemSuccessV1::Written(length))
         },
         StorageFilesystemOperationV1::Create { path, kind } => {
@@ -350,20 +384,17 @@ fn write_range(
     let end_offset = offset
         .checked_add(data_length)
         .ok_or_else(|| FilesystemError::InvalidPath(path.as_str().to_owned()))?;
-    if current_length.max(end_offset) > STORAGE_FILESYSTEM_MAX_IO_BYTES {
+    if current_length.max(end_offset) > i64::MAX as u64 {
         return Err(FilesystemError::InvalidPath(path.as_str().to_owned()));
     }
-    let mut bytes = filesystem.read(&path, 0, current_length)?;
-    let start = usize::try_from(offset)
-        .map_err(|_| FilesystemError::InvalidPath(path.as_str().to_owned()))?;
-    let end = start
-        .checked_add(data.len())
-        .ok_or_else(|| FilesystemError::InvalidPath(path.as_str().to_owned()))?;
-    if end > bytes.len() {
-        bytes.resize(end, 0);
-    }
-    bytes[start..end].copy_from_slice(data);
-    filesystem.write(&path, &bytes)?;
+    range::replace(
+        filesystem,
+        &path,
+        current_length,
+        current_length.max(end_offset),
+        offset,
+        data,
+    )?;
     Ok(StorageFilesystemSuccessV1::Written(
         current_length.max(end_offset),
     ))

--- a/crates/astrid-kernel/src/storage_mount/filesystem/range.rs
+++ b/crates/astrid-kernel/src/storage_mount/filesystem/range.rs
@@ -1,0 +1,146 @@
+//! Stream replacement bytes without treating the RPC payload ceiling as a file limit.
+use super::*;
+
+pub(super) fn replace(
+    filesystem: &impl CallbackFilesystem,
+    path: &FilesystemPath,
+    old_length: u64,
+    new_length: u64,
+    offset: u64,
+    data: &[u8],
+) -> Result<(), FilesystemError> {
+    // Publication happens only after the reader finishes, so reads still see the
+    // original file. The mount callback serializes its mutations.
+    filesystem.write_streaming(
+        path,
+        Replacement {
+            filesystem,
+            path,
+            old_length,
+            new_length,
+            offset,
+            data,
+            position: 0,
+        },
+    )
+}
+
+struct Replacement<'a, F> {
+    filesystem: &'a F,
+    path: &'a FilesystemPath,
+    old_length: u64,
+    new_length: u64,
+    offset: u64,
+    data: &'a [u8],
+    position: u64,
+}
+
+impl<F: CallbackFilesystem> Read for Replacement<'_, F> {
+    fn read(&mut self, output: &mut [u8]) -> std::io::Result<usize> {
+        let remaining = self.new_length.saturating_sub(self.position);
+        let count = usize::try_from(remaining.min(STORAGE_FILESYSTEM_MAX_IO_BYTES))
+            .unwrap_or(usize::MAX)
+            .min(output.len());
+        if count == 0 {
+            return Ok(0);
+        }
+        let patch_end = self.offset.strict_add(self.data.len() as u64);
+        let count = if self.position >= self.offset && self.position < patch_end {
+            let count = count
+                .min(usize::try_from(patch_end.strict_sub(self.position)).unwrap_or(usize::MAX));
+            let start = usize::try_from(self.position.strict_sub(self.offset))
+                .map_err(|_| std::io::Error::other("patch offset exceeds address space"))?;
+            output[..count].copy_from_slice(&self.data[start..start.strict_add(count)]);
+            count
+        } else {
+            let boundary = if self.position < self.offset {
+                self.offset
+            } else {
+                self.new_length
+            };
+            let count = count
+                .min(usize::try_from(boundary.strict_sub(self.position)).unwrap_or(usize::MAX));
+            if self.position < self.old_length {
+                let count = count.min(
+                    usize::try_from(self.old_length.strict_sub(self.position))
+                        .unwrap_or(usize::MAX),
+                );
+                let bytes = self
+                    .filesystem
+                    .read(self.path, self.position, count as u64)
+                    .map_err(|error| std::io::Error::other(error.to_string()))?;
+                if bytes.len() != count {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::UnexpectedEof,
+                        "mounted file changed during replacement",
+                    ));
+                }
+                output[..count].copy_from_slice(&bytes);
+                count
+            } else {
+                output[..count].fill(0);
+                count
+            }
+        };
+        self.position = self.position.strict_add(count as u64);
+        Ok(count)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn mounted_large_file_range_writes_resize_and_sync() {
+        let temporary = tempfile::tempdir().unwrap();
+        let home = astrid_core::dirs::AstridHome::from_path(temporary.path().join(".astrid"));
+        let kernel = crate::test_kernel_with_home(home).await;
+        let store = kernel.principal_store.clone().unwrap();
+        let fs = AstridFilesystem::new(
+            store.content(),
+            StateOwner::Principal(astrid_core::PrincipalUid::from_bytes([0xB8; 32])),
+        );
+        let path = FilesystemPath::new("large.bin").unwrap();
+        fs.write(&path, b"seed").unwrap();
+        let offset = STORAGE_FILESYSTEM_MAX_IO_BYTES + 1;
+        execute_blocking(
+            &fs,
+            StorageFilesystemOperationV1::Write {
+                path: path.as_str().into(),
+                offset,
+                data: b"tail".to_vec(),
+            },
+        )
+        .unwrap();
+        assert_eq!(fs.stat(&path).unwrap().logical_bytes(), offset + 4);
+        assert_eq!(fs.read(&path, 0, 4).unwrap(), b"seed");
+        assert_eq!(fs.read(&path, offset - 1, 5).unwrap(), b"\0tail");
+        execute_blocking(
+            &fs,
+            StorageFilesystemOperationV1::Write {
+                path: path.as_str().into(),
+                offset: 1,
+                data: b"XY".to_vec(),
+            },
+        )
+        .unwrap();
+        assert_eq!(fs.read(&path, 0, 4).unwrap(), b"sXYd");
+        assert_eq!(fs.read(&path, offset, 4).unwrap(), b"tail");
+        for length in [offset + 8, offset + 2, 0] {
+            execute_blocking(
+                &fs,
+                StorageFilesystemOperationV1::SetLength {
+                    path: path.as_str().into(),
+                    length,
+                },
+            )
+            .unwrap();
+            assert_eq!(fs.stat(&path).unwrap().logical_bytes(), length);
+            if length == offset + 8 {
+                assert_eq!(fs.read(&path, offset, 8).unwrap(), b"tail\0\0\0\0");
+            }
+        }
+        execute_blocking(&fs, StorageFilesystemOperationV1::Sync).unwrap();
+    }
+}

--- a/crates/astrid-kernel/src/storage_mount/filesystem/range.rs
+++ b/crates/astrid-kernel/src/storage_mount/filesystem/range.rs
@@ -9,6 +9,13 @@ pub(super) fn replace(
     offset: u64,
     data: &[u8],
 ) -> Result<(), FilesystemError> {
+    // Gaps are currently materialized, not sparse. Bound generated zeros by the
+    // per-callback byte budget: a tiny resize must not hold the shared mutation
+    // lock while generating unbounded bytes. This is not a total file-size cap.
+    let zero_fill = offset.min(new_length).saturating_sub(old_length);
+    if zero_fill > STORAGE_FILESYSTEM_MAX_IO_BYTES {
+        return Err(FilesystemError::InvalidPath(path.as_str().to_owned()));
+    }
     // Publication happens only after the reader finishes, so reads still see the
     // original file. The mount callback serializes its mutations.
     filesystem.write_streaming(
@@ -90,6 +97,52 @@ impl<F: CallbackFilesystem> Read for Replacement<'_, F> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn mounted_materialized_gaps_reject_before_publication() {
+        let temporary = tempfile::tempdir().unwrap();
+        let home = astrid_core::dirs::AstridHome::from_path(temporary.path().join(".astrid"));
+        let kernel = crate::test_kernel_with_home(home).await;
+        let store = kernel.principal_store.clone().unwrap();
+        let fs = AstridFilesystem::new(
+            store.content(),
+            StateOwner::Principal(astrid_core::PrincipalUid::from_bytes([0xB9; 32])),
+        );
+        let path = FilesystemPath::new("gap.bin").unwrap();
+        fs.write(&path, b"seed").unwrap();
+        for length in [4 + STORAGE_FILESYSTEM_MAX_IO_BYTES + 1, i64::MAX as u64] {
+            for operation in [
+                StorageFilesystemOperationV1::SetLength {
+                    path: path.as_str().into(),
+                    length,
+                },
+                StorageFilesystemOperationV1::Write {
+                    path: path.as_str().into(),
+                    offset: length,
+                    data: vec![1],
+                },
+            ] {
+                assert!(matches!(
+                    execute_blocking(&fs, operation),
+                    Err(FilesystemError::InvalidPath(_))
+                ));
+                assert_eq!(fs.stat(&path).unwrap().logical_bytes(), 4);
+                assert_eq!(fs.read(&path, 0, 4).unwrap(), b"seed");
+            }
+        }
+        // Exact budget is allowed even when total length exceeds the ceiling.
+        for length in [4 + STORAGE_FILESYSTEM_MAX_IO_BYTES, 0] {
+            execute_blocking(
+                &fs,
+                StorageFilesystemOperationV1::SetLength {
+                    path: path.as_str().into(),
+                    length,
+                },
+            )
+            .unwrap();
+            assert_eq!(fs.stat(&path).unwrap().logical_bytes(), length);
+        }
+    }
 
     #[tokio::test]
     async fn mounted_large_file_range_writes_resize_and_sync() {

--- a/crates/astrid-kernel/src/storage_mount/tests.rs
+++ b/crates/astrid-kernel/src/storage_mount/tests.rs
@@ -179,6 +179,15 @@ impl<F: CallbackFilesystem> CallbackFilesystem for ReadBoundarySpy<F> {
         self.inner.create_dir(path)
     }
 
+    fn write_streaming(
+        &self,
+        path: &FilesystemPath,
+        source: impl std::io::Read,
+    ) -> Result<(), FilesystemError> {
+        self.writes.fetch_add(1, Ordering::AcqRel);
+        self.inner.write_streaming(path, source)
+    }
+
     fn remove(&self, path: &FilesystemPath) -> Result<(), FilesystemError> {
         self.inner.remove(path)
     }
@@ -231,7 +240,7 @@ async fn oversized_set_length_and_random_write_preflight_before_full_read() {
         &spy,
         StorageFilesystemOperationV1::SetLength {
             path: "probe.bin".to_owned(),
-            length: STORAGE_FILESYSTEM_MAX_IO_BYTES.saturating_add(1),
+            length: (i64::MAX as u64) + 1,
         },
     );
     let set_length_preflighted =
@@ -243,7 +252,7 @@ async fn oversized_set_length_and_random_write_preflight_before_full_read() {
         &spy,
         StorageFilesystemOperationV1::Write {
             path: "probe.bin".to_owned(),
-            offset: STORAGE_FILESYSTEM_MAX_IO_BYTES,
+            offset: i64::MAX as u64,
             data: vec![0x5A],
         },
     );
@@ -254,7 +263,7 @@ async fn oversized_set_length_and_random_write_preflight_before_full_read() {
 
     assert!(
         set_length_preflighted,
-        "SetLength above the callback/quota ceiling must fail during preflight"
+        "SetLength outside the native offset domain must fail during preflight"
     );
     assert_eq!(
         set_length_reads, 0,
@@ -285,8 +294,8 @@ async fn oversized_set_length_and_random_write_preflight_before_full_read() {
         },
     );
     assert!(
-        matches!(truncation, Err(FilesystemError::InvalidPath(path)) if path == "oversized.bin"),
-        "truncating an already oversized file must fail before rebuilding its contents"
+        truncation.is_ok(),
+        "truncating a large file must succeed without reading its old contents"
     );
     assert_eq!(
         reads.load(Ordering::Acquire),
@@ -295,8 +304,8 @@ async fn oversized_set_length_and_random_write_preflight_before_full_read() {
     );
     assert_eq!(
         writes.load(Ordering::Acquire),
-        0,
-        "oversized truncation must not publish replacement bytes"
+        1,
+        "truncation publishes the empty replacement"
     );
 }
 

--- a/crates/astrid-storage/src/content/store/workspace/filesystem.rs
+++ b/crates/astrid-storage/src/content/store/workspace/filesystem.rs
@@ -143,6 +143,20 @@ where
             .write(&self.owner, self.branch, &path.file_name()?, bytes)
     }
 
+    /// Atomically publish streamed bytes into this branch, preserving quota checks.
+    pub fn write_streaming<R: std::io::Read>(
+        &self,
+        path: &FilesystemPath,
+        source: R,
+    ) -> Result<(), WorkspaceBranchError> {
+        self.require_parent(path)?;
+        if self.directory_exists(path)? {
+            return Err(FilesystemError::IsDirectory(path.clone()).into());
+        }
+        self.branches
+            .write_streaming(&self.owner, self.branch, &path.file_name()?, source)
+    }
+
     /// Create an explicit empty directory marker.
     pub fn create_dir(&self, path: &FilesystemPath) -> Result<(), WorkspaceBranchError> {
         if path.as_str().is_empty() {

--- a/crates/astrid-storage/src/content/store/workspace/operations.rs
+++ b/crates/astrid-storage/src/content/store/workspace/operations.rs
@@ -533,6 +533,50 @@ where
         })
     }
 
+    /// Publish streamed bytes after branch quota authorization.
+    ///
+    /// # Errors
+    ///
+    /// Returns source, content, quota, or branch publication errors.
+    pub fn write_streaming<R: std::io::Read>(
+        &self,
+        owner: &P,
+        id: WorkspaceUid,
+        name: &ContentName,
+        source: R,
+    ) -> Result<(), WorkspaceBranchError> {
+        // Defer admission until the existing branch transaction checks quota.
+        let profile = crate::content_dag::ChunkingProfile::ASTRID_V1;
+        let (verified, staged) =
+            if let Some((bound, limit)) = self.content.quota_staging_bound(owner)? {
+                self.content
+                    .stage_deferred_bounded(source, profile, bound, limit)?
+            } else {
+                self.content.stage_deferred(source, profile)?
+            };
+        let descriptor = verified.descriptor();
+        self.mutate_catalog(owner, id, None, |root, records| {
+            let mutation = super::insert(
+                root,
+                name,
+                super::CatalogValue {
+                    file: descriptor.file(),
+                    logical_bytes: descriptor.logical_bytes(),
+                },
+                &mut |object| self.content.load_required_for(owner, object),
+                &|record| self.content.engine.identify_object(record),
+            )?;
+            records.extend(
+                staged
+                    .iter()
+                    .cloned()
+                    .map(|record| (self.content.engine.identify_object(&record), record)),
+            );
+            records.extend(mutation.records);
+            Ok(mutation.root)
+        })
+    }
+
     /// Remove one named file from a branch.  Directory markers are treated as
     /// ordinary named values by this lower-level API; the filesystem wrapper
     /// enforces directory semantics.

--- a/crates/astrid-storage/src/content/store/workspace/tests.rs
+++ b/crates/astrid-storage/src/content/store/workspace/tests.rs
@@ -29,6 +29,53 @@ fn content_with_engine() -> (Arc<TestContent>, Arc<TestEngine>) {
 }
 
 #[test]
+fn workspace_streaming_preserves_base_and_failed_source_does_not_publish() {
+    use std::io::{self, Read};
+    struct Failing;
+    impl Read for Failing {
+        fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
+            Err(io::Error::other("injected source failure"))
+        }
+    }
+    let content = content();
+    let branches = WorkspaceBranchStore::new(Arc::clone(&content));
+    let owner = owner();
+    let name = ContentName::new("large").unwrap();
+    content.put(&owner, &name, b"base").unwrap();
+    let id = WorkspaceUid::from_bytes([83; 16]);
+    branches.begin_with_uid(&owner, id).unwrap();
+    let fs = branches.filesystem(owner, id);
+    let path = FilesystemPath::new("large").unwrap();
+    let size = 4 * 1024 * 1024 + 1;
+    fs.write_streaming(&path, io::repeat(0x5a).take(size))
+        .unwrap();
+    assert_eq!(fs.stat(&path).unwrap().logical_bytes(), size);
+    assert_eq!(fs.read(&path, size - 4, 4).unwrap(), [0x5a; 4]);
+    assert_eq!(content.read(&owner, &name).unwrap().unwrap(), b"base");
+    assert!(fs.write_streaming(&path, Failing).is_err());
+    assert_eq!(fs.stat(&path).unwrap().logical_bytes(), size);
+    assert_eq!(fs.read(&path, size - 4, 4).unwrap(), [0x5a; 4]);
+}
+
+#[test]
+fn workspace_streaming_refuses_quota_without_replacing_the_file() {
+    use std::io::Read;
+    let content = content_with_quota(64);
+    let branches = WorkspaceBranchStore::new(Arc::clone(&content));
+    let owner = owner();
+    let id = WorkspaceUid::from_bytes([84; 16]);
+    branches.begin_with_uid(&owner, id).unwrap();
+    let fs = branches.filesystem(owner, id);
+    let path = FilesystemPath::new("note").unwrap();
+    fs.write(&path, b"original").unwrap();
+    assert!(
+        fs.write_streaming(&path, std::io::repeat(0).take(65))
+            .is_err()
+    );
+    assert_eq!(fs.read(&path, 0, 8).unwrap(), b"original");
+}
+
+#[test]
 fn fork_shares_root_and_divergent_write_isolated() {
     let content = content();
     let branches = WorkspaceBranchStore::new(Arc::clone(&content));

--- a/crates/astrid-storage/src/engine/durable/representations/activation.rs
+++ b/crates/astrid-storage/src/engine/durable/representations/activation.rs
@@ -135,27 +135,42 @@ pub(super) fn append_new_reachable_map_nodes(
     map: &CanonicalPhysicalMap,
     durable: &BTreeSet<crate::storage_model::PhysicalMapNodeId>,
     appended: &mut BTreeSet<crate::storage_model::PhysicalMapNodeId>,
-) -> Result<(), DurableError> {
+    complete: &mut BTreeSet<crate::storage_model::PhysicalMapNodeId>,
+) -> Result<usize, DurableError> {
     let Some(root) = map.root() else {
-        return Ok(());
+        return Ok(0);
     };
     let mut pending = vec![(root, false)];
     let mut visited = BTreeSet::new();
     while let Some((id, expanded)) = pending.pop() {
         if expanded {
+            let node = map
+                .nodes()
+                .get(&id)
+                .ok_or(DurableError::InvalidRepresentationState(
+                    "active physical map is missing a reachable node",
+                ))?;
+            // A persisted parent alone does not establish durable descendants.
+            // Cache only closures checked against the append-only persisted set.
+            let children_complete = match node {
+                PhysicalMapNode::Branch { zero, one, .. } => {
+                    complete.contains(zero) && complete.contains(one)
+                },
+                PhysicalMapNode::Radix { children, .. } => {
+                    children.iter().all(|child| complete.contains(child))
+                },
+                PhysicalMapNode::Leaf { .. } | PhysicalMapNode::Page { .. } => true,
+            };
+            if durable.contains(&id) && children_complete {
+                complete.insert(id);
+            }
             if !durable.contains(&id) && !appended.contains(&id) {
-                let node = map
-                    .nodes()
-                    .get(&id)
-                    .ok_or(DurableError::InvalidRepresentationState(
-                        "active physical map is missing a reachable node",
-                    ))?;
                 metadata.push(MetadataFrame::map_node(&Blake3PhysicalIdentity, node)?);
                 appended.insert(id);
             }
             continue;
         }
-        if !visited.insert(id) {
+        if complete.contains(&id) || !visited.insert(id) {
             continue;
         }
         let node = map
@@ -176,7 +191,7 @@ pub(super) fn append_new_reachable_map_nodes(
             PhysicalMapNode::Leaf { .. } | PhysicalMapNode::Page { .. } => {},
         }
     }
-    Ok(())
+    Ok(visited.len())
 }
 
 pub(super) trait MapNodeRef {
@@ -227,15 +242,88 @@ mod tests {
     }
 
     #[test]
+    fn verified_durable_subtrees_skip_unchanged_nodes() {
+        let mut map = dense_map();
+        let durable = map.nodes().keys().copied().collect();
+        let mut complete = BTreeSet::new();
+        let mut metadata = Vec::new();
+        let mut appended = BTreeSet::new();
+        let cold = append_new_reachable_map_nodes(
+            &mut metadata,
+            &map,
+            &durable,
+            &mut appended,
+            &mut complete,
+        )
+        .unwrap();
+        assert_eq!(cold, map.nodes().len());
+        assert!(metadata.is_empty());
+        let warm = append_new_reachable_map_nodes(
+            &mut metadata,
+            &map,
+            &durable,
+            &mut appended,
+            &mut complete,
+        )
+        .unwrap();
+        assert_eq!(warm, 0);
+
+        map.insert(
+            &Blake3PhysicalIdentity,
+            PhysicalMapKey::new([42; 32]),
+            vec![7],
+        )
+        .unwrap();
+        let changed = append_new_reachable_map_nodes(
+            &mut metadata,
+            &map,
+            &durable,
+            &mut appended,
+            &mut complete,
+        )
+        .unwrap();
+        assert!(changed > 0 && changed < cold);
+        let mut cold_metadata = Vec::new();
+        let mut cold_appended = BTreeSet::new();
+        append_new_reachable_map_nodes(
+            &mut cold_metadata,
+            &map,
+            &durable,
+            &mut cold_appended,
+            &mut BTreeSet::new(),
+        )
+        .unwrap();
+        assert_eq!(appended, cold_appended);
+        assert_eq!(
+            metadata
+                .iter()
+                .map(|frame| frame.encode().unwrap())
+                .collect::<Vec<_>>(),
+            cold_metadata
+                .iter()
+                .map(|frame| frame.encode().unwrap())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
     fn durable_parent_does_not_hide_missing_descendants() {
         let map = dense_map();
         let root = map.root().unwrap();
         let mut metadata = Vec::new();
         let mut appended = BTreeSet::new();
 
-        append_new_reachable_map_nodes(&mut metadata, &map, &BTreeSet::from([root]), &mut appended)
-            .unwrap();
+        let mut complete = BTreeSet::new();
+        append_new_reachable_map_nodes(
+            &mut metadata,
+            &map,
+            &BTreeSet::from([root]),
+            &mut appended,
+            &mut complete,
+        )
+        .unwrap();
 
+        assert!(!complete.contains(&root));
         assert!(!appended.contains(&root));
         assert_eq!(appended.len(), map.nodes().len().checked_sub(1).unwrap());
         assert_eq!(metadata.len(), appended.len());
@@ -247,8 +335,14 @@ mod tests {
         let root = map.root().unwrap();
         let mut metadata = Vec::new();
         let mut appended = BTreeSet::new();
-        append_new_reachable_map_nodes(&mut metadata, &map, &BTreeSet::new(), &mut appended)
-            .unwrap();
+        append_new_reachable_map_nodes(
+            &mut metadata,
+            &map,
+            &BTreeSet::new(),
+            &mut appended,
+            &mut BTreeSet::new(),
+        )
+        .unwrap();
 
         let positions = metadata
             .iter()

--- a/crates/astrid-storage/src/engine/durable/representations/mod.rs
+++ b/crates/astrid-storage/src/engine/durable/representations/mod.rs
@@ -104,6 +104,8 @@ pub(super) struct RepresentationStore {
     representations: CanonicalPhysicalMap,
     placement_entries: CanonicalPhysicalMap,
     persisted_map_nodes: BTreeSet<crate::storage_model::PhysicalMapNodeId>,
+    // Memoized durable descendant closures; discarded when the store is reopened.
+    complete_map_subtrees: BTreeSet<crate::storage_model::PhysicalMapNodeId>,
     direct_profile: RepresentationProfileId,
     reverse: BTreeMap<ObjectId, Vec<RepresentationRecordId>>,
 }
@@ -434,12 +436,14 @@ impl RepresentationStore {
             &self.representations,
             &self.persisted_map_nodes,
             &mut appended_map_nodes,
+            &mut self.complete_map_subtrees,
         )?;
         append_new_reachable_map_nodes(
             &mut metadata,
             &self.placement_entries,
             &self.persisted_map_nodes,
             &mut appended_map_nodes,
+            &mut self.complete_map_subtrees,
         )?;
         let (catalogue, placements, state) = self.next_authority()?;
         let state_id = state.identify(&Blake3PhysicalIdentity);
@@ -516,6 +520,7 @@ impl RepresentationStore {
                 map,
                 &self.persisted_map_nodes,
                 &mut appended_map_nodes,
+                &mut self.complete_map_subtrees,
             )?;
         }
         let (catalogue, placements, state) = self.next_authority()?;
@@ -844,6 +849,7 @@ impl RepresentationStore {
             representations,
             placement_entries,
             persisted_map_nodes: index.nodes.keys().copied().collect(),
+            complete_map_subtrees: BTreeSet::new(),
             direct_profile,
             reverse,
         })

--- a/scripts/ci/install_gnu_build_packages.sh
+++ b/scripts/ci/install_gnu_build_packages.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Bullseye supplies the glibc 2.31 build baseline, but LTS ended 2026-08-31.
+# Freeze its final package sources rather than raising the binary ABI floor.
+# Only these immutable snapshots waive freshness; APT still verifies Debian
+# signatures and package hashes. Do not apply this policy to live repositories.
+sources=$(mktemp)
+trap 'rm -f "$sources"' EXIT
+printf '%s\n' \
+  'deb [check-valid-until=no] https://snapshot.debian.org/archive/debian/20260901T000000Z/ bullseye main' \
+  'deb [check-valid-until=no] https://snapshot.debian.org/archive/debian-security/20260901T000000Z/ bullseye-security main' \
+  > "$sources"
+options=(-o "Dir::Etc::sourcelist=$sources" -o Dir::Etc::sourceparts=-)
+apt-get "${options[@]}" update
+apt-get "${options[@]}" install -y --no-install-recommends "$@"

--- a/scripts/ci/test-release-contracts.sh
+++ b/scripts/ci/test-release-contracts.sh
@@ -20,3 +20,4 @@ bash scripts/test_channel_workflow_contract.sh
 bash scripts/test_certify_musl_release_archive_contract.sh
 bash scripts/test_native_storage_certification_contract.sh
 bash scripts/test_ci_workflow_contract.sh
+python3 scripts/test_gnu_build_packages.py

--- a/scripts/test_ci_workflow_contract.sh
+++ b/scripts/test_ci_workflow_contract.sh
@@ -37,16 +37,30 @@ unless concurrency["cancel-in-progress"] == expected_cancel
   fail("cancel-in-progress must be enabled only for first-attempt pull_request events")
 end
 
-# Keep this contract wired to both CI trigger classes. Parse the trigger map so
+# Keep this contract wired to filtered pushes and unconditional PRs. Parse so
 # comments or similarly named text cannot make an absent path entry pass.
 triggers = workflow["on"] || workflow[true]
 fail("missing workflow trigger map") unless triggers.is_a?(Hash)
-%w[push pull_request].each do |event_name|
+%w[push].each do |event_name|
   event = triggers.fetch(event_name) { fail("missing #{event_name} trigger") }
   paths = event.fetch("paths") { fail("missing #{event_name}.paths filter") }
   unless paths.is_a?(Array) && paths.count("scripts/test_ci_workflow_contract.sh") == 1
     fail("contract test must appear exactly once in #{event_name}.paths")
   end
+end
+
+# Required checks cannot depend on the base branch or changed file paths.
+# A YAML null pull_request value is the intended unconditional event.
+fail("missing pull_request trigger") unless triggers.key?("pull_request")
+fail("pull_request must be unconditional") unless triggers["pull_request"].nil?
+pr_checks_path = File.join(File.dirname(workflow_path), "pr-checks.yml")
+pr_checks = YAML.safe_load(File.read(pr_checks_path), aliases: false)
+pr_events = (pr_checks["on"] || pr_checks[true]).fetch("pull_request")
+fail("PR Checks must allow stacked bases") if pr_events.key?("branches") || pr_events.key?("branches-ignore")
+
+%w[ci.yml release.yml].each do |name|
+  text = File.read(File.join(File.dirname(workflow_path), name))
+  fail("#{name} must use shared GNU package setup") unless text.include?('bash scripts/ci/install_gnu_build_packages.sh "${packages[@]}"')
 end
 
 def group(workflow_name, event_name, pr_number, run_id, run_attempt)

--- a/scripts/test_gnu_build_packages.py
+++ b/scripts/test_gnu_build_packages.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Exercise package-source scope, argument forwarding and update failure."""
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+SCRIPT = Path(__file__).parent / "ci/install_gnu_build_packages.sh"
+
+
+class PackageSetupTests(unittest.TestCase):
+    def run_setup(self, fail_update=False):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            log = root / "calls.jsonl"
+            apt = root / "apt-get"
+            apt.write_text(
+                "#!/usr/bin/env python3\n"
+                "import json, os, pathlib, sys\n"
+                "args = sys.argv[1:]\n"
+                "source = next(a.split('=', 1)[1] for a in args "
+                "if a.startswith('Dir::Etc::sourcelist='))\n"
+                "with open(os.environ['APT_TEST_LOG'], 'a') as log:\n"
+                " log.write(json.dumps({'args': args, 'path': source, "
+                "'sources': pathlib.Path(source).read_text()}) + '\\n')\n"
+                "if 'update' in args and os.environ['APT_TEST_FAIL'] == '1': "
+                "sys.exit(100)\n"
+            )
+            apt.chmod(0o755)
+            env = dict(os.environ, PATH=f"{root}:{os.environ['PATH']}",
+                       APT_TEST_LOG=str(log), APT_TEST_FAIL=str(int(fail_update)))
+            result = subprocess.run(
+                ["bash", str(SCRIPT), "cmake", "gcc-aarch64-linux-gnu"],
+                env=env, check=False,
+            )
+            calls = [json.loads(line) for line in log.read_text().splitlines()]
+            for call in calls:
+                self.assertFalse(Path(call["path"]).exists(), "temporary source leaked")
+            return result.returncode, calls
+
+    def test_signed_snapshot_sources_and_forwarded_packages(self):
+        code, calls = self.run_setup()
+        self.assertEqual(code, 0)
+        self.assertEqual(len(calls), 2)
+        for call in calls:
+            self.assertIn("Dir::Etc::sourceparts=-", call["args"])
+            self.assertNotIn("--allow-unauthenticated", call["args"])
+            lines = call["sources"].splitlines()
+            self.assertEqual(len(lines), 2)
+            for line in lines:
+                self.assertIn("https://snapshot.debian.org/archive/", line)
+                self.assertIn("/20260901T000000Z/", line)
+                self.assertIn("[check-valid-until=no]", line)
+                self.assertNotIn("trusted=yes", line)
+        self.assertEqual(calls[0]["sources"], calls[1]["sources"])
+        self.assertEqual(calls[1]["args"][-5:],
+                         ["install", "-y", "--no-install-recommends",
+                          "cmake", "gcc-aarch64-linux-gnu"])
+
+    def test_failed_update_never_installs(self):
+        code, calls = self.run_setup(fail_update=True)
+        self.assertEqual(code, 100)
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0]["args"][-1], "update")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Linked Issue

Closes #1880

## Summary

Avoid repeatedly walking unchanged representation and placement map subtrees on every durable write. This is a performance follow-up to #1879, not a change to the volume format or durability policy.

## Changes

- Memoize only subtrees whose complete descendant closure has been checked against the append-only persisted map-node set.
- Do not treat a persisted parent as evidence that its children exist. Newly appended nodes are not cached as persisted during the same traversal.
- Reset the in-memory memo on reopen; no new on-disk authority or recovery shortcut.
- Preserve children-before-parent emission and byte-identical metadata. Memo entries are a subset of already retained persisted node identities.

## Verification

- `cargo test -p astrid-storage engine::durable --lib`: 175 passed, 0 failed, 1 intentionally ignored throughput probe.
- `cargo clippy -p astrid-storage --all-targets -- -D warnings`: PASS.
- `cargo fmt --all --check` and `git diff --check`: PASS.
- New regression proves initial traversal, zero-node unchanged traversal, changed-path traversal, and byte-identical emitted metadata versus an uncached walk.
- Existing missing-descendant and children-before-parent tests retained. Crash/replay and compaction tests pass.
- Actual macOS arm64 FSKit mount, same accumulated disposable volume, three samples: 32 MiB fsync 5.23–5.47 s before versus 2.67–3.04 s after; 16 small-file create/read/stat/rename/delete/list operations 14.50–15.55 s before versus 2.29–2.39 s after. SHA256 readbacks pass. Warm OS caches, not a CI gate, not SOTA or cross-platform performance proof.
- Actual >8 MiB overwrite, zero-fill extension/gap, shrink, sync, unmount/remount, SHA256 readback and truncate-zero regression PASS.
- Returning to the old binary on the same growing volume reproduced 6.66–6.91 s flushes and 21.40–22.24 s small-file batches, with SHA256 checks passing. This supports the optimization rather than a warm-cache-only explanation, but is not a frozen-volume laboratory experiment. No format, verification, or fsync-policy changes.

## Test Plan

Run the commands above, then exercise the release daemon through the actual FSKit mount with 32 MiB write/fsync/SHA256 checks and overwrite/resize/sync/unmount/remount verification. Compare old/new/old binaries on the same disposable volume. Native APFS warm-cache measurements are context, not a like-for-like durability design claim.

## AI / Tool Assistance

Assisted-by: Codex:gpt-6-astra

Assisted with profiling, implementation, regression tests, and mounted validation. Reviewed the persisted-descendant invariant and publication/recovery behavior directly.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added
- [x] Changes reviewed for design, risks, and validation
- [x] Tool-generated output reviewed and tested
- [x] Matching Signed-off-by trailer


Integration update: the branch now includes the landed CI prerequisite #1891 and the materialized-gap regression repair from #1879. Its own performance change is preserved. Earlier benchmark measurements remain labelled by their original candidate; current combined-head checks run separately.
