### PR TITLE
fix(ci): validate stacked PRs and restore GNU builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ on:
       - 'scripts/test_channel_publication.py'
       - 'scripts/test_channel_workflow_contract.sh'
       - 'scripts/test_ci_workflow_contract.sh'
+      - 'scripts/test_gnu_build_packages.py'
       - 'scripts/nightly_version.py'
       - 'scripts/test_nightly_version.py'
       - 'release/nightly.toml'
@@ -57,62 +58,8 @@ on:
       - '.github/workflows/ci.yml'
       - '.github/workflows/native-storage-certification.yml'
       - '.github/workflows/release.yml'
+  # Required build/test checks must also run for stacked and docs-only PRs.
   pull_request:
-    branches: [main]
-    paths:
-      - '**.rs'
-      - 'scripts/install-windows.ps1'
-      - 'scripts/uninstall-windows.ps1'
-      - 'scripts/windows_release_manifest.py'
-      - 'scripts/test_windows_release_manifest.py'
-      - 'scripts/release_manifest.py'
-      - 'scripts/test_release_manifest.py'
-      - 'scripts/musl_release_manifest.py'
-      - 'scripts/test_musl_release_manifest.py'
-      - 'scripts/package_release_archive.py'
-      - 'scripts/test_validate_release_archive.py'
-      - 'scripts/validate_release_archive.py'
-      - 'scripts/build-macos-fskit.sh'
-      - 'scripts/check-macos-fskit.sh'
-      - 'scripts/manage-macos-fskit.sh'
-      - 'scripts/test_manage_macos_fskit.sh'
-      - 'scripts/validate-macos-fskit.sh'
-      - 'scripts/validate_macos_release.py'
-      - 'scripts/test_macos_release_packaging.py'
-      - 'scripts/test_v0104_linux_upgrade.sh'
-      - 'scripts/test_v0104_macos_upgrade.sh'
-      - 'scripts/ci/**'
-      - 'scripts/fixtures/windows-release-extension.toml'
-      - 'scripts/check_glibc.py'
-      - 'scripts/test_check_glibc.py'
-      - 'scripts/check_dco.py'
-      - 'scripts/test_check_dco.py'
-      - 'scripts/changelog.py'
-      - 'scripts/test_changelog.py'
-      - 'scripts/check_static_elf.py'
-      - 'scripts/test_check_static_elf.py'
-      - 'scripts/release_publication.py'
-      - 'scripts/test_release_publication.py'
-      - 'scripts/release_draft_recovery.py'
-      - 'scripts/test_release_draft_recovery.py'
-      - 'scripts/crate_publication.py'
-      - 'scripts/test_crate_publication.py'
-      - 'scripts/channel_metadata.py'
-      - 'scripts/test_channel_metadata.py'
-      - 'scripts/channel_publication.py'
-      - 'scripts/test_channel_publication.py'
-      - 'scripts/test_channel_workflow_contract.sh'
-      - 'scripts/test_ci_workflow_contract.sh'
-      - 'scripts/nightly_version.py'
-      - 'scripts/test_nightly_version.py'
-      - 'release/nightly.toml'
-      - 'crates/astrid-storage-provider-fskit/**'
-      - 'native/macos/**'
-      - '**/Cargo.toml'
-      - '**/Cargo.lock'
-      - '.github/workflows/ci.yml'
-      - '.github/workflows/native-storage-certification.yml'
-      - '.github/workflows/release.yml'
 permissions:
   contents: read
 
@@ -183,8 +130,7 @@ jobs:
                 packages+=(gcc-aarch64-linux-gnu libc6-dev-arm64-cross)
                 export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
               fi
-              apt-get update
-              apt-get install -y --no-install-recommends "${packages[@]}"
+              bash scripts/ci/install_gnu_build_packages.sh "${packages[@]}"
               git config --global --add safe.directory /workspace
               [[ "$(git rev-parse --short=12 HEAD)" == "$SOURCE_SHA" ]]
               cargo build \

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -2,7 +2,6 @@ name: PR Checks
 
 on:
   pull_request:
-    branches: [main]
     types: [opened, edited, reopened, labeled, unlabeled, synchronize]
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -261,8 +261,7 @@ jobs:
                 packages+=(gcc-aarch64-linux-gnu libc6-dev-arm64-cross)
                 export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
               fi
-              apt-get update
-              apt-get install -y --no-install-recommends "${packages[@]}"
+              bash scripts/ci/install_gnu_build_packages.sh "${packages[@]}"
               git config --global --add safe.directory /workspace
               [[ "$(git rev-parse --short=12 HEAD)" == "$SOURCE_SHA" ]]
               cargo build \

--- a/changes/1890.fixed.md
+++ b/changes/1890.fixed.md
@@ -1,0 +1,2 @@
+Run CI and contribution checks for stacked pull requests, and restore GNU
+compatibility builds using signed, dated Bullseye package snapshots.

--- a/scripts/ci/install_gnu_build_packages.sh
+++ b/scripts/ci/install_gnu_build_packages.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Bullseye supplies the glibc 2.31 build baseline, but LTS ended 2026-08-31.
+# Freeze its final package sources rather than raising the binary ABI floor.
+# Only these immutable snapshots waive freshness; APT still verifies Debian
+# signatures and package hashes. Do not apply this policy to live repositories.
+sources=$(mktemp)
+trap 'rm -f "$sources"' EXIT
+printf '%s\n' \
+  'deb [check-valid-until=no] https://snapshot.debian.org/archive/debian/20260901T000000Z/ bullseye main' \
+  'deb [check-valid-until=no] https://snapshot.debian.org/archive/debian-security/20260901T000000Z/ bullseye-security main' \
+  > "$sources"
+options=(-o "Dir::Etc::sourcelist=$sources" -o Dir::Etc::sourceparts=-)
+apt-get "${options[@]}" update
+apt-get "${options[@]}" install -y --no-install-recommends "$@"

--- a/scripts/ci/test-release-contracts.sh
+++ b/scripts/ci/test-release-contracts.sh
@@ -20,3 +20,4 @@ bash scripts/test_channel_workflow_contract.sh
 bash scripts/test_certify_musl_release_archive_contract.sh
 bash scripts/test_native_storage_certification_contract.sh
 bash scripts/test_ci_workflow_contract.sh
+python3 scripts/test_gnu_build_packages.py

--- a/scripts/test_ci_workflow_contract.sh
+++ b/scripts/test_ci_workflow_contract.sh
@@ -37,16 +37,30 @@ unless concurrency["cancel-in-progress"] == expected_cancel
   fail("cancel-in-progress must be enabled only for first-attempt pull_request events")
 end
 
-# Keep this contract wired to both CI trigger classes. Parse the trigger map so
+# Keep this contract wired to filtered pushes and unconditional PRs. Parse so
 # comments or similarly named text cannot make an absent path entry pass.
 triggers = workflow["on"] || workflow[true]
 fail("missing workflow trigger map") unless triggers.is_a?(Hash)
-%w[push pull_request].each do |event_name|
+%w[push].each do |event_name|
   event = triggers.fetch(event_name) { fail("missing #{event_name} trigger") }
   paths = event.fetch("paths") { fail("missing #{event_name}.paths filter") }
   unless paths.is_a?(Array) && paths.count("scripts/test_ci_workflow_contract.sh") == 1
     fail("contract test must appear exactly once in #{event_name}.paths")
   end
+end
+
+# Required checks cannot depend on the base branch or changed file paths.
+# A YAML null pull_request value is the intended unconditional event.
+fail("missing pull_request trigger") unless triggers.key?("pull_request")
+fail("pull_request must be unconditional") unless triggers["pull_request"].nil?
+pr_checks_path = File.join(File.dirname(workflow_path), "pr-checks.yml")
+pr_checks = YAML.safe_load(File.read(pr_checks_path), aliases: false)
+pr_events = (pr_checks["on"] || pr_checks[true]).fetch("pull_request")
+fail("PR Checks must allow stacked bases") if pr_events.key?("branches") || pr_events.key?("branches-ignore")
+
+%w[ci.yml release.yml].each do |name|
+  text = File.read(File.join(File.dirname(workflow_path), name))
+  fail("#{name} must use shared GNU package setup") unless text.include?('bash scripts/ci/install_gnu_build_packages.sh "${packages[@]}"')
 end
 
 def group(workflow_name, event_name, pr_number, run_id, run_attempt)

--- a/scripts/test_gnu_build_packages.py
+++ b/scripts/test_gnu_build_packages.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Exercise package-source scope, argument forwarding and update failure."""
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+SCRIPT = Path(__file__).parent / "ci/install_gnu_build_packages.sh"
+
+
+class PackageSetupTests(unittest.TestCase):
+    def run_setup(self, fail_update=False):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            log = root / "calls.jsonl"
+            apt = root / "apt-get"
+            apt.write_text(
+                "#!/usr/bin/env python3\n"
+                "import json, os, pathlib, sys\n"
+                "args = sys.argv[1:]\n"
+                "source = next(a.split('=', 1)[1] for a in args "
+                "if a.startswith('Dir::Etc::sourcelist='))\n"
+                "with open(os.environ['APT_TEST_LOG'], 'a') as log:\n"
+                " log.write(json.dumps({'args': args, 'path': source, "
+                "'sources': pathlib.Path(source).read_text()}) + '\\n')\n"
+                "if 'update' in args and os.environ['APT_TEST_FAIL'] == '1': "
+                "sys.exit(100)\n"
+            )
+            apt.chmod(0o755)
+            env = dict(os.environ, PATH=f"{root}:{os.environ['PATH']}",
+                       APT_TEST_LOG=str(log), APT_TEST_FAIL=str(int(fail_update)))
+            result = subprocess.run(
+                ["bash", str(SCRIPT), "cmake", "gcc-aarch64-linux-gnu"],
+                env=env, check=False,
+            )
+            calls = [json.loads(line) for line in log.read_text().splitlines()]
+            for call in calls:
+                self.assertFalse(Path(call["path"]).exists(), "temporary source leaked")
+            return result.returncode, calls
+
+    def test_signed_snapshot_sources_and_forwarded_packages(self):
+        code, calls = self.run_setup()
+        self.assertEqual(code, 0)
+        self.assertEqual(len(calls), 2)
+        for call in calls:
+            self.assertIn("Dir::Etc::sourceparts=-", call["args"])
+            self.assertNotIn("--allow-unauthenticated", call["args"])
+            lines = call["sources"].splitlines()
+            self.assertEqual(len(lines), 2)
+            for line in lines:
+                self.assertIn("https://snapshot.debian.org/archive/", line)
+                self.assertIn("/20260901T000000Z/", line)
+                self.assertIn("[check-valid-until=no]", line)
+                self.assertNotIn("trusted=yes", line)
+        self.assertEqual(calls[0]["sources"], calls[1]["sources"])
+        self.assertEqual(calls[1]["args"][-5:],
+                         ["install", "-y", "--no-install-recommends",
+                          "cmake", "gcc-aarch64-linux-gnu"])
+
+    def test_failed_update_never_installs(self):
+        code, calls = self.run_setup(fail_update=True)
+        self.assertEqual(code, 100)
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0]["args"][-1], "update")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Linked Issue

Closes #1890

## Summary

Validate stacked pull requests and restore GNU package setup after Bullseye LTS.
No storage changes or release dispatch. Based on main, independent of the storage
performance stack.

## Changes

- CI runs for every PR base and path; push filters and first-attempt cancellation
  remain. Unconditional PR checks prevent required checks hanging on docs-only PRs.
- Contribution checks accept stacked bases.
- CI and release packaging share dated Debian snapshot package sources while
  preserving the pinned Rust image and glibc 2.31 baseline.
- Snapshot sources alone disable freshness checking; Debian signature and package
  hash verification remain enabled. Live package sources are not modified.

## Verification

- Full scripts/ci/test-release-contracts.sh PASS.
- actionlint on all three changed workflows PASS; shellcheck PASS.
- Actual pinned linux/amd64 Rust container installed cmake and the ARM64 cross
  compiler/libc successfully from signed snapshots. This reproduces the formerly
  failing setup, not a claim that the full GNU build has completed.
- Package tests verify source scope, forwarding, cleanup and no install after a
  failed update; parsed workflow contract rejects base/path-filtered PR CI.

## Test Plan

Run exact-head CI, including both GNU builds, and inspect the resulting checks.
Main build/test protection uses stable job names without replacing existing
contribution/signature/review requirements. Existing stacked branches need these
workflow changes before they gain direct PR CI.

## AI / Tool Assistance

Assisted-by: Codex:gpt-6-astra

## Checklist

- [x] Linked issue and changelog
- [x] Local contracts and real container package setup
- [x] GPG signature and DCO
- [ ] Hosted CI complete
