### PR TITLE
fix(cli): render multi-digit Markdown numbered lists

### DIFF
--- a/changes/459.fixed.md
+++ b/changes/459.fixed.md
@@ -1,0 +1,1 @@
+Render multi-digit Markdown numbered lists with the same marker styling and indentation as single-digit items in the TUI. Closes #459.

--- a/crates/astrid-cli/src/tui/render.rs
+++ b/crates/astrid-cli/src/tui/render.rs
@@ -90,14 +90,20 @@ fn markdown_to_spans<'a>(line: &str, theme: &Theme) -> Vec<Span<'a>> {
     }
 
     // Numbered list: 1. item
-    if let Some(rest) = trimmed
-        .strip_prefix(|c: char| c.is_ascii_digit())
-        .and_then(|s| s.strip_prefix(". "))
-    {
+    let digit_end = trimmed
+        .char_indices()
+        .find(|(_, c)| !c.is_ascii_digit())
+        .map_or(trimmed.len(), |(index, _)| index);
+    let (number, suffix) = trimmed.split_at(digit_end);
+    let numbered_rest = if number.is_empty() {
+        None
+    } else {
+        suffix.strip_prefix(". ")
+    };
+    if let Some(rest) = numbered_rest {
         let indent = &line[..line.len().saturating_sub(trimmed.len())];
-        let num_char = trimmed.chars().next().expect("trimmed matched a digit");
         spans.push(Span::styled(
-            format!("{indent}{num_char}. "),
+            format!("{indent}{number}. "),
             Style::default().fg(theme.tool),
         ));
         spans.extend(parse_inline_markdown(rest, theme));
@@ -164,6 +170,10 @@ fn parse_inline_markdown<'a>(text: &str, theme: &Theme) -> Vec<Span<'a>> {
 
     spans
 }
+
+#[cfg(test)]
+#[path = "render_tests.rs"]
+mod tests;
 
 /// Render a completed tool inline in the message stream.
 fn render_inline_tool(lines: &mut Vec<Line<'_>>, app: &App, idx: usize, theme: &Theme) {

--- a/crates/astrid-cli/src/tui/render_tests.rs
+++ b/crates/astrid-cli/src/tui/render_tests.rs
@@ -1,0 +1,22 @@
+use super::markdown_to_spans;
+use crate::tui::theme::Theme;
+
+#[test]
+fn markdown_numbered_list_styles_single_and_multi_digit_markers() {
+    let theme = Theme::default();
+
+    for (line, expected_marker, expected_text) in [
+        ("1. first", "1. ", "first"),
+        ("9. ninth", "9. ", "ninth"),
+        ("10. tenth", "10. ", "tenth"),
+        ("  123. last", "  123. ", "last"),
+    ] {
+        let spans = markdown_to_spans(line, &theme);
+
+        assert_eq!(spans.len(), 2, "unexpected spans for {line:?}");
+        assert_eq!(spans[0].content.as_ref(), expected_marker);
+        assert_eq!(spans[0].style.fg, Some(theme.tool));
+        assert_eq!(spans[1].content.as_ref(), expected_text);
+        assert_eq!(spans[1].style.fg, Some(theme.assistant));
+    }
+}


### PR DESCRIPTION
## Linked Issue

Closes #459

## Summary

Fix TUI Markdown rendering for numbered-list items whose markers contain two or more digits.

## Changes

- Preserve existing indentation and colored marker styling for multi-digit items.
- Add focused regression coverage for items 10 and 123, including indentation.
- Add `changes/459.fixed.md`.

## Verification

- `rustfmt --edition 2024 --check crates/astrid-cli/src/tui/render.rs crates/astrid-cli/src/tui/render_tests.rs`
- A focused source-level behavior check passed for `10. tenth`.

## AI / Tool Assistance

Assisted-by: Claude Agent SDK

The assistance covered inspection of the existing TUI parser and tests, the minimal digit-scanning fix, focused regression coverage, changelog wording, and validation review. The diff was kept to the parser, its focused test module, and the issue changelog fragment.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/{issue}.{kind}.md`
- [x] Focused regression coverage added
- [x] Full workspace test, clippy, and Cargo-driven format checks require Rust 1.95

Validation observed for this change:
- `rustfmt --edition 2024 --check crates/astrid-cli/src/tui/render.rs crates/astrid-cli/src/tui/render_tests.rs`
- `python3 -c 'from pathlib import Path; source=Path("crates/astrid-cli/src/tui/render.rs").read_text(); assert "char_indices()" in source; line="10. tenth"; digit_end=next((i for i, c in enumerate(line) if not c.isdigit()), len(line)); number, suffix=line[:digit_end], line[digit_end:]; assert number == "10" and suffix.startswith(". "); print("final multi-digit marker parsing check passed")'`

Fixes #459

<!-- repo-agent-case:c090b148-a014-48ca-8e4d-986bfa86f7fb -->