### PR TITLE
feat(release): prepare Astrid 2026.9.1 hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ Version numbers follow [year.month.patch](release/VERSIONING.md) beginning with
 
 ## [Unreleased]
 
+## [2026.9.1] - 2026-09-10
+
+### Fixed
+
+- Preserve installed capsule content across idle shutdown, explicit stop, and
+  restart. All graceful shutdown paths finalize the same durable projection;
+  capsule files held only in the volume are no longer mistaken for deletions.
+- Keep initialization connected through installation batches and final grants,
+  preventing idle retirement from interrupting first boot. Provisioning traffic
+  no longer fills the connection's unread broadcast queue.
+- Honor explicit `init --grant-capsules` for the complete verified distro after
+  a resumed install, including earlier batches. Plain resume does not grant
+  access implicitly.
+- Leave unset optional distro credentials absent during initialization instead of
+  attempting to store invalid empty secrets. Reinitialization preserves existing
+  credentials; nonempty secrets still use the daemon's typed secret API.
+
+- Allow a daemon that retired its generation markers during clean shutdown to
+  finish exiting before reporting an identity error. Process identity and
+  singleton-lock checks remain enforced.
+- Deliver capsule-supplied stdin to synchronous native subprocesses, close the
+  pipe after delivery, and drain output concurrently. Native request/response
+  adapters now receive their requests without full-pipe deadlocks.
+- Correct filesystem identification in the macOS legacy-upgrade mount test.
+
 ## [2026.9.0] - 2026-09-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1158,7 +1158,8 @@ Breaking changes to note: `Capsule.toml` moves to `[publish]` / `[subscribe]` ta
 Initial tracked release. See the [repository history](https://github.com/astrid-runtime/astrid/commits/v0.2.0)
 for changes included in this version.
 
-[Unreleased]: https://github.com/astrid-runtime/astrid/compare/v2026.9.0...HEAD
+[Unreleased]: https://github.com/astrid-runtime/astrid/compare/v2026.9.1...HEAD
+[2026.9.1]: https://github.com/astrid-runtime/astrid/compare/v2026.9.0...v2026.9.1
 [2026.9.0]: https://github.com/astrid-runtime/astrid/compare/v0.10.4...v2026.9.0
 [0.10.4]: https://github.com/astrid-runtime/astrid/compare/v0.10.3...v0.10.4
 [0.10.3]: https://github.com/astrid-runtime/astrid/compare/v0.10.2...v0.10.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,7 +233,7 @@ dependencies = [
 
 [[package]]
 name = "astrid"
-version = "2026.9.0"
+version = "2026.9.1"
 dependencies = [
  "anyhow",
  "arboard",
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-approval"
-version = "2026.9.0"
+version = "2026.9.1"
 dependencies = [
  "astrid-audit",
  "astrid-capabilities",
@@ -318,7 +318,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-audit"
-version = "2026.9.0"
+version = "2026.9.1"
 dependencies = [
  "astrid-capabilities",
  "astrid-core",
@@ -338,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-build"
-version = "2026.9.0"
+version = "2026.9.1"
 dependencies = [
  "anyhow",
  "astrid-core",
@@ -360,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-capabilities"
-version = "2026.9.0"
+version = "2026.9.1"
 dependencies = [
  "astrid-core",
  "astrid-crypto",
@@ -378,7 +378,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-capsule"
-version = "2026.9.0"
+version = "2026.9.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -431,7 +431,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-capsule-install"
-version = "2026.9.0"
+version = "2026.9.1"
 dependencies = [
  "anyhow",
  "astrid-build",
@@ -459,7 +459,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-capsule-types"
-version = "2026.9.0"
+version = "2026.9.1"
 dependencies = [
  "astrid-core",
  "dashmap",
@@ -475,7 +475,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-config"
-version = "2026.9.0"
+version = "2026.9.1"
 dependencies = [
  "astrid-core",
  "directories",
@@ -489,7 +489,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-core"
-version = "2026.9.0"
+version = "2026.9.1"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -514,7 +514,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-crypto"
-version = "2026.9.0"
+version = "2026.9.1"
 dependencies = [
  "base64 0.23.1",
  "blake3",
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-daemon"
-version = "2026.9.0"
+version = "2026.9.1"
 dependencies = [
  "anyhow",
  "astrid-capsule",
@@ -555,7 +555,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-emit"
-version = "2026.9.0"
+version = "2026.9.1"
 dependencies = [
  "anyhow",
  "astrid-core",
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-events"
-version = "2026.9.0"
+version = "2026.9.1"
 dependencies = [
  "astrid-core",
  "astrid-runtime",
@@ -590,7 +590,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-gateway"
-version = "2026.9.0"
+version = "2026.9.1"
 dependencies = [
  "anyhow",
  "astrid-audit",
@@ -638,7 +638,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-hooks"
-version = "2026.9.0"
+version = "2026.9.1"
 dependencies = [
  "astrid-capabilities",
  "astrid-capsule",
@@ -666,7 +666,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-integration-tests"
-version = "2026.9.0"
+version = "2026.9.1"
 dependencies = [
  "arc-swap",
  "astrid-approval",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-kernel"
-version = "2026.9.0"
+version = "2026.9.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -748,7 +748,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-mcp"
-version = "2026.9.0"
+version = "2026.9.1"
 dependencies = [
  "astrid-audit",
  "astrid-capabilities",
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-prelude"
-version = "2026.9.0"
+version = "2026.9.1"
 dependencies = [
  "astrid-audit",
  "astrid-capabilities",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-runtime"
-version = "2026.9.0"
+version = "2026.9.1"
 dependencies = [
  "futures",
  "tokio",
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-storage"
-version = "2026.9.0"
+version = "2026.9.1"
 dependencies = [
  "arc-swap",
  "astrid-core",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-storage-chunker-evidence"
-version = "2026.9.0"
+version = "2026.9.1"
 dependencies = [
  "anyhow",
  "astrid-storage",
@@ -852,7 +852,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-storage-provider-fskit"
-version = "2026.9.0"
+version = "2026.9.1"
 dependencies = [
  "anyhow",
  "astrid-core",
@@ -868,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-storage-provider-fuse"
-version = "2026.9.0"
+version = "2026.9.1"
 dependencies = [
  "anyhow",
  "astrid-core",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-storage-provider-winfsp"
-version = "2026.9.0"
+version = "2026.9.1"
 dependencies = [
  "anyhow",
  "astrid-core",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-telemetry"
-version = "2026.9.0"
+version = "2026.9.1"
 dependencies = [
  "astrid-config",
  "chrono",
@@ -921,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-test"
-version = "2026.9.0"
+version = "2026.9.1"
 dependencies = [
  "astrid-core",
  "chrono",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-types"
-version = "2026.9.0"
+version = "2026.9.1"
 dependencies = [
  "chrono",
  "getrandom 0.4.3",
@@ -946,7 +946,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-uplink"
-version = "2026.9.0"
+version = "2026.9.1"
 dependencies = [
  "anyhow",
  "astrid-config",
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-vfs"
-version = "2026.9.0"
+version = "2026.9.1"
 dependencies = [
  "astrid-capabilities",
  "astrid-core",
@@ -985,7 +985,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-workspace"
-version = "2026.9.0"
+version = "2026.9.1"
 dependencies = [
  "astrid-core",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2026.9.0"
+version = "2026.9.1"
 edition = "2024"
 authors = ["Joshua J. Bouw <dev@joshuajbouw.com>", "Unicity Labs <info@unicity-labs.com>"]
 license = "MIT OR Apache-2.0"
@@ -44,33 +44,33 @@ repository = "https://github.com/astrid-runtime/astrid"
 rust-version = "1.95"
 
 [workspace.dependencies]
-astrid-approval = { path = "crates/astrid-approval", version = "2026.9.0" }
-astrid-audit = { path = "crates/astrid-audit", version = "2026.9.0" }
-astrid-capabilities = { path = "crates/astrid-capabilities", version = "2026.9.0" }
-astrid-build = { path = "crates/astrid-build", version = "2026.9.0" }
-astrid-capsule = { path = "crates/astrid-capsule", version = "2026.9.0" }
-astrid-capsule-install = { path = "crates/astrid-capsule-install", version = "2026.9.0" }
-astrid-capsule-types = { path = "crates/astrid-capsule-types", version = "2026.9.0" }
-astrid-config = { path = "crates/astrid-config", version = "2026.9.0" }
-astrid-daemon = { path = "crates/astrid-daemon", version = "2026.9.0" }
-astrid-core = { path = "crates/astrid-core", version = "2026.9.0" }
-astrid-crypto = { path = "crates/astrid-crypto", version = "2026.9.0" }
-astrid-emit = { path = "crates/astrid-emit", version = "2026.9.0" }
-astrid-events = { path = "crates/astrid-events", version = "2026.9.0" }
-astrid-hooks = { path = "crates/astrid-hooks", version = "2026.9.0" }
-astrid-kernel = { path = "crates/astrid-kernel", version = "2026.9.0" }
-astrid-mcp = { path = "crates/astrid-mcp", version = "2026.9.0" }
-astrid-prelude = { path = "crates/astrid-prelude", version = "2026.9.0" }
-astrid-runtime = { path = "crates/astrid-runtime", version = "2026.9.0" }
-astrid-storage = { path = "crates/astrid-storage", version = "2026.9.0" }
-astrid-storage-provider-winfsp = { path = "crates/astrid-storage-provider-winfsp", version = "2026.9.0" }
-astrid-telemetry = { path = "crates/astrid-telemetry", version = "2026.9.0" }
+astrid-approval = { path = "crates/astrid-approval", version = "2026.9.1" }
+astrid-audit = { path = "crates/astrid-audit", version = "2026.9.1" }
+astrid-capabilities = { path = "crates/astrid-capabilities", version = "2026.9.1" }
+astrid-build = { path = "crates/astrid-build", version = "2026.9.1" }
+astrid-capsule = { path = "crates/astrid-capsule", version = "2026.9.1" }
+astrid-capsule-install = { path = "crates/astrid-capsule-install", version = "2026.9.1" }
+astrid-capsule-types = { path = "crates/astrid-capsule-types", version = "2026.9.1" }
+astrid-config = { path = "crates/astrid-config", version = "2026.9.1" }
+astrid-daemon = { path = "crates/astrid-daemon", version = "2026.9.1" }
+astrid-core = { path = "crates/astrid-core", version = "2026.9.1" }
+astrid-crypto = { path = "crates/astrid-crypto", version = "2026.9.1" }
+astrid-emit = { path = "crates/astrid-emit", version = "2026.9.1" }
+astrid-events = { path = "crates/astrid-events", version = "2026.9.1" }
+astrid-hooks = { path = "crates/astrid-hooks", version = "2026.9.1" }
+astrid-kernel = { path = "crates/astrid-kernel", version = "2026.9.1" }
+astrid-mcp = { path = "crates/astrid-mcp", version = "2026.9.1" }
+astrid-prelude = { path = "crates/astrid-prelude", version = "2026.9.1" }
+astrid-runtime = { path = "crates/astrid-runtime", version = "2026.9.1" }
+astrid-storage = { path = "crates/astrid-storage", version = "2026.9.1" }
+astrid-storage-provider-winfsp = { path = "crates/astrid-storage-provider-winfsp", version = "2026.9.1" }
+astrid-telemetry = { path = "crates/astrid-telemetry", version = "2026.9.1" }
 astrid-test = { path = "crates/astrid-test" }
-astrid-types = { path = "crates/astrid-types", version = "2026.9.0", features = ["clock"] }
-astrid-uplink = { path = "crates/astrid-uplink", version = "2026.9.0" }
-astrid-gateway = { path = "crates/astrid-gateway", version = "2026.9.0" }
-astrid-vfs = { path = "crates/astrid-vfs", version = "2026.9.0" }
-astrid-workspace = { path = "crates/astrid-workspace", version = "2026.9.0" }
+astrid-types = { path = "crates/astrid-types", version = "2026.9.1", features = ["clock"] }
+astrid-uplink = { path = "crates/astrid-uplink", version = "2026.9.1" }
+astrid-gateway = { path = "crates/astrid-gateway", version = "2026.9.1" }
+astrid-vfs = { path = "crates/astrid-vfs", version = "2026.9.1" }
+astrid-workspace = { path = "crates/astrid-workspace", version = "2026.9.1" }
 anyhow = "1.0"
 arboard = "3"
 arc-swap = "1.7"

--- a/changes/1905.fixed.md
+++ b/changes/1905.fixed.md
@@ -1,1 +1,0 @@
-Honor explicit `init --grant-capsules` for the complete verified distro after a resumed install, including capsules completed in earlier batches. Plain resume still does not grant access implicitly.

--- a/changes/1907.fixed.md
+++ b/changes/1907.fixed.md
@@ -1,9 +1,0 @@
-Preserve volume-only capsule WASM across idle daemon shutdown and restart. Host-projection receipts now track only materialized files, preventing first-boot capsule installs from being mistaken for deleted host files when initialization resumes.
-
-Unify graceful daemon finalization across idle exit, signals, and explicit stop. Both daemon entry points drain their task runtime before packing the final host projection under a stable lifecycle fence; CLI recovery uses the same finalizer.
-
-Keep an existing ephemeral daemon connected throughout initialization, preventing idle retirement between provisioning requests while initialization still writes the running projection.
-
-Retain that connection through Distro Apply's final self-grant, and resolve the lifecycle fence independently of each process's temporary-directory environment.
-
-Drain provisioning-lease broadcasts so capsule installation cannot fill its socket queue and disconnect the lease midway through first boot.

--- a/changes/1910.fixed.md
+++ b/changes/1910.fixed.md
@@ -1,7 +1,0 @@
-Leave unset optional distro credentials absent during initialization instead of
-attempting to store invalid empty secrets. Reinitialization preserves existing
-credentials; nonempty secrets still use the daemon's typed secret API.
-
-Allow a daemon that retired its generation markers during clean shutdown to
-finish exiting before reporting an identity error. No unverified process is
-signalled; runtime cleanup still requires the singleton lock.

--- a/changes/1912.fixed.md
+++ b/changes/1912.fixed.md
@@ -1,1 +1,0 @@
-- Deliver capsule-supplied stdin to synchronous native subprocesses and close the pipe after delivery. Drain output concurrently so request/response adapters cannot deadlock on full pipes.

--- a/changes/1914.fixed.md
+++ b/changes/1914.fixed.md
@@ -1,1 +1,0 @@
-Check the actual filesystem type in the macOS legacy-upgrade mount test instead of interpreting BSD stat's directory marker as a filesystem name.

--- a/release/RELEASE-2026.9.1.md
+++ b/release/RELEASE-2026.9.1.md
@@ -1,0 +1,26 @@
+# Astrid 2026.9.1 hotfix
+
+Patch release following published v2026.9.0. See the corresponding
+[Keep a Changelog entry](../CHANGELOG.md#202691---2026-09-10).
+
+This release repairs initialization, durable capsule preservation, daemon
+retirement, and synchronous subprocess input. The volume format is unchanged.
+Existing v2026.9.0 tags and release artifacts remain immutable. Preservation
+fixes do not recreate capsule data already lost by an earlier run; reinstall
+affected capsules from their original trusted source if necessary.
+
+The source changes were exercised together through signed disposable AOS/Oracle
+packages: credential-free Codex, Claude, and Grok setup, real MCP capsule calls,
+an authored capsule invoking a native adapter, and stop/restart with repeated
+calls. Published v0.10.4 migration and a macOS FSKit read/write/sync/unmount
+round-trip also passed. Private rehearsal signatures are not production signatures.
+
+Production release execution must pass GNU/musl builds and archive validation,
+Darwin signing/notarization, supervised verification of the exact Darwin archive,
+and authenticated publication. Publish and promote Astrid first; downstream AOS
+must bind the resulting production metadata and packaged runtime bytes before
+its release. Oracle follows the compatible AOS patch.
+
+All 32 workspace package versions advance to 2026.9.1. Third-party dependency
+versions and sources are unchanged from v2026.9.0. Windows remains outside this
+release's published archive inventory.

--- a/release/VERSIONING.md
+++ b/release/VERSIONING.md
@@ -13,7 +13,7 @@ CalSemVer here. The month is not zero-padded.
   Document breaking changes and migrations in release notes; the year component
   is not a traditional SemVer compatibility-major guarantee.
 
-Astrid targets `2026.9.0` for this release, with Git tag `v2026.9.0`.
+Astrid targets `2026.9.1` for this release, with Git tag `v2026.9.1`.
 Downstream distributions and integrations own their version and tag policies.
 
 Previously published versions are immutable. Astrid `0.10.x` retains its

--- a/scripts/certify_fskit_local.py
+++ b/scripts/certify_fskit_local.py
@@ -20,6 +20,16 @@ import tempfile
 from supervised_fskit import CHECKS, TARGET, manifest, sha256
 
 
+def is_astridfs(mount, mount_table):
+    """Bind macOS mount output to the exact canonical mount, not a sibling."""
+    expected = str(mount.resolve())
+    for line in mount_table.splitlines():
+        match = re.fullmatch(r".+ on (.+) \(([^, )]+)(?:, [^\n]*)?\)", line)
+        if match and match[1] == expected and match[2] == "astridfs":
+            return True
+    return False
+
+
 def inventory(root):
     result = {}
     for path in sorted(root.rglob("*")):
@@ -115,7 +125,7 @@ def main():
         started = True
         cli("start")
         cli("storage", "mount", "--as", "default", str(mount))
-        if run("/usr/bin/stat", "-f", "%T", str(mount)).strip() != "astridfs":
+        if not is_astridfs(mount, run("/sbin/mount")):
             raise ValueError("mount is not astridfs")
         status(False)
         checks["mount"] = True
@@ -133,7 +143,7 @@ def main():
         status(False)
         checks["delete_sync"] = True
         cli("storage", "unmount", str(mount))
-        if run("/usr/bin/stat", "-f", "%T", str(mount)).strip() == "astridfs":
+        if is_astridfs(mount, run("/sbin/mount")):
             raise ValueError("filesystem remained mounted")
         checks["unmount"] = True
         cli("stop")
@@ -145,7 +155,7 @@ def main():
         if started:
             # Only this script's mount and runtime; never pkill or remove app.
             try:
-                if run("/usr/bin/stat", "-f", "%T", str(mount)).strip() == "astridfs":
+                if is_astridfs(mount, run("/sbin/mount")):
                     cli("storage", "unmount", str(mount))
             finally:
                 cli("stop")

--- a/scripts/ci/test-release-contracts.sh
+++ b/scripts/ci/test-release-contracts.sh
@@ -23,3 +23,4 @@ bash scripts/test_ci_workflow_contract.sh
 python3 scripts/test_gnu_build_packages.py
 python3 scripts/test_supervised_fskit.py
 python3 scripts/test_macos_profiles.py
+python3 scripts/test_runtime_crash_capture.py

--- a/scripts/e2e/runtime-crash-smoke.sh
+++ b/scripts/e2e/runtime-crash-smoke.sh
@@ -53,12 +53,15 @@ principal = sys.argv[2]
 timeout_secs = float(sys.argv[3])
 out_path = Path(sys.argv[4])
 args = sys.argv[5:]
+# Structured output must not absorb update notices or other stderr diagnostics.
+json_output = any(a == "--format" and b == "json" for a, b in zip(args, args[1:]))
+stderr_path = out_path.with_name(out_path.name + ".stderr")
 
 try:
     proc = subprocess.run(
         [binary, "--principal", principal, *args],
         stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
+        stderr=subprocess.PIPE if json_output else subprocess.STDOUT,
         text=True,
         timeout=timeout_secs,
         check=False,
@@ -68,9 +71,16 @@ except subprocess.TimeoutExpired as exc:
     if isinstance(stdout, bytes):
         stdout = stdout.decode("utf-8", errors="replace")
     out_path.write_text(stdout, encoding="utf-8")
+    if json_output:
+        stderr = exc.stderr or b""
+        if isinstance(stderr, bytes):
+            stderr = stderr.decode("utf-8", errors="replace")
+        stderr_path.write_text(stderr, encoding="utf-8")
     raise SystemExit(124) from exc
 
 out_path.write_text(proc.stdout, encoding="utf-8")
+if json_output:
+    stderr_path.write_text(proc.stderr, encoding="utf-8")
 raise SystemExit(proc.returncode)
 PY
 }

--- a/scripts/test_nightly_version.py
+++ b/scripts/test_nightly_version.py
@@ -13,7 +13,7 @@ import nightly_version
 COMMIT = "0123456789abcdef0123456789abcdef01234567"
 VERSION = f"0.10.0-nightly.20260717.g{COMMIT}"
 LIVE_BASE_VERSION = "2026.10.0"
-LIVE_SOURCE_VERSION = "2026.9.0"
+LIVE_SOURCE_VERSION = "2026.9.1"
 
 
 class NightlyVersionTests(unittest.TestCase):

--- a/scripts/test_runtime_crash_capture.py
+++ b/scripts/test_runtime_crash_capture.py
@@ -1,0 +1,42 @@
+"""Exercise the real crash-smoke capture helper with noisy CLI diagnostics."""
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+class CaptureTests(unittest.TestCase):
+    def test_json_preserves_stdout_and_records_stderr(self):
+        script = Path(__file__).parent / "e2e/runtime-crash-smoke.sh"
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            binary = root / "target/debug/astrid"
+            binary.parent.mkdir(parents=True)
+            binary.write_text(
+                "#!/bin/sh\n"
+                "echo 'Update available: v2026.9.1 -> v2026.9.0' >&2\n"
+                "echo '[{\"principal\":\"default\",\"owner_uid\":\"test-owner\"}]'\n"
+                'exit "${FAKE_EXIT:-0}"\n'
+            )
+            binary.chmod(0o755)
+            output = root / "roster.json"
+            for status in (0, 7):
+                with self.subTest(status=status):
+                    result = subprocess.run(
+                        ["bash", "-c", 'source "$1"; bounded_principal_cli default 8 "$2" agent list --format json',
+                         "capture-test", str(script), str(output)],
+                        env={**os.environ, "CORE_DIR": str(root), "PYTHON": sys.executable,
+                             "FAKE_EXIT": str(status)},
+                        capture_output=True, text=True, check=False,
+                    )
+                    self.assertEqual(result.returncode, status, result.stderr)
+                    self.assertEqual(json.loads(output.read_text())[0]["owner_uid"], "test-owner")
+                    self.assertIn("Update available", (root / "roster.json.stderr").read_text())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_supervised_fskit.py
+++ b/scripts/test_supervised_fskit.py
@@ -14,6 +14,22 @@ import certify_fskit_local as local
 
 
 class ApprovalTests(unittest.TestCase):
+    def test_local_mount_type_is_bound_to_exact_mount(self):
+        with tempfile.TemporaryDirectory() as directory:
+            mount = Path(directory) / "mount with spaces"
+            mount.mkdir()
+            name = str(mount.resolve())
+            self.assertTrue(local.is_astridfs(mount, f"AOS on {name} (astridfs, local)"))
+            for table in (
+                f"AOS on {name}-other (astridfs, local)",
+                f"disk on {name} (apfs, local)",
+                f"AOS on {name} (astridfs-other, local)",
+                "/",
+                "",
+            ):
+                with self.subTest(table=table):
+                    self.assertFalse(local.is_astridfs(mount, table))
+
     def setUp(self):
         self.expected = {"schema": 1, "source_commit": "a" * 40, "run_id": "123",
                          "run_attempt": "2", "target": cert.TARGET,


### PR DESCRIPTION
## Linked Issue

Closes #1916

## Summary

Release Astrid 2026.9.1, the tested hotfix following published v2026.9.0.

## Changes

- Bump all 32 workspace packages and matching workspace dependencies to 2026.9.1; leave third-party dependency versions unchanged.
- Roll and consolidate the five landed fragments into net user-facing Keep a Changelog fixes.
- Document upgrade limits, completed private package rehearsal, and production verification steps.
- Keep the next nightly series at 2026.10.0 and update its current-stable test expectation.
- Apply the already-tested macOS filesystem identification correction to the supervised release helper too; regress exact mount paths, sibling paths, APFS, and absent mounts.
- Preserve JSON stdout separately from update notices in the crash-recovery test helper. The release candidate exposed its previous stderr merge; no runtime crash behavior is changed.

## Verification

- Locked offline Cargo metadata resolves the release workspace.
- The actual capture helper parses JSON despite stderr notices and preserves both successful and failing CLI exit codes. Exact-head Runtime E2E must rerun after this correction.
- Nine supervised-certification tests pass. Read-only observation of the existing Astrid mount confirms BSD stat returns `/` while the exact mount-table lookup identifies `astridfs`; no existing mount was changed.
- Changelog and nightly-version tests pass; release notes require no unrolled fragments.
- Runtime fixes passed hosted GNU/musl, Linux/macOS upgrade, and Runtime E2E checks before landing.
- Combined private signed packages exercised actual Codex/Claude/Grok MCP tools, an authored capsule with native subprocess input, repeated calls after restart, volume-only stop, and v0.10.4 migration with a real FSKit mount round-trip.
- Production signing, artifact verification, and supervised macOS certification remain required in the tag workflow. Rehearsal hashes are not future release hashes.

## AI / Tool Assistance

Assisted-by: Codex:Astra

Release metadata and net changelog consolidation checked against the published baseline and tested landed source.

## Checklist

- [x] Linked to an issue
- [x] Release roll consumes landed fragments
- [x] I understand the changes and their validation limits.
- [x] Meaningful generated output reviewed and tested.
- [x] Signed-off-by trailer and GPG-signed commit.
