### PR TITLE
feat(mcp): add authenticated Streamable HTTP transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,6 +251,7 @@ dependencies = [
  "astrid-telemetry",
  "astrid-types",
  "astrid-uplink",
+ "axum",
  "base64 0.23.1",
  "blake3",
  "chrono",
@@ -279,6 +280,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sigstore-verify",
+ "subtle",
  "syn 3.0.4",
  "syntect",
  "tar",
@@ -5874,26 +5876,34 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "3.1.4"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a15bc53261a9dc37e105df006e4656c598379a8f9581f8950debb130f27a7cf"
+checksum = "42b6914fac0be956fe704a38239c3f44a9f841d1b06a5713d2f638065593f5b5"
 dependencies = [
+ "async-trait",
  "base64 0.23.1",
+ "bytes",
  "chrono",
  "futures",
  "hmac 0.13.0",
+ "http",
+ "http-body",
+ "http-body-util",
  "indexmap",
  "pastey",
  "pin-project-lite",
+ "rand 0.10.2",
  "rmcp-macros",
  "schemars",
  "serde",
  "serde_json",
  "sha2 0.11.0",
+ "sse-stream",
  "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "tokio-util",
+ "tower-service",
  "tracing",
  "url",
  "uuid",
@@ -5902,9 +5912,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "3.1.4"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a85d45508e9b4ba024fe996c2638799635d75b6dd0ba8f32ccf08f8026f0c780"
+checksum = "873b730df6f0a9b74b13eb514e0dca4c2db0d8b68b74af98a2e9bf3f9d436585"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -6738,6 +6748,19 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
+]
+
+[[package]]
+name = "sse-stream"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c25ac7aff0abd1dbc474536e40416e1102c7dd9bfba0b9861c6d357f835dcfb4"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -200,7 +200,7 @@ reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"
 # changes in minor versions. Cargo.lock is committed, but the patch range also
 # prevents fresh resolution from silently adopting a future incompatible minor.
 # It still admits compatible bug and security fixes.
-rmcp = { version = "~3.1.4", features = ["server", "client", "transport-io", "elicitation", "macros", "request-state", "schemars"] }
+rmcp = { version = "~3.2.0", features = ["server", "client", "transport-io", "elicitation", "macros", "request-state", "schemars"] }
 rustyline = { version = "18", features = ["derive"] }
 semver = "1"
 serde = { version = "1.0", features = ["derive"] }

--- a/changes/1919.added.md
+++ b/changes/1919.added.md
@@ -1,0 +1,1 @@
+- Added an opt-in, bearer-authenticated loopback MCP Streamable HTTP endpoint using RMCP 3.2.0. It shares the stdio broker's principal, tool invocation, and consent handling, supports MCP 2026 stateless requests and tool-change subscriptions, and retains older-client session compatibility.

--- a/crates/astrid-cli/Cargo.toml
+++ b/crates/astrid-cli/Cargo.toml
@@ -62,7 +62,9 @@ nix = { workspace = true }
 ratatui = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["json", "stream"] }
-rmcp = { workspace = true }
+rmcp = { workspace = true, features = ["transport-streamable-http-server"] }
+axum = { workspace = true }
+subtle = { workspace = true }
 rustyline = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }

--- a/crates/astrid-cli/src/cli/mcp.rs
+++ b/crates/astrid-cli/src/cli/mcp.rs
@@ -37,6 +37,19 @@ pub(crate) enum McpCommands {
     },
     /// Run the persistent per-user MCP gateway.
     Gateway,
+    /// Serve authenticated Streamable HTTP at /mcp (loopback only).
+    /// The listener is explicitly operator-managed; stop it with Ctrl-C.
+    Http {
+        /// Override `gateway.mcp_http.listen` (127.0.0.1:8081 by default).
+        #[arg(long)]
+        listen: Option<std::net::SocketAddr>,
+        /// Private file containing a bearer token, never the token itself.
+        #[arg(long)]
+        token_file: Option<PathBuf>,
+        /// Fixed project context for this endpoint; clients cannot override it.
+        #[arg(long)]
+        workspace: Option<PathBuf>,
+    },
     /// Wait for the gateway without running doctor or installation flows.
     Ready {
         /// Output format: `hook`, `pretty`, or `json`.

--- a/crates/astrid-cli/src/cli_mcp_tests.rs
+++ b/crates/astrid-cli/src/cli_mcp_tests.rs
@@ -3,6 +3,38 @@ use super::{Cli, Commands, McpCommands};
 use clap::Parser;
 
 #[test]
+fn mcp_http_accepts_explicit_endpoint_credentials_and_workspace() {
+    let parsed = Cli::try_parse_from([
+        "astrid",
+        "--principal",
+        "codex-code",
+        "mcp",
+        "http",
+        "--listen",
+        "127.0.0.1:9000",
+        "--token-file",
+        "/tmp/token",
+        "--workspace",
+        "/tmp/project",
+    ])
+    .unwrap();
+    let Some(Commands::Mcp {
+        command:
+            McpCommands::Http {
+                listen,
+                token_file,
+                workspace,
+            },
+    }) = parsed.command
+    else {
+        panic!("expected MCP HTTP command");
+    };
+    assert_eq!(listen, Some("127.0.0.1:9000".parse().unwrap()));
+    assert_eq!(token_file.unwrap(), std::path::PathBuf::from("/tmp/token"));
+    assert_eq!(workspace.unwrap(), std::path::PathBuf::from("/tmp/project"));
+}
+
+#[test]
 fn mcp_serve_accepts_aos_host_plugin_flags() {
     let parsed = Cli::try_parse_from([
         "astrid",

--- a/crates/astrid-cli/src/commands/mcp/http/auth.rs
+++ b/crates/astrid-cli/src/commands/mcp/http/auth.rs
@@ -1,0 +1,98 @@
+//! Bearer authentication before any RMCP dispatch or broker work.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use axum::extract::{Request, State};
+use axum::http::{StatusCode, header};
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+use subtle::ConstantTimeEq;
+use zeroize::Zeroizing;
+
+pub(super) struct BearerToken(Zeroizing<Vec<u8>>);
+
+impl BearerToken {
+    pub(super) fn read(path: &Path) -> Result<Self> {
+        #[cfg(unix)]
+        {
+            use std::io::Read;
+            use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+            let file = std::fs::OpenOptions::new()
+                .read(true)
+                .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK)
+                .open(path)
+                .with_context(|| format!("open private MCP token file {}", path.display()))?;
+            let meta = file.metadata()?;
+            anyhow::ensure!(
+                meta.is_file() && meta.permissions().mode().trailing_zeros() >= 6,
+                "MCP token must be a regular private file (chmod 600)"
+            );
+            anyhow::ensure!(
+                meta.len() <= 514,
+                "MCP token file exceeds the credential format limit"
+            );
+            let mut bytes = Zeroizing::new(Vec::new());
+            // Credential format ceiling, not an operational request limit.
+            file.take(514).read_to_end(&mut bytes)?;
+            while bytes.last().is_some_and(|b| matches!(b, b'\n' | b'\r')) {
+                bytes.pop();
+            }
+            Self::from_bytes(bytes)
+        }
+        #[cfg(not(unix))]
+        anyhow::bail!(
+            "MCP HTTP token file ACL validation is not yet supported on this platform: {}",
+            path.display()
+        )
+    }
+
+    fn from_bytes(bytes: Zeroizing<Vec<u8>>) -> Result<Self> {
+        anyhow::ensure!(
+            (32..=512).contains(&bytes.len()) && bytes.iter().all(u8::is_ascii_graphic),
+            "MCP bearer token must contain 32..512 printable non-space ASCII bytes"
+        );
+        Ok(Self(bytes))
+    }
+
+    fn accepts(&self, request: &Request) -> bool {
+        let mut headers = request.headers().get_all(header::AUTHORIZATION).iter();
+        let Some(value) = headers.next() else {
+            return false;
+        };
+        if headers.next().is_some() {
+            return false;
+        }
+        let bytes = value.as_bytes();
+        let Some(scheme) = bytes.get(..7) else {
+            return false;
+        };
+        scheme.eq_ignore_ascii_case(b"Bearer ") && bool::from(self.0.as_slice().ct_eq(&bytes[7..]))
+    }
+}
+
+pub(super) async fn authorize(
+    State(token): State<Arc<BearerToken>>,
+    request: Request,
+    next: Next,
+) -> Response {
+    // This endpoint serves native MCP clients, not browser scripts. Reject all
+    // browser origins (including null) rather than enabling credentialed CORS.
+    if request.headers().contains_key(header::ORIGIN) {
+        return StatusCode::FORBIDDEN.into_response();
+    }
+    if !token.accepts(&request) {
+        return (
+            StatusCode::UNAUTHORIZED,
+            [(header::WWW_AUTHENTICATE, "Bearer")],
+        )
+            .into_response();
+    }
+    next.run(request).await
+}
+
+#[cfg(test)]
+pub(super) fn test_token() -> BearerToken {
+    BearerToken::from_bytes(Zeroizing::new(vec![b'a'; 32])).unwrap()
+}

--- a/crates/astrid-cli/src/commands/mcp/http/auth.rs
+++ b/crates/astrid-cli/src/commands/mcp/http/auth.rs
@@ -3,7 +3,9 @@
 use std::path::Path;
 use std::sync::Arc;
 
-use anyhow::{Context, Result};
+#[cfg(unix)]
+use anyhow::Context;
+use anyhow::Result;
 use axum::extract::{Request, State};
 use axum::http::{StatusCode, header};
 use axum::middleware::Next;

--- a/crates/astrid-cli/src/commands/mcp/http/handler.rs
+++ b/crates/astrid-cli/src/commands/mcp/http/handler.rs
@@ -1,0 +1,95 @@
+//! Per-transport lifetime around the shared broker, not another tool handler.
+
+use std::borrow::Cow;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use rmcp::model::{
+    CallToolRequestParams, CallToolResponse, ListToolsResult, PaginatedRequestParams,
+    ProtocolVersion, ServerInfo, SubscriptionFilter,
+};
+use rmcp::service::{NotificationContext, RequestContext, RoleServer, SubscriptionContext};
+use rmcp::{ErrorData, ServerHandler};
+use tokio_util::sync::CancellationToken;
+
+use super::super::server::AstridMcpServer;
+
+pub(super) struct HttpHandler {
+    broker: Arc<AstridMcpServer>,
+    principal: astrid_core::PrincipalId,
+    root: PathBuf,
+    lifetime: CancellationToken,
+}
+
+impl HttpHandler {
+    pub(super) fn new(
+        broker: Arc<AstridMcpServer>,
+        principal: astrid_core::PrincipalId,
+        root: PathBuf,
+    ) -> Self {
+        Self {
+            broker,
+            principal,
+            root,
+            lifetime: CancellationToken::new(),
+        }
+    }
+}
+
+impl Drop for HttpHandler {
+    fn drop(&mut self) {
+        self.lifetime.cancel();
+    }
+}
+
+impl ServerHandler for HttpHandler {
+    fn supported_protocol_versions(&self) -> Cow<'static, [ProtocolVersion]> {
+        self.broker.supported_protocol_versions()
+    }
+
+    fn get_info(&self) -> ServerInfo {
+        self.broker.get_info()
+    }
+
+    async fn list_tools(
+        &self,
+        request: Option<PaginatedRequestParams>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<ListToolsResult, ErrorData> {
+        self.broker.list_tools(request, context).await
+    }
+
+    async fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResponse, ErrorData> {
+        self.broker.call_tool(request, context).await
+    }
+
+    fn accepted_subscription_filter(
+        &self,
+        requested: &SubscriptionFilter,
+    ) -> Option<SubscriptionFilter> {
+        self.broker.accepted_subscription_filter(requested)
+    }
+
+    async fn listen(&self, context: SubscriptionContext) -> Result<(), ErrorData> {
+        self.broker.listen(context).await
+    }
+
+    async fn on_initialized(&self, context: NotificationContext<RoleServer>) {
+        // Only legacy sessions initialize. Modern clients use request-scoped
+        // subscriptions/listen above. Dropping this RMCP session cancels its
+        // watcher even when no later capsule-change event arrives.
+        let lifetime = self.lifetime.clone();
+        let principal = self.principal.to_string();
+        let root = self.root.clone();
+        tokio::spawn(async move {
+            tokio::select! {
+                () = lifetime.cancelled() => {},
+                () = super::super::watch::run(context.peer, principal, root) => {},
+            }
+        });
+    }
+}

--- a/crates/astrid-cli/src/commands/mcp/http/mod.rs
+++ b/crates/astrid-cli/src/commands/mcp/http/mod.rs
@@ -1,0 +1,142 @@
+//! Streamable HTTP transport over the same authenticated broker as stdio.
+//!
+//! One endpoint has one operator-selected principal and workspace. HTTP client
+//! metadata never selects authority. The shared handler also preserves MRTR
+//! keys and one-time redemption across independent stateless requests.
+
+use std::net::SocketAddr;
+use std::path::Path;
+use std::process::ExitCode;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use axum::{Router, middleware};
+use rmcp::ServerHandler;
+use rmcp::transport::streamable_http_server::{
+    StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
+};
+use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
+
+mod auth;
+mod handler;
+#[cfg(test)]
+mod tests;
+
+/// Start an explicitly managed, authenticated loopback MCP listener.
+pub(crate) async fn run(
+    listen: Option<SocketAddr>,
+    token_file: Option<&Path>,
+    workspace: Option<&Path>,
+) -> Result<ExitCode> {
+    let root = std::env::current_dir().context("read MCP runtime directory")?;
+    let config = astrid_config::Config::load(Some(&root))?.config;
+    let settings = &config.gateway.mcp_http;
+    let bind = listen.unwrap_or(settings.listen);
+    validate_bind(bind)?;
+    let token = auth::BearerToken::read(
+        token_file
+            .or(settings.token_file.as_deref())
+            .context("MCP HTTP requires --token-file or gateway.mcp_http.token_file")?,
+    )?;
+    let principal = crate::principal::current();
+    anyhow::ensure!(
+        principal != astrid_core::PrincipalId::anonymous(),
+        "MCP HTTP requires a named principal"
+    );
+    let workspace = workspace
+        .unwrap_or(&root)
+        .canonicalize()
+        .context("resolve MCP workspace")?;
+    // Bind and validate credentials before starting any runtime process.
+    let listener = tokio::net::TcpListener::bind(bind)
+        .await
+        .context("bind MCP HTTP listener")?;
+    let address = listener.local_addr()?;
+    crate::commands::daemon::ensure_daemon_quiet("mcp-http", Some(&root)).await?;
+    let daemon_pid =
+        crate::commands::daemon_control::read_pid_file(&crate::socket_client::pid_path())
+            .map(|(pid, _)| pid);
+    let session = astrid_core::SessionId::from_uuid(uuid::Uuid::new_v4());
+    let mut client =
+        crate::socket_client::connect_for_workspace(session, principal.clone(), Some(&root))
+            .await?;
+    super::require_authenticated_unless_anonymous(&principal, client.is_authenticated())?;
+    super::readiness::wait_for_broker(&mut client, &principal).await?;
+    let server = Arc::new(super::server::AstridMcpServer::new(
+        Arc::new(Mutex::new(client)),
+        principal.clone(),
+        root.clone(),
+        workspace,
+    )?);
+    let shutdown = CancellationToken::new();
+    let endpoint_principal = principal.clone();
+    let app = router(
+        move || {
+            Ok(handler::HttpHandler::new(
+                server.clone(),
+                endpoint_principal.clone(),
+                root.clone(),
+            ))
+        },
+        token,
+        address,
+        shutdown.clone(),
+    );
+    eprintln!("MCP Streamable HTTP ready at http://{address}/mcp (principal {principal})");
+    let stop = shutdown.clone();
+    let serving = axum::serve(listener, app).with_graceful_shutdown(async move {
+        shutdown_signal().await;
+        stop.cancel();
+    });
+    let result = serving.await.context("serve MCP HTTP");
+    shutdown.cancel();
+    crate::commands::daemon::retire_disconnected_projection(daemon_pid).await?;
+    result.map(|()| ExitCode::SUCCESS)
+}
+
+fn validate_bind(address: SocketAddr) -> Result<()> {
+    anyhow::ensure!(
+        address.ip().is_loopback(),
+        "MCP HTTP must bind to loopback; use an authenticated tunnel for remote access"
+    );
+    Ok(())
+}
+
+fn router<S: ServerHandler + 'static>(
+    factory: impl Fn() -> std::io::Result<S> + Send + Sync + 'static,
+    token: auth::BearerToken,
+    address: SocketAddr,
+    shutdown: CancellationToken,
+) -> Router {
+    // The SDK always serves 2026 statelessly; retain the SDK's session
+    // compatibility for older clients, not a separate legacy SSE server.
+    let mut config = StreamableHttpServerConfig::default();
+    config.json_response = true;
+    config.cancellation_token = shutdown;
+    config.allowed_hosts = vec![address.to_string(), format!("localhost:{}", address.port())];
+    let service =
+        StreamableHttpService::new(factory, Arc::new(LocalSessionManager::default()), config);
+    Router::new()
+        .nest_service("/mcp", service)
+        .layer(middleware::from_fn_with_state(
+            Arc::new(token),
+            auth::authorize,
+        ))
+}
+
+async fn shutdown_signal() {
+    #[cfg(unix)]
+    {
+        match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+            Ok(mut terminate) => {
+                tokio::select! { _ = tokio::signal::ctrl_c() => {}, _ = terminate.recv() => {} }
+            },
+            Err(_) => {
+                let _ = tokio::signal::ctrl_c().await;
+            },
+        }
+    }
+    #[cfg(not(unix))]
+    let _ = tokio::signal::ctrl_c().await;
+}

--- a/crates/astrid-cli/src/commands/mcp/http/tests.rs
+++ b/crates/astrid-cli/src/commands/mcp/http/tests.rs
@@ -1,0 +1,256 @@
+use std::borrow::Cow;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use rmcp::model::*;
+use rmcp::service::{RequestContext, RoleServer};
+use serde_json::{Value, json};
+
+use super::*;
+
+#[derive(Default)]
+struct Probe(AtomicUsize);
+
+impl ServerHandler for Probe {
+    fn supported_protocol_versions(&self) -> Cow<'static, [ProtocolVersion]> {
+        Cow::Owned(vec![
+            ProtocolVersion::V_2026_07_28,
+            ProtocolVersion::V_2025_11_25,
+        ])
+    }
+
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(
+            ServerCapabilities::builder()
+                .enable_tools()
+                .enable_tool_list_changed()
+                .build(),
+        )
+    }
+
+    fn accepted_subscription_filter(
+        &self,
+        requested: &SubscriptionFilter,
+    ) -> Option<SubscriptionFilter> {
+        (requested.tools_list_changed == Some(true))
+            .then(|| SubscriptionFilter::builder().tools_list_changed().build())
+    }
+
+    async fn listen(
+        &self,
+        context: rmcp::service::SubscriptionContext,
+    ) -> Result<(), rmcp::ErrorData> {
+        context.sink().notify_tool_list_changed().await.unwrap();
+        Ok(())
+    }
+
+    async fn list_tools(
+        &self,
+        _: Option<PaginatedRequestParams>,
+        _: RequestContext<RoleServer>,
+    ) -> Result<ListToolsResult, rmcp::ErrorData> {
+        self.0.fetch_add(1, Ordering::Relaxed);
+        Ok(ListToolsResult::with_all_items(vec![]))
+    }
+
+    async fn call_tool(
+        &self,
+        _: CallToolRequestParams,
+        _: RequestContext<RoleServer>,
+    ) -> Result<CallToolResponse, rmcp::ErrorData> {
+        self.0.fetch_add(1, Ordering::Relaxed);
+        Ok(CallToolResult::success(vec![ContentBlock::text("invoked")]).into())
+    }
+}
+
+struct Endpoint {
+    url: String,
+    probe: Arc<Probe>,
+    task: tokio::task::JoinHandle<()>,
+    cancel: CancellationToken,
+}
+
+impl Drop for Endpoint {
+    fn drop(&mut self) {
+        self.cancel.cancel();
+        self.task.abort();
+    }
+}
+
+async fn endpoint() -> Endpoint {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let probe = Arc::new(Probe::default());
+    let cancel = CancellationToken::new();
+    let factory_probe = probe.clone();
+    let app = router(
+        move || Ok(factory_probe.clone()),
+        auth::test_token(),
+        address,
+        cancel.clone(),
+    );
+    let task = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    Endpoint {
+        url: format!("http://{address}/mcp"),
+        probe,
+        task,
+        cancel,
+    }
+}
+
+fn request(endpoint: &Endpoint, method: &str) -> reqwest::RequestBuilder {
+    let params = json!({"_meta": {
+        "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+        "io.modelcontextprotocol/clientInfo": {"name":"test", "version":"1"},
+        "io.modelcontextprotocol/clientCapabilities": {}
+    }});
+    let mut body = json!({"jsonrpc":"2.0","id":1,"method":method,"params":params});
+    if method == "tools/call" {
+        body["params"]["name"] = json!("probe");
+        body["params"]["arguments"] = json!({});
+    }
+    if method == "subscriptions/listen" {
+        body["params"]["notifications"] = json!({"toolsListChanged":true});
+    }
+    let request = reqwest::Client::new()
+        .post(&endpoint.url)
+        .bearer_auth("a".repeat(32))
+        .header("Accept", "application/json, text/event-stream")
+        .header("MCP-Protocol-Version", "2026-07-28")
+        .header("Mcp-Method", method)
+        .json(&body);
+    if method == "tools/call" {
+        request.header("Mcp-Name", "probe")
+    } else {
+        request
+    }
+}
+
+#[tokio::test]
+async fn stateless_discovery_and_concurrent_calls_use_the_real_http_service() {
+    let endpoint = endpoint().await;
+    let response = request(&endpoint, "tools/list").send().await.unwrap();
+    assert_eq!(response.status(), 200);
+    assert!(!response.headers().contains_key("Mcp-Session-Id"));
+    let body: Value = response.json().await.unwrap();
+    assert_eq!(body["result"]["tools"], json!([]));
+    let (a, b) = tokio::join!(
+        request(&endpoint, "tools/call").send(),
+        request(&endpoint, "tools/call").send()
+    );
+    for response in [a.unwrap(), b.unwrap()] {
+        assert_eq!(response.status(), 200);
+        let body: Value = response.json().await.unwrap();
+        assert_eq!(body["result"]["content"][0]["text"], "invoked");
+    }
+    assert_eq!(endpoint.probe.0.load(Ordering::Relaxed), 3);
+}
+
+#[tokio::test]
+async fn auth_origin_and_dns_rebinding_fail_before_handler_dispatch() {
+    let endpoint = endpoint().await;
+    let missing = reqwest::Client::new()
+        .post(&endpoint.url)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(missing.status(), 401);
+    let bad = request(&endpoint, "tools/list")
+        .bearer_auth("wrong")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(bad.status(), 401);
+    let origin = request(&endpoint, "tools/list")
+        .header("Origin", "null")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(origin.status(), 403);
+    let host = request(&endpoint, "tools/list")
+        .header("Host", "attacker.example")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(host.status(), 403);
+    assert_eq!(endpoint.probe.0.load(Ordering::Relaxed), 0);
+}
+
+#[tokio::test]
+async fn modern_subscription_emits_acknowledgment_and_tool_change_on_post_stream() {
+    let endpoint = endpoint().await;
+    let response = request(&endpoint, "subscriptions/listen")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
+    assert!(!response.headers().contains_key("Mcp-Session-Id"));
+    let body = response.text().await.unwrap();
+    assert!(
+        body.contains("notifications/subscriptions/acknowledged"),
+        "{body}"
+    );
+    assert!(body.contains("notifications/tools/list_changed"), "{body}");
+}
+
+#[tokio::test]
+async fn legacy_client_can_initialize_then_list_through_the_same_endpoint() {
+    let endpoint = endpoint().await;
+    let client = reqwest::Client::new();
+    let response = client.post(&endpoint.url).bearer_auth("a".repeat(32))
+        .header("Accept", "application/json, text/event-stream")
+        .json(&json!({"jsonrpc":"2.0", "id":1, "method":"initialize", "params":{
+            "protocolVersion":"2025-11-25", "capabilities":{}, "clientInfo":{"name":"legacy", "version":"1"}
+        }})).send().await.unwrap();
+    assert_eq!(response.status(), 200);
+    let session = response.headers().get("Mcp-Session-Id").unwrap().clone();
+    for (id, method) in [(None, "notifications/initialized"), (Some(2), "tools/list")] {
+        let mut body = json!({"jsonrpc":"2.0", "method":method});
+        if let Some(id) = id {
+            body["id"] = json!(id);
+        }
+        let response = client
+            .post(&endpoint.url)
+            .bearer_auth("a".repeat(32))
+            .header("Accept", "application/json, text/event-stream")
+            .header("MCP-Protocol-Version", "2025-11-25")
+            .header("Mcp-Session-Id", session.clone())
+            .json(&body)
+            .send()
+            .await
+            .unwrap();
+        assert!(response.status().is_success());
+        if id.is_some() {
+            assert!(response.text().await.unwrap().contains("tools"));
+        }
+    }
+    assert_eq!(endpoint.probe.0.load(Ordering::Relaxed), 1);
+}
+
+#[test]
+fn listener_cannot_silently_expose_the_principal_to_the_network() {
+    assert!(validate_bind("127.0.0.1:0".parse().unwrap()).is_ok());
+    assert!(validate_bind("[::1]:8081".parse().unwrap()).is_ok());
+    assert!(validate_bind("0.0.0.0:8081".parse().unwrap()).is_err());
+    assert!(validate_bind("192.168.1.2:8081".parse().unwrap()).is_err());
+}
+
+#[cfg(unix)]
+#[test]
+fn credential_requires_a_private_regular_file() {
+    use std::os::unix::fs::{PermissionsExt, symlink};
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("token");
+    std::fs::write(&path, "a".repeat(32)).unwrap();
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
+    assert!(auth::BearerToken::read(&path).is_ok());
+    let link = dir.path().join("link");
+    symlink(&path, &link).unwrap();
+    assert!(auth::BearerToken::read(&link).is_err());
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+    assert!(auth::BearerToken::read(&path).is_err());
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
+    std::fs::write(&path, "short").unwrap();
+    assert!(auth::BearerToken::read(&path).is_err());
+}

--- a/crates/astrid-cli/src/commands/mcp/mod.rs
+++ b/crates/astrid-cli/src/commands/mcp/mod.rs
@@ -69,6 +69,7 @@ mod gateway {
     }
 }
 mod grant;
+pub(crate) mod http;
 mod ingress;
 #[cfg(unix)]
 mod lifecycle;

--- a/crates/astrid-cli/src/commands/mcp/server.rs
+++ b/crates/astrid-cli/src/commands/mcp/server.rs
@@ -446,6 +446,27 @@ fn next_grant_step(reply: &Value, grants_resolved: usize) -> GrantStep {
 }
 
 impl ServerHandler for AstridMcpServer {
+    fn accepted_subscription_filter(
+        &self,
+        requested: &rmcp::model::SubscriptionFilter,
+    ) -> Option<rmcp::model::SubscriptionFilter> {
+        (requested.tools_list_changed == Some(true)).then(|| {
+            rmcp::model::SubscriptionFilter::builder()
+                .tools_list_changed()
+                .build()
+        })
+    }
+
+    async fn listen(&self, context: rmcp::service::SubscriptionContext) -> Result<(), McpError> {
+        super::watch::run_subscription(
+            context,
+            self.principal.to_string(),
+            self.daemon_root.clone(),
+        )
+        .await;
+        Ok(())
+    }
+
     fn supported_protocol_versions(&self) -> Cow<'static, [ProtocolVersion]> {
         Cow::Borrowed(ASTRID_MCP_PROTOCOL_VERSIONS)
     }

--- a/crates/astrid-cli/src/commands/mcp/watch.rs
+++ b/crates/astrid-cli/src/commands/mcp/watch.rs
@@ -73,6 +73,38 @@ const ENUMERATE_DEADLINE: Duration = Duration::from_secs(55);
 /// handlers. The function owns a freshly-connected [`SocketClient`] and
 /// drives it to EOF; it returns when the daemon closes the watch uplink.
 pub(super) async fn run(peer: Peer<RoleServer>, principal: String, daemon_root: PathBuf) {
+    run_with_sink(ChangeSink::Legacy(peer), principal, daemon_root).await;
+}
+
+/// The 2026 subscription is request-scoped on both stdio and HTTP. Cancelling
+/// it drops its watcher uplink; it never owns the shared broker connection.
+pub(super) async fn run_subscription(
+    context: rmcp::service::SubscriptionContext,
+    principal: String,
+    daemon_root: PathBuf,
+) {
+    tokio::select! {
+        () = context.cancelled() => {},
+        () = run_with_sink(ChangeSink::Subscription(context.sink().clone()), principal, daemon_root) => {},
+    }
+}
+
+enum ChangeSink {
+    Legacy(Peer<RoleServer>),
+    Subscription(rmcp::service::SubscriptionSink),
+}
+
+impl ChangeSink {
+    async fn notify(&self) -> anyhow::Result<()> {
+        match self {
+            Self::Legacy(peer) => peer.notify_tool_list_changed().await?,
+            Self::Subscription(sink) => sink.notify_tool_list_changed().await?,
+        }
+        Ok(())
+    }
+}
+
+async fn run_with_sink(sink: ChangeSink, principal: String, daemon_root: PathBuf) {
     // The watch uplink's session id is ephemeral — it only keys this
     // transport's frames. Bind the connection to the SAME principal the
     // request handlers use: the native uplink binds that principal during the
@@ -174,7 +206,7 @@ pub(super) async fn run(peer: Peer<RoleServer>, principal: String, daemon_root: 
             continue;
         }
 
-        if let Err(e) = peer.notify_tool_list_changed().await {
+        if let Err(e) = sink.notify().await {
             // Peer channel closed -> the transport is gone; stop.
             warn!(error = %e, "MCP hot-reload watcher: notify failed (peer closed); stopping");
             return;

--- a/crates/astrid-cli/src/dispatch.rs
+++ b/crates/astrid-cli/src/dispatch.rs
@@ -484,6 +484,11 @@ async fn dispatch_mcp(command: McpCommands) -> Result<ExitCode> {
             commands::mcp::attach(None, workspace.as_deref()).await
         },
         McpCommands::Gateway => commands::mcp::gateway(None).await,
+        McpCommands::Http {
+            listen,
+            token_file,
+            workspace,
+        } => commands::mcp::http::run(listen, token_file.as_deref(), workspace.as_deref()).await,
         McpCommands::Ready { format } => commands::mcp::ready(None, &format).await,
         McpCommands::Gc => commands::mcp::gc(),
     }

--- a/crates/astrid-config/src/defaults.toml
+++ b/crates/astrid-config/src/defaults.toml
@@ -354,6 +354,12 @@ idle_shutdown_secs = 30
 # Interval (seconds) between stale session cleanup sweeps.
 session_cleanup_interval_secs = 60
 
+# Starts only with `astrid mcp http`; no listener is enabled automatically.
+[gateway.mcp_http]
+listen = "127.0.0.1:8081"
+# Private file containing a random bearer token (at least 32 bytes).
+# token_file = "/path/to/mcp-http.token"
+
 # ============================================================================
 # Timeout Configuration
 # ============================================================================

--- a/crates/astrid-config/src/gateway.rs
+++ b/crates/astrid-config/src/gateway.rs
@@ -1,0 +1,97 @@
+//! Gateway and MCP listener configuration.
+
+use serde::{Deserialize, Serialize};
+
+/// Gateway daemon configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct GatewaySection {
+    /// Authenticated loopback Streamable HTTP endpoint settings.
+    pub mcp_http: McpHttpSection,
+    /// Directory for gateway runtime state (PID file, socket). `None` uses
+    /// the platform default (e.g. `$XDG_STATE_HOME/astrid`).
+    pub state_dir: Option<String>,
+    /// Path to a secrets file for credential management.
+    pub secrets_file: Option<String>,
+    /// Whether to watch configuration files and reload on change.
+    pub hot_reload: bool,
+    /// Whether to watch plugin directories and hot-reload on file changes.
+    pub watch_plugins: bool,
+    /// Interval (in seconds) between health checks for managed servers.
+    pub health_interval_secs: u64,
+    /// Grace period (in seconds) for a clean shutdown before force-killing
+    /// child processes.
+    pub shutdown_timeout_secs: u64,
+    /// MCP gateway grace period after its final host connection closes.
+    /// Open connections are never considered idle solely for lack of traffic.
+    pub idle_shutdown_secs: u64,
+    /// Interval (in seconds) between stale session cleanup sweeps.
+    pub session_cleanup_interval_secs: u64,
+    /// When `true`, `send_input` publishes a `user.prompt` IPC event to the
+    /// capsule pipeline instead of running the monolithic runtime turn.
+    /// Default: `false`. Use for testing the capsule pipeline.
+    pub use_capsule_pipeline: bool,
+}
+
+impl Default for GatewaySection {
+    fn default() -> Self {
+        Self {
+            mcp_http: McpHttpSection::default(),
+            state_dir: None,
+            secrets_file: None,
+            hot_reload: true,
+            watch_plugins: true,
+            health_interval_secs: 30,
+            shutdown_timeout_secs: 30,
+            idle_shutdown_secs: 30,
+            session_cleanup_interval_secs: 60,
+            use_capsule_pipeline: false,
+        }
+    }
+}
+
+/// Configuration for the explicitly started `astrid mcp http` listener.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct McpHttpSection {
+    /// Loopback bind address. Remote exposure requires a separately managed tunnel.
+    pub listen: std::net::SocketAddr,
+    /// Private bearer credential file; no unauthenticated default is provided.
+    pub token_file: Option<std::path::PathBuf>,
+}
+
+impl Default for McpHttpSection {
+    fn default() -> Self {
+        Self {
+            listen: std::net::SocketAddr::from(([127, 0, 0, 1], 8081)),
+            token_file: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Config;
+
+    #[test]
+    fn mcp_http_defaults_are_loopback_and_have_no_implicit_credential() {
+        let config: Config = toml::from_str("").unwrap();
+        assert_eq!(config.gateway.mcp_http.listen.to_string(), "127.0.0.1:8081");
+        assert!(config.gateway.mcp_http.token_file.is_none());
+    }
+
+    #[test]
+    fn mcp_http_configuration_survives_serialization() {
+        let config: Config = toml::from_str(
+            "[gateway.mcp_http]\nlisten = '[::1]:9000'\ntoken_file = '/private/token'\n",
+        )
+        .unwrap();
+        let encoded = toml::to_string(&config).unwrap();
+        let decoded: Config = toml::from_str(&encoded).unwrap();
+        assert_eq!(decoded.gateway.mcp_http.listen.to_string(), "[::1]:9000");
+        assert_eq!(
+            decoded.gateway.mcp_http.token_file.unwrap(),
+            std::path::PathBuf::from("/private/token")
+        );
+    }
+}

--- a/crates/astrid-config/src/lib.rs
+++ b/crates/astrid-config/src/lib.rs
@@ -46,6 +46,8 @@ pub mod env;
 pub mod error;
 /// Native filesystem presentation settings.
 pub mod filesystem;
+/// Gateway and MCP listener configuration.
+pub mod gateway;
 /// Configuration file discovery and loading.
 pub mod loader;
 /// Layered configuration merging with precedence.

--- a/crates/astrid-config/src/types.rs
+++ b/crates/astrid-config/src/types.rs
@@ -605,50 +605,7 @@ impl Default for LoggingSection {
 // GatewaySection
 // ---------------------------------------------------------------------------
 
-/// Gateway daemon configuration.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(default)]
-pub struct GatewaySection {
-    /// Directory for gateway runtime state (PID file, socket). `None` uses
-    /// the platform default (e.g. `$XDG_STATE_HOME/astrid`).
-    pub state_dir: Option<String>,
-    /// Path to a secrets file for credential management.
-    pub secrets_file: Option<String>,
-    /// Whether to watch configuration files and reload on change.
-    pub hot_reload: bool,
-    /// Whether to watch plugin directories and hot-reload on file changes.
-    pub watch_plugins: bool,
-    /// Interval (in seconds) between health checks for managed servers.
-    pub health_interval_secs: u64,
-    /// Grace period (in seconds) for a clean shutdown before force-killing
-    /// child processes.
-    pub shutdown_timeout_secs: u64,
-    /// MCP gateway grace period after its final host connection closes.
-    /// Open connections are never considered idle solely for lack of traffic.
-    pub idle_shutdown_secs: u64,
-    /// Interval (in seconds) between stale session cleanup sweeps.
-    pub session_cleanup_interval_secs: u64,
-    /// When `true`, `send_input` publishes a `user.prompt` IPC event to the
-    /// capsule pipeline instead of running the monolithic runtime turn.
-    /// Default: `false`. Use for testing the capsule pipeline.
-    pub use_capsule_pipeline: bool,
-}
-
-impl Default for GatewaySection {
-    fn default() -> Self {
-        Self {
-            state_dir: None,
-            secrets_file: None,
-            hot_reload: true,
-            watch_plugins: true,
-            health_interval_secs: 30,
-            shutdown_timeout_secs: 30,
-            idle_shutdown_secs: 30,
-            session_cleanup_interval_secs: 60,
-            use_capsule_pipeline: false,
-        }
-    }
-}
+pub use crate::gateway::GatewaySection;
 
 // ---------------------------------------------------------------------------
 // TimeoutsSection

--- a/docs/mcp-http.md
+++ b/docs/mcp-http.md
@@ -76,3 +76,9 @@ options.
 Successful HTTP discovery and invocation do not prove that any particular host
 refreshes its model-visible catalog after a tool change. That remains a separate
 client integration test, not a promise of this transport.
+
+In the September 12 Codex desktop trial, existing HTTP tools were callable, but
+a newly installed tool did not enter the same conversation's catalog on the
+next turn, despite server notification emission and an updated `tools/list`.
+A new session or connection toggle is currently needed in that tested client.
+Changing from stdio to HTTP does not itself solve client catalog refresh.

--- a/docs/mcp-http.md
+++ b/docs/mcp-http.md
@@ -1,0 +1,78 @@
+# MCP over Streamable HTTP
+
+`astrid mcp http` exposes the existing capsule MCP broker through RMCP's
+Streamable HTTP service at `/mcp`. It does not implement a second broker or the
+retired HTTP+SSE transport. Stdio and Unix-socket attach remain unchanged.
+
+## Start locally
+
+Create a random bearer credential outside the managed runtime directory:
+
+```sh
+umask 077
+openssl rand -hex 32 > /private/path/mcp-http.token
+```
+
+Start from the running runtime's directory, as the principal whose tools the
+endpoint should expose:
+
+```sh
+astrid --principal my-agent mcp http \
+  --listen 127.0.0.1:8081 \
+  --token-file /private/path/mcp-http.token \
+  --workspace /path/to/project
+```
+
+Every request needs `Authorization: Bearer <token>`. Keep the token out of URLs,
+command arguments, source control, and logs. The file must be private, regular,
+and not a symlink. Restart the listener after rotating it.
+
+The equivalent non-secret settings are available in runtime configuration:
+
+```toml
+[gateway.mcp_http]
+listen = "127.0.0.1:8081"
+token_file = "/private/path/mcp-http.token"
+```
+
+CLI options take precedence over these settings. No listener starts merely
+because configuration exists. This explicit foreground service stays available
+until Ctrl-C or SIGTERM; it is not tied to an individual client's TCP connection.
+Shutdown releases its uplinks without terminating an operator-owned daemon.
+
+## Authority and compatibility
+
+- One endpoint has one operator-selected principal and workspace. Requests
+  cannot select another principal or project through client metadata.
+- All tools still pass through the existing broker, capability and consent
+  checks. Sharing a bearer shares that principal's authority.
+- MCP `2026-07-28` requests are stateless, without `Mcp-Session-Id`.
+  `subscriptions/listen` carries tool-change notifications on its POST stream.
+  MRTR state and its one-time redemption fence are shared across requests in
+  this process; this is not a replicated, load-balanced service.
+- Older supported clients use RMCP's session compatibility on the same `/mcp`
+  endpoint. Their initialized sessions own and clean up their change watchers.
+- HTTP requests can overlap; the existing broker socket still serializes its
+  round trips. This change makes no throughput claim.
+- Only loopback binds are accepted. Native clients only: browser Origin headers
+  are rejected, and RMCP validates Host. Remote use requires an authenticated
+  tunnel to loopback; direct public listening and an OAuth deployment are not
+  implemented here. Private token-file permission validation currently requires
+  Unix; Windows refuses startup rather than silently omitting that validation.
+
+## Rehearse the real broker
+
+`scripts/test_mcp_http_live.py` starts only the candidate frontend, checks a wrong
+bearer, lists tools, invokes the supplied read-only tool, and verifies clean
+frontend shutdown. It requires an already-running runtime socket. It does not
+install capsules or edit plugin configuration.
+
+For a branded distribution, preserve its actual runtime environment, including
+`ASTRID_RUN_DIR` and `ASTRID_WORKSPACE_STATE_DIR`; the durable home alone is not
+the complete socket identity. Supply the candidate executable, runtime home,
+workspace, principal, tool name, and JSON arguments explicitly with the script's
+options.
+
+Successful HTTP discovery and invocation do not prove that any particular host
+refreshes its model-visible catalog after a tool change. That remains a separate
+client integration test, not a promise of this transport.

--- a/e2e/cli-scenarios.toml
+++ b/e2e/cli-scenarios.toml
@@ -495,6 +495,13 @@ status = "mapped"
 mode = "long_running"
 principal = "agent"
 
+[commands."mcp http"]
+scenario = "mcp_http_loopback_admission"
+status = "covered"
+mode = "bounded_failure"
+principal = "agent"
+reason = "Runtime CLI smoke executes public-bind refusal; scripts/test_mcp_http_live.py separately rehearses authenticated discovery and invocation against an installed broker."
+
 [commands."mcp gateway"]
 scenario = "mcp_bounded_smoke"
 status = "mapped"

--- a/e2e/runtime-scenario-specs.toml
+++ b/e2e/runtime-scenario-specs.toml
@@ -320,6 +320,15 @@ state = ["MCP server process is terminated deterministically"]
 evidence = ["MCP transcript and process cleanup artifact"]
 remaining = ["persistent mcp attach, gateway, ready, and gc lifecycle paths are mapped but need a hosted gateway harness"]
 
+[scenarios.mcp_http_loopback_admission]
+status = "covered"
+surfaces = ["cli"]
+auth = ["agent"]
+success = ["public bind exits with the loopback diagnostic"]
+denial = ["mcp http --listen 0.0.0.0:0 is refused before broker access"]
+state = ["no HTTP listener is started"]
+evidence = ["cli-mcp-http-public-bind-denied.err and CLI transcript"]
+
 [scenarios.model_principal_isolation]
 status = "covered"
 surfaces = ["cli", "http", "capsule"]

--- a/scripts/e2e/runtime-cli-smoke.sh
+++ b/scripts/e2e/runtime-cli-smoke.sh
@@ -259,6 +259,10 @@ PY
   run_cli_stdin_timeout "cli-chat-eof" 20 --format json chat
   grep -q "Goodbye" "$ARTIFACTS/cli-chat-eof.out" || fail "chat EOF path did not exit cleanly"
   run_cli_mcp_stdio_smoke "cli-mcp-serve-handshake" 20 --principal anonymous mcp serve
+  assert_principal_cli_failure "$user_principal" "cli-mcp-http-public-bind-denied" \
+    mcp http --listen 0.0.0.0:0
+  grep -Fq "MCP HTTP must bind to loopback" "$ARTIFACTS/cli-mcp-http-public-bind-denied.err" \
+    || fail "MCP HTTP public bind missed the loopback diagnostic"
   run_cli_daemon_lifecycle_smoke
 }
 

--- a/scripts/test_mcp_http_live.py
+++ b/scripts/test_mcp_http_live.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Explicit opt-in rehearsal against an installed broker and read-only tool.
+
+Starts only the candidate HTTP frontend, never replaces installed binaries or
+plugin configuration. The supplied runtime should already be running. The
+operator selects the tool and its arguments; no capsule installation occurs.
+"""
+
+import argparse
+import concurrent.futures
+import json
+import os
+from pathlib import Path
+import re
+import secrets
+import socket
+import subprocess
+import tempfile
+import urllib.error
+import urllib.request
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--binary", type=Path, required=True)
+    parser.add_argument("--runtime-home", type=Path, required=True)
+    parser.add_argument("--workspace", type=Path, required=True)
+    parser.add_argument("--principal", required=True)
+    parser.add_argument("--tool", required=True)
+    parser.add_argument("--arguments", default="{}")
+    args = parser.parse_args()
+    arguments = json.loads(args.arguments)
+    env = dict(os.environ, ASTRID_HOME=str(args.runtime_home.resolve()))
+    run_dir = Path(env.get("ASTRID_RUN_DIR", args.runtime_home / "run"))
+    with socket.socket(socket.AF_UNIX) as probe:
+        probe.settimeout(3)
+        probe.connect(str(run_dir / "system.sock"))
+    with tempfile.TemporaryDirectory(prefix="astrid-http-") as scratch:
+        token = secrets.token_hex(32)
+        token_path = Path(scratch) / "token"
+        token_path.touch(mode=0o600)
+        token_path.write_text(token)
+        with (Path(scratch) / "server.log").open("w+") as log:
+            process = subprocess.Popen([
+                str(args.binary.resolve()), "--principal", args.principal,
+                "mcp", "http", "--listen", "127.0.0.1:0",
+                "--token-file", str(token_path), "--workspace", str(args.workspace.resolve()),
+            ], cwd=args.runtime_home, env=env, stdout=log, stderr=subprocess.PIPE, text=True)
+            try:
+                # A bounded reader prevents a failed startup from hanging CI.
+                def ready():
+                    output = []
+                    for line in process.stderr:
+                        output.append(line)
+                        match = re.search(r"ready at (http://127\.0\.0\.1:\d+/mcp)", line)
+                        if match:
+                            return match[1]
+                    raise RuntimeError("HTTP startup failed: " + "".join(output)[-2000:])
+
+                executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+                try:
+                    url = executor.submit(ready).result(timeout=90)
+                finally:
+                    executor.shutdown(wait=False)
+
+                def call(method, params, credential=token):
+                    params = dict(params, _meta={
+                        "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                        "io.modelcontextprotocol/clientInfo": {"name": "http-rehearsal", "version": "1"},
+                        "io.modelcontextprotocol/clientCapabilities": {},
+                    })
+                    headers = {
+                        "Content-Type": "application/json",
+                        "Accept": "application/json, text/event-stream",
+                        "Authorization": "Bearer " + credential,
+                        "MCP-Protocol-Version": "2026-07-28", "Mcp-Method": method,
+                    }
+                    if "name" in params:
+                        headers["Mcp-Name"] = params["name"]
+                    request = urllib.request.Request(url, data=json.dumps({
+                        "jsonrpc": "2.0", "id": 1, "method": method, "params": params,
+                    }).encode(), headers=headers)
+                    with urllib.request.urlopen(request, timeout=65) as response:
+                        assert response.headers.get("Mcp-Session-Id") is None
+                        result = json.load(response)
+                    assert "error" not in result, result
+                    return result["result"]
+
+                try:
+                    call("tools/list", {}, "wrong")
+                    raise AssertionError("wrong bearer accepted")
+                except urllib.error.HTTPError as error:
+                    assert error.code == 401, error.code
+                tools = call("tools/list", {})["tools"]
+                assert any(tool["name"] == args.tool for tool in tools), tools
+                result = call("tools/call", {"name": args.tool, "arguments": arguments})
+                assert not result.get("isError"), result
+                assert result.get("content"), result
+                print(json.dumps({"principal": args.principal, "tool_count": len(tools),
+                                  "tool": args.tool, "result": result}, indent=2))
+            finally:
+                process.terminate()
+                try:
+                    process.wait(timeout=15)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait()
+                    raise AssertionError("HTTP frontend did not shut down cleanly")
+                process.stderr.close()
+                assert process.returncode == 0, f"HTTP shutdown exit: {process.returncode}"
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Linked Issue

Closes #1919

## Summary

Add an opt-in authenticated loopback `/mcp` endpoint using RMCP 3.2.0 Streamable HTTP. It reuses the existing broker, execution, and consent paths. Stdio remains supported.

## Changes

- Add `astrid --principal NAME mcp http`, listener and credential-file configuration, and CLI overrides.
- Preserve principal/workspace authority and shared MRTR redemption state across stateless requests.
- Support MCP 2026 subscriptions and older-client session compatibility.
- Enforce loopback bind, private bearer file, Host validation, and Origin refusal.
- Include transport, credential, config, and executable CLI admission coverage.
- Fix the Windows unused Unix-only Context import and register the HTTP CLI scenario that CI previously rejected.
- Document the observed Codex catalog-refresh limitation.

## Verification

At the corrected source tree:
- `cargo test -p astrid --bin astrid --locked`: 748 passed, 2 intentionally ignored subprocess tests.
- `cargo test -p astrid --test e2e_surface_manifest_contract --locked`: 4 passed.
- `cargo clippy -p astrid --bin astrid --locked -- -D warnings`: passed.
- Formatting, shell syntax, and diff checks passed.
- Executable public-bind probe rejected 0.0.0.0 with the expected loopback diagnostic and left the disposable durable root unchanged.

Earlier transport rehearsal at 809a7c43: the candidate frontend used installed AOS 2026.9.1, listed 12 tools, and invoked program_context_info and program_query. After connecting Codex to the local HTTP endpoint, both tools were also invoked from the actual conversation. A temporary hot-installed tool appeared in HTTP tools/list and emitted a change notification, but did not appear in the existing conversation on its next turn. The temporary capsule was removed. Its invocation was denied without a capsule grant; no successful probe invocation is claimed.

## Test Plan

- Require fresh CI on the corrected head, including Windows compilation and Runtime CLI + HTTP sweep.
- Run transport tests for auth, subscriptions, stateless calls, and older-client initialization.
- Use scripts/test_mcp_http_live.py for an explicitly selected installed read-only tool with the correct distribution runtime environment.

## Boundaries

- HTTP is an additional transport, not a Codex catalog-refresh fix.
- One operator-managed principal/workspace endpoint; no replicated OAuth service or throughput claim.
- Remote use requires an authenticated tunnel to loopback. Windows token ACL validation is not implemented and startup refuses it.
- Local Codex HTTP trial configuration is separate from this source change; the published stdio plugin is unchanged.
- No release or promotion. Hosted CI on this successor remains pending.

## AI / Tool Assistance

Assisted-by: OpenAI: Codex

## Checklist

- [x] Linked issue
- [x] Changelog fragment
- [x] Local tests and inline review
- [x] Signed commit and DCO
