### PR TITLE
fix(release): certify exact Darwin bytes through supervised approval

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -427,14 +427,12 @@ jobs:
     name: Native FSKit mount certification
     needs: [classify, build]
     if: ${{ !inputs.prepare_only }}
-    uses: ./.github/workflows/native-storage-certification.yml
+    uses: ./.github/workflows/supervised-storage-certification.yml
     permissions:
       contents: read
       actions: read
     with:
       source_commit: ${{ needs.classify.outputs.source-commit }}
-      runner_contract_acknowledged: true
-      consume_same_run_artifacts: true
 
   # ── Create the GitHub release with all binaries ───────────────────
   github-release:

--- a/.github/workflows/supervised-storage-certification.yml
+++ b/.github/workflows/supervised-storage-certification.yml
@@ -1,0 +1,81 @@
+name: Supervised native storage certification
+
+on:
+  workflow_call:
+    inputs:
+      source_commit:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  identify:
+    name: Identify archive for supervised FSKit test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.source_commit }}
+          persist-credentials: false
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: binary-aarch64-apple-darwin
+          path: archive
+      - name: Record exact archive identity
+        env:
+          SOURCE_COMMIT: ${{ inputs.source_commit }}
+        run: |
+          test "$SOURCE_COMMIT" = "$GITHUB_SHA"
+          python3 scripts/supervised_fskit.py manifest archive "$SOURCE_COMMIT" "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT" > fskit-manifest.json
+          {
+            echo '## Supervised FSKit certification required'
+            echo 'Download the binary-aarch64-apple-darwin and supervised-fskit-manifest artifacts from this run.'
+            echo 'Follow release/SUPERVISED-FSKIT.md. Do not approve until local certification passes.'
+            echo 'Paste the complete PASS receipt JSON as the protected release approval comment.'
+            echo 'A generic approval, stale attempt, or different archive is rejected.'
+            echo '```json'
+            cat fskit-manifest.json
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: supervised-fskit-manifest-${{ github.run_attempt }}
+          path: fskit-manifest.json
+
+  certify:
+    name: Native FSKit mount certification
+    needs: identify
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.source_commit }}
+          persist-credentials: false
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: binary-aarch64-apple-darwin
+          path: archive
+      - name: Verify protected approval against these exact bytes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_COMMIT: ${{ inputs.source_commit }}
+        run: |
+          python3 scripts/supervised_fskit.py manifest archive "$SOURCE_COMMIT" "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT" > fskit-manifest.json
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/approvals" > approvals.json
+          python3 scripts/supervised_fskit.py verify fskit-manifest.json approvals.json > fskit-receipt.json
+          echo 'Supervised operator-attested FSKit certification passed; this hosted job did not execute FSKit.' >> "$GITHUB_STEP_SUMMARY"
+          cat fskit-receipt.json >> "$GITHUB_STEP_SUMMARY"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: supervised-fskit-receipt-${{ github.run_attempt }}
+          path: fskit-receipt.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,8 @@ Version numbers follow [year.month.patch](release/VERSIONING.md) beginning with
 
 ### Fixed
 
+- Release publication supports supervised, exact-archive macOS certification
+  through protected operator approval when a dedicated FSKit runner is absent.
 - Authoritative stop waits for the daemon and MCP gateway to exit and clears
   coordination state. Failed MCP launches clean up children; ephemeral daemons
   shut down after their final client disconnects. Cancelling the host that

--- a/release/SUPERVISED-FSKIT.md
+++ b/release/SUPERVISED-FSKIT.md
@@ -1,0 +1,76 @@
+# Supervised macOS release certification
+
+The Release workflow builds the signed/notarized Darwin archive, identifies its
+SHA-256, then waits at the existing protected `release` environment. No GitHub
+runner software runs on the operator's Mac. This is an operator-attested native
+test, not a claim that the hosted Linux approval job executed FSKit.
+
+The dedicated clean-Mac workflow remains available for future infrastructure.
+This supervised path currently certifies Apple Silicon. It does not assert a
+second physical Intel-Mac run. Hosted builds still validate both Darwin archives.
+
+## Before changing the Mac
+
+1. Download **this Release run's** `binary-aarch64-apple-darwin` artifact into
+   its own directory and `supervised-fskit-manifest-<attempt>` separately.
+   Compare source commit, run ID and attempt with the GitHub run. Do not use a
+   rebuilt archive or a preceding prepare run.
+2. Validate the staged app's Developer ID, team, version, notarization and
+   companion with `macos/validate-macos-fskit.sh` from the extracted archive.
+   The local certification script repeats those checks.
+3. Inventory existing Astrid mounts, their backing homes and daemon ownership.
+   Sync and unmount only explicitly identified mounts during a supervised
+   maintenance window. Never run the dedicated runner's blanket cleanup here.
+4. Preserve the existing app and companion, including permissions and extended
+   attributes, in an operator-owned backup outside the installation destination.
+   Record their hashes and the previous extension selection. Preserve backing
+   volumes; do not delete application homes or terminate unrelated daemons.
+5. Use the archive's manager to update the intended installed app and enable it.
+   Its transactional update validates the candidate before replacement. macOS
+   may require operator approval. Do not disable Gatekeeper or substitute an
+   unsigned app. Keep the explicit backup until restoration or acceptance of
+   the new installation has been verified.
+
+The actual app swap is deliberately **not automated** by the certification
+script. A separate macOS account does not isolate `/Applications` or FSKit
+registration. A failed installation or incomplete restoration stops the
+supervised operation and must be reported before proceeding.
+
+## Execute and retain evidence
+
+Run from the exact release source checkout, with Python 3.12 or newer:
+
+```sh
+python3 scripts/certify_fskit_local.py \
+  /absolute/archive-directory/astrid-2026.9.0-aarch64-apple-darwin.tar.gz \
+  /absolute/manifest-directory/fskit-manifest.json \
+  --app /Applications/AstridFS.app
+```
+
+The script hashes the archive, safely extracts it, compares every installed app
+file's bytes/mode, validates Apple trust and bound provider identity, then tests
+a fresh runtime: real `astridfs` mount, write/rename/read, dirty/sync status,
+delete/sync, unmount and stop leaving exactly `astrid.volume`. It never installs
+or uninstalls an app, changes extension election, or kills foreign processes.
+It retains commands, checks and the PASS receipt in the printed `/tmp/fsc.*`
+evidence directory. Failure produces no PASS receipt. Preserve that directory.
+
+Restore the previous app/companion and any deliberately paused mounts, or
+explicitly accept retaining the tested version. Verify the chosen host state
+before approving publication; the native test receipt alone does not certify
+restoration of the operator's separate development environment.
+
+## Approve the exact result
+
+Only after the native test passes and the Mac is in the agreed state, paste the
+complete `receipt.json` as the protected release approval comment. The gate
+requires Joshua's `joshuajbouw` approval for environment `release`, with exact
+source, archive hash/name, target, run ID, run attempt, and all required checks
+literally `true`. Generic approval, missing checks, different bytes or a stale
+attempt fail. Do not manufacture a receipt from a planned test.
+
+The hosted job uploads the accepted receipt to the same Release run and reports
+the named certification check. GitHub publication still depends on that check
+and retains its existing signature, immutable-release and protected-environment
+controls. A new run attempt requires a fresh receipt. Normal publication approval
+may be requested separately; it is not permission to skip the local test.

--- a/scripts/certify_fskit_local.py
+++ b/scripts/certify_fskit_local.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Test released bytes on a supervised Mac without installing/removing an app.
+
+The operator must first install and enable the archive's signed app. This script
+only starts its own disposable runtime and never kills foreign processes. Logs
+and the receipt are retained under a short temporary directory on failure too.
+"""
+
+import argparse
+import json
+import os
+from pathlib import Path, PurePosixPath
+import platform
+import re
+import stat
+import subprocess
+import tarfile
+import tempfile
+
+from supervised_fskit import CHECKS, TARGET, manifest, sha256
+
+
+def inventory(root):
+    result = {}
+    for path in sorted(root.rglob("*")):
+        if path.is_symlink():
+            raise ValueError(f"redirected app member: {path}")
+        relative = str(path.relative_to(root))
+        if path.is_file():
+            result[relative] = (stat.S_IMODE(path.stat().st_mode), sha256(path))
+        elif path.is_dir():
+            result[relative] = ("directory",)
+        else:
+            raise ValueError(f"special app member: {path}")
+    if not result:
+        raise ValueError("empty app inventory")
+    return result
+
+
+def unpack(archive, destination):
+    root_name = archive.name.removesuffix(".tar.gz")
+    with tarfile.open(archive, "r:gz") as stream:
+        members = stream.getmembers()
+        if len(members) > 20000 or sum(member.size for member in members) > 2 * 1024**3:
+            raise ValueError("archive exceeds member/size limit")
+        seen = set()
+        for member in members:
+            path = PurePosixPath(member.name)
+            if path.is_absolute() or ".." in path.parts or not path.parts or path.parts[0] != root_name:
+                raise ValueError("archive member escapes expected root")
+            if path in seen or not (member.isfile() or member.isdir()):
+                raise ValueError("duplicate, redirected or special archive member")
+            seen.add(path)
+        stream.extractall(destination, filter="data")
+    return destination / root_name
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("archive", type=Path)
+    parser.add_argument("manifest", type=Path)
+    parser.add_argument("--app", type=Path, default=Path("/Applications/AstridFS.app"))
+    args = parser.parse_args()
+    if platform.system() != "Darwin" or platform.machine() != "arm64":
+        parser.error("this certification covers an Apple Silicon macOS host")
+    expected = json.loads(args.manifest.read_text())
+    archive = args.archive.absolute()
+    # Hash the selected archive, not a filename inferred from some other tree.
+    actual = manifest(archive.parent, expected["source_commit"], expected["run_id"], expected["run_attempt"])
+    if actual != expected or actual["archive"] != archive.name or actual["target"] != TARGET:
+        raise ValueError("archive differs from the release-run manifest")
+    if args.app.is_symlink() or not args.app.is_dir():
+        raise ValueError("installed app must be a real directory")
+    root = Path(tempfile.mkdtemp(prefix="fsc.", dir="/tmp")).resolve()
+    print(f"Evidence directory: {root}", flush=True)
+    stage = unpack(archive, root / "release")
+    if inventory(stage / "AstridFS.app") != inventory(args.app):
+        raise ValueError("installed app differs from archive; no runtime started or app changed")
+    home, mount = root / "home", root / "mount"
+    mount.mkdir()
+    env = {key: value for key, value in os.environ.items() if not key.startswith("ASTRID_")}
+    env.update(ASTRID_HOME=str(home), ASTRID_FSKIT_APP_DEST=str(args.app.absolute()),
+               ASTRID_FSKIT_BIN_DIR=str(stage), PATH=f"{stage}:{env.get('PATH', '')}")
+    version = archive.name.removeprefix("astrid-").removesuffix(f"-{TARGET}.tar.gz")
+    env["ASTRID_FSKIT_EXPECTED_VERSION"] = version
+    checks = {key: False for key in CHECKS}
+    checks["installed_app_bytes"] = True
+    binary = str(stage / "astrid")
+
+    def run(*command):
+        completed = subprocess.run(command, env=env, text=True, stdout=subprocess.PIPE,
+                                   stderr=subprocess.STDOUT, timeout=90, check=False)
+        with (root / "commands.log").open("a") as log:
+            log.write(f"command={command!r}\nexit={completed.returncode}\n{completed.stdout}\n")
+        if completed.returncode:
+            raise RuntimeError(f"command failed ({completed.returncode}): {command}; see commands.log")
+        return completed.stdout
+
+    def cli(*command):
+        return run(binary, "--principal", "default", *command)
+
+    def status(dirty):
+        output = cli("storage", "status", str(mount))
+        if f"dirty={str(dirty).lower()}" not in output or "ReadWrite" not in output:
+            raise ValueError(f"unexpected mount status: {output}")
+
+    run("/bin/bash", str(stage / "macos/validate-macos-fskit.sh"), str(stage / "AstridFS.app"))
+    checks["apple_trust"] = True
+    for command in ("validate", "status", "check-process"):
+        run("/bin/bash", str(stage / "macos/manage-macos-fskit.sh"), command)
+    checks["provider_identity"] = True
+    started = False
+    try:
+        # Own this disposable home even if a partially successful start fails.
+        started = True
+        cli("start")
+        cli("storage", "mount", "--as", "default", str(mount))
+        if run("/usr/bin/stat", "-f", "%T", str(mount)).strip() != "astridfs":
+            raise ValueError("mount is not astridfs")
+        status(False)
+        checks["mount"] = True
+        (mount / "probe.txt").write_text("supervised FSKit round trip\n")
+        (mount / "probe.txt").rename(mount / "renamed.txt")
+        if (mount / "renamed.txt").read_text() != "supervised FSKit round trip\n":
+            raise ValueError("mounted read differs from write")
+        status(True)
+        checks["write_rename_read"] = True
+        cli("storage", "sync", str(mount))
+        status(False)
+        checks["sync"] = True
+        (mount / "renamed.txt").unlink()
+        cli("storage", "sync", str(mount))
+        status(False)
+        checks["delete_sync"] = True
+        cli("storage", "unmount", str(mount))
+        if run("/usr/bin/stat", "-f", "%T", str(mount)).strip() == "astridfs":
+            raise ValueError("filesystem remained mounted")
+        checks["unmount"] = True
+        cli("stop")
+        started = False
+        if {path.name for path in home.iterdir()} != {"astrid.volume"}:
+            raise ValueError("stopped runtime is not exactly astrid.volume")
+        checks["stop"] = True
+    finally:
+        if started:
+            # Only this script's mount and runtime; never pkill or remove app.
+            try:
+                if run("/usr/bin/stat", "-f", "%T", str(mount)).strip() == "astridfs":
+                    cli("storage", "unmount", str(mount))
+            finally:
+                cli("stop")
+        (root / "checks.json").write_text(json.dumps(checks, sort_keys=True))
+    if inventory(stage / "AstridFS.app") != inventory(args.app):
+        raise ValueError("installed app changed during certification")
+    if manifest(archive.parent, expected["source_commit"], expected["run_id"], expected["run_attempt"]) != expected:
+        raise ValueError("archive changed during certification")
+    receipt = dict(expected, result="PASS", checks=checks)
+    (root / "receipt.json").write_text(json.dumps(receipt, sort_keys=True) + "\n")
+    print(json.dumps(receipt, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/test-release-contracts.sh
+++ b/scripts/ci/test-release-contracts.sh
@@ -21,3 +21,4 @@ bash scripts/test_certify_musl_release_archive_contract.sh
 bash scripts/test_native_storage_certification_contract.sh
 bash scripts/test_ci_workflow_contract.sh
 python3 scripts/test_gnu_build_packages.py
+python3 scripts/test_supervised_fskit.py

--- a/scripts/supervised_fskit.py
+++ b/scripts/supervised_fskit.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Bind an operator's supervised FSKit attestation to one release archive.
+
+This validates evidence identity, not physical execution. The protected release
+reviewer attests the local checks; GitHub retains that review and this receipt.
+"""
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import re
+
+
+CHECKS = {
+    "apple_trust", "installed_app_bytes", "provider_identity", "mount",
+    "write_rename_read", "sync", "delete_sync", "unmount", "stop",
+}
+TARGET = "aarch64-apple-darwin"
+
+
+def sha256(path):
+    with Path(path).open("rb") as stream:
+        return hashlib.file_digest(stream, "sha256").hexdigest()
+
+
+def manifest(directory, source, run_id, attempt):
+    if not re.fullmatch(r"[0-9a-f]{40}", source):
+        raise ValueError("invalid source commit")
+    if not re.fullmatch(r"[1-9][0-9]*", run_id) or not re.fullmatch(r"[1-9][0-9]*", attempt):
+        raise ValueError("invalid run identity")
+    archives = list(Path(directory).iterdir())
+    if len(archives) != 1:
+        raise ValueError("expected exactly one release archive")
+    archive = archives[0]
+    if archive.is_symlink() or not archive.is_file():
+        raise ValueError("archive must be a regular file")
+    if not re.fullmatch(r"astrid-[0-9][0-9A-Za-z.+-]*-aarch64-apple-darwin\.tar\.gz", archive.name):
+        raise ValueError("unexpected Darwin archive name")
+    return {"schema": 1, "source_commit": source, "run_id": run_id,
+            "run_attempt": attempt, "target": TARGET, "archive": archive.name,
+            "archive_sha256": sha256(archive)}
+
+
+def approved_receipt(expected, reviews):
+    for review in reviews:
+        if review.get("state") != "approved":
+            continue
+        if review.get("user", {}).get("login") != "joshuajbouw":
+            continue
+        if not any(env.get("name") == "release" for env in review.get("environments", [])):
+            continue
+        try:
+            receipt = json.loads(review.get("comment", ""))
+        except (ValueError, TypeError):
+            continue
+        if not isinstance(receipt, dict):
+            continue
+        if set(receipt) != set(expected) | {"result", "checks"}:
+            continue
+        if any(receipt.get(key) != value for key, value in expected.items()):
+            continue
+        if receipt.get("result") != "PASS":
+            continue
+        checks = receipt.get("checks")
+        if not isinstance(checks, dict) or set(checks) != CHECKS:
+            continue
+        if not all(value is True for value in checks.values()):
+            continue
+        return receipt
+    raise ValueError("no protected operator approval matches this archive, run attempt and complete PASS")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    build = commands.add_parser("manifest")
+    for name in ("directory", "source", "run_id", "attempt"):
+        build.add_argument(name)
+    verify = commands.add_parser("verify")
+    verify.add_argument("manifest", type=Path)
+    verify.add_argument("reviews", type=Path)
+    args = parser.parse_args()
+    if args.command == "manifest":
+        result = manifest(args.directory, args.source, args.run_id, args.attempt)
+    else:
+        result = approved_receipt(json.loads(args.manifest.read_text()), json.loads(args.reviews.read_text()))
+    print(json.dumps(result, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_supervised_fskit.py
+++ b/scripts/test_supervised_fskit.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Executable regressions for supervised release approval binding."""
+
+import copy
+import json
+from pathlib import Path
+import tempfile
+import io
+import tarfile
+import unittest
+
+import supervised_fskit as cert
+import certify_fskit_local as local
+
+
+class ApprovalTests(unittest.TestCase):
+    def setUp(self):
+        self.expected = {"schema": 1, "source_commit": "a" * 40, "run_id": "123",
+                         "run_attempt": "2", "target": cert.TARGET,
+                         "archive": "astrid-2026.9.0-aarch64-apple-darwin.tar.gz",
+                         "archive_sha256": "b" * 64}
+        self.receipt = dict(self.expected, result="PASS", checks=dict.fromkeys(cert.CHECKS, True))
+        self.review = {"state": "approved", "user": {"login": "joshuajbouw"},
+                       "environments": [{"name": "release"}],
+                       "comment": json.dumps(self.receipt)}
+
+    def test_exact_approval(self):
+        self.assertEqual(cert.approved_receipt(self.expected, [self.review]), self.receipt)
+
+    def test_stale_or_different_identity(self):
+        for field in ("source_commit", "archive_sha256", "run_id", "run_attempt", "target", "archive"):
+            with self.subTest(field=field):
+                receipt = dict(self.receipt, **{field: "different"})
+                with self.assertRaises(ValueError):
+                    cert.approved_receipt(self.expected, [dict(self.review, comment=json.dumps(receipt))])
+
+    def test_no_generic_approval_or_incomplete_claims(self):
+        for comment in ("Ship it!", "{}", "null", "[]", "true", "", json.dumps(self.expected)):
+            with self.subTest(comment=comment), self.assertRaises(ValueError):
+                cert.approved_receipt(self.expected, [dict(self.review, comment=comment)])
+        for value in (False, "true", 1, None):
+            receipt = copy.deepcopy(self.receipt)
+            receipt["checks"]["mount"] = value
+            with self.subTest(value=value), self.assertRaises(ValueError):
+                cert.approved_receipt(self.expected, [dict(self.review, comment=json.dumps(receipt))])
+
+    def test_untrusted_review(self):
+        for change in ({"state": "rejected"}, {"user": {"login": "someone"}},
+                       {"environments": [{"name": "unprotected"}]}):
+            with self.subTest(change=change), self.assertRaises(ValueError):
+                cert.approved_receipt(self.expected, [dict(self.review, **change)])
+
+    def test_manifest_hashes_actual_archive(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / self.expected["archive"]
+            path.write_bytes(b"first")
+            first = cert.manifest(directory, "a" * 40, "123", "2")
+            path.write_bytes(b"second")
+            second = cert.manifest(directory, "a" * 40, "123", "2")
+            self.assertNotEqual(first["archive_sha256"], second["archive_sha256"])
+            (Path(directory) / "extra").write_text("unexpected")
+            with self.assertRaises(ValueError):
+                cert.manifest(directory, "a" * 40, "123", "2")
+
+    def test_workflow_keeps_protected_gate_and_same_run_bytes(self):
+        root = Path(__file__).resolve().parents[1]
+        text = (root / ".github/workflows/supervised-storage-certification.yml").read_text()
+        self.assertIn("environment: release", text)
+        self.assertEqual(text.count("name: binary-aarch64-apple-darwin"), 2)
+        self.assertIn('test "$SOURCE_COMMIT" = "$GITHUB_SHA"', text)
+        self.assertIn("/actions/runs/$GITHUB_RUN_ID/approvals", text)
+        self.assertIn("supervised_fskit.py verify", text)
+        self.assertNotIn("secrets.", text)
+        release = (root / ".github/workflows/release.yml").read_text()
+        self.assertIn("needs: [classify, build, fskit-certification]", release)
+        self.assertIn("uses: ./.github/workflows/supervised-storage-certification.yml", release)
+
+    def test_local_app_inventory_detects_changed_bytes_and_links(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            member = root / "file"
+            member.write_text("first")
+            before = local.inventory(root)
+            member.write_text("second")
+            self.assertNotEqual(before, local.inventory(root))
+            (root / "link").symlink_to(member)
+            with self.assertRaises(ValueError):
+                local.inventory(root)
+
+    def test_local_extraction_refuses_escape_and_links(self):
+        for name, kind in (("../outside", tarfile.REGTYPE), ("root/link", tarfile.SYMTYPE)):
+            with self.subTest(name=name), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                archive = root / "root.tar.gz"
+                with tarfile.open(archive, "w:gz") as stream:
+                    member = tarfile.TarInfo(name)
+                    member.type = kind
+                    member.linkname = "/tmp/outside"
+                    stream.addfile(member, io.BytesIO())
+                with self.assertRaises(ValueError):
+                    local.unpack(archive, root / "out")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Linked Issue

Closes #1897

## Summary

Allow supervised certification of the exact release-built Apple Silicon archive without registering an operator's development Mac as a GitHub runner. Publication remains gated on a complete, protected operator attestation and the existing artifact authentication checks.

## Changes

- Identify and hash the same-run Darwin archive before protected release approval.
- Require the release approval comment to contain a complete PASS receipt bound to source commit, archive name/hash, target, run ID and attempt. Generic approvals, stale receipts and incomplete checks fail.
- Record the accepted receipt as a workflow artifact; clearly label it operator-attested rather than hosted native execution.
- Provide a local native test for Apple trust, installed-app byte identity, provider identity, mount, write/rename/read, sync, delete/sync, unmount and volume-only stop. Only its own disposable home and mount are cleaned up. No app replacement, broad process kill or runner registration is automated.
- Document supervised app backup/swap/restoration. Retain the dedicated-runner workflow for future use.
- Add the net change to the pending 2026.9.0 changelog without introducing a new version.

## Verification

- `python3 scripts/test_supervised_fskit.py`: 8 tests pass, including changed bytes, stale run attempts, untrusted reviewers, generic approvals, incomplete results, unsafe extraction and app inventory changes.
- `bash scripts/ci/test-release-contracts.sh`: all suites pass.
- `actionlint .github/workflows/supervised-storage-certification.yml .github/workflows/release.yml`: passes.
- Diff checks pass. Commit is GPG-signed with DCO.
- No production native run is claimed: it requires the tag-built archive. Existing app, mounts, daemons and GitHub environment rules remain unchanged.

## AI / Tool Assistance

Assisted-by: Codex:Astra

Implementation and tests were checked against the existing release dependencies, protected-environment policy and GitHub review-history API. Native execution remains an explicit supervised release step, not a unit-test claim.

## Checklist

- [x] Linked to an issue
- [x] Pending release changelog updated directly
- [x] I understand the change, risks and verification boundaries
- [x] Tool-generated output reviewed and tested
- [x] Signed-off-by trailer matches the signed commit
