### PR TITLE
fix(process): deliver stdin to synchronous capsule subprocesses

### DIFF
--- a/changes/1912.fixed.md
+++ b/changes/1912.fixed.md
@@ -1,0 +1,1 @@
+- Deliver capsule-supplied stdin to synchronous native subprocesses and close the pipe after delivery. Drain output concurrently so request/response adapters cannot deadlock on full pipes.

--- a/crates/astrid-capsule/src/engine/wasm/host/audit_sink_tests.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host/audit_sink_tests.rs
@@ -227,6 +227,39 @@ async fn audit_net_reports_bind_denied() {
 }
 
 #[tokio::test]
+async fn oversized_spawn_stdin_reports_one_failed_audit() {
+    use crate::engine::wasm::bindings::astrid::process1_1_0::host::{
+        ErrorCode, Host, SpawnRequest,
+    };
+    let (mut state, sink) = state_with_sink(tokio::runtime::Handle::current());
+    let result = state.spawn(SpawnRequest {
+        cmd: "must-not-execute".into(),
+        args: vec![],
+        stdin: Some(vec![0; 4 * 1024 * 1024 + 1]),
+        env: vec![],
+        cwd: None,
+        limits: None,
+        file_injections: vec![],
+        label: None,
+        keep_stdin_open: None,
+        overflow: None,
+        log_ring_bytes: None,
+        exit_retention_ms: None,
+        idle_timeout_ms: None,
+        max_lifetime_ms: None,
+    });
+    assert!(matches!(result, Err(ErrorCode::TooLarge)));
+    assert_eq!(
+        sink.snapshot(),
+        vec![(
+            PrincipalId::new("alice").unwrap(),
+            CapturedEvent::ProcessSpawn("must-not-execute".into()),
+            CapturedOutcome::Failed("ErrorCode::TooLarge".into()),
+        )]
+    );
+}
+
+#[tokio::test]
 async fn audit_process_reports_spawn() {
     let (state, sink) = state_with_sink(tokio::runtime::Handle::current());
     let alice = PrincipalId::new("alice").unwrap();

--- a/crates/astrid-capsule/src/engine/wasm/host/process/mod.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host/process/mod.rs
@@ -179,12 +179,15 @@ include!("host_ops_methods.rs");
 
 impl process::Host for HostState {
     fn spawn(&mut self, request: SpawnRequest) -> Result<ProcessResult, ErrorCode> {
+        let cmd_for_audit = request.cmd.clone();
         if request
             .stdin
             .as_ref()
             .is_some_and(|input| input.len() > MAX_SPAWN_STDIN_BYTES)
         {
-            return Err(ErrorCode::TooLarge);
+            let result: Result<ProcessResult, ErrorCode> = Err(ErrorCode::TooLarge);
+            audit_process(self, "astrid:process/host.spawn", &cmd_for_audit, &result);
+            return result;
         }
         let security = self.security.clone();
         let capsule_id = self.capsule_id.as_str().to_owned();
@@ -194,7 +197,6 @@ impl process::Host for HostState {
         let process_tracker = self.process_tracker.clone();
         let call_id = extract_call_id(self);
 
-        let cmd_for_audit = request.cmd.clone();
         let _env_for_audit = env_summary(&request.env);
 
         if !self.principal_process_allows(&request.cmd) {

--- a/crates/astrid-capsule/src/engine/wasm/host/process/mod.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host/process/mod.rs
@@ -31,6 +31,7 @@ mod handle;
 mod inject;
 mod managed;
 mod persistent;
+mod synchronous;
 mod tracker;
 
 use std::collections::VecDeque;
@@ -178,6 +179,13 @@ include!("host_ops_methods.rs");
 
 impl process::Host for HostState {
     fn spawn(&mut self, request: SpawnRequest) -> Result<ProcessResult, ErrorCode> {
+        if request
+            .stdin
+            .as_ref()
+            .is_some_and(|input| input.len() > MAX_SPAWN_STDIN_BYTES)
+        {
+            return Err(ErrorCode::TooLarge);
+        }
         let security = self.security.clone();
         let capsule_id = self.capsule_id.as_str().to_owned();
         let handle = self.runtime_handle.clone();
@@ -298,6 +306,11 @@ impl process::Host for HostState {
         };
         sandboxed_cmd.stdout(Stdio::piped());
         sandboxed_cmd.stderr(Stdio::piped());
+        sandboxed_cmd.stdin(if request.stdin.is_some() {
+            Stdio::piped()
+        } else {
+            Stdio::null()
+        });
 
         let child = match sandboxed_cmd.spawn() {
             Ok(child) => child,
@@ -321,10 +334,12 @@ impl process::Host for HostState {
 
         let output_result =
             util::bounded_block_on_cancellable(&handle, &semaphore, &cancel_token, async move {
-                tokio::task::spawn_blocking(move || child.wait_with_output())
-                    .await
-                    .map_err(std::io::Error::other)
-                    .and_then(|r| r)
+                tokio::task::spawn_blocking(move || {
+                    synchronous::wait_with_input(child, request.stdin)
+                })
+                .await
+                .map_err(std::io::Error::other)
+                .and_then(|r| r)
             });
 
         let result: Result<ProcessResult, ErrorCode> = match output_result {

--- a/crates/astrid-capsule/src/engine/wasm/host/process/synchronous.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host/process/synchronous.rs
@@ -1,0 +1,92 @@
+//! Finite stdin delivery while stdout and stderr are drained concurrently.
+
+use std::io::{self, Write};
+use std::process::{Child, Output};
+
+pub(super) fn wait_with_input(mut child: Child, input: Option<Vec<u8>>) -> io::Result<Output> {
+    let pipe = child.stdin.take();
+    let Some(input) = input else {
+        drop(pipe);
+        return child.wait_with_output();
+    };
+    let Some(mut pipe) = pipe else {
+        let _ = child.kill();
+        let _ = child.wait();
+        return Err(io::Error::other("spawn stdin pipe unavailable"));
+    };
+    std::thread::scope(|scope| {
+        // Writing before collecting output deadlocks when the child fills an
+        // output pipe before reading input. Dropping the writer supplies EOF.
+        let writer = match std::thread::Builder::new()
+            .name("process-stdin".into())
+            .spawn_scoped(scope, move || pipe.write_all(&input))
+        {
+            Ok(writer) => writer,
+            Err(error) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(error);
+            },
+        };
+        let output = child.wait_with_output();
+        let written = writer
+            .join()
+            .map_err(|_| io::Error::other("spawn stdin writer panicked"))?;
+        written?;
+        output
+    })
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use std::process::{Command, Stdio};
+
+    fn shell(script: &str) -> Child {
+        Command::new("/bin/sh")
+            .args(["-c", script])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap()
+    }
+
+    #[test]
+    fn delivers_json_and_eof() {
+        let input = b"{\"operation\":\"slice\",\"query\":\"run_init\"}\n".to_vec();
+        let output = wait_with_input(shell("cat"), Some(input.clone())).unwrap();
+        assert!(output.status.success());
+        assert_eq!(output.stdout, input);
+    }
+
+    #[test]
+    fn empty_and_absent_input_close_stdin() {
+        for input in [None, Some(Vec::new())] {
+            let output = wait_with_input(shell("cat; printf eof"), input).unwrap();
+            assert!(output.status.success());
+            assert_eq!(output.stdout, b"eof");
+        }
+    }
+
+    #[test]
+    fn early_stdin_close_reports_write_failure_and_reaps_child() {
+        let child = shell("exec 0<&-; exit 0");
+        let error = wait_with_input(child, Some(vec![b'x'; super::super::MAX_SPAWN_STDIN_BYTES]))
+            .unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::BrokenPipe);
+    }
+
+    #[test]
+    fn drains_output_while_delivering_large_input() {
+        let input = vec![b'x'; super::super::MAX_SPAWN_STDIN_BYTES];
+        let child = shell(
+            "dd if=/dev/zero bs=65536 count=4 2>/dev/null; dd if=/dev/zero bs=65536 count=4 >&2 2>/dev/null; cat",
+        );
+        let output = wait_with_input(child, Some(input.clone())).unwrap();
+        assert!(output.status.success());
+        assert_eq!(&output.stdout[..262_144], vec![0; 262_144]);
+        assert_eq!(&output.stdout[262_144..], input);
+        assert_eq!(output.stderr, vec![0; 262_144]);
+    }
+}


### PR DESCRIPTION
## Linked Issue

Closes #1912

## Summary

Deliver the stdin supplied by a capsule to synchronous native subprocesses. The real `aos-program-context` MCP invocation reached its native adapter with empty input because `Host::spawn` never consumed `request.stdin`.

## Changes

- Pipe input only when supplied, enforce the existing 4 MiB WIT bound before spawning, and close stdin after delivery.
- Write input concurrently with stdout/stderr collection to avoid pipe-capacity deadlocks.
- Preserve existing sandbox checks, process tracking, cancellation and audit handling.
- Add regressions for JSON/EOF, empty or absent input, early pipe closure, and large bidirectional I/O.
- Audit oversized-input rejection exactly once, with a regression through the real host function.

## Verification

All four synchronous stdin regressions passed. Strict `cargo clippy -p astrid-capsule --all-targets -- -D warnings` passed. A release-built daemon was composed into a privately signed AOS package and exercised through the installed Codex Oracle/MCP launcher with the existing `aos-program-context` capsule. `program_query(slice, run_init)` returned the function, caller and continuation, both before and after runtime stop/restart; both stops left exactly `astrid.volume`. The prototype helper also needed its own LSP shutdown/exit correction instead of a sandbox-denied signal. No sandbox permissions were relaxed. This is private rehearsal evidence, not production publication or desktop-plugin activation. Hosted CI is still pending.

## Test Plan

The audit amendment `32666b97` passes the new oversized-input host regression,
the four stdin regressions, and strict all-target capsule Clippy. A combined
release build with merged #1911 passed fresh all-host Oracle install (180.33s),
actual Codex/Claude/Grok calls, authored-capsule invocation before and after
restart, repeated host calls and volume-only stops. Published v0.10.4 migration
also passed with real FSKit mount/write/sync/read/unmount using the test
assertion correction tracked in #1914. Hosted CI is running on this amendment,
not being inferred from its predecessor.

Run `cargo test -p astrid-capsule synchronous::tests --lib`, ordinary CI, and the existing `aos-program-context` capsule through the installed Codex Oracle in a disposable packaged runtime. Repeat the query after stop/restart. Do not replace the real invocation with tool discovery or a direct native-adapter call.

## AI / Tool Assistance

Assisted-by: Codex:gpt-6-astra

Used for diagnosis, implementation and regression testing.

## Checklist

- [x] Linked issue and changelog fragment
- [x] Signed commit and DCO
- [x] Regression coverage
- [ ] Final packaged invocation and CI complete
