### PR TITLE
fix(runtime): unify shutdown finalization and preserve capsule content

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,6 +540,7 @@ dependencies = [
  "astrid-core",
  "astrid-gateway",
  "astrid-kernel",
+ "astrid-storage",
  "astrid-telemetry",
  "astrid-uplink",
  "clap",

--- a/changes/1907.fixed.md
+++ b/changes/1907.fixed.md
@@ -1,0 +1,3 @@
+Preserve volume-only capsule WASM across idle daemon shutdown and restart. Host-projection receipts now track only materialized files, preventing first-boot capsule installs from being mistaken for deleted host files when initialization resumes.
+
+Unify graceful daemon finalization across idle exit, signals, and explicit stop. Both daemon entry points drain their task runtime before packing the final host projection under a stable lifecycle fence; CLI recovery uses the same finalizer.

--- a/changes/1907.fixed.md
+++ b/changes/1907.fixed.md
@@ -1,3 +1,5 @@
 Preserve volume-only capsule WASM across idle daemon shutdown and restart. Host-projection receipts now track only materialized files, preventing first-boot capsule installs from being mistaken for deleted host files when initialization resumes.
 
 Unify graceful daemon finalization across idle exit, signals, and explicit stop. Both daemon entry points drain their task runtime before packing the final host projection under a stable lifecycle fence; CLI recovery uses the same finalizer.
+
+Keep an existing ephemeral daemon connected throughout initialization, preventing idle retirement between provisioning requests while initialization still writes the running projection.

--- a/changes/1907.fixed.md
+++ b/changes/1907.fixed.md
@@ -3,3 +3,5 @@ Preserve volume-only capsule WASM across idle daemon shutdown and restart. Host-
 Unify graceful daemon finalization across idle exit, signals, and explicit stop. Both daemon entry points drain their task runtime before packing the final host projection under a stable lifecycle fence; CLI recovery uses the same finalizer.
 
 Keep an existing ephemeral daemon connected throughout initialization, preventing idle retirement between provisioning requests while initialization still writes the running projection.
+
+Retain that connection through Distro Apply's final self-grant, and resolve the lifecycle fence independently of each process's temporary-directory environment.

--- a/changes/1907.fixed.md
+++ b/changes/1907.fixed.md
@@ -5,3 +5,5 @@ Unify graceful daemon finalization across idle exit, signals, and explicit stop.
 Keep an existing ephemeral daemon connected throughout initialization, preventing idle retirement between provisioning requests while initialization still writes the running projection.
 
 Retain that connection through Distro Apply's final self-grant, and resolve the lifecycle fence independently of each process's temporary-directory environment.
+
+Drain provisioning-lease broadcasts so capsule installation cannot fill its socket queue and disconnect the lease midway through first boot.

--- a/crates/astrid-cli/src/commands/daemon.rs
+++ b/crates/astrid-cli/src/commands/daemon.rs
@@ -204,6 +204,12 @@ async fn ensure_daemon_inner_locked(
         .await
         .context("failed to probe daemon endpoint")?;
     let action = decide_ensure_action(&outcome, recorded_daemon_pid_is_alive());
+    if matches!(
+        action,
+        EnsureAction::CleanStaleAndSpawn | EnsureAction::Spawn
+    ) {
+        projection::ensure_finalization_finished()?;
+    }
     let needs_boot = match action {
         EnsureAction::UseExisting => {
             if let astrid_core::local_transport::ConnectOutcome::Connected(stream) = outcome {
@@ -553,6 +559,7 @@ async fn handle_start_locked() -> Result<()> {
             Ok(())
         },
         StartAction::HealAndSpawn => {
+            projection::ensure_finalization_finished()?;
             // Dead/absent recorded PID: a crashed daemon's stale run files. No
             // live process owns them, so clear ALL stale sentinels (socket,
             // readiness, PID) and spawn onto a clean run-dir.

--- a/crates/astrid-cli/src/commands/daemon/projection.rs
+++ b/crates/astrid-cli/src/commands/daemon/projection.rs
@@ -1,9 +1,19 @@
-//! CLI-side retirement of the volume-backed running projection.
-
-use std::sync::Arc;
+//! Recovery retirement after an already-dead daemon, using the shared finalizer.
 
 use anyhow::{Context, Result};
 use astrid_core::dirs::AstridHome;
+
+/// Refuse stale healing while a daemon is still retiring its host projection.
+/// The caller holds the CLI start fence; the daemon owns the lifecycle fence
+/// through runtime teardown, even after its socket/PID have disappeared.
+pub(super) fn ensure_finalization_finished() -> Result<()> {
+    let home = AstridHome::resolve()?;
+    drop(
+        astrid_storage::principal_state::RuntimeLifecycleGuard::acquire(&home)
+            .context("daemon is still finalizing; retry start after it exits")?,
+    );
+    Ok(())
+}
 
 /// Finish natural MCP retirement without stopping an operator-owned daemon.
 /// Recheck under the startup fence so a replacement cannot race the pack.
@@ -27,15 +37,6 @@ pub(crate) async fn retire_disconnected_projection(pid: Option<u32>) -> Result<(
     pack_stopped_projection().await
 }
 
-#[expect(
-    clippy::unnecessary_wraps,
-    reason = "the quota hook requires the storage projection's Result shape"
-)]
-fn unbounded(owner: &astrid_storage::StateOwner) -> astrid_storage::StorageResult<Option<u64>> {
-    let _ = owner;
-    Ok(None)
-}
-
 /// Reopen the stopped volume, publish the final projection, and retire hosts.
 pub(super) async fn pack_stopped_projection() -> Result<()> {
     let home =
@@ -53,32 +54,9 @@ pub(super) async fn pack_stopped_projection_for_home(home: &AstridHome) -> Resul
         return Ok(());
     }
 
-    let quota: Arc<dyn astrid_storage::KvQuotaResolver<astrid_storage::StateOwner>> =
-        Arc::new(unbounded);
-    let store = astrid_storage::principal_state::open_runtime_principal_store_for_pack(home, quota)
+    astrid_storage::principal_state::RuntimeLifecycleGuard::acquire(home)
+        .context("shutdown stage durable_projection_fence")?
+        .finish()
         .await
-        .context("shutdown stage durable_projection_open")?;
-    store
-        .pack_and_retire_runtime_projection(home)
-        .context("shutdown stage durable_projection_pack")?;
-    retire_stopped_projection(home)
-}
-
-/// Remove durable projections after the CLI-only post-exit pack.
-///
-/// The canonical media file is the only survivor.
-pub(super) fn retire_stopped_projection(home: &AstridHome) -> Result<()> {
-    let root = home.root();
-    if !root
-        .try_exists()
-        .context("shutdown stage durable_root_probe")?
-    {
-        return Ok(());
-    }
-    astrid_core::dirs::retire_projection_root(root).with_context(|| {
-        format!(
-            "shutdown stage durable_projection_cleanup: {}",
-            root.display()
-        )
-    })
+        .context("shutdown stage durable_projection_pack")
 }

--- a/crates/astrid-cli/src/commands/init.rs
+++ b/crates/astrid-cli/src/commands/init.rs
@@ -24,6 +24,8 @@ mod signed_source;
 
 use signed_source::{PreparedDistro, prepare_distro_source, unpack_prepared};
 
+mod lifetime;
+
 /// Options controlling the init / `distro apply` flow.
 ///
 /// Carries the headless and trust flags so the interactive prompts can
@@ -100,8 +102,11 @@ fn validate_install_source(
     Ok(shuttle_install)
 }
 
-/// Run the init flow: workspace setup + distro-based capsule installation.
-pub(crate) async fn run_init(distro_source: &str, opts: &InitOpts) -> anyhow::Result<()> {
+/// Run initialization and return its daemon lease for post-install operations.
+pub(crate) async fn run_init(
+    distro_source: &str,
+    opts: &InitOpts,
+) -> anyhow::Result<astrid_uplink::KernelClient> {
     let home = AstridHome::resolve()?;
     let operator = crate::principal::current();
     let target = opts.target_principal.clone();
@@ -117,18 +122,7 @@ pub(crate) async fn run_init(distro_source: &str, opts: &InitOpts) -> anyhow::Re
         prepare_distro_source(distro_source, opts, &home).await?
     };
 
-    // The kernel must admit a fresh home and publish its migration ledger
-    // before the CLI creates any v2 layout state. Init spans multiple admin
-    // connections, so its daemon must remain alive between those requests.
-    crate::commands::daemon::ensure_persistent_daemon("init")
-        .await
-        .context("init could not ensure the runtime daemon")?;
-    // An existing daemon can be ephemeral. Own a connection for the entire
-    // provisioning pass so gaps between admin requests cannot trigger retirement
-    // while this CLI still writes the running projection.
-    let _daemon_lease = crate::socket_client::connect_kernel_for_workspace(None)
-        .await
-        .context("init could not retain its runtime connection")?;
+    let daemon_lease = lifetime::retain_daemon().await?;
 
     if opts.grant_capsules {
         grant::preflight_grants(&operator, &target).await?;
@@ -136,7 +130,8 @@ pub(crate) async fn run_init(distro_source: &str, opts: &InitOpts) -> anyhow::Re
 
     let _provisioning_lock = ensure_init_workspace(&home, &target)?;
     if matches!(prepared, PreparedDistro::Shuttle) {
-        return run_init_from_shuttle(distro_source, opts).await;
+        run_init_from_shuttle(distro_source, opts).await?;
+        return Ok(daemon_lease);
     }
 
     // Distro.lock is an outcome record, not a completion shortcut. Every
@@ -254,7 +249,7 @@ pub(crate) async fn run_init(distro_source: &str, opts: &InitOpts) -> anyhow::Re
         );
         grant::apply_or_hint_grants(&operator, &target, &grant_names, opts.grant_capsules).await?;
         eprintln!("  Run {} to start.", Theme::prompt("astrid"));
-        Ok(())
+        Ok(daemon_lease)
     } else {
         // Partial provision (0 < succeeded < total): no lock was written, so
         // a re-run retries the rest. Exit NON-ZERO so automation and the

--- a/crates/astrid-cli/src/commands/init.rs
+++ b/crates/astrid-cli/src/commands/init.rs
@@ -123,6 +123,12 @@ pub(crate) async fn run_init(distro_source: &str, opts: &InitOpts) -> anyhow::Re
     crate::commands::daemon::ensure_persistent_daemon("init")
         .await
         .context("init could not ensure the runtime daemon")?;
+    // An existing daemon can be ephemeral. Own a connection for the entire
+    // provisioning pass so gaps between admin requests cannot trigger retirement
+    // while this CLI still writes the running projection.
+    let _daemon_lease = crate::socket_client::connect_kernel_for_workspace(None)
+        .await
+        .context("init could not retain its runtime connection")?;
 
     if opts.grant_capsules {
         grant::preflight_grants(&operator, &target).await?;

--- a/crates/astrid-cli/src/commands/init.rs
+++ b/crates/astrid-cli/src/commands/init.rs
@@ -25,6 +25,7 @@ mod signed_source;
 use signed_source::{PreparedDistro, prepare_distro_source, unpack_prepared};
 
 mod lifetime;
+pub(crate) use lifetime::ProvisioningLease;
 
 /// Options controlling the init / `distro apply` flow.
 ///
@@ -106,7 +107,7 @@ fn validate_install_source(
 pub(crate) async fn run_init(
     distro_source: &str,
     opts: &InitOpts,
-) -> anyhow::Result<astrid_uplink::KernelClient> {
+) -> anyhow::Result<ProvisioningLease> {
     let home = AstridHome::resolve()?;
     let operator = crate::principal::current();
     let target = opts.target_principal.clone();

--- a/crates/astrid-cli/src/commands/init/lifetime.rs
+++ b/crates/astrid-cli/src/commands/init/lifetime.rs
@@ -2,7 +2,17 @@
 
 use anyhow::Context as _;
 
-pub(super) async fn retain_daemon() -> anyhow::Result<astrid_uplink::KernelClient> {
+pub(crate) struct ProvisioningLease {
+    reader: tokio::task::JoinHandle<()>,
+}
+
+impl Drop for ProvisioningLease {
+    fn drop(&mut self) {
+        self.reader.abort();
+    }
+}
+
+pub(super) async fn retain_daemon() -> anyhow::Result<ProvisioningLease> {
     // The kernel must admit a fresh home and publish its migration ledger
     // before the CLI creates any v2 layout state. Init spans multiple admin
     // connections, so its daemon must remain alive between those requests.
@@ -11,7 +21,16 @@ pub(super) async fn retain_daemon() -> anyhow::Result<astrid_uplink::KernelClien
         .context("init could not ensure the runtime daemon")?;
     // An existing daemon can be ephemeral. Return the connection to the caller
     // so even post-init self-grants finish before the final lease is dropped.
-    crate::socket_client::connect_kernel_for_workspace(None)
-        .await
-        .context("init could not retain its runtime connection")
+    let mut client = crate::socket_client::connect_for_workspace(
+        astrid_core::SessionId::from_uuid(uuid::Uuid::new_v4()),
+        crate::principal::current(),
+        None,
+    )
+    .await
+    .context("init could not retain its runtime connection")?;
+    // The uplink receives broadcasts while capsules install. An unread socket
+    // fills its outbound queue and is disconnected, defeating a passive lease.
+    let reader =
+        tokio::spawn(async move { while matches!(client.read_message().await, Ok(Some(_))) {} });
+    Ok(ProvisioningLease { reader })
 }

--- a/crates/astrid-cli/src/commands/init/lifetime.rs
+++ b/crates/astrid-cli/src/commands/init/lifetime.rs
@@ -1,0 +1,17 @@
+//! Keep provisioning and its caller's post-install operations in one lifetime.
+
+use anyhow::Context as _;
+
+pub(super) async fn retain_daemon() -> anyhow::Result<astrid_uplink::KernelClient> {
+    // The kernel must admit a fresh home and publish its migration ledger
+    // before the CLI creates any v2 layout state. Init spans multiple admin
+    // connections, so its daemon must remain alive between those requests.
+    crate::commands::daemon::ensure_persistent_daemon("init")
+        .await
+        .context("init could not ensure the runtime daemon")?;
+    // An existing daemon can be ephemeral. Return the connection to the caller
+    // so even post-init self-grants finish before the final lease is dropped.
+    crate::socket_client::connect_kernel_for_workspace(None)
+        .await
+        .context("init could not retain its runtime connection")
+}

--- a/crates/astrid-cli/src/daemon.rs
+++ b/crates/astrid-cli/src/daemon.rs
@@ -1,6 +1,6 @@
 //! Bundled daemon binary — installed alongside `astrid` via `cargo install astrid`.
 //!
-//! Delegates to the shared `astrid_daemon::run()` library function. This is
+//! Delegates to the shared `astrid_daemon::run_to_completion()` lifecycle. This is
 //! identical to the standalone `astrid-daemon` binary but co-installed with
 //! the CLI so `find_companion_binary("astrid-daemon")` always finds it.
 
@@ -25,8 +25,5 @@ fn main() -> anyhow::Result<()> {
     #[cfg(unix)]
     let _ = nix::unistd::setsid();
 
-    tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()?
-        .block_on(astrid_daemon::run())
+    astrid_daemon::run_to_completion()
 }

--- a/crates/astrid-cli/src/dispatch.rs
+++ b/crates/astrid-cli/src/dispatch.rs
@@ -210,7 +210,7 @@ async fn dispatch_subcommand(
                 grant_capsules,
                 require_signed: false,
             };
-            commands::init::run_init(&distro, &opts).await?;
+            let _daemon_lease = commands::init::run_init(&distro, &opts).await?;
             commands::self_update::ensure_path_setup()?;
             Ok(ExitCode::SUCCESS)
         },
@@ -527,7 +527,7 @@ async fn dispatch_distro(command: DistroCommands) -> Result<ExitCode> {
                 grant_capsules: false,
                 require_signed: true,
             };
-            commands::init::run_init(&distro, &opts).await?;
+            let _daemon_lease = commands::init::run_init(&distro, &opts).await?;
             if apply_self_grant_required(&distro) {
                 commands::init::apply_self_grant(&opts.target_principal).await?;
             }

--- a/crates/astrid-cli/tests/daemon_finalization.rs
+++ b/crates/astrid-cli/tests/daemon_finalization.rs
@@ -1,0 +1,127 @@
+//! Every graceful termination source must leave the same durable root.
+#![cfg(unix)]
+
+use std::path::Path;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+struct Daemon(Child);
+
+impl Drop for Daemon {
+    fn drop(&mut self) {
+        if !matches!(self.0.try_wait(), Ok(Some(_))) {
+            let _ = self.0.kill();
+            let _ = self.0.wait();
+        }
+    }
+}
+
+fn command(binary: &str, home: &Path) -> Command {
+    let mut command = Command::new(binary);
+    command
+        .env("ASTRID_HOME", home)
+        .env_remove("ASTRID_RUN_DIR")
+        .env_remove("ASTRID_CONFIG")
+        .env("ASTRID_DAEMON_LOG_TARGET", "stderr")
+        .current_dir(home);
+    command
+}
+
+fn start(home: &Path, ephemeral: bool, log: &Path) -> Daemon {
+    let mut command = command(env!("CARGO_BIN_EXE_astrid-daemon"), home);
+    command.arg("--workspace").arg(home);
+    if ephemeral {
+        command.arg("--ephemeral");
+    }
+    let mut child = Daemon(
+        command
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(std::fs::File::create(log).unwrap())
+            .spawn()
+            .unwrap(),
+    );
+    let started = Instant::now();
+    while !home.join("run/system.ready").exists() {
+        assert!(
+            child.0.try_wait().unwrap().is_none(),
+            "boot exited: {}",
+            std::fs::read_to_string(log).unwrap()
+        );
+        assert!(started.elapsed() < Duration::from_secs(30), "boot timeout");
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    child
+}
+
+fn wait(child: &mut Daemon, log: &Path) {
+    let started = Instant::now();
+    loop {
+        if let Some(status) = child.0.try_wait().unwrap() {
+            assert!(
+                status.success(),
+                "shutdown failed: {}",
+                std::fs::read_to_string(log).unwrap()
+            );
+            return;
+        }
+        assert!(
+            started.elapsed() < Duration::from_secs(30),
+            "shutdown timeout"
+        );
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}
+
+fn stop(child: &mut Daemon, home: &Path, log: &Path) {
+    let mut cli = command(env!("CARGO_BIN_EXE_astrid"), home)
+        .arg("stop")
+        .spawn()
+        .unwrap();
+    // This test is the daemon's parent. Reap it while stop waits for process
+    // exit, rather than leaving a zombie that kill(pid, 0) still sees as live.
+    wait(child, log);
+    assert!(cli.wait().unwrap().success());
+}
+
+#[test]
+fn idle_signal_and_cli_stop_finalize_and_restore_identically() {
+    for mode in ["idle", "signal", "cli"] {
+        let directory = tempfile::tempdir().unwrap();
+        let home = directory.path().join("runtime");
+        std::fs::create_dir(&home).unwrap();
+        let log = directory.path().join("daemon.log");
+        let mut daemon = start(&home, mode == "idle", &log);
+        assert!(
+            command(env!("CARGO_BIN_EXE_astrid-daemon"), &home)
+                .arg("--version")
+                .output()
+                .unwrap()
+                .status
+                .success()
+        );
+        std::fs::write(home.join("final-write.txt"), mode).unwrap();
+        match mode {
+            "signal" => nix::sys::signal::kill(
+                nix::unistd::Pid::from_raw(i32::try_from(daemon.0.id()).unwrap()),
+                nix::sys::signal::Signal::SIGTERM,
+            )
+            .unwrap(),
+            "cli" => stop(&mut daemon, &home, &log),
+            _ => {},
+        }
+        wait(&mut daemon, &log);
+        let entries = std::fs::read_dir(&home)
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(entries.len(), 1, "{mode} left host sidecars");
+        assert_eq!(entries[0].file_name(), "astrid.volume");
+        let mut restarted = start(&home, false, &log);
+        assert_eq!(
+            std::fs::read_to_string(home.join("final-write.txt")).unwrap(),
+            mode
+        );
+        stop(&mut restarted, &home, &log);
+    }
+}

--- a/crates/astrid-core/src/dirs.rs
+++ b/crates/astrid-core/src/dirs.rs
@@ -325,13 +325,20 @@ impl AstridHome {
     ///
     /// Unlike `run/system.lock`, this inode survives volume-only retirement.
     /// Physical path resolution makes aliases of the same home share a fence.
+    /// The private sibling control directory is independent of process TMPDIR.
     ///
     /// # Errors
     /// Returns an error if the existing ancestor cannot be resolved.
     pub fn lifecycle_lock_path(&self) -> io::Result<PathBuf> {
         let root = run_dir::physical_path(self.root())?;
         let digest = blake3::hash(root.as_os_str().as_encoded_bytes());
-        Ok(std::env::temp_dir()
+        let parent = root.parent().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "runtime root has no control parent",
+            )
+        })?;
+        Ok(parent
             .join(format!("astrid-lifecycle-{digest}"))
             .join("runtime.lock"))
     }

--- a/crates/astrid-core/src/dirs.rs
+++ b/crates/astrid-core/src/dirs.rs
@@ -321,6 +321,21 @@ impl AstridHome {
         Self { root: root.into() }
     }
 
+    /// Stable control lock outside the disposable runtime projection.
+    ///
+    /// Unlike `run/system.lock`, this inode survives volume-only retirement.
+    /// Physical path resolution makes aliases of the same home share a fence.
+    ///
+    /// # Errors
+    /// Returns an error if the existing ancestor cannot be resolved.
+    pub fn lifecycle_lock_path(&self) -> io::Result<PathBuf> {
+        let root = run_dir::physical_path(self.root())?;
+        let digest = blake3::hash(root.as_os_str().as_encoded_bytes());
+        Ok(std::env::temp_dir()
+            .join(format!("astrid-lifecycle-{digest}"))
+            .join("runtime.lock"))
+    }
+
     /// Validate the durable root without creating a parallel state tree.
     ///
     /// Fresh initialization leaves only the private root for the storage layer

--- a/crates/astrid-core/src/dirs_run_dir.rs
+++ b/crates/astrid-core/src/dirs_run_dir.rs
@@ -73,7 +73,7 @@ fn invalid(detail: &str) -> io::Error {
     io::Error::new(io::ErrorKind::InvalidInput, format!("{VARIABLE} {detail}"))
 }
 
-fn physical_path(path: &Path) -> io::Result<PathBuf> {
+pub(super) fn physical_path(path: &Path) -> io::Result<PathBuf> {
     if let Ok(physical) = std::fs::canonicalize(path) {
         return Ok(physical);
     }

--- a/crates/astrid-daemon/Cargo.toml
+++ b/crates/astrid-daemon/Cargo.toml
@@ -23,6 +23,7 @@ astrid-config = { workspace = true }
 astrid-core = { workspace = true }
 astrid-gateway = { workspace = true }
 astrid-kernel = { workspace = true }
+astrid-storage = { workspace = true }
 astrid-telemetry = { workspace = true, features = ["config"] }
 astrid-uplink = { workspace = true }
 clap = { workspace = true }

--- a/crates/astrid-daemon/src/lib.rs
+++ b/crates/astrid-daemon/src/lib.rs
@@ -15,6 +15,34 @@ use anyhow::Context;
 use anyhow::Result;
 use clap::Parser;
 
+/// Run the daemon and finalize its durable home after all runtime tasks stop.
+///
+/// Both binary entry points use this path for API, signal, and idle shutdown.
+/// The lifecycle fence outlives the task runtime and the final volume pack.
+///
+/// # Errors
+/// Returns boot, shutdown, or durable-finalization errors without claiming a
+/// successful retirement. Failed boots retain their recovery evidence.
+pub fn run_to_completion() -> Result<()> {
+    // Help/version must not acquire ownership of a running installation.
+    let args = Args::parse();
+    let home = astrid_core::dirs::AstridHome::resolve()?;
+    let lifecycle = astrid_storage::principal_state::RuntimeLifecycleGuard::acquire(&home)?;
+    {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()?;
+        runtime.block_on(run_with_args(args))?;
+        // Drop joins blocking work and cancels remaining async tasks before any
+        // projection file can be retired. No kernel handles cross this scope.
+    }
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?
+        .block_on(lifecycle.finish())?;
+    Ok(())
+}
+
 #[cfg(unix)]
 mod signal;
 
@@ -190,20 +218,23 @@ fn write_readiness_then_arm_ephemeral<T, E>(
 
 /// Run the Astrid daemon with the given arguments.
 ///
-/// This is the shared entry point used by both the standalone `astrid-daemon`
-/// binary and the `astrid` CLI's bundled daemon binary.
+/// Async service loop. Binary hosts use [`run_to_completion`] so task-runtime
+/// teardown and durable finalization are also completed before process exit.
 ///
 /// # Errors
 ///
 /// Returns an error if the kernel fails to boot, the native local uplink cannot
 /// claim its listener, or the readiness file cannot be written.
+pub async fn run() -> Result<()> {
+    run_with_args(Args::parse()).await
+}
+
 #[cfg(unix)]
 #[expect(
     clippy::too_many_lines,
     reason = "boot sequence: sequential config resolution + kernel/capsule setup that does not benefit from splitting"
 )]
-pub async fn run() -> Result<()> {
-    let args = Args::parse();
+async fn run_with_args(args: Args) -> Result<()> {
     let workspace_layout = match std::env::var("ASTRID_WORKSPACE_STATE_DIR") {
         Ok(value) => astrid_core::dirs::WorkspaceLayout::new(value)
             .context("invalid ASTRID_WORKSPACE_STATE_DIR")?,
@@ -469,7 +500,7 @@ pub async fn run() -> Result<()> {
     clippy::unused_async,
     reason = "the cross-platform daemon entry point remains async even when startup is unsupported"
 )]
-pub async fn run() -> Result<()> {
+async fn run_with_args(_args: Args) -> Result<()> {
     anyhow::bail!("native Astrid daemon startup is not yet supported on this platform")
 }
 

--- a/crates/astrid-daemon/src/main.rs
+++ b/crates/astrid-daemon/src/main.rs
@@ -1,6 +1,6 @@
 //! Standalone daemon binary entry point.
 //!
-//! Delegates to the shared `astrid_daemon::run()` library function.
+//! Delegates to the shared `astrid_daemon::run_to_completion()` lifecycle.
 
 /// Detach the daemon into its own session as the very first action — before the
 /// async runtime is built or any boot work runs.
@@ -19,8 +19,5 @@ fn main() -> anyhow::Result<()> {
     #[cfg(unix)]
     let _ = nix::unistd::setsid();
 
-    tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()?
-        .block_on(astrid_daemon::run())
+    astrid_daemon::run_to_completion()
 }

--- a/crates/astrid-kernel/src/lib.rs
+++ b/crates/astrid-kernel/src/lib.rs
@@ -3531,8 +3531,8 @@ impl Kernel {
         // release independent of drain time.
         #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
         self.audit_sink.shutdown();
-        // Publish the final host projection while the durable engine is still
-        // open. CLI stop owns retirement only after the process has exited.
+        // Publish before closing the engine. Daemon-host retirement follows
+        // task teardown; CLI recovery uses that same finalizer after process exit.
         #[cfg(not(target_family = "wasm"))]
         if let Some(store) = self.principal_store.as_ref()
             && let Err(error) = store.publish_runtime_projection(&self.astrid_home)

--- a/crates/astrid-storage/src/principal_state.rs
+++ b/crates/astrid-storage/src/principal_state.rs
@@ -51,6 +51,8 @@ mod format_amendment_tests;
 mod format_identity_tests;
 #[cfg(test)]
 mod format_migration_tests;
+mod lifecycle;
+pub use lifecycle::RuntimeLifecycleGuard;
 #[cfg(test)]
 mod hosted_volume_tests;
 mod migrations;
@@ -613,8 +615,8 @@ impl RuntimePrincipalStore {
     /// Publish the live running projection while retaining host files.
     ///
     /// Graceful kernel shutdown calls this before its durable projections are
-    /// closed. Host retirement remains an explicit post-exit CLI stop duty so
-    /// the process can still read its projected files.
+    /// closed. The daemon host finalizes after its task runtime is dropped;
+    /// CLI recovery uses the same finalizer for an already-dead daemon.
     ///
     /// # Errors
     ///
@@ -630,6 +632,8 @@ impl RuntimePrincipalStore {
     /// receipts) after the normal projection reconciliation. A catalog
     /// mutation without a matching ACTIVE transition would otherwise leave
     /// clean-stop receipt validation comparing a stale object identity.
+    /// Volume-only content is not part of this host inventory until materialized;
+    /// its absence from the host must not authorize deleting durable content.
     ///
     /// # Errors
     ///

--- a/crates/astrid-storage/src/principal_state/lifecycle.rs
+++ b/crates/astrid-storage/src/principal_state/lifecycle.rs
@@ -1,0 +1,151 @@
+//! One finalization path, shared by graceful daemon exit and CLI recovery.
+
+use std::fs::File;
+use std::io;
+use std::sync::Arc;
+
+use astrid_core::dirs::AstridHome;
+
+use super::{StateOwner, native_io, open_runtime_principal_store_for_pack};
+use crate::{KvQuotaResolver, StorageError, StorageResult};
+
+/// Fence a runtime from before boot until its host projection is retired.
+///
+/// The fence is outside the runtime root: deleting `run/` cannot let a new
+/// daemon bypass it by opening a replacement lock inode. Drop never deletes
+/// the lock file. Callers must drain and drop their task runtime before finish.
+pub struct RuntimeLifecycleGuard {
+    home: AstridHome,
+    _lock: File,
+}
+
+impl RuntimeLifecycleGuard {
+    /// Acquire exclusive lifecycle ownership without creating the runtime root.
+    ///
+    /// # Errors
+    /// Refuses a competing daemon/finalizer or an unsafe control directory.
+    pub fn acquire(home: &AstridHome) -> io::Result<Self> {
+        home.validate_run_dir()?;
+        let path = home.lifecycle_lock_path()?;
+        let parent = path
+            .parent()
+            .ok_or_else(|| io::Error::other("lifecycle lock has no parent"))?;
+        native_io::ensure_private_directory(parent).map_err(io::Error::other)?;
+        let directory = cap_std::fs::Dir::open_ambient_dir(parent, cap_std::ambient_authority())?;
+        let name = path
+            .file_name()
+            .ok_or_else(|| io::Error::other("lifecycle lock has no name"))?;
+        if directory
+            .symlink_metadata(name)
+            .is_ok_and(|metadata| !metadata.is_file() || metadata.is_symlink())
+        {
+            return Err(io::Error::other("lifecycle lock is not a regular file"));
+        }
+        let mut options = cap_std::fs::OpenOptions::new();
+        options.read(true).write(true).create(true);
+        #[cfg(unix)]
+        {
+            use cap_std::fs::OpenOptionsExt as _;
+            options.mode(0o600).custom_flags(libc::O_NOFOLLOW);
+        }
+        let lock = directory.open_with(name, &options)?.into_std();
+        lock.try_lock().map_err(|error| {
+            io::Error::other(format!("runtime is running or finalizing: {error}"))
+        })?;
+        Ok(Self {
+            home: home.clone(),
+            _lock: lock,
+        })
+    }
+
+    /// Pack final host writes and leave exactly the durable volume.
+    ///
+    /// The kernel and every task using its projection must already be stopped.
+    /// A failure preserves recoverable host files and never reports completion.
+    /// Repeating this after a successful graceful exit is harmless.
+    ///
+    /// # Errors
+    /// Returns a storage error if opening, publishing, or retirement fails.
+    pub async fn finish(self) -> StorageResult<()> {
+        if !self
+            .home
+            .storage_volume_path()
+            .try_exists()
+            .map_err(|error| StorageError::Internal(error.to_string()))?
+        {
+            return Ok(());
+        }
+        let quota: Arc<dyn KvQuotaResolver<StateOwner>> = Arc::new(|_: &StateOwner| Ok(None));
+        let store = open_runtime_principal_store_for_pack(&self.home, quota).await?;
+        store.pack_and_retire_runtime_projection(&self.home)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ContentName, open_runtime_principal_store};
+
+    #[tokio::test]
+    async fn finalizer_fences_replacement_and_is_idempotent() {
+        let parent = tempfile::tempdir().unwrap();
+        let home = AstridHome::from_path(parent.path().join("runtime"));
+        let lifecycle = RuntimeLifecycleGuard::acquire(&home).unwrap();
+        assert!(
+            !home.root().exists(),
+            "fencing must not preempt fresh-home admission"
+        );
+        let original_path = home.lifecycle_lock_path().unwrap();
+        let quota: Arc<dyn KvQuotaResolver<StateOwner>> = Arc::new(|_: &StateOwner| Ok(None));
+        let store = open_runtime_principal_store(&home, quota.clone())
+            .await
+            .unwrap();
+        let name = ContentName::new("bin/test.wasm").unwrap();
+        store
+            .content()
+            .put(&StateOwner::System, &name, b"capsule")
+            .unwrap();
+        store.publish_runtime_projection(&home).unwrap();
+        drop(store);
+        assert_eq!(original_path, home.lifecycle_lock_path().unwrap());
+        assert!(RuntimeLifecycleGuard::acquire(&home).is_err());
+        lifecycle.finish().await.unwrap();
+        let entries = std::fs::read_dir(home.root())
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].file_name(), "astrid.volume");
+        RuntimeLifecycleGuard::acquire(&home)
+            .unwrap()
+            .finish()
+            .await
+            .unwrap();
+        let store = open_runtime_principal_store(&home, quota).await.unwrap();
+        assert_eq!(
+            store.content().read(&StateOwner::System, &name).unwrap(),
+            Some(b"capsule".to_vec())
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn failed_finalization_preserves_recovery_evidence() {
+        let parent = tempfile::tempdir().unwrap();
+        let home = AstridHome::from_path(parent.path().join("runtime"));
+        let lifecycle = RuntimeLifecycleGuard::acquire(&home).unwrap();
+        let quota: Arc<dyn KvQuotaResolver<StateOwner>> = Arc::new(|_: &StateOwner| Ok(None));
+        let store = open_runtime_principal_store(&home, quota).await.unwrap();
+        std::fs::write(home.root().join("config.toml"), b"keep").unwrap();
+        drop(store);
+        std::os::unix::fs::symlink(parent.path(), home.root().join("redirect")).unwrap();
+        assert!(lifecycle.finish().await.is_err());
+        assert_eq!(
+            std::fs::read(home.root().join("config.toml")).unwrap(),
+            b"keep"
+        );
+        assert!(home.root().join("redirect").symlink_metadata().is_ok());
+        assert!(RuntimeLifecycleGuard::acquire(&home).is_ok());
+    }
+}

--- a/crates/astrid-storage/src/principal_state/lifecycle.rs
+++ b/crates/astrid-storage/src/principal_state/lifecycle.rs
@@ -97,6 +97,29 @@ mod tests {
             "fencing must not preempt fresh-home admission"
         );
         let original_path = home.lifecycle_lock_path().unwrap();
+        assert_eq!(
+            original_path.parent().unwrap().parent().unwrap(),
+            std::fs::canonicalize(parent.path()).unwrap(),
+            "control storage must be a stable sibling, not process temp storage"
+        );
+        let other_temp = tempfile::tempdir().unwrap();
+        let probe = std::process::Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "principal_state::lifecycle::tests::different_temp_process_cannot_acquire_fence",
+                "--nocapture",
+            ])
+            .env("ASTRID_TEST_LIFECYCLE_ROOT", home.root())
+            .env("TMPDIR", other_temp.path())
+            .env("TMP", other_temp.path())
+            .env("TEMP", other_temp.path())
+            .output()
+            .unwrap();
+        assert!(
+            probe.status.success(),
+            "{}",
+            String::from_utf8_lossy(&probe.stderr)
+        );
         let quota: Arc<dyn KvQuotaResolver<StateOwner>> = Arc::new(|_: &StateOwner| Ok(None));
         let store = open_runtime_principal_store(&home, quota.clone())
             .await
@@ -147,5 +170,13 @@ mod tests {
         );
         assert!(home.root().join("redirect").symlink_metadata().is_ok());
         assert!(RuntimeLifecycleGuard::acquire(&home).is_ok());
+    }
+
+    #[test]
+    fn different_temp_process_cannot_acquire_fence() {
+        let Some(root) = std::env::var_os("ASTRID_TEST_LIFECYCLE_ROOT") else {
+            return;
+        };
+        assert!(RuntimeLifecycleGuard::acquire(&AstridHome::from_path(root)).is_err());
     }
 }

--- a/crates/astrid-storage/src/principal_state/runtime_tree.rs
+++ b/crates/astrid-storage/src/principal_state/runtime_tree.rs
@@ -628,7 +628,22 @@ pub(super) fn establish_active_receipt(
     home: &AstridHome,
     store: &RuntimePrincipalStore,
 ) -> StorageResult<()> {
-    let entries = active_projection_entries(home, store)?;
+    // ACTIVE records what was actually materialized, not everything owned by
+    // System. Capsule installs can add volume-only WASM while a host projection
+    // survives an idle exit. Claiming those names here would turn their host
+    // absence into a deletion on the next publication. RETIRING still records
+    // the complete durable inventory through active_projection_entries.
+    let projected = scan(home.root())?
+        .into_iter()
+        .map(|entry| entry.name)
+        .collect::<std::collections::BTreeSet<_>>();
+    let entries = active_projection_entries(home, store)?
+        .into_iter()
+        .filter(|entry| {
+            projected.contains(&entry.name)
+                || projection::surviving_directory(home.root(), entry.name.as_str())
+        })
+        .collect::<Vec<_>>();
     rotate_active_receipt(home, store, &entries)
 }
 

--- a/crates/astrid-storage/src/principal_state/runtime_tree_tests.rs
+++ b/crates/astrid-storage/src/principal_state/runtime_tree_tests.rs
@@ -24,6 +24,67 @@ fn unlimited_quota() -> Arc<dyn KvQuotaResolver<StateOwner>> {
     })
 }
 
+#[tokio::test]
+async fn surviving_projection_does_not_claim_volume_only_capsule_bytes() {
+    let directory = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(directory.path());
+    let name = ContentName::new("bin/capsule.wasm").unwrap();
+    let bytes = b"durable capsule bytes";
+    let store = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    std::fs::write(home.root().join("config.toml"), b"# running config\n").unwrap();
+    store
+        .content()
+        .put(&StateOwner::System, &name, bytes)
+        .unwrap();
+    assert!(!home.root().join(name.as_str()).exists());
+    // Idle shutdown publishes but leaves the running host projection behind.
+    store.publish_runtime_projection(&home).unwrap();
+    drop(store);
+
+    let reopened = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    // Kernel admission refreshes the receipt, then layout completion publishes.
+    reopened
+        .establish_runtime_projection_receipt(&home)
+        .unwrap();
+    reopened.publish_runtime_projection(&home).unwrap();
+    assert_eq!(
+        reopened.content().read(&StateOwner::System, &name).unwrap(),
+        Some(bytes.to_vec()),
+        "absence of a never-materialized file is not a host deletion"
+    );
+    assert!(
+        !active::read(&home, &reopened)
+            .unwrap()
+            .unwrap()
+            .contains_inventory_name(name.as_str())
+    );
+    reopened.pack_and_retire_runtime_projection(&home).unwrap();
+    drop(reopened);
+    assert_stopped_volume_only(&home);
+
+    let restored = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    assert_eq!(
+        std::fs::read(home.root().join(name.as_str())).unwrap(),
+        bytes
+    );
+    // Once materialized, a real host deletion must still remove the catalog entry.
+    std::fs::remove_file(home.root().join(name.as_str())).unwrap();
+    restored.publish_runtime_projection(&home).unwrap();
+    assert!(
+        restored
+            .content()
+            .read(&StateOwner::System, &name)
+            .unwrap()
+            .is_none()
+    );
+}
+
 fn write_active_identity_receipt(
     home: &AstridHome,
     store: &RuntimePrincipalStore,


### PR DESCRIPTION
## Linked Issue

Closes #1907

## Summary

Preserve capsule WASM when initialization resumes after an idle daemon exit, and give graceful shutdown one shared finalization path.

## Changes

- ACTIVE receipts inventory actual host projections, not unmaterialized System content. RETIRING still covers the complete durable catalog.
- Both daemon binaries finish API, signal, and idle shutdown by dropping the service runtime before packing and retiring the host projection.
- A per-runtime control fence outside the retired home excludes replacement daemons through finalization. CLI stale healing checks it before touching sentinels; already-dead recovery uses the same finalizer.
- Preserve the existing asynchronous service entry point for library consumers; binary hosts use `run_to_completion`.
- Initialization holds a daemon connection throughout provisioning, preventing an existing ephemeral daemon from retiring between requests while the CLI still writes its projection.
- Retain fail-closed cleanup, true host deletion semantics, existing shutdown watchdogs, and help/version operation while a daemon runs.

## Verification

- Storage regression fails on unchanged main: a volume-only capsule disappears after surviving-projection reopen, receipt refresh, and publication. It passes with the repair.
- Runtime-tree tests cover real deletions, relocation, invalid receipts, redirects, volume-only retirement, and restore.
- New lifecycle tests cover exclusion, idempotent finalization, and retaining recovery evidence on failure.
- New process regression exercises idle, SIGTERM, and CLI stop, then checks exactly `astrid.volume`, restart, and final-write preservation.
- Published AOS 2026.9.0 plus candidate release-mode Astrid: ephemeral-start initialization completes all 22 capsules across the rate-limit windows; explicit stop/restart retains a nonempty MCP WASM hash. Disposable home only; no real LLM.
- Local results: storage 833 passed / 7 ignored; core directory tests 74 passed; real-process shutdown regression passed for all three exit modes; strict Clippy passed. The final AOS reproduction also passed with the initialization connection lease. Earlier reproduction without that lease caught a real mid-install idle-retirement race.

### Follow-up verification

The provisioning lease now extends through Distro Apply self-grant. The lifecycle lock uses a private physical-home sibling rather than process TMPDIR. A subprocess regression confirms different temporary-directory environments cannot bypass the held fence. The init lifetime helper also brings init.rs below the file-size cap without deleting its invariant comments.

Local cargo check, strict Clippy, cross-process lifecycle regression, and release-mode idle/SIGTERM/CLI-stop finalization regression passed. The signed-Distro rehearsal completed 22/22 installs plus Distro self-grant. A passive connection was insufficient: capsule broadcasts filled its outbound queue and caused disconnect. The provisioning lease now drains broadcasts for its complete lifetime. Real MCP initialization, tool discovery, explicit session-consent handling, and a write/read round-trip passed with the candidate binary. Stopping afterward leaves exactly astrid.volume. The separate system_status tool still returns NotFound and is not claimed as passing. This is a disposable-home candidate rehearsal, not a published-runtime or live Codex-plugin success.

## Test Plan

- `cargo test -p astrid-storage --lib`
- `cargo test -p astrid-core dirs -- --quiet`
- `cargo test --release -p astrid --test daemon_finalization -- --nocapture`
- `cargo clippy -p astrid-storage -p astrid-daemon -p astrid --all-targets -- -D warnings`
- Rehearse published AOS init with an ephemeral daemon and the candidate runtime, then stop/restart and inspect MCP.

The local executable rehearsal is macOS; hosted checks must cover supported Unix targets. This does not replace installed release bytes, change version metadata, repair already-missing catalog entries, or publish a release. Abrupt termination still relies on existing recovery.

## AI / Tool Assistance

Assisted-by: OpenAI Codex:gpt-6-astra

Assisted with diagnosis, implementation, and regression tests. Reviewed lifecycle ordering, ownership exclusion, failure preservation, and old/new reproduction results.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added
- [x] Reviewed the design, risks, and validation
- [x] Reviewed and tested meaningful tool-generated changes
- [x] Signed-off-by trailer on the commit
