### PR TITLE
fix(storage): bound hosted extent mutation scans

### DIFF
--- a/changes/1888.fixed.md
+++ b/changes/1888.fixed.md
@@ -1,0 +1,1 @@
+Bound hosted-volume extent mutation scans to the affected range, avoiding repeated scans of unchanged extent prefixes during appends and truncation without changing logical byte mappings or the volume format.

--- a/crates/astrid-storage/src/volume/hosted/extent_mutation_tests.rs
+++ b/crates/astrid-storage/src/volume/hosted/extent_mutation_tests.rs
@@ -1,0 +1,102 @@
+use super::*;
+
+fn seeded_extents() -> BTreeMap<u64, Extent> {
+    (0_u64..4096)
+        .map(|index| {
+            let start = index.strict_mul(8);
+            (
+                start,
+                Extent {
+                    logical_end: start.strict_add(4),
+                    physical_offset: start,
+                },
+            )
+        })
+        .collect()
+}
+
+fn reset_visits() {
+    MUTATION_EXTENT_VISITS.with(|count| count.set(0));
+}
+
+fn visits() -> usize {
+    MUTATION_EXTENT_VISITS.with(Cell::get)
+}
+
+#[test]
+fn append_does_not_scan_existing_extents() {
+    let mut extents = seeded_extents();
+    reset_visits();
+    overlay_extent(&mut extents, 32768, 32772, 90000);
+    assert_eq!(visits(), 0);
+    assert_eq!(extents.len(), 4097);
+}
+
+#[test]
+fn overwrite_visits_only_the_crossing_predecessor_and_overlaps() {
+    let mut extents = seeded_extents();
+    reset_visits();
+    overlay_extent(&mut extents, 16002, 16018, 90000);
+    assert_eq!(visits(), 3);
+    assert_eq!(extents.get(&16000).unwrap().logical_end, 16002);
+    assert_eq!(extents.get(&16018).unwrap().physical_offset, 16018);
+    assert_eq!(extents.get(&16018).unwrap().logical_end, 16020);
+}
+
+#[test]
+fn truncate_visits_only_the_removed_suffix() {
+    let mut extents = seeded_extents();
+    reset_visits();
+    truncate_extents(&mut extents, 32770);
+    assert_eq!(visits(), 0);
+    reset_visits();
+    truncate_extents(&mut extents, 32761);
+    assert_eq!(visits(), 1);
+    assert_eq!(extents.get(&32760).unwrap().logical_end, 32761);
+}
+
+#[test]
+fn extent_mutations_match_a_byte_address_oracle() {
+    let mut extents = BTreeMap::new();
+    let mut expected = [None; 256];
+    let mut seed = 42_u64;
+    for operation in 0_u64..2000 {
+        // Wrapping arithmetic belongs to this deterministic test generator,
+        // never to the logical offset or physical address calculations.
+        let mut next = || {
+            seed = seed.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1);
+            usize::try_from((seed >> 32).checked_rem(256).unwrap()).unwrap()
+        };
+        let start = next();
+        let end = next().max(start);
+        if operation.checked_rem(7).unwrap() == 0 {
+            truncate_extents(&mut extents, u64::try_from(start).unwrap());
+            expected[start..].fill(None);
+        } else {
+            let physical = operation.strict_mul(1024);
+            overlay_extent(
+                &mut extents,
+                u64::try_from(start).unwrap(),
+                u64::try_from(end).unwrap(),
+                physical,
+            );
+            for (offset, byte) in expected[start..end].iter_mut().enumerate() {
+                *byte = Some(physical.strict_add(u64::try_from(offset).unwrap()));
+            }
+        }
+        let mut actual = [None; 256];
+        for (start, extent) in &extents {
+            let range =
+                usize::try_from(*start).unwrap()..usize::try_from(extent.logical_end).unwrap();
+            for (offset, byte) in actual[range].iter_mut().enumerate() {
+                assert!(byte.is_none(), "extents overlap at operation {operation}");
+                *byte = Some(
+                    extent
+                        .physical_offset
+                        .strict_add(u64::try_from(offset).unwrap()),
+                );
+            }
+        }
+        assert_eq!(actual, expected, "operation {operation}");
+    }
+}

--- a/crates/astrid-storage/src/volume/hosted/mod.rs
+++ b/crates/astrid-storage/src/volume/hosted/mod.rs
@@ -38,6 +38,7 @@ struct Extent {
 thread_local! {
     static REGION_STATE_CLONES: Cell<usize> = const { Cell::new(0) };
     static EXTENT_VISITS: Cell<usize> = const { Cell::new(0) };
+    static MUTATION_EXTENT_VISITS: Cell<usize> = const { Cell::new(0) };
 }
 
 #[derive(Debug, Default)]
@@ -617,8 +618,12 @@ fn overlay_extent(extents: &mut BTreeMap<u64, Extent>, start: u64, end: u64, phy
     if start >= end {
         return;
     }
+    // Extents never overlap, so only the predecessor can cross `start`.
+    // All earlier extents are irrelevant even when this is a pure append.
+    let first = mutation_start(extents, start);
     let overlapping = extents
-        .range(..end)
+        .range(first..end)
+        .inspect(|_| record_mutation_extent_visit())
         .filter(|(_, extent)| extent.logical_end > start)
         .map(|(offset, extent)| (*offset, *extent))
         .collect::<Vec<_>>();
@@ -655,8 +660,10 @@ fn overlay_extent(extents: &mut BTreeMap<u64, Extent>, start: u64, end: u64, phy
 }
 
 fn truncate_extents(extents: &mut BTreeMap<u64, Extent>, length: u64) {
+    let first = mutation_start(extents, length);
     let affected = extents
-        .range(..)
+        .range(first..)
+        .inspect(|_| record_mutation_extent_visit())
         .filter(|(start, extent)| **start >= length || extent.logical_end > length)
         .map(|(start, extent)| (*start, *extent))
         .collect::<Vec<_>>();
@@ -674,6 +681,19 @@ fn truncate_extents(extents: &mut BTreeMap<u64, Extent>, length: u64) {
     }
 }
 
+fn mutation_start(extents: &BTreeMap<u64, Extent>, offset: u64) -> u64 {
+    extents
+        .range(..=offset)
+        .next_back()
+        .and_then(|(start, extent)| (extent.logical_end > offset).then_some(*start))
+        .unwrap_or(offset)
+}
+
+fn record_mutation_extent_visit() {
+    #[cfg(test)]
+    MUTATION_EXTENT_VISITS.with(|count| count.set(count.get().saturating_add(1)));
+}
+
 #[cfg(test)]
 pub(crate) use stream::write_record_payloads;
 
@@ -682,3 +702,6 @@ mod tests;
 
 #[cfg(test)]
 mod sync_tests;
+
+#[cfg(test)]
+mod extent_mutation_tests;


### PR DESCRIPTION
## Linked Issue

Closes #1888

## Summary

Bound hosted extent overlay/truncate scans to the affected logical range. The
non-overlapping extent invariant means only the predecessor can cross the start
offset; unchanged earlier extents do not need to be visited.

Depends on #1887 (`perf/skip-clean-volume-sync`); now targets main. No format or durability change.

## Changes

- Locate the only possible crossing predecessor with a BTreeMap range lookup.
- Visit affected extents only for writes and truncation.
- Add deterministic visit-count tests over 4,096 extents and a 2,000-operation
  byte-address oracle covering overwrite, split, holes, and truncation.

## Verification

- Hosted-volume suite: 28 tests PASS.
- Strict storage all-target Clippy and formatting PASS.
- Full storage suite: 830 passed, 7 ignored, no failures.
- Release daemon build PASS. Actual FSKit large-file overwrite/resize/remount
  SHA256 regression PASS.
- Mounted three-sample median: 32 MiB fsync 0.9704 → 0.9635 seconds;
  16-file mixed batch 2.7744 → 2.6653 seconds. Modest differences, not a decisive
  latency win; warm-cache sequential A/B on an accumulated disposable volume.
- Exact combined-head CI run 34214835970 is not green: both GNU release-smoke
  jobs fail before compilation because Debian bullseye-security InRelease has
  expired. Clippy, MSRV, Wasm, Format, Check, Linux FUSE E2E and Security Audit
  passed at inspection; other jobs remained in progress. No failure waived.
- Appending after 4,096 extents visits zero old entries; bounded overwrite visits
  three overlaps; tail truncation visits one affected entry.

## Test Plan

Run the storage suite including crash/replay tests. Compare the same 32 MiB
mounted write/fsync/readback and 16-file mixed-operation workloads on the previous
and new daemon. Verify the large-file overwrite/resize/remount regression.
Do not transfer operation-count bounds into an unmeasured latency claim.

## AI / Tool Assistance

Assisted-by: Codex:gpt-6-astra

Implementation and tests were tool-assisted, inspected against the extent ordering
invariant and validated with a separate byte-address oracle.

## Checklist

- [x] Linked issue and changelog
- [x] Changes inspected and tested
- [x] Signed-off-by and GPG signature


Integration update: the branch now includes the landed CI prerequisite #1891 and the materialized-gap regression repair from #1879. Its own performance change is preserved. Earlier benchmark measurements remain labelled by their original candidate; current combined-head checks run separately.

Current integration head: `5fca3b6218e9914766183dc5c269a92ed7ebf9a1`, rebased onto landed main `e385d6df`. Prior measurements above retain their original source identity; the performance implementation is unchanged. This PR now targets main. Fresh CI is pending; no old green result is presented as a new-head result.

Current ancestry correction: f820b2ccf6b6adcdad89489515860d186b0e9399 has sole parent 5c8bfe213c835745c4caaaa4aed8adc7c2ab108d. Its full tree is byte-identical to 5fca3b6218e9914766183dc5c269a92ed7ebf9a1 (git diff --exit-code passes). Only commit ancestry/signature changed after the prerequisite squash; existing implementation, regression, and benchmark evidence remain applicable to the unchanged tree. Hosted required checks must attach to the new head before merge.
