### PR TITLE
fix(release): specify PKCS12 format for macOS signing import

### DIFF
--- a/scripts/ci/import_macos_signing.sh
+++ b/scripts/ci/import_macos_signing.sh
@@ -119,7 +119,9 @@ create_signing_keychain() {
 }
 
 import_developer_id() {
+  # The temporary filename ends in a PID, so format inference cannot use .p12.
   security import "$P12_PATH" \
+    -f pkcs12 \
     -k "$SIGNING_KEYCHAIN" \
     -P "$ASTRID_MACOS_DEVELOPER_ID_P12_PASSWORD" \
     -T /usr/bin/codesign

--- a/scripts/test_channel_workflow_contract.sh
+++ b/scripts/test_channel_workflow_contract.sh
@@ -618,6 +618,14 @@ case "$1" in
   delete-keychain)
     rm -f "${*: -1}"
     ;;
+  import)
+    # Numbered temporary filenames cannot use security's extension inference.
+    [[ "${2:-}" == *.p12.* ]] || exit 93
+    [[ "${3:-}" == "-f" && "${4:-}" == pkcs12 ]] || {
+      echo 'security: SecKeychainItemImport: Unknown format in import.' >&2
+      exit 94
+    }
+    ;;
   set-key-partition-list)
     [[ "${2:-}" == "-S" && "${4:-}" == "-k" ]] || exit 90
     printf 'partition-password=%s\\n' "$5" >> "$fixture/behavior.log"


### PR DESCRIPTION
## Linked Issue

Closes #1901

## Summary

Fix the Darwin release signing import without changing runtime code or version metadata.

## Changes

- Pass `-f pkcs12` to `security import`: its temporary filename ends in a PID, so automatic format inference fails.
- Make the executable signing-helper fixture reject omission of the explicit format for that numbered filename.
- Preserve certificate, team, keychain, and notarization checks.

## Verification

- Regression added first: channel workflow contract failed with the same unknown-format error before the fix; passed after it.
- Full `bash scripts/ci/test-release-contracts.sh` passed.
- ShellCheck passed on the import helper; warning/error-level ShellCheck passed on the contract script (its existing literal-pattern SC2016 informational diagnostics remain).
- Native macOS disposable identity reproduction: identical legacy PKCS12 bytes failed with `.p12.12345` and automatic detection, succeeded with explicit `-f pkcs12`, and succeeded with `.p12` and automatic detection. Disposable fixture/keychain removed; no production identity used in that test.
- Production release execution remains the verification of actual hosted signing/notarization, not a claim from the fixture.

## AI / Tool Assistance

Assisted-by: Codex:gpt-6-astra

Assisted with diagnosis, the two-file repair, and regression testing. Reviewed the full diff and executed the regression before and after the repair, plus the full release-contract suite.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment omitted for CI-only fix
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
