### PR TITLE
fix(test): identify the macOS upgrade filesystem correctly

### DIFF
--- a/changes/1914.fixed.md
+++ b/changes/1914.fixed.md
@@ -1,0 +1,1 @@
+Check the actual filesystem type in the macOS legacy-upgrade mount test instead of interpreting BSD stat's directory marker as a filesystem name.

--- a/scripts/test_v0104_macos_upgrade.sh
+++ b/scripts/test_v0104_macos_upgrade.sh
@@ -728,7 +728,11 @@ attempt_mount_round_trip() {
   if [[ ${mount_status} -eq 0 ]]; then
     grep -Eq '^mounted [0-9a-f-]{36} at ' "${TEST_ROOT}/mount.log" \
       || fail "mount succeeded without a lease id"
-    [[ "$(stat -f %T "${MOUNTPOINT}")" == astridfs ]] \
+    # BSD stat's %T is a file-type marker ("/" for directories), not the
+    # filesystem name. Bind the kernel mount table to the canonical target.
+    local canonical_mountpoint
+    canonical_mountpoint="$(cd -- "${MOUNTPOINT}" && pwd -P)"
+    [[ "$(/sbin/mount)" == *" on ${canonical_mountpoint} (astridfs,"* ]] \
       || fail "mount succeeded but the mountpoint is not astridfs"
     printf 'upgrade-mount-probe\n' >"${MOUNTPOINT}/upgrade-mount-probe.txt"
     run_current storage sync "${MOUNTPOINT}"


### PR DESCRIPTION
## Linked Issue

Closes #1914

## Summary

Correct the filesystem-type assertion in the live mount branch of the macOS legacy upgrade test. BSD `stat -f %T` returns `/` for directories, including actual FSKit mounts; it is not the filesystem name. Match the exact canonical target and `astridfs` type in the kernel mount table instead.

## Changes

- Use the canonical mountpoint and actual filesystem name from `/sbin/mount`.
- Keep real write/sync/read/unmount assertions and existing extension-unavailable reporting.
- Add a changelog fragment for the corrected test.

## Verification

- Reproduced the false failure after successful migration/reopening and mount.
- The corrected test passed using combined release-mode hotfix binaries: published v0.10.4 upgrade, retirement, writes, reopening, real FSKit mount/write/sync/read/unmount. No mount skip.
- Exact target/type matching accepts the intended mount and rejects an APFS mount, a path-prefix collision and an absent mount.
- Bash syntax and diff checks pass. Runtime code and mount permissions are unchanged.

## Test Plan

Run the existing published-v0.10.4 macOS upgrade workflow. On a host with an enabled extension, require the full mount round-trip. Preserve the existing explicitly reported extension-unavailable path on hosted runners.

## AI / Tool Assistance

Assisted-by: Codex:gpt-6-astra

Used for diagnosis, implementation and executable verification.

## Checklist

- [x] Linked issue and changelog fragment
- [x] Signed commit and DCO
- [x] Reproduced failing assertion and exercised corrected live mount path
