### PR TITLE
fix(init): honor explicit grants after completed batch resume

### DIFF
--- a/changes/1905.fixed.md
+++ b/changes/1905.fixed.md
@@ -1,0 +1,1 @@
+Honor explicit `init --grant-capsules` for the complete verified distro after a resumed install, including capsules completed in earlier batches. Plain resume still does not grant access implicitly.

--- a/crates/astrid-cli/src/commands/init.rs
+++ b/crates/astrid-cli/src/commands/init.rs
@@ -223,8 +223,8 @@ pub(crate) async fn run_init(distro_source: &str, opts: &InitOpts) -> anyhow::Re
     // selection). A partial run deliberately writes NO lock so a re-run
     // actually retries the missing capsules instead of short-circuiting on a
     // stale member set — see `should_write_lock`.
-    // The grant set is exactly the names that performed a new install. A
-    // durable resume has no grant side effect.
+    // Plain resume has no grant side effect. An explicit grant request covers
+    // the complete verified set, including members completed in earlier batches.
     let lock = create_lock_from_parts(
         schema_version,
         &distro_id,
@@ -241,15 +241,12 @@ pub(crate) async fn run_init(distro_source: &str, opts: &InitOpts) -> anyhow::Re
         // On a grant failure the capsules are already installed and the lock
         // is written; this returns Err so init exits non-zero with the exact
         // manual command to finish.
-        if !newly_installed_names.is_empty() {
-            grant::apply_or_hint_grants(
-                &operator,
-                &target,
-                &newly_installed_names,
-                opts.grant_capsules,
-            )
-            .await?;
-        }
+        let grant_names = grant::completed_grant_names(
+            opts.grant_capsules,
+            &lock.capsules,
+            &newly_installed_names,
+        );
+        grant::apply_or_hint_grants(&operator, &target, &grant_names, opts.grant_capsules).await?;
         eprintln!("  Run {} to start.", Theme::prompt("astrid"));
         Ok(())
     } else {

--- a/crates/astrid-cli/src/commands/init_grant.rs
+++ b/crates/astrid-cli/src/commands/init_grant.rs
@@ -20,6 +20,23 @@ use fs2::FileExt;
 
 use crate::theme::Theme;
 
+/// Called only after the complete selected set earned its durable lock.
+/// Explicit grants include verified resumed members; plain resume remains inert.
+pub(super) fn completed_grant_names(
+    explicit: bool,
+    completed: &[super::LockedCapsule],
+    newly_installed: &[String],
+) -> Vec<String> {
+    if explicit {
+        completed
+            .iter()
+            .map(|capsule| capsule.name.clone())
+            .collect()
+    } else {
+        newly_installed.to_vec()
+    }
+}
+
 /// Guard: `--grant-capsules` may only be honoured alongside a distro
 /// install, because the grant set is exactly the capsules that distro
 /// installs. `distro_present` is whether a non-empty distro source
@@ -525,6 +542,31 @@ mod tests {
     use super::*;
     use crate::commands::capsule::{install, meta};
     use crate::commands::init::LockedCapsule;
+
+    #[test]
+    fn explicit_grants_include_completed_batches_and_idempotent_resume() {
+        let completed: Vec<_> = (0..22)
+            .map(|i| LockedCapsule {
+                name: format!("capsule-{i}"),
+                version: "1.0.0".into(),
+                source: "local.capsule".into(),
+                hash: "verified".into(),
+                resolved_ref: None,
+            })
+            .collect();
+        let expected: Vec<_> = completed.iter().map(|cap| cap.name.clone()).collect();
+        let final_batch = expected[20..].to_vec();
+        assert_eq!(
+            completed_grant_names(true, &completed, &final_batch),
+            expected
+        );
+        assert_eq!(completed_grant_names(true, &completed, &[]), expected);
+        assert_eq!(
+            completed_grant_names(false, &completed, &final_batch),
+            final_batch
+        );
+        assert!(completed_grant_names(false, &completed, &[]).is_empty());
+    }
     use std::sync::Arc;
 
     /// (c) The flag is only meaningful with a distro to resolve the grant


### PR DESCRIPTION
## Linked Issue

Closes #1905

## Summary

Honor explicit init --grant-capsules after bounded installation resumes. Previously only the last newly installed members received grants, and a fully completed re-run granted nothing.

## Changes

- Choose the complete verified selected set only for explicit grants, after successful durable lock persistence.
- Preserve plain resume behavior, partial-install refusal, existing principal authorization, and distro apply semantics.
- Add regression coverage for the 22-member final batch, full resume, and absent opt-in.

## Verification

All 58 focused initialization tests PASS, including 17 grant tests. cargo clippy -p astrid --bin astrid -- -D warnings PASS; formatting and diff checks PASS. Hosted CI is still required. No change to published v2026.9.0 or its binaries. AOS release recovery uses an independent compatibility fix.

## Test Plan

Require CI before merging. Explicit grant replay includes earlier completed members; plain resume grants nothing implicitly. Keep this follow-up independent of the AOS release.

## AI / Tool Assistance

Assisted-by: Codex:Astra

Implementation and inline review; executable tests validate grant selection.