### PR TITLE
fix(storage): reuse canonical chunks for mounted appends

### DIFF
--- a/changes/1884.fixed.md
+++ b/changes/1884.fixed.md
@@ -1,0 +1,1 @@
+Mounted appends reuse verified prefix chunks instead of rereading and rechunking the complete file. The final chunk is rebuilt with the appended bytes, preserving canonical content identity, quotas, and atomic source-checked publication; cold proofs and workspace writes retain the validating streaming fallback.

--- a/crates/astrid-kernel/src/storage_mount/filesystem.rs
+++ b/crates/astrid-kernel/src/storage_mount/filesystem.rs
@@ -13,6 +13,14 @@ pub(super) trait CallbackFilesystem {
         length: u64,
     ) -> Result<Vec<u8>, FilesystemError>;
     fn write(&self, path: &FilesystemPath, bytes: &[u8]) -> Result<(), FilesystemError>;
+    fn try_append(
+        &self,
+        _path: &FilesystemPath,
+        _expected_length: u64,
+        _bytes: &[u8],
+    ) -> Result<bool, FilesystemError> {
+        Ok(false)
+    }
     fn write_streaming(
         &self,
         path: &FilesystemPath,
@@ -53,6 +61,15 @@ where
 
     fn write(&self, path: &FilesystemPath, bytes: &[u8]) -> Result<(), FilesystemError> {
         AstridFilesystem::write(self, path, bytes)
+    }
+
+    fn try_append(
+        &self,
+        path: &FilesystemPath,
+        expected_length: u64,
+        bytes: &[u8],
+    ) -> Result<bool, FilesystemError> {
+        AstridFilesystem::try_append(self, path, expected_length, bytes)
     }
 
     fn write_streaming(
@@ -177,6 +194,15 @@ where
         OwnerSubtreeFilesystem::write(self, path, bytes)
     }
 
+    fn try_append(
+        &self,
+        path: &FilesystemPath,
+        expected_length: u64,
+        bytes: &[u8],
+    ) -> Result<bool, FilesystemError> {
+        OwnerSubtreeFilesystem::try_append(self, path, expected_length, bytes)
+    }
+
     fn write_streaming(
         &self,
         path: &FilesystemPath,
@@ -231,6 +257,15 @@ impl<F> PrefixedFilesystem<F> {
 }
 
 impl<F: CallbackFilesystem> CallbackFilesystem for PrefixedFilesystem<F> {
+    fn try_append(
+        &self,
+        path: &FilesystemPath,
+        expected_length: u64,
+        bytes: &[u8],
+    ) -> Result<bool, FilesystemError> {
+        self.inner
+            .try_append(&self.path(path)?, expected_length, bytes)
+    }
     fn stat(&self, path: &FilesystemPath) -> Result<FilesystemEntry, FilesystemError> {
         self.inner.stat(&self.path(path)?)
     }
@@ -386,6 +421,9 @@ fn write_range(
         .ok_or_else(|| FilesystemError::InvalidPath(path.as_str().to_owned()))?;
     if current_length.max(end_offset) > i64::MAX as u64 {
         return Err(FilesystemError::InvalidPath(path.as_str().to_owned()));
+    }
+    if offset == current_length && filesystem.try_append(&path, current_length, data)? {
+        return Ok(StorageFilesystemSuccessV1::Written(end_offset));
     }
     range::replace(
         filesystem,

--- a/crates/astrid-storage/src/content/store.rs
+++ b/crates/astrid-storage/src/content/store.rs
@@ -385,10 +385,26 @@ where
         verified: VerifiedContent,
         staged_records: &[ObjectRecord],
     ) -> Result<ContentWriteOutcome, PrincipalContentError> {
+        self.publish_deferred_expected(principal, name, verified, staged_records, None)
+    }
+
+    fn publish_deferred_expected(
+        &self,
+        principal: &P,
+        name: &ContentName,
+        verified: VerifiedContent,
+        staged_records: &[ObjectRecord],
+        expected_file: Option<ObjectId>,
+    ) -> Result<ContentWriteOutcome, PrincipalContentError> {
         let descriptor = verified.descriptor();
         loop {
             let mut header = self.header(principal)?.as_ref().clone();
             let previous = self.catalog_lookup(principal, header.catalog, name)?;
+            if let Some(expected) = expected_file
+                && previous.is_none_or(|entry| entry.file != expected)
+            {
+                return Err(PrincipalContentError::BatchPreconditionFailed);
+            }
             if previous.is_some_and(|entry| entry.file == descriptor.file()) {
                 let root = header.root.ok_or_else(|| {
                     invalid(
@@ -938,6 +954,7 @@ where
     }
 }
 
+mod append;
 mod bulk;
 mod constructors;
 mod internals;

--- a/crates/astrid-storage/src/content/store/append.rs
+++ b/crates/astrid-storage/src/content/store/append.rs
@@ -1,0 +1,50 @@
+use super::{
+    ContentName, EngineIdentity, EngineSource, PrincipalContentError, PrincipalContentStore,
+    PrincipalProjectionEngine, map_read_error,
+};
+
+impl<P, E> PrincipalContentStore<P, E>
+where
+    P: Clone + Ord + Send + Sync,
+    E: PrincipalProjectionEngine<P>,
+{
+    /// Append using a cached canonical proof, or leave the file untouched.
+    ///
+    /// A cold/unverified source returns false so the caller can use its validating
+    /// streaming path. The read handle pins the old closure through root publication.
+    pub(crate) fn try_append(
+        &self,
+        principal: &P,
+        name: &ContentName,
+        expected_length: u64,
+        bytes: &[u8],
+    ) -> Result<bool, PrincipalContentError> {
+        let Some(handle) = self.open_read(principal, name)? else {
+            return Err(PrincipalContentError::BatchPreconditionFailed);
+        };
+        if handle.descriptor().logical_bytes() != expected_length {
+            return Err(PrincipalContentError::BatchPreconditionFailed);
+        }
+        let Some(verified) = handle.verified() else {
+            return Ok(false);
+        };
+        let appended = crate::content_dag::append_verified_content(
+            &EngineIdentity::<P, E>::new(self.engine.as_ref()),
+            &EngineSource::<P, E>::new(self.engine.as_ref(), principal),
+            verified,
+            bytes,
+        )
+        .map_err(map_read_error)?;
+        self.publish_deferred_expected(
+            principal,
+            name,
+            appended.verified,
+            &appended.records,
+            Some(verified.descriptor().file()),
+        )?;
+        Ok(true)
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/astrid-storage/src/content/store/append/tests.rs
+++ b/crates/astrid-storage/src/content/store/append/tests.rs
@@ -1,0 +1,195 @@
+use std::sync::Arc;
+
+use super::*;
+use crate::Blake3ObjectIdentityV1;
+use crate::content_dag::{ChunkingProfile, append_verified_content, build_content};
+use crate::engine::InMemoryEngine;
+
+#[test]
+fn unverified_append_leaves_source_untouched_for_streaming_fallback() {
+    let engine = Arc::new(InMemoryEngine::new(Blake3ObjectIdentityV1));
+    let store = PrincipalContentStore::from_engine(engine);
+    let owner = "alice".to_owned();
+    let name = ContentName::new("file").unwrap();
+    store.put(&owner, &name, b"old").unwrap();
+    assert!(!store.try_append(&owner, &name, 3, b"new").unwrap());
+    assert_eq!(store.read(&owner, &name).unwrap().unwrap(), b"old");
+}
+
+#[test]
+fn conditional_append_rejects_changed_file_but_allows_unrelated_catalog_changes() {
+    let engine = Arc::new(InMemoryEngine::new(Blake3ObjectIdentityV1));
+    let store = PrincipalContentStore::from_engine(Arc::clone(&engine));
+    let owner = "alice".to_owned();
+    let name = ContentName::new("file").unwrap();
+    let old = build_content(&Blake3ObjectIdentityV1, ChunkingProfile::ASTRID_V1, b"old").unwrap();
+    store.put(&owner, &name, b"old").unwrap();
+    let delta = append_verified_content(
+        &Blake3ObjectIdentityV1,
+        &EngineSource::new(engine.as_ref(), &owner),
+        old.verified_content(),
+        b"new",
+    )
+    .unwrap();
+    store
+        .put(&owner, &ContentName::new("unrelated").unwrap(), b"other")
+        .unwrap();
+    store
+        .publish_deferred_expected(
+            &owner,
+            &name,
+            delta.verified,
+            &delta.records,
+            Some(old.descriptor().file()),
+        )
+        .unwrap();
+    assert_eq!(store.read(&owner, &name).unwrap().unwrap(), b"oldnew");
+    // Same-length replacement must also reject: length alone is not identity.
+    store.put(&owner, &name, b"NEW").unwrap();
+    let root = engine.root(&owner);
+    let objects = engine.object_count();
+    assert!(matches!(
+        store.publish_deferred_expected(
+            &owner,
+            &name,
+            delta.verified,
+            &delta.records,
+            Some(old.descriptor().file())
+        ),
+        Err(PrincipalContentError::BatchPreconditionFailed)
+    ));
+    assert_eq!(engine.root(&owner), root);
+    assert_eq!(engine.object_count(), objects);
+    assert_eq!(store.read(&owner, &name).unwrap().unwrap(), b"NEW");
+}
+
+#[test]
+fn quota_rejected_append_admits_no_delta_records_and_preserves_root() {
+    let engine = Arc::new(InMemoryEngine::new(Blake3ObjectIdentityV1));
+    let store = PrincipalContentStore::from_engine_with_quota(
+        Arc::clone(&engine),
+        Arc::new(|_: &String| Ok(Some(128))),
+    );
+    let owner = "alice".to_owned();
+    let name = ContentName::new("file").unwrap();
+    let old = build_content(&Blake3ObjectIdentityV1, ChunkingProfile::ASTRID_V1, b"old").unwrap();
+    store.put(&owner, &name, b"old").unwrap();
+    let delta = append_verified_content(
+        &Blake3ObjectIdentityV1,
+        &EngineSource::new(engine.as_ref(), &owner),
+        old.verified_content(),
+        &[42; 256],
+    )
+    .unwrap();
+    let root = engine.root(&owner);
+    let objects = engine.object_count();
+    assert!(matches!(
+        store.publish_deferred_expected(
+            &owner,
+            &name,
+            delta.verified,
+            &delta.records,
+            Some(old.descriptor().file())
+        ),
+        Err(PrincipalContentError::QuotaExceeded { .. })
+    ));
+    assert_eq!(engine.root(&owner), root);
+    assert_eq!(engine.object_count(), objects);
+}
+
+struct ConcurrentReplacement {
+    inner: Arc<InMemoryEngine<String, Blake3ObjectIdentityV1>>,
+    armed: std::sync::atomic::AtomicBool,
+}
+
+impl PrincipalProjectionEngine<String> for ConcurrentReplacement {
+    fn identify_object(
+        &self,
+        record: &crate::storage_model::ObjectRecord,
+    ) -> crate::storage_model::ObjectId {
+        self.inner.identify_object(record)
+    }
+
+    fn stage_object(
+        &self,
+        record: crate::storage_model::ObjectRecord,
+    ) -> Result<
+        (
+            crate::storage_model::ObjectId,
+            crate::storage_model::InsertOutcome,
+        ),
+        crate::engine::PrincipalProjectionError,
+    > {
+        self.inner.stage_object(record)
+    }
+
+    fn current_root(
+        &self,
+        owner: &String,
+    ) -> Result<Option<crate::storage_model::RootState>, crate::engine::PrincipalProjectionError>
+    {
+        self.inner.current_root(owner)
+    }
+
+    fn load_object(
+        &self,
+        id: crate::storage_model::ObjectId,
+    ) -> Result<Option<crate::storage_model::ObjectRecord>, crate::engine::PrincipalProjectionError>
+    {
+        self.inner.load_object(id)
+    }
+
+    fn commit_root(
+        &self,
+        transaction: crate::engine::RootTransaction<String>,
+    ) -> Result<crate::engine::CommitOutcome, crate::engine::PrincipalProjectionError> {
+        if self.armed.swap(false, std::sync::atomic::Ordering::SeqCst) {
+            PrincipalContentStore::from_engine(Arc::clone(&self.inner))
+                .put(
+                    transaction.principal(),
+                    &ContentName::new("file").unwrap(),
+                    b"NEW",
+                )
+                .unwrap();
+        }
+        self.inner.commit_root(transaction)
+    }
+
+    fn flush_projection(&self) -> Result<(), crate::engine::PrincipalProjectionError> {
+        Ok(())
+    }
+}
+
+#[test]
+fn append_rechecks_expected_identity_after_root_cas_conflict() {
+    let engine = Arc::new(ConcurrentReplacement {
+        inner: Arc::new(InMemoryEngine::new(Blake3ObjectIdentityV1)),
+        armed: std::sync::atomic::AtomicBool::new(false),
+    });
+    let store = PrincipalContentStore::from_engine(Arc::clone(&engine));
+    let owner = "alice".to_owned();
+    let name = ContentName::new("file").unwrap();
+    let old = build_content(&Blake3ObjectIdentityV1, ChunkingProfile::ASTRID_V1, b"old").unwrap();
+    store.put(&owner, &name, b"old").unwrap();
+    let delta = append_verified_content(
+        &Blake3ObjectIdentityV1,
+        &EngineSource::new(engine.as_ref(), &owner),
+        old.verified_content(),
+        b"new",
+    )
+    .unwrap();
+    engine
+        .armed
+        .store(true, std::sync::atomic::Ordering::SeqCst);
+    assert!(matches!(
+        store.publish_deferred_expected(
+            &owner,
+            &name,
+            delta.verified,
+            &delta.records,
+            Some(old.descriptor().file())
+        ),
+        Err(PrincipalContentError::BatchPreconditionFailed)
+    ));
+    assert_eq!(store.read(&owner, &name).unwrap().unwrap(), b"NEW");
+}

--- a/crates/astrid-storage/src/content/store/read_handle.rs
+++ b/crates/astrid-storage/src/content/store/read_handle.rs
@@ -173,7 +173,7 @@ where
         Ok(bytes)
     }
 
-    fn verified(&self) -> Option<VerifiedContent> {
+    pub(super) fn verified(&self) -> Option<VerifiedContent> {
         self.engine
             .load_projection_cache(
                 &self.principal,

--- a/crates/astrid-storage/src/content_dag/append.rs
+++ b/crates/astrid-storage/src/content_dag/append.rs
@@ -1,0 +1,75 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use super::build::{append_chunks, build_tree, file_record};
+use super::read::traversal::verified_chunks;
+use super::{
+    ContentDescriptor, ContentError, ContentReadError, ContentSource, OpenedContent,
+    VerifiedContent, insert_record, read_verified_content_range,
+};
+use crate::storage_model::{ObjectIdentity, ObjectRecord};
+
+/// A delta, not a complete closure: unchanged objects remain in the pinned source.
+pub(crate) struct AppendedContent {
+    pub(crate) verified: VerifiedContent,
+    pub(crate) records: Vec<ObjectRecord>,
+}
+
+/// Rechunk only the old EOF chunk and appended bytes, retaining canonical identity.
+///
+/// All preceding boundaries are final because the input carries a full verification
+/// proof. Metadata is rebuilt canonically; this is O(chunk count) metadata work, not
+/// a right-spine-only update. The caller must pin the old closure through publication.
+pub(crate) fn append_verified_content<I: ObjectIdentity, S: ContentSource>(
+    identity: &I,
+    source: &S,
+    old: VerifiedContent,
+    bytes: &[u8],
+) -> Result<AppendedContent, ContentReadError<S::Error>> {
+    let descriptor = old.descriptor();
+    let logical_bytes = descriptor
+        .logical_bytes()
+        .checked_add(u64::try_from(bytes.len()).map_err(|_| ContentError::LengthOverflow)?)
+        .ok_or(ContentError::LengthOverflow)?;
+    let mut chunks = verified_chunks(source, old)?;
+    let mut tail = if let Some(last) = chunks.pop() {
+        read_verified_content_range(
+            source,
+            old,
+            descriptor
+                .logical_bytes()
+                .checked_sub(last.logical_bytes)
+                .ok_or(ContentError::LengthOverflow)?,
+            last.logical_bytes,
+        )?
+    } else {
+        Vec::new()
+    };
+    tail.try_reserve(bytes.len())
+        .map_err(|_| ContentError::LengthOverflow)?;
+    tail.extend_from_slice(bytes);
+    let mut records = BTreeMap::new();
+    // The whole-file small-value exception is not a small-tail exception.
+    append_chunks(
+        identity,
+        descriptor.profile(),
+        &tail,
+        logical_bytes <= u64::from(descriptor.profile().maximum_bytes()),
+        &mut records,
+        &mut chunks,
+        &mut BTreeSet::new(),
+    )?;
+    let chunk_count = u64::try_from(chunks.len()).map_err(|_| ContentError::LengthOverflow)?;
+    let content = build_tree(identity, &mut records, chunks)?;
+    let file = file_record(descriptor.profile(), logical_bytes, chunk_count, content)?;
+    let file = insert_record(identity, &mut records, file)?;
+    Ok(AppendedContent {
+        verified: VerifiedContent::new(OpenedContent::new(
+            ContentDescriptor::new(file, logical_bytes, chunk_count, descriptor.profile()),
+            content.map(|child| child.id),
+        )),
+        records: records.into_values().collect(),
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/astrid-storage/src/content_dag/append/tests.rs
+++ b/crates/astrid-storage/src/content_dag/append/tests.rs
@@ -1,0 +1,150 @@
+use std::{cell::Cell, collections::BTreeMap, convert::Infallible};
+
+use super::*;
+use crate::content_dag::{
+    ChunkingProfile, build_content, read_content,
+    tests::{TestIdentity, deterministic_bytes},
+};
+use crate::storage_model::{ObjectId, ObjectKind};
+
+struct Source {
+    records: BTreeMap<ObjectId, ObjectRecord>,
+    payload_loads: Cell<usize>,
+}
+
+impl ContentSource for Source {
+    type Error = Infallible;
+
+    fn load_content_object(&self, id: ObjectId) -> Result<Option<ObjectRecord>, Self::Error> {
+        let record = self.records.get(&id);
+        if record.is_some_and(|record| record.kind() == ObjectKind::Chunk) {
+            self.payload_loads
+                .set(self.payload_loads.get().strict_add(1));
+        }
+        Ok(record.cloned())
+    }
+}
+
+#[test]
+fn append_matches_full_builder_across_small_file_threshold_and_tree_levels() {
+    let profile = ChunkingProfile::ASTRID_V1;
+    let max = profile.maximum_bytes() as usize;
+    let bytes = deterministic_bytes(12 * 1024 * 1024);
+    for split in [0, 1, max - 1, max, max + 1, max * 2 + 7, 10 * 1024 * 1024] {
+        for added in [0, 1, 8193, max, max + 1] {
+            let old = build_content(&TestIdentity, profile, &bytes[..split]).unwrap();
+            let mut source = Source {
+                records: old.records().iter().cloned().collect(),
+                payload_loads: Cell::new(0),
+            };
+            let append = append_verified_content(
+                &TestIdentity,
+                &source,
+                old.verified_content(),
+                &bytes[split..split + added],
+            )
+            .unwrap();
+            let expected = build_content(&TestIdentity, profile, &bytes[..split + added]).unwrap();
+            assert_eq!(
+                append.verified,
+                expected.verified_content(),
+                "{split}+{added}"
+            );
+            assert_eq!(
+                source.payload_loads.get(),
+                usize::from(split != 0),
+                "{split}+{added}"
+            );
+            for record in append.records {
+                source
+                    .records
+                    .insert(TestIdentity.identify(&record), record);
+            }
+            assert_eq!(
+                read_content(&source, append.verified.descriptor().file()).unwrap(),
+                &bytes[..split + added]
+            );
+        }
+    }
+}
+
+#[test]
+fn fragmented_append_preserves_canonical_identity_for_repetitive_and_random_data() {
+    for bytes in [vec![0_u8; 1024 * 1024], deterministic_bytes(1024 * 1024)] {
+        let old = build_content(&TestIdentity, ChunkingProfile::ASTRID_V1, &[]).unwrap();
+        let mut verified = old.verified_content();
+        let mut source = Source {
+            records: old.records().iter().cloned().collect(),
+            payload_loads: Cell::new(0),
+        };
+        let mut length = 0;
+        for fragment in bytes.chunks(7919) {
+            let append =
+                append_verified_content(&TestIdentity, &source, verified, fragment).unwrap();
+            length += fragment.len();
+            assert_eq!(
+                append.verified,
+                build_content(&TestIdentity, ChunkingProfile::ASTRID_V1, &bytes[..length])
+                    .unwrap()
+                    .verified_content()
+            );
+            verified = append.verified;
+            for record in append.records {
+                source
+                    .records
+                    .insert(TestIdentity.identify(&record), record);
+            }
+        }
+    }
+}
+
+#[test]
+fn missing_tail_fails_instead_of_publishing_truncated_content() {
+    let old = build_content(&TestIdentity, ChunkingProfile::ASTRID_V1, b"old").unwrap();
+    let mut source = Source {
+        records: old.records().iter().cloned().collect(),
+        payload_loads: Cell::new(0),
+    };
+    source.records.remove(
+        &old.verified_content()
+            .opened_content()
+            .content_root()
+            .unwrap(),
+    );
+    assert!(
+        append_verified_content(&TestIdentity, &source, old.verified_content(), b"new").is_err()
+    );
+}
+
+#[test]
+fn append_preserves_seeded_and_legacy_odd_profiles() {
+    let bytes = deterministic_bytes(128 * 1024);
+    for profile in [
+        ChunkingProfile::fastcdc_v2020(64, 256, 1024, 42).unwrap(),
+        ChunkingProfile::fastcdc_v2020(65, 256, 1025, 42).unwrap(),
+    ] {
+        for split in [1, 1023, 1024, 1025, 1026, 8191, 65_537] {
+            let old = build_content(&TestIdentity, profile, &bytes[..split]).unwrap();
+            let source = Source {
+                records: old.records().iter().cloned().collect(),
+                payload_loads: Cell::new(0),
+            };
+            for added in [0, 1, 2, 65, 1024, 8193] {
+                let delta = append_verified_content(
+                    &TestIdentity,
+                    &source,
+                    old.verified_content(),
+                    &bytes[split..split + added],
+                )
+                .unwrap();
+                assert_eq!(
+                    delta.verified,
+                    build_content(&TestIdentity, profile, &bytes[..split + added])
+                        .unwrap()
+                        .verified_content(),
+                    "{profile:?}: {split}+{added}"
+                );
+            }
+        }
+    }
+}

--- a/crates/astrid-storage/src/content_dag/build.rs
+++ b/crates/astrid-storage/src/content_dag/build.rs
@@ -83,17 +83,46 @@ pub fn build_content<I: ObjectIdentity>(
     let mut chunks = Vec::new();
     let mut unique_chunks = BTreeSet::new();
 
+    append_chunks(
+        identity,
+        profile,
+        source,
+        source.len() <= profile.maximum_bytes() as usize,
+        &mut records,
+        &mut chunks,
+        &mut unique_chunks,
+    )?;
+
+    let chunk_count = u64::try_from(chunks.len()).map_err(|_| ContentError::LengthOverflow)?;
+    let content = build_tree(identity, &mut records, chunks)?;
+    let file = file_record(profile, logical_bytes, chunk_count, content)?;
+    let file = insert_record(identity, &mut records, file)?;
+    let descriptor = ContentDescriptor::new(file, logical_bytes, chunk_count, profile);
+    Ok(BuiltContent {
+        verified: VerifiedContent::new(OpenedContent::new(
+            descriptor,
+            content.map(|child| child.id),
+        )),
+        records: records.into_iter().collect(),
+        unique_chunks: u64::try_from(unique_chunks.len())
+            .map_err(|_| ContentError::LengthOverflow)?,
+    })
+}
+
+pub(super) fn append_chunks<I: ObjectIdentity>(
+    identity: &I,
+    profile: ChunkingProfile,
+    source: &[u8],
+    whole_small_file: bool,
+    records: &mut BTreeMap<ObjectId, ObjectRecord>,
+    chunks: &mut Vec<Child>,
+    unique_chunks: &mut BTreeSet<ObjectId>,
+) -> Result<(), ContentError> {
     if !source.is_empty() {
         let maximum =
             usize::try_from(profile.maximum_bytes()).map_err(|_| ContentError::LengthOverflow)?;
-        if source.len() <= maximum {
-            push_chunk(
-                identity,
-                &mut records,
-                &mut chunks,
-                &mut unique_chunks,
-                source,
-            )?;
+        if whole_small_file {
+            push_chunk(identity, records, chunks, unique_chunks, source)?;
         } else if profile.uses_legacy_fastcdc_v4() {
             let chunker = FastCDCV4::with_level_and_seed(
                 source,
@@ -113,13 +142,7 @@ pub fn build_content<I: ObjectIdentity>(
                 let bytes = source
                     .get(chunk.offset..end)
                     .ok_or(ContentError::LengthOverflow)?;
-                push_chunk(
-                    identity,
-                    &mut records,
-                    &mut chunks,
-                    &mut unique_chunks,
-                    bytes,
-                )?;
+                push_chunk(identity, records, chunks, unique_chunks, bytes)?;
             }
         } else {
             let chunker = FastCDC::with_level_and_seed(
@@ -140,31 +163,12 @@ pub fn build_content<I: ObjectIdentity>(
                 let bytes = source
                     .get(chunk.offset..end)
                     .ok_or(ContentError::LengthOverflow)?;
-                push_chunk(
-                    identity,
-                    &mut records,
-                    &mut chunks,
-                    &mut unique_chunks,
-                    bytes,
-                )?;
+                push_chunk(identity, records, chunks, unique_chunks, bytes)?;
             }
         }
     }
 
-    let chunk_count = u64::try_from(chunks.len()).map_err(|_| ContentError::LengthOverflow)?;
-    let content = build_tree(identity, &mut records, chunks)?;
-    let file = file_record(profile, logical_bytes, chunk_count, content)?;
-    let file = insert_record(identity, &mut records, file)?;
-    let descriptor = ContentDescriptor::new(file, logical_bytes, chunk_count, profile);
-    Ok(BuiltContent {
-        verified: VerifiedContent::new(OpenedContent::new(
-            descriptor,
-            content.map(|child| child.id),
-        )),
-        records: records.into_iter().collect(),
-        unique_chunks: u64::try_from(unique_chunks.len())
-            .map_err(|_| ContentError::LengthOverflow)?,
-    })
+    Ok(())
 }
 
 fn push_chunk<I: ObjectIdentity>(
@@ -185,7 +189,7 @@ fn push_chunk<I: ObjectIdentity>(
     Ok(())
 }
 
-fn build_tree<I: ObjectIdentity>(
+pub(super) fn build_tree<I: ObjectIdentity>(
     identity: &I,
     records: &mut BTreeMap<ObjectId, ObjectRecord>,
     mut level: Vec<Child>,

--- a/crates/astrid-storage/src/content_dag/mod.rs
+++ b/crates/astrid-storage/src/content_dag/mod.rs
@@ -20,6 +20,8 @@ use alloc::collections::BTreeMap;
 use alloc::vec::Vec;
 use core::fmt;
 
+mod append;
+pub(crate) use append::append_verified_content;
 mod boundary;
 mod build;
 mod read;

--- a/crates/astrid-storage/src/content_dag/read.rs
+++ b/crates/astrid-storage/src/content_dag/read.rs
@@ -462,6 +462,6 @@ pub fn read_verified_content_range<S: ContentSource>(
     .map(|(bytes, _)| bytes)
 }
 
-mod traversal;
+pub(super) mod traversal;
 
 use traversal::{BoundaryMode, decode_file, load, read_decoded_range};

--- a/crates/astrid-storage/src/content_dag/read/traversal.rs
+++ b/crates/astrid-storage/src/content_dag/read/traversal.rs
@@ -22,6 +22,61 @@ pub(super) enum BoundaryMode<'a> {
     Reuse(&'a ContentVerificationState),
 }
 
+/// Enumerate immutable chunk identities without loading their payloads.
+/// The caller holds a full canonical-boundary proof and pins its source closure.
+pub(in crate::content_dag) fn verified_chunks<S: ContentSource>(
+    source: &S,
+    verified: crate::content_dag::VerifiedContent,
+) -> Result<Vec<crate::content_dag::build::Child>, ContentReadError<S::Error>> {
+    let opened = verified.opened_content();
+    let descriptor = opened.descriptor();
+    let Some(root) = opened.content_root() else {
+        return Ok(Vec::new());
+    };
+    let shape = ExpectedShape {
+        logical_bytes: descriptor.logical_bytes(),
+        chunk_count: descriptor.chunk_count(),
+        tree_depth: canonical_tree_depth(descriptor.chunk_count()),
+        profile: descriptor.profile(),
+        ends_file: true,
+    };
+    let mut pending = vec![(root, shape)];
+    let mut chunks = Vec::new();
+    while let Some((object, shape)) = pending.pop() {
+        if shape.tree_depth == 0 {
+            chunks.push(crate::content_dag::build::Child {
+                id: object,
+                logical_bytes: shape.logical_bytes,
+                chunk_count: 1,
+            });
+            continue;
+        }
+        let record = load(source, object)?;
+        if record.kind() != ObjectKind::ChunkTree {
+            return Err(ContentError::InvalidObject {
+                object,
+                detail: "expected verified chunk-tree object",
+            }
+            .into());
+        }
+        let children = decode_tree(object, &record, shape)?;
+        let last = children.len().saturating_sub(1);
+        for (index, (id, logical_bytes, chunk_count)) in children.into_iter().enumerate().rev() {
+            pending.push((
+                id,
+                ExpectedShape {
+                    logical_bytes,
+                    chunk_count,
+                    tree_depth: shape.tree_depth.strict_sub(1),
+                    profile: shape.profile,
+                    ends_file: shape.ends_file && index == last,
+                },
+            ));
+        }
+    }
+    Ok(chunks)
+}
+
 pub(super) fn read_decoded_range<S: ContentSource>(
     source: &S,
     file: ObjectId,

--- a/crates/astrid-storage/src/filesystem.rs
+++ b/crates/astrid-storage/src/filesystem.rs
@@ -328,6 +328,23 @@ where
         self.inner.write_streaming(&self.path(path)?, source)
     }
 
+    /// Attempt a canonical append relative to the fixed subtree root.
+    ///
+    /// Returns false without mutation when the cached proof is unavailable.
+    ///
+    /// # Errors
+    ///
+    /// Returns a path, concurrent-change, quota, or storage error.
+    pub fn try_append(
+        &self,
+        path: &FilesystemPath,
+        expected_length: u64,
+        bytes: &[u8],
+    ) -> Result<bool, FilesystemError> {
+        self.inner
+            .try_append(&self.path(path)?, expected_length, bytes)
+    }
+
     /// Create a directory relative to the fixed subtree root.
     ///
     /// # Errors
@@ -544,6 +561,29 @@ where
             .put_streaming(&self.owner, &path.file_name()?, source)?;
         self.remember_directory(&path.parent());
         Ok(())
+    }
+
+    /// Attempt an append without rereading unchanged verified chunk payloads.
+    ///
+    /// Returns false without mutation when no canonical proof is cached; callers
+    /// must then use the ordinary validating write path. A changed source is an error.
+    ///
+    /// # Errors
+    ///
+    /// Returns a path, concurrent-change, quota, or storage error.
+    pub fn try_append(
+        &self,
+        path: &FilesystemPath,
+        expected_length: u64,
+        bytes: &[u8],
+    ) -> Result<bool, FilesystemError> {
+        self.require_parent(path)?;
+        if self.directory_exists(path)? {
+            return Err(FilesystemError::IsDirectory(path.clone()));
+        }
+        Ok(self
+            .content
+            .try_append(&self.owner, &path.file_name()?, expected_length, bytes)?)
     }
 
     /// Create an explicit empty directory.

--- a/crates/astrid-storage/src/filesystem/tests.rs
+++ b/crates/astrid-storage/src/filesystem/tests.rs
@@ -5,6 +5,40 @@ use astrid_core::PrincipalUid;
 use super::*;
 use crate::{KvQuotaResolver, StateOwner, open_runtime_principal_store};
 
+#[tokio::test]
+async fn canonical_append_uses_durable_proof_and_survives_reopen() {
+    let (directory, filesystem) = filesystem().await;
+    let path = FilesystemPath::new("append.bin").unwrap();
+    let initial = vec![19; 1024 * 1024];
+    let suffix = vec![23; 1024 * 1024];
+    filesystem.write(&path, &initial).unwrap();
+    assert!(
+        filesystem
+            .try_append(&path, initial.len() as u64, &suffix)
+            .unwrap()
+    );
+    assert!(
+        filesystem
+            .try_append(&path, initial.len() as u64, b"stale")
+            .is_err()
+    );
+    filesystem.sync().unwrap();
+    drop(filesystem);
+    let home = astrid_core::dirs::AstridHome::from_path(directory.path());
+    let store = open_runtime_principal_store(&home, Arc::new(|_: &StateOwner| Ok(Some(u64::MAX))))
+        .await
+        .unwrap();
+    let reopened = AstridFilesystem::new(
+        store.content(),
+        StateOwner::Principal(PrincipalUid::from_bytes([7; 32])),
+    );
+    let expected: Vec<_> = initial.into_iter().chain(suffix).collect();
+    assert_eq!(
+        reopened.read(&path, 0, expected.len() as u64).unwrap(),
+        expected
+    );
+}
+
 async fn filesystem() -> (
     tempfile::TempDir,
     AstridFilesystem<


### PR DESCRIPTION
## Linked Issue

Closes #1884

## Summary

Avoid rereading and rechunking the complete file on every mounted append. This is stacked on #1883 and changes neither the content format nor durability policy.

## Changes

- Reuse a cached full canonical-boundary proof and enumerate unchanged chunk metadata without loading its payloads.
- Rechunk the old final chunk plus appended bytes using the same builder as full-file writes. Preserve the whole-small-file exception, seeded profiles, legacy odd-size profiles, and canonical metadata fanout.
- Pin the old read closure through publication, require its exact file identity on every root-CAS attempt, and enforce quota before admitting delta objects.
- Wire owner, subtree, and prefixed mounted appends to this path. Cold proof caches and workspace views retain the validating streaming fallback. The 4 MiB callback payload bound is unchanged.
- Add equivalence, one-tail-payload-read, missing-tail, quota, stale identity, actual CAS-conflict, fallback, and durable-reopen regressions.

## Verification

At signed head `69c14a68652a42517ed2b6d76fea4f48e731c7e3`:

- `cargo test -p astrid-storage --lib -- --quiet`: 820 passed, 0 failed, 7 ignored.
- `cargo test -p astrid-kernel storage_mount --lib -- --quiet`: 24 passed.
- `cargo clippy -p astrid-storage -p astrid-kernel --all-targets -- -D warnings`: passed.
- `cargo fmt --all -- --check`: passed.
- Separate release builds of the daemon and CLI passed.
- Actual FSKit mount: >8 MiB write, cross-4-MiB overwrite, zero extension, gap fill, shrink, sync, unmount/remount, SHA256 readback, and truncate-to-zero passed.

Mounted A/B/A observation on Apple M2 Ultra, 192 GiB RAM, macOS 26.6.2, APFS-backed disposable Astrid volume, same FSKit app build 664:

| Daemon | 32 MiB fsync, three samples |
| --- | --- |
| Parent 874ad12d | 3.173 / 2.767 / 2.612 s |
| Candidate 69c14a68 | 1.052 / 0.848 / 0.868 s |
| Parent restored | 3.272 / 2.709 / 2.702 s |

The application write loop took another 3–6 ms on the mounted path. Median write+fsync improves about 3.17x against the preceding baseline. SHA256 reads passed. Small-file batches were broadly unchanged (about 2.3–2.5 s for 16 create/read/stat/rename/delete operations).

This is observational mounted evidence, not a CI performance gate: the volume history grows between runs, payloads are independently random, OS caches are warm, and there is no cache purge. Warm read timings are not backend read-throughput claims. This is not native-APFS parity, a SOTA claim, or Linux/Windows mounted certification. Metadata enumeration/rebuild still scales with chunk count; random overwrites and workspace writes still use full streaming reconstruction.

## Test Plan

- [x] Compare append descriptors with the full canonical builder across thresholds, profiles, and fragmented input.
- [x] Prove one old chunk payload is read, rather than the file prefix.
- [x] Reject stale publication both before and after a root-CAS conflict.
- [x] Preserve root and object count on quota refusal.
- [x] Exercise the actual mounted path with fsync and remount verification.
- [ ] Complete current-head CI after retargeting to main.

## AI / Tool Assistance

Assisted-by: Codex:Astra

Used for implementation, regression tests, inline adversarial review, and local mounted measurements. Reviewed canonical boundary preservation, conditional publication, quota refusal, cached-proof fallback, and measurement limitations.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching Signed-off-by trailer.


Integration update: the branch now includes the landed CI prerequisite #1891 and the materialized-gap regression repair from #1879. Its own performance change is preserved. Earlier benchmark measurements remain labelled by their original candidate; current combined-head checks run separately.

Current integration head: `8dffd3f6e41f0a2d52da1db93599741c6aa3e2be`, rebased onto landed main `e385d6df`. Prior measurements above retain their original source identity; the performance implementation is unchanged. This PR now targets main. Fresh CI is pending; no old green result is presented as a new-head result.
