### PR TITLE
fix(storage): skip full flushes of unchanged hosted volumes

### DIFF
--- a/changes/1884.fixed.md
+++ b/changes/1884.fixed.md
@@ -1,0 +1,1 @@
+Mounted appends reuse verified prefix chunks instead of rereading and rechunking the complete file. The final chunk is rebuilt with the appended bytes, preserving canonical content identity, quotas, and atomic source-checked publication; cold proofs and workspace writes retain the validating streaming fallback.

--- a/changes/1886.fixed.md
+++ b/changes/1886.fixed.md
@@ -1,0 +1,1 @@
+Avoid redundant full device flushes when a hosted volume has not changed since its last successful flush. Failed writes and flushes still require a successful retry, and recovered or replaced containers do not inherit an in-memory durability proof.

--- a/crates/astrid-kernel/src/storage_mount/filesystem.rs
+++ b/crates/astrid-kernel/src/storage_mount/filesystem.rs
@@ -13,6 +13,14 @@ pub(super) trait CallbackFilesystem {
         length: u64,
     ) -> Result<Vec<u8>, FilesystemError>;
     fn write(&self, path: &FilesystemPath, bytes: &[u8]) -> Result<(), FilesystemError>;
+    fn try_append(
+        &self,
+        _path: &FilesystemPath,
+        _expected_length: u64,
+        _bytes: &[u8],
+    ) -> Result<bool, FilesystemError> {
+        Ok(false)
+    }
     fn write_streaming(
         &self,
         path: &FilesystemPath,
@@ -53,6 +61,15 @@ where
 
     fn write(&self, path: &FilesystemPath, bytes: &[u8]) -> Result<(), FilesystemError> {
         AstridFilesystem::write(self, path, bytes)
+    }
+
+    fn try_append(
+        &self,
+        path: &FilesystemPath,
+        expected_length: u64,
+        bytes: &[u8],
+    ) -> Result<bool, FilesystemError> {
+        AstridFilesystem::try_append(self, path, expected_length, bytes)
     }
 
     fn write_streaming(
@@ -177,6 +194,15 @@ where
         OwnerSubtreeFilesystem::write(self, path, bytes)
     }
 
+    fn try_append(
+        &self,
+        path: &FilesystemPath,
+        expected_length: u64,
+        bytes: &[u8],
+    ) -> Result<bool, FilesystemError> {
+        OwnerSubtreeFilesystem::try_append(self, path, expected_length, bytes)
+    }
+
     fn write_streaming(
         &self,
         path: &FilesystemPath,
@@ -231,6 +257,15 @@ impl<F> PrefixedFilesystem<F> {
 }
 
 impl<F: CallbackFilesystem> CallbackFilesystem for PrefixedFilesystem<F> {
+    fn try_append(
+        &self,
+        path: &FilesystemPath,
+        expected_length: u64,
+        bytes: &[u8],
+    ) -> Result<bool, FilesystemError> {
+        self.inner
+            .try_append(&self.path(path)?, expected_length, bytes)
+    }
     fn stat(&self, path: &FilesystemPath) -> Result<FilesystemEntry, FilesystemError> {
         self.inner.stat(&self.path(path)?)
     }
@@ -386,6 +421,9 @@ fn write_range(
         .ok_or_else(|| FilesystemError::InvalidPath(path.as_str().to_owned()))?;
     if current_length.max(end_offset) > i64::MAX as u64 {
         return Err(FilesystemError::InvalidPath(path.as_str().to_owned()));
+    }
+    if offset == current_length && filesystem.try_append(&path, current_length, data)? {
+        return Ok(StorageFilesystemSuccessV1::Written(end_offset));
     }
     range::replace(
         filesystem,

--- a/crates/astrid-storage/src/content/store.rs
+++ b/crates/astrid-storage/src/content/store.rs
@@ -385,10 +385,26 @@ where
         verified: VerifiedContent,
         staged_records: &[ObjectRecord],
     ) -> Result<ContentWriteOutcome, PrincipalContentError> {
+        self.publish_deferred_expected(principal, name, verified, staged_records, None)
+    }
+
+    fn publish_deferred_expected(
+        &self,
+        principal: &P,
+        name: &ContentName,
+        verified: VerifiedContent,
+        staged_records: &[ObjectRecord],
+        expected_file: Option<ObjectId>,
+    ) -> Result<ContentWriteOutcome, PrincipalContentError> {
         let descriptor = verified.descriptor();
         loop {
             let mut header = self.header(principal)?.as_ref().clone();
             let previous = self.catalog_lookup(principal, header.catalog, name)?;
+            if let Some(expected) = expected_file
+                && previous.is_none_or(|entry| entry.file != expected)
+            {
+                return Err(PrincipalContentError::BatchPreconditionFailed);
+            }
             if previous.is_some_and(|entry| entry.file == descriptor.file()) {
                 let root = header.root.ok_or_else(|| {
                     invalid(
@@ -938,6 +954,7 @@ where
     }
 }
 
+mod append;
 mod bulk;
 mod constructors;
 mod internals;

--- a/crates/astrid-storage/src/content/store/append.rs
+++ b/crates/astrid-storage/src/content/store/append.rs
@@ -1,0 +1,50 @@
+use super::{
+    ContentName, EngineIdentity, EngineSource, PrincipalContentError, PrincipalContentStore,
+    PrincipalProjectionEngine, map_read_error,
+};
+
+impl<P, E> PrincipalContentStore<P, E>
+where
+    P: Clone + Ord + Send + Sync,
+    E: PrincipalProjectionEngine<P>,
+{
+    /// Append using a cached canonical proof, or leave the file untouched.
+    ///
+    /// A cold/unverified source returns false so the caller can use its validating
+    /// streaming path. The read handle pins the old closure through root publication.
+    pub(crate) fn try_append(
+        &self,
+        principal: &P,
+        name: &ContentName,
+        expected_length: u64,
+        bytes: &[u8],
+    ) -> Result<bool, PrincipalContentError> {
+        let Some(handle) = self.open_read(principal, name)? else {
+            return Err(PrincipalContentError::BatchPreconditionFailed);
+        };
+        if handle.descriptor().logical_bytes() != expected_length {
+            return Err(PrincipalContentError::BatchPreconditionFailed);
+        }
+        let Some(verified) = handle.verified() else {
+            return Ok(false);
+        };
+        let appended = crate::content_dag::append_verified_content(
+            &EngineIdentity::<P, E>::new(self.engine.as_ref()),
+            &EngineSource::<P, E>::new(self.engine.as_ref(), principal),
+            verified,
+            bytes,
+        )
+        .map_err(map_read_error)?;
+        self.publish_deferred_expected(
+            principal,
+            name,
+            appended.verified,
+            &appended.records,
+            Some(verified.descriptor().file()),
+        )?;
+        Ok(true)
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/astrid-storage/src/content/store/append/tests.rs
+++ b/crates/astrid-storage/src/content/store/append/tests.rs
@@ -1,0 +1,195 @@
+use std::sync::Arc;
+
+use super::*;
+use crate::Blake3ObjectIdentityV1;
+use crate::content_dag::{ChunkingProfile, append_verified_content, build_content};
+use crate::engine::InMemoryEngine;
+
+#[test]
+fn unverified_append_leaves_source_untouched_for_streaming_fallback() {
+    let engine = Arc::new(InMemoryEngine::new(Blake3ObjectIdentityV1));
+    let store = PrincipalContentStore::from_engine(engine);
+    let owner = "alice".to_owned();
+    let name = ContentName::new("file").unwrap();
+    store.put(&owner, &name, b"old").unwrap();
+    assert!(!store.try_append(&owner, &name, 3, b"new").unwrap());
+    assert_eq!(store.read(&owner, &name).unwrap().unwrap(), b"old");
+}
+
+#[test]
+fn conditional_append_rejects_changed_file_but_allows_unrelated_catalog_changes() {
+    let engine = Arc::new(InMemoryEngine::new(Blake3ObjectIdentityV1));
+    let store = PrincipalContentStore::from_engine(Arc::clone(&engine));
+    let owner = "alice".to_owned();
+    let name = ContentName::new("file").unwrap();
+    let old = build_content(&Blake3ObjectIdentityV1, ChunkingProfile::ASTRID_V1, b"old").unwrap();
+    store.put(&owner, &name, b"old").unwrap();
+    let delta = append_verified_content(
+        &Blake3ObjectIdentityV1,
+        &EngineSource::new(engine.as_ref(), &owner),
+        old.verified_content(),
+        b"new",
+    )
+    .unwrap();
+    store
+        .put(&owner, &ContentName::new("unrelated").unwrap(), b"other")
+        .unwrap();
+    store
+        .publish_deferred_expected(
+            &owner,
+            &name,
+            delta.verified,
+            &delta.records,
+            Some(old.descriptor().file()),
+        )
+        .unwrap();
+    assert_eq!(store.read(&owner, &name).unwrap().unwrap(), b"oldnew");
+    // Same-length replacement must also reject: length alone is not identity.
+    store.put(&owner, &name, b"NEW").unwrap();
+    let root = engine.root(&owner);
+    let objects = engine.object_count();
+    assert!(matches!(
+        store.publish_deferred_expected(
+            &owner,
+            &name,
+            delta.verified,
+            &delta.records,
+            Some(old.descriptor().file())
+        ),
+        Err(PrincipalContentError::BatchPreconditionFailed)
+    ));
+    assert_eq!(engine.root(&owner), root);
+    assert_eq!(engine.object_count(), objects);
+    assert_eq!(store.read(&owner, &name).unwrap().unwrap(), b"NEW");
+}
+
+#[test]
+fn quota_rejected_append_admits_no_delta_records_and_preserves_root() {
+    let engine = Arc::new(InMemoryEngine::new(Blake3ObjectIdentityV1));
+    let store = PrincipalContentStore::from_engine_with_quota(
+        Arc::clone(&engine),
+        Arc::new(|_: &String| Ok(Some(128))),
+    );
+    let owner = "alice".to_owned();
+    let name = ContentName::new("file").unwrap();
+    let old = build_content(&Blake3ObjectIdentityV1, ChunkingProfile::ASTRID_V1, b"old").unwrap();
+    store.put(&owner, &name, b"old").unwrap();
+    let delta = append_verified_content(
+        &Blake3ObjectIdentityV1,
+        &EngineSource::new(engine.as_ref(), &owner),
+        old.verified_content(),
+        &[42; 256],
+    )
+    .unwrap();
+    let root = engine.root(&owner);
+    let objects = engine.object_count();
+    assert!(matches!(
+        store.publish_deferred_expected(
+            &owner,
+            &name,
+            delta.verified,
+            &delta.records,
+            Some(old.descriptor().file())
+        ),
+        Err(PrincipalContentError::QuotaExceeded { .. })
+    ));
+    assert_eq!(engine.root(&owner), root);
+    assert_eq!(engine.object_count(), objects);
+}
+
+struct ConcurrentReplacement {
+    inner: Arc<InMemoryEngine<String, Blake3ObjectIdentityV1>>,
+    armed: std::sync::atomic::AtomicBool,
+}
+
+impl PrincipalProjectionEngine<String> for ConcurrentReplacement {
+    fn identify_object(
+        &self,
+        record: &crate::storage_model::ObjectRecord,
+    ) -> crate::storage_model::ObjectId {
+        self.inner.identify_object(record)
+    }
+
+    fn stage_object(
+        &self,
+        record: crate::storage_model::ObjectRecord,
+    ) -> Result<
+        (
+            crate::storage_model::ObjectId,
+            crate::storage_model::InsertOutcome,
+        ),
+        crate::engine::PrincipalProjectionError,
+    > {
+        self.inner.stage_object(record)
+    }
+
+    fn current_root(
+        &self,
+        owner: &String,
+    ) -> Result<Option<crate::storage_model::RootState>, crate::engine::PrincipalProjectionError>
+    {
+        self.inner.current_root(owner)
+    }
+
+    fn load_object(
+        &self,
+        id: crate::storage_model::ObjectId,
+    ) -> Result<Option<crate::storage_model::ObjectRecord>, crate::engine::PrincipalProjectionError>
+    {
+        self.inner.load_object(id)
+    }
+
+    fn commit_root(
+        &self,
+        transaction: crate::engine::RootTransaction<String>,
+    ) -> Result<crate::engine::CommitOutcome, crate::engine::PrincipalProjectionError> {
+        if self.armed.swap(false, std::sync::atomic::Ordering::SeqCst) {
+            PrincipalContentStore::from_engine(Arc::clone(&self.inner))
+                .put(
+                    transaction.principal(),
+                    &ContentName::new("file").unwrap(),
+                    b"NEW",
+                )
+                .unwrap();
+        }
+        self.inner.commit_root(transaction)
+    }
+
+    fn flush_projection(&self) -> Result<(), crate::engine::PrincipalProjectionError> {
+        Ok(())
+    }
+}
+
+#[test]
+fn append_rechecks_expected_identity_after_root_cas_conflict() {
+    let engine = Arc::new(ConcurrentReplacement {
+        inner: Arc::new(InMemoryEngine::new(Blake3ObjectIdentityV1)),
+        armed: std::sync::atomic::AtomicBool::new(false),
+    });
+    let store = PrincipalContentStore::from_engine(Arc::clone(&engine));
+    let owner = "alice".to_owned();
+    let name = ContentName::new("file").unwrap();
+    let old = build_content(&Blake3ObjectIdentityV1, ChunkingProfile::ASTRID_V1, b"old").unwrap();
+    store.put(&owner, &name, b"old").unwrap();
+    let delta = append_verified_content(
+        &Blake3ObjectIdentityV1,
+        &EngineSource::new(engine.as_ref(), &owner),
+        old.verified_content(),
+        b"new",
+    )
+    .unwrap();
+    engine
+        .armed
+        .store(true, std::sync::atomic::Ordering::SeqCst);
+    assert!(matches!(
+        store.publish_deferred_expected(
+            &owner,
+            &name,
+            delta.verified,
+            &delta.records,
+            Some(old.descriptor().file())
+        ),
+        Err(PrincipalContentError::BatchPreconditionFailed)
+    ));
+    assert_eq!(store.read(&owner, &name).unwrap().unwrap(), b"NEW");
+}

--- a/crates/astrid-storage/src/content/store/read_handle.rs
+++ b/crates/astrid-storage/src/content/store/read_handle.rs
@@ -173,7 +173,7 @@ where
         Ok(bytes)
     }
 
-    fn verified(&self) -> Option<VerifiedContent> {
+    pub(super) fn verified(&self) -> Option<VerifiedContent> {
         self.engine
             .load_projection_cache(
                 &self.principal,

--- a/crates/astrid-storage/src/content_dag/append.rs
+++ b/crates/astrid-storage/src/content_dag/append.rs
@@ -1,0 +1,75 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use super::build::{append_chunks, build_tree, file_record};
+use super::read::traversal::verified_chunks;
+use super::{
+    ContentDescriptor, ContentError, ContentReadError, ContentSource, OpenedContent,
+    VerifiedContent, insert_record, read_verified_content_range,
+};
+use crate::storage_model::{ObjectIdentity, ObjectRecord};
+
+/// A delta, not a complete closure: unchanged objects remain in the pinned source.
+pub(crate) struct AppendedContent {
+    pub(crate) verified: VerifiedContent,
+    pub(crate) records: Vec<ObjectRecord>,
+}
+
+/// Rechunk only the old EOF chunk and appended bytes, retaining canonical identity.
+///
+/// All preceding boundaries are final because the input carries a full verification
+/// proof. Metadata is rebuilt canonically; this is O(chunk count) metadata work, not
+/// a right-spine-only update. The caller must pin the old closure through publication.
+pub(crate) fn append_verified_content<I: ObjectIdentity, S: ContentSource>(
+    identity: &I,
+    source: &S,
+    old: VerifiedContent,
+    bytes: &[u8],
+) -> Result<AppendedContent, ContentReadError<S::Error>> {
+    let descriptor = old.descriptor();
+    let logical_bytes = descriptor
+        .logical_bytes()
+        .checked_add(u64::try_from(bytes.len()).map_err(|_| ContentError::LengthOverflow)?)
+        .ok_or(ContentError::LengthOverflow)?;
+    let mut chunks = verified_chunks(source, old)?;
+    let mut tail = if let Some(last) = chunks.pop() {
+        read_verified_content_range(
+            source,
+            old,
+            descriptor
+                .logical_bytes()
+                .checked_sub(last.logical_bytes)
+                .ok_or(ContentError::LengthOverflow)?,
+            last.logical_bytes,
+        )?
+    } else {
+        Vec::new()
+    };
+    tail.try_reserve(bytes.len())
+        .map_err(|_| ContentError::LengthOverflow)?;
+    tail.extend_from_slice(bytes);
+    let mut records = BTreeMap::new();
+    // The whole-file small-value exception is not a small-tail exception.
+    append_chunks(
+        identity,
+        descriptor.profile(),
+        &tail,
+        logical_bytes <= u64::from(descriptor.profile().maximum_bytes()),
+        &mut records,
+        &mut chunks,
+        &mut BTreeSet::new(),
+    )?;
+    let chunk_count = u64::try_from(chunks.len()).map_err(|_| ContentError::LengthOverflow)?;
+    let content = build_tree(identity, &mut records, chunks)?;
+    let file = file_record(descriptor.profile(), logical_bytes, chunk_count, content)?;
+    let file = insert_record(identity, &mut records, file)?;
+    Ok(AppendedContent {
+        verified: VerifiedContent::new(OpenedContent::new(
+            ContentDescriptor::new(file, logical_bytes, chunk_count, descriptor.profile()),
+            content.map(|child| child.id),
+        )),
+        records: records.into_values().collect(),
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/astrid-storage/src/content_dag/append/tests.rs
+++ b/crates/astrid-storage/src/content_dag/append/tests.rs
@@ -1,0 +1,150 @@
+use std::{cell::Cell, collections::BTreeMap, convert::Infallible};
+
+use super::*;
+use crate::content_dag::{
+    ChunkingProfile, build_content, read_content,
+    tests::{TestIdentity, deterministic_bytes},
+};
+use crate::storage_model::{ObjectId, ObjectKind};
+
+struct Source {
+    records: BTreeMap<ObjectId, ObjectRecord>,
+    payload_loads: Cell<usize>,
+}
+
+impl ContentSource for Source {
+    type Error = Infallible;
+
+    fn load_content_object(&self, id: ObjectId) -> Result<Option<ObjectRecord>, Self::Error> {
+        let record = self.records.get(&id);
+        if record.is_some_and(|record| record.kind() == ObjectKind::Chunk) {
+            self.payload_loads
+                .set(self.payload_loads.get().strict_add(1));
+        }
+        Ok(record.cloned())
+    }
+}
+
+#[test]
+fn append_matches_full_builder_across_small_file_threshold_and_tree_levels() {
+    let profile = ChunkingProfile::ASTRID_V1;
+    let max = profile.maximum_bytes() as usize;
+    let bytes = deterministic_bytes(12 * 1024 * 1024);
+    for split in [0, 1, max - 1, max, max + 1, max * 2 + 7, 10 * 1024 * 1024] {
+        for added in [0, 1, 8193, max, max + 1] {
+            let old = build_content(&TestIdentity, profile, &bytes[..split]).unwrap();
+            let mut source = Source {
+                records: old.records().iter().cloned().collect(),
+                payload_loads: Cell::new(0),
+            };
+            let append = append_verified_content(
+                &TestIdentity,
+                &source,
+                old.verified_content(),
+                &bytes[split..split + added],
+            )
+            .unwrap();
+            let expected = build_content(&TestIdentity, profile, &bytes[..split + added]).unwrap();
+            assert_eq!(
+                append.verified,
+                expected.verified_content(),
+                "{split}+{added}"
+            );
+            assert_eq!(
+                source.payload_loads.get(),
+                usize::from(split != 0),
+                "{split}+{added}"
+            );
+            for record in append.records {
+                source
+                    .records
+                    .insert(TestIdentity.identify(&record), record);
+            }
+            assert_eq!(
+                read_content(&source, append.verified.descriptor().file()).unwrap(),
+                &bytes[..split + added]
+            );
+        }
+    }
+}
+
+#[test]
+fn fragmented_append_preserves_canonical_identity_for_repetitive_and_random_data() {
+    for bytes in [vec![0_u8; 1024 * 1024], deterministic_bytes(1024 * 1024)] {
+        let old = build_content(&TestIdentity, ChunkingProfile::ASTRID_V1, &[]).unwrap();
+        let mut verified = old.verified_content();
+        let mut source = Source {
+            records: old.records().iter().cloned().collect(),
+            payload_loads: Cell::new(0),
+        };
+        let mut length = 0;
+        for fragment in bytes.chunks(7919) {
+            let append =
+                append_verified_content(&TestIdentity, &source, verified, fragment).unwrap();
+            length += fragment.len();
+            assert_eq!(
+                append.verified,
+                build_content(&TestIdentity, ChunkingProfile::ASTRID_V1, &bytes[..length])
+                    .unwrap()
+                    .verified_content()
+            );
+            verified = append.verified;
+            for record in append.records {
+                source
+                    .records
+                    .insert(TestIdentity.identify(&record), record);
+            }
+        }
+    }
+}
+
+#[test]
+fn missing_tail_fails_instead_of_publishing_truncated_content() {
+    let old = build_content(&TestIdentity, ChunkingProfile::ASTRID_V1, b"old").unwrap();
+    let mut source = Source {
+        records: old.records().iter().cloned().collect(),
+        payload_loads: Cell::new(0),
+    };
+    source.records.remove(
+        &old.verified_content()
+            .opened_content()
+            .content_root()
+            .unwrap(),
+    );
+    assert!(
+        append_verified_content(&TestIdentity, &source, old.verified_content(), b"new").is_err()
+    );
+}
+
+#[test]
+fn append_preserves_seeded_and_legacy_odd_profiles() {
+    let bytes = deterministic_bytes(128 * 1024);
+    for profile in [
+        ChunkingProfile::fastcdc_v2020(64, 256, 1024, 42).unwrap(),
+        ChunkingProfile::fastcdc_v2020(65, 256, 1025, 42).unwrap(),
+    ] {
+        for split in [1, 1023, 1024, 1025, 1026, 8191, 65_537] {
+            let old = build_content(&TestIdentity, profile, &bytes[..split]).unwrap();
+            let source = Source {
+                records: old.records().iter().cloned().collect(),
+                payload_loads: Cell::new(0),
+            };
+            for added in [0, 1, 2, 65, 1024, 8193] {
+                let delta = append_verified_content(
+                    &TestIdentity,
+                    &source,
+                    old.verified_content(),
+                    &bytes[split..split + added],
+                )
+                .unwrap();
+                assert_eq!(
+                    delta.verified,
+                    build_content(&TestIdentity, profile, &bytes[..split + added])
+                        .unwrap()
+                        .verified_content(),
+                    "{profile:?}: {split}+{added}"
+                );
+            }
+        }
+    }
+}

--- a/crates/astrid-storage/src/content_dag/build.rs
+++ b/crates/astrid-storage/src/content_dag/build.rs
@@ -83,17 +83,46 @@ pub fn build_content<I: ObjectIdentity>(
     let mut chunks = Vec::new();
     let mut unique_chunks = BTreeSet::new();
 
+    append_chunks(
+        identity,
+        profile,
+        source,
+        source.len() <= profile.maximum_bytes() as usize,
+        &mut records,
+        &mut chunks,
+        &mut unique_chunks,
+    )?;
+
+    let chunk_count = u64::try_from(chunks.len()).map_err(|_| ContentError::LengthOverflow)?;
+    let content = build_tree(identity, &mut records, chunks)?;
+    let file = file_record(profile, logical_bytes, chunk_count, content)?;
+    let file = insert_record(identity, &mut records, file)?;
+    let descriptor = ContentDescriptor::new(file, logical_bytes, chunk_count, profile);
+    Ok(BuiltContent {
+        verified: VerifiedContent::new(OpenedContent::new(
+            descriptor,
+            content.map(|child| child.id),
+        )),
+        records: records.into_iter().collect(),
+        unique_chunks: u64::try_from(unique_chunks.len())
+            .map_err(|_| ContentError::LengthOverflow)?,
+    })
+}
+
+pub(super) fn append_chunks<I: ObjectIdentity>(
+    identity: &I,
+    profile: ChunkingProfile,
+    source: &[u8],
+    whole_small_file: bool,
+    records: &mut BTreeMap<ObjectId, ObjectRecord>,
+    chunks: &mut Vec<Child>,
+    unique_chunks: &mut BTreeSet<ObjectId>,
+) -> Result<(), ContentError> {
     if !source.is_empty() {
         let maximum =
             usize::try_from(profile.maximum_bytes()).map_err(|_| ContentError::LengthOverflow)?;
-        if source.len() <= maximum {
-            push_chunk(
-                identity,
-                &mut records,
-                &mut chunks,
-                &mut unique_chunks,
-                source,
-            )?;
+        if whole_small_file {
+            push_chunk(identity, records, chunks, unique_chunks, source)?;
         } else if profile.uses_legacy_fastcdc_v4() {
             let chunker = FastCDCV4::with_level_and_seed(
                 source,
@@ -113,13 +142,7 @@ pub fn build_content<I: ObjectIdentity>(
                 let bytes = source
                     .get(chunk.offset..end)
                     .ok_or(ContentError::LengthOverflow)?;
-                push_chunk(
-                    identity,
-                    &mut records,
-                    &mut chunks,
-                    &mut unique_chunks,
-                    bytes,
-                )?;
+                push_chunk(identity, records, chunks, unique_chunks, bytes)?;
             }
         } else {
             let chunker = FastCDC::with_level_and_seed(
@@ -140,31 +163,12 @@ pub fn build_content<I: ObjectIdentity>(
                 let bytes = source
                     .get(chunk.offset..end)
                     .ok_or(ContentError::LengthOverflow)?;
-                push_chunk(
-                    identity,
-                    &mut records,
-                    &mut chunks,
-                    &mut unique_chunks,
-                    bytes,
-                )?;
+                push_chunk(identity, records, chunks, unique_chunks, bytes)?;
             }
         }
     }
 
-    let chunk_count = u64::try_from(chunks.len()).map_err(|_| ContentError::LengthOverflow)?;
-    let content = build_tree(identity, &mut records, chunks)?;
-    let file = file_record(profile, logical_bytes, chunk_count, content)?;
-    let file = insert_record(identity, &mut records, file)?;
-    let descriptor = ContentDescriptor::new(file, logical_bytes, chunk_count, profile);
-    Ok(BuiltContent {
-        verified: VerifiedContent::new(OpenedContent::new(
-            descriptor,
-            content.map(|child| child.id),
-        )),
-        records: records.into_iter().collect(),
-        unique_chunks: u64::try_from(unique_chunks.len())
-            .map_err(|_| ContentError::LengthOverflow)?,
-    })
+    Ok(())
 }
 
 fn push_chunk<I: ObjectIdentity>(
@@ -185,7 +189,7 @@ fn push_chunk<I: ObjectIdentity>(
     Ok(())
 }
 
-fn build_tree<I: ObjectIdentity>(
+pub(super) fn build_tree<I: ObjectIdentity>(
     identity: &I,
     records: &mut BTreeMap<ObjectId, ObjectRecord>,
     mut level: Vec<Child>,

--- a/crates/astrid-storage/src/content_dag/mod.rs
+++ b/crates/astrid-storage/src/content_dag/mod.rs
@@ -20,6 +20,8 @@ use alloc::collections::BTreeMap;
 use alloc::vec::Vec;
 use core::fmt;
 
+mod append;
+pub(crate) use append::append_verified_content;
 mod boundary;
 mod build;
 mod read;

--- a/crates/astrid-storage/src/content_dag/read.rs
+++ b/crates/astrid-storage/src/content_dag/read.rs
@@ -462,6 +462,6 @@ pub fn read_verified_content_range<S: ContentSource>(
     .map(|(bytes, _)| bytes)
 }
 
-mod traversal;
+pub(super) mod traversal;
 
 use traversal::{BoundaryMode, decode_file, load, read_decoded_range};

--- a/crates/astrid-storage/src/content_dag/read/traversal.rs
+++ b/crates/astrid-storage/src/content_dag/read/traversal.rs
@@ -22,6 +22,61 @@ pub(super) enum BoundaryMode<'a> {
     Reuse(&'a ContentVerificationState),
 }
 
+/// Enumerate immutable chunk identities without loading their payloads.
+/// The caller holds a full canonical-boundary proof and pins its source closure.
+pub(in crate::content_dag) fn verified_chunks<S: ContentSource>(
+    source: &S,
+    verified: crate::content_dag::VerifiedContent,
+) -> Result<Vec<crate::content_dag::build::Child>, ContentReadError<S::Error>> {
+    let opened = verified.opened_content();
+    let descriptor = opened.descriptor();
+    let Some(root) = opened.content_root() else {
+        return Ok(Vec::new());
+    };
+    let shape = ExpectedShape {
+        logical_bytes: descriptor.logical_bytes(),
+        chunk_count: descriptor.chunk_count(),
+        tree_depth: canonical_tree_depth(descriptor.chunk_count()),
+        profile: descriptor.profile(),
+        ends_file: true,
+    };
+    let mut pending = vec![(root, shape)];
+    let mut chunks = Vec::new();
+    while let Some((object, shape)) = pending.pop() {
+        if shape.tree_depth == 0 {
+            chunks.push(crate::content_dag::build::Child {
+                id: object,
+                logical_bytes: shape.logical_bytes,
+                chunk_count: 1,
+            });
+            continue;
+        }
+        let record = load(source, object)?;
+        if record.kind() != ObjectKind::ChunkTree {
+            return Err(ContentError::InvalidObject {
+                object,
+                detail: "expected verified chunk-tree object",
+            }
+            .into());
+        }
+        let children = decode_tree(object, &record, shape)?;
+        let last = children.len().saturating_sub(1);
+        for (index, (id, logical_bytes, chunk_count)) in children.into_iter().enumerate().rev() {
+            pending.push((
+                id,
+                ExpectedShape {
+                    logical_bytes,
+                    chunk_count,
+                    tree_depth: shape.tree_depth.strict_sub(1),
+                    profile: shape.profile,
+                    ends_file: shape.ends_file && index == last,
+                },
+            ));
+        }
+    }
+    Ok(chunks)
+}
+
 pub(super) fn read_decoded_range<S: ContentSource>(
     source: &S,
     file: ObjectId,

--- a/crates/astrid-storage/src/filesystem.rs
+++ b/crates/astrid-storage/src/filesystem.rs
@@ -328,6 +328,23 @@ where
         self.inner.write_streaming(&self.path(path)?, source)
     }
 
+    /// Attempt a canonical append relative to the fixed subtree root.
+    ///
+    /// Returns false without mutation when the cached proof is unavailable.
+    ///
+    /// # Errors
+    ///
+    /// Returns a path, concurrent-change, quota, or storage error.
+    pub fn try_append(
+        &self,
+        path: &FilesystemPath,
+        expected_length: u64,
+        bytes: &[u8],
+    ) -> Result<bool, FilesystemError> {
+        self.inner
+            .try_append(&self.path(path)?, expected_length, bytes)
+    }
+
     /// Create a directory relative to the fixed subtree root.
     ///
     /// # Errors
@@ -544,6 +561,29 @@ where
             .put_streaming(&self.owner, &path.file_name()?, source)?;
         self.remember_directory(&path.parent());
         Ok(())
+    }
+
+    /// Attempt an append without rereading unchanged verified chunk payloads.
+    ///
+    /// Returns false without mutation when no canonical proof is cached; callers
+    /// must then use the ordinary validating write path. A changed source is an error.
+    ///
+    /// # Errors
+    ///
+    /// Returns a path, concurrent-change, quota, or storage error.
+    pub fn try_append(
+        &self,
+        path: &FilesystemPath,
+        expected_length: u64,
+        bytes: &[u8],
+    ) -> Result<bool, FilesystemError> {
+        self.require_parent(path)?;
+        if self.directory_exists(path)? {
+            return Err(FilesystemError::IsDirectory(path.clone()));
+        }
+        Ok(self
+            .content
+            .try_append(&self.owner, &path.file_name()?, expected_length, bytes)?)
     }
 
     /// Create an explicit empty directory.

--- a/crates/astrid-storage/src/filesystem/tests.rs
+++ b/crates/astrid-storage/src/filesystem/tests.rs
@@ -5,6 +5,40 @@ use astrid_core::PrincipalUid;
 use super::*;
 use crate::{KvQuotaResolver, StateOwner, open_runtime_principal_store};
 
+#[tokio::test]
+async fn canonical_append_uses_durable_proof_and_survives_reopen() {
+    let (directory, filesystem) = filesystem().await;
+    let path = FilesystemPath::new("append.bin").unwrap();
+    let initial = vec![19; 1024 * 1024];
+    let suffix = vec![23; 1024 * 1024];
+    filesystem.write(&path, &initial).unwrap();
+    assert!(
+        filesystem
+            .try_append(&path, initial.len() as u64, &suffix)
+            .unwrap()
+    );
+    assert!(
+        filesystem
+            .try_append(&path, initial.len() as u64, b"stale")
+            .is_err()
+    );
+    filesystem.sync().unwrap();
+    drop(filesystem);
+    let home = astrid_core::dirs::AstridHome::from_path(directory.path());
+    let store = open_runtime_principal_store(&home, Arc::new(|_: &StateOwner| Ok(Some(u64::MAX))))
+        .await
+        .unwrap();
+    let reopened = AstridFilesystem::new(
+        store.content(),
+        StateOwner::Principal(PrincipalUid::from_bytes([7; 32])),
+    );
+    let expected: Vec<_> = initial.into_iter().chain(suffix).collect();
+    assert_eq!(
+        reopened.read(&path, 0, expected.len() as u64).unwrap(),
+        expected
+    );
+}
+
 async fn filesystem() -> (
     tempfile::TempDir,
     AstridFilesystem<

--- a/crates/astrid-storage/src/volume/hosted/mod.rs
+++ b/crates/astrid-storage/src/volume/hosted/mod.rs
@@ -57,6 +57,12 @@ impl Clone for RegionState {
     }
 }
 
+#[derive(Debug, PartialEq, Eq)]
+enum FlushState {
+    Required,
+    Confirmed,
+}
+
 #[derive(Debug)]
 struct ContainerState {
     file: File,
@@ -67,6 +73,9 @@ struct ContainerState {
     last_commit_has_snapshot: bool,
     boundary_pending: bool,
     footer_pending: bool,
+    // Process-local proof only: set after a successful full flush, cleared
+    // before any file mutation. A recovered footer is not this proof.
+    flush_state: FlushState,
     regions: BTreeMap<VolumeRegion, RegionState>,
 }
 
@@ -119,6 +128,7 @@ impl HostedFileVolume {
 
         // A footer occupies the old valid-end until the next append. Truncate
         // it before writing the next ASTREG1 record; valid_len excludes it.
+        state.flush_state = FlushState::Required;
         state.footer_pending = true;
         state.file.set_len(state.valid_len)?;
         state.file.seek(SeekFrom::Start(state.valid_len))?;
@@ -147,13 +157,24 @@ impl HostedFileVolume {
     }
 
     fn make_durable(state: &mut ContainerState) -> io::Result<()> {
+        Self::make_durable_with(state, File::sync_all)
+    }
+
+    fn make_durable_with(
+        state: &mut ContainerState,
+        flush: impl FnOnce(&File) -> io::Result<()>,
+    ) -> io::Result<()> {
+        if state.flush_state == FlushState::Confirmed {
+            return Ok(());
+        }
         if state.last_commit_offset == 0
             && state.valid_len == VOLUME_MAGIC.len() as u64
             && state.regions.is_empty()
         {
             // Preserve the empty-container grammar: there is no commit to
             // point at until the first namespace mutation is durable.
-            state.file.sync_all()?;
+            flush(&state.file)?;
+            state.flush_state = FlushState::Confirmed;
             return Ok(());
         }
         if (state.valid_len != state.durable_len
@@ -178,9 +199,10 @@ impl HostedFileVolume {
                 state.sequence,
             )?;
         }
-        state.file.sync_all()?;
+        flush(&state.file)?;
         state.boundary_pending = false;
         state.footer_pending = false;
+        state.flush_state = FlushState::Confirmed;
         Ok(())
     }
 }
@@ -657,3 +679,6 @@ pub(crate) use stream::write_record_payloads;
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+mod sync_tests;

--- a/crates/astrid-storage/src/volume/hosted/open.rs
+++ b/crates/astrid-storage/src/volume/hosted/open.rs
@@ -129,6 +129,7 @@ impl HostedFileVolume {
             last_commit_has_snapshot: recovery.last_commit_has_snapshot,
             boundary_pending: false,
             footer_pending,
+            flush_state: super::FlushState::Required,
             regions: recovery.regions,
         };
         if footer_pending {

--- a/crates/astrid-storage/src/volume/hosted/reclaim.rs
+++ b/crates/astrid-storage/src/volume/hosted/reclaim.rs
@@ -156,6 +156,7 @@ pub(super) fn reclaim(volume: &HostedFileVolume) -> io::Result<()> {
         last_commit_has_snapshot: false,
         boundary_pending: false,
         footer_pending: true,
+        flush_state: super::FlushState::Required,
         regions: BTreeMap::new(),
     };
     rebuilt.file.write_all(&VOLUME_MAGIC)?;
@@ -206,6 +207,9 @@ pub(super) fn reclaim(volume: &HostedFileVolume) -> io::Result<()> {
     // Close the old locked inode before replacement. Recovery of the sibling
     // artifacts handles a process crash between either rename.
     let placeholder = OpenOptions::new().read(true).write(true).open(&temporary)?;
+    // From here on the file handle may change even if reclaim returns an
+    // error. Never carry the previous inode's flush proof across that swap.
+    state.flush_state = super::FlushState::Required;
     let old_file = std::mem::replace(&mut state.file, placeholder);
     old_file.unlock()?;
     drop(old_file);

--- a/crates/astrid-storage/src/volume/hosted/stream.rs
+++ b/crates/astrid-storage/src/volume/hosted/stream.rs
@@ -68,6 +68,7 @@ pub(super) fn append_from(
     match append_from_inner(state, operation, region, offset, payload_len, payload) {
         Ok(result) => Ok(result),
         Err(error) => {
+            state.flush_state = super::FlushState::Required;
             let _ = state.file.set_len(start);
             let _ = state.file.seek(SeekFrom::Start(start));
             if state.last_commit_offset != 0 && start == state.durable_len {
@@ -114,6 +115,7 @@ fn append_from_inner(
     // The previous footer ends at `valid_len`; remove it before publishing a
     // new record. A failed stream leaves footer_pending set so the next sync
     // restores the prior durable footer.
+    state.flush_state = super::FlushState::Required;
     state.footer_pending = true;
     state.file.set_len(state.valid_len)?;
     state.file.seek(SeekFrom::Start(state.valid_len))?;

--- a/crates/astrid-storage/src/volume/hosted/sync_tests.rs
+++ b/crates/astrid-storage/src/volume/hosted/sync_tests.rs
@@ -1,0 +1,138 @@
+use super::*;
+
+fn counted_sync(volume: &HostedFileVolume) -> usize {
+    let mut calls = 0_usize;
+    HostedFileVolume::make_durable_with(&mut volume.state.lock(), |file| {
+        calls = calls.strict_add(1);
+        file.sync_all()
+    })
+    .unwrap();
+    calls
+}
+
+#[test]
+fn unchanged_volume_flushes_once_after_each_mutation() {
+    let directory = tempfile::tempdir().unwrap();
+    let volume = HostedFileVolume::open(directory.path().join("astrid.volume")).unwrap();
+    assert_eq!(counted_sync(&volume), 0);
+    let region = VolumeRegion::new("objects").unwrap();
+    volume.create_region(&region, true).unwrap();
+    assert_eq!(counted_sync(&volume), 1);
+    assert_eq!(counted_sync(&volume), 0);
+    volume.write_region_at(&region, 0, b"bytes").unwrap();
+    assert_eq!(counted_sync(&volume), 1);
+    assert_eq!(counted_sync(&volume), 0);
+    volume
+        .write_region_from(&region, 5, 4, &mut &b"tail"[..])
+        .unwrap();
+    assert_eq!(counted_sync(&volume), 1);
+    assert_eq!(counted_sync(&volume), 0);
+    volume.set_region_len(&region, 3).unwrap();
+    assert_eq!(counted_sync(&volume), 1);
+    let renamed = VolumeRegion::new("renamed").unwrap();
+    volume.rename_region(&region, &renamed).unwrap();
+    assert_eq!(counted_sync(&volume), 1);
+    volume.remove_region(&renamed).unwrap();
+    assert_eq!(counted_sync(&volume), 1);
+    assert_eq!(counted_sync(&volume), 0);
+}
+
+#[test]
+fn failed_flush_is_retried_without_appending_another_commit() {
+    let directory = tempfile::tempdir().unwrap();
+    let volume = HostedFileVolume::open(directory.path().join("astrid.volume")).unwrap();
+    volume
+        .create_region(&VolumeRegion::new("objects").unwrap(), true)
+        .unwrap();
+    let mut state = volume.state.lock();
+    assert!(
+        HostedFileVolume::make_durable_with(&mut state, |_| {
+            Err(io::Error::other("injected flush failure"))
+        })
+        .is_err()
+    );
+    assert_eq!(state.flush_state, FlushState::Required);
+    let sequence = state.sequence;
+    drop(state);
+    assert_eq!(counted_sync(&volume), 1);
+    assert_eq!(volume.state.lock().sequence, sequence);
+    assert_eq!(counted_sync(&volume), 0);
+}
+
+#[test]
+fn failed_stream_invalidates_prior_flush_proof() {
+    let directory = tempfile::tempdir().unwrap();
+    let volume = HostedFileVolume::open(directory.path().join("astrid.volume")).unwrap();
+    let region = VolumeRegion::new("objects").unwrap();
+    volume.create_region(&region, true).unwrap();
+    volume.write_region_at(&region, 0, b"original").unwrap();
+    volume.sync().unwrap();
+    assert!(
+        volume
+            .write_region_from(&region, 0, 8, &mut &b"short"[..])
+            .is_err()
+    );
+    assert_eq!(counted_sync(&volume), 1);
+    assert_eq!(counted_sync(&volume), 0);
+    let mut actual = [0; 8];
+    volume.read_region_at(&region, 0, &mut actual).unwrap();
+    assert_eq!(&actual, b"original");
+}
+
+#[test]
+fn new_write_after_failed_flush_is_durable_before_drop() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("astrid.volume");
+    let volume = HostedFileVolume::open(&path).unwrap();
+    let region = VolumeRegion::new("objects").unwrap();
+    volume.create_region(&region, true).unwrap();
+    volume.write_region_at(&region, 0, b"before").unwrap();
+    assert!(
+        HostedFileVolume::make_durable_with(&mut volume.state.lock(), |_| {
+            Err(io::Error::other("injected flush failure"))
+        })
+        .is_err()
+    );
+    volume.write_region_at(&region, 0, b"after!").unwrap();
+    assert_eq!(counted_sync(&volume), 1);
+    assert_eq!(counted_sync(&volume), 0);
+    // Copy before Drop can do any additional work. The acknowledged boundary
+    // must be sufficient for a fresh recovery, including the later write.
+    let copy = directory.path().join("recovered.volume");
+    std::fs::copy(&path, &copy).unwrap();
+    let recovered = HostedFileVolume::open(copy).unwrap();
+    let mut actual = [0; 6];
+    assert_eq!(
+        recovered.read_region_at(&region, 0, &mut actual).unwrap(),
+        6
+    );
+    assert_eq!(&actual, b"after!");
+}
+
+#[test]
+fn recovered_footer_is_not_a_process_local_flush_proof() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("astrid.volume");
+    let volume = HostedFileVolume::open(&path).unwrap();
+    volume
+        .create_region(&VolumeRegion::new("objects").unwrap(), true)
+        .unwrap();
+    volume.sync().unwrap();
+    drop(volume);
+    let reopened = HostedFileVolume::open(&path).unwrap();
+    assert_eq!(counted_sync(&reopened), 1);
+    assert_eq!(counted_sync(&reopened), 0);
+}
+
+#[test]
+fn reclaim_does_not_reuse_the_old_inode_flush_proof() {
+    let directory = tempfile::tempdir().unwrap();
+    let volume = HostedFileVolume::open(directory.path().join("astrid.volume")).unwrap();
+    volume
+        .create_region(&VolumeRegion::new("objects").unwrap(), true)
+        .unwrap();
+    volume.sync().unwrap();
+    reclaim::reclaim(&volume).unwrap();
+    assert_eq!(counted_sync(&volume), 1);
+    assert_eq!(counted_sync(&volume), 0);
+}


### PR DESCRIPTION
## Linked Issue

Closes #1886

## Summary

Skip redundant full device flushes when a hosted volume has not changed since
its last successful flush. This removes work without delaying durable
acknowledgments or substituting a weaker flush operation.

Depends on #1885 (`perf/canonical-content-append`); now targets main.

## Changes

- Track a process-local `FlushState` under the existing container mutex.
- Invalidate before record writes, stream writes/rollback, and reclaim inode swaps.
- Confirm only after successful full flush; never derive confirmation from a recovered footer.
- Preserve failed-flush retry and existing commit/footer grammar.
- Add six regressions for clean reuse, mutation invalidation, failed flushes/streams,
  pre-drop recovery after a subsequent write, reopen, and reclaim.

## Verification

- Final exact-source full storage suite: 826 passed, 7 ignored, no failures.
- Final hosted-volume suite: 24 passed, no failures.
- Strict storage all-target Clippy: PASS.
- Formatting and diff checks: PASS.
- Release daemon build: PASS.
- Actual FSKit >8MiB write, cross-4MiB overwrite, zero-extension/gap, shrink,
  sync/unmount/remount and SHA256 readback: PASS. Stopped runtime remains exactly
  astrid.volume. Both disposable mounts restored.
- Mounted 48-file small-operation total: 7.678s before, 7.592s after; no meaningful
  overall improvement. Repeated unchanged-file sync is measured separately.
- Actual FSKit unchanged-file fsync median: preserved parent 5.501ms, candidate
  0.490ms (48 calls each, roughly 11.2x). Same disposable volume, Apple M2 Ultra,
  macOS 26.6.2, warm caches; observational, not a CI gate or general filesystem claim.

## Test Plan

Repeat clean sync without mutations and count flush calls; inject a failed flush,
retry it, and verify no duplicate commit. Inject a short stream after a successful
flush. Copy an acknowledged volume before Drop and reopen its later bytes. Reopen
and reclaim must not inherit the old process/inode proof. Run the same disposable
FSKit small-file workload before and after with unchanged durability policy.

## AI / Tool Assistance

Assisted-by: Codex:gpt-6-astra

Implementation and regression tests were tool-assisted and checked against all
hosted-container mutation paths, with executable tests and strict linting.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added
- [x] Changes inspected and tested
- [x] Matching Signed-off-by trailer and GPG signature


Integration update: the branch now includes the landed CI prerequisite #1891 and the materialized-gap regression repair from #1879. Its own performance change is preserved. Earlier benchmark measurements remain labelled by their original candidate; current combined-head checks run separately.

Current integration head: `bea2da4c11166dbcd24aa79080fb5aef5f681f0f`, rebased onto landed main `e385d6df`. Prior measurements above retain their original source identity; the performance implementation is unchanged. This PR now targets main. Fresh CI is pending; no old green result is presented as a new-head result.
