### PR TITLE
feat(release): prepare Astrid 2026.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Version numbers follow [year.month.patch](release/VERSIONING.md) beginning with
 
 ## [Unreleased]
 
+## [2026.9.2] - 2026-09-12
+
+### Added
+
+- Added an opt-in, bearer-authenticated loopback MCP Streamable HTTP endpoint using RMCP 3.2.0. It shares the stdio broker's principal, tool invocation, and consent handling, supports MCP 2026 stateless requests and tool-change subscriptions, and retains older-client session compatibility.
+
 ## [2026.9.1] - 2026-09-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1164,7 +1164,8 @@ Breaking changes to note: `Capsule.toml` moves to `[publish]` / `[subscribe]` ta
 Initial tracked release. See the [repository history](https://github.com/astrid-runtime/astrid/commits/v0.2.0)
 for changes included in this version.
 
-[Unreleased]: https://github.com/astrid-runtime/astrid/compare/v2026.9.1...HEAD
+[Unreleased]: https://github.com/astrid-runtime/astrid/compare/v2026.9.2...HEAD
+[2026.9.2]: https://github.com/astrid-runtime/astrid/compare/v2026.9.1...v2026.9.2
 [2026.9.1]: https://github.com/astrid-runtime/astrid/compare/v2026.9.0...v2026.9.1
 [2026.9.0]: https://github.com/astrid-runtime/astrid/compare/v0.10.4...v2026.9.0
 [0.10.4]: https://github.com/astrid-runtime/astrid/compare/v0.10.3...v0.10.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Version numbers follow [year.month.patch](release/VERSIONING.md) beginning with
 
 ### Added
 
-- Added an opt-in, bearer-authenticated loopback MCP Streamable HTTP endpoint using RMCP 3.2.0. It shares the stdio broker's principal, tool invocation, and consent handling, supports MCP 2026 stateless requests and tool-change subscriptions, and retains older-client session compatibility.
+- Added an opt-in, bearer-authenticated loopback MCP Streamable HTTP endpoint using RMCP 3.2.0. It shares the stdio broker's principal, tool invocation, and consent handling, supports MCP 2026 stateless requests and tool-change subscriptions, and retains older-client session compatibility. Listener and token settings honor the selected workspace layout, including branded layouts.
 
 ## [2026.9.1] - 2026-09-10
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,7 +233,7 @@ dependencies = [
 
 [[package]]
 name = "astrid"
-version = "2026.9.1"
+version = "2026.9.2"
 dependencies = [
  "anyhow",
  "arboard",
@@ -300,7 +300,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-approval"
-version = "2026.9.1"
+version = "2026.9.2"
 dependencies = [
  "astrid-audit",
  "astrid-capabilities",
@@ -320,7 +320,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-audit"
-version = "2026.9.1"
+version = "2026.9.2"
 dependencies = [
  "astrid-capabilities",
  "astrid-core",
@@ -340,7 +340,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-build"
-version = "2026.9.1"
+version = "2026.9.2"
 dependencies = [
  "anyhow",
  "astrid-core",
@@ -362,7 +362,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-capabilities"
-version = "2026.9.1"
+version = "2026.9.2"
 dependencies = [
  "astrid-core",
  "astrid-crypto",
@@ -380,7 +380,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-capsule"
-version = "2026.9.1"
+version = "2026.9.2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -433,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-capsule-install"
-version = "2026.9.1"
+version = "2026.9.2"
 dependencies = [
  "anyhow",
  "astrid-build",
@@ -461,7 +461,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-capsule-types"
-version = "2026.9.1"
+version = "2026.9.2"
 dependencies = [
  "astrid-core",
  "dashmap",
@@ -477,7 +477,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-config"
-version = "2026.9.1"
+version = "2026.9.2"
 dependencies = [
  "astrid-core",
  "directories",
@@ -491,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-core"
-version = "2026.9.1"
+version = "2026.9.2"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-crypto"
-version = "2026.9.1"
+version = "2026.9.2"
 dependencies = [
  "base64 0.23.1",
  "blake3",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-daemon"
-version = "2026.9.1"
+version = "2026.9.2"
 dependencies = [
  "anyhow",
  "astrid-capsule",
@@ -557,7 +557,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-emit"
-version = "2026.9.1"
+version = "2026.9.2"
 dependencies = [
  "anyhow",
  "astrid-core",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-events"
-version = "2026.9.1"
+version = "2026.9.2"
 dependencies = [
  "astrid-core",
  "astrid-runtime",
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-gateway"
-version = "2026.9.1"
+version = "2026.9.2"
 dependencies = [
  "anyhow",
  "astrid-audit",
@@ -640,7 +640,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-hooks"
-version = "2026.9.1"
+version = "2026.9.2"
 dependencies = [
  "astrid-capabilities",
  "astrid-capsule",
@@ -668,7 +668,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-integration-tests"
-version = "2026.9.1"
+version = "2026.9.2"
 dependencies = [
  "arc-swap",
  "astrid-approval",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-kernel"
-version = "2026.9.1"
+version = "2026.9.2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-mcp"
-version = "2026.9.1"
+version = "2026.9.2"
 dependencies = [
  "astrid-audit",
  "astrid-capabilities",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-prelude"
-version = "2026.9.1"
+version = "2026.9.2"
 dependencies = [
  "astrid-audit",
  "astrid-capabilities",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-runtime"
-version = "2026.9.1"
+version = "2026.9.2"
 dependencies = [
  "futures",
  "tokio",
@@ -800,7 +800,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-storage"
-version = "2026.9.1"
+version = "2026.9.2"
 dependencies = [
  "arc-swap",
  "astrid-core",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-storage-chunker-evidence"
-version = "2026.9.1"
+version = "2026.9.2"
 dependencies = [
  "anyhow",
  "astrid-storage",
@@ -854,7 +854,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-storage-provider-fskit"
-version = "2026.9.1"
+version = "2026.9.2"
 dependencies = [
  "anyhow",
  "astrid-core",
@@ -870,7 +870,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-storage-provider-fuse"
-version = "2026.9.1"
+version = "2026.9.2"
 dependencies = [
  "anyhow",
  "astrid-core",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-storage-provider-winfsp"
-version = "2026.9.1"
+version = "2026.9.2"
 dependencies = [
  "anyhow",
  "astrid-core",
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-telemetry"
-version = "2026.9.1"
+version = "2026.9.2"
 dependencies = [
  "astrid-config",
  "chrono",
@@ -923,7 +923,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-test"
-version = "2026.9.1"
+version = "2026.9.2"
 dependencies = [
  "astrid-core",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-types"
-version = "2026.9.1"
+version = "2026.9.2"
 dependencies = [
  "chrono",
  "getrandom 0.4.3",
@@ -948,7 +948,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-uplink"
-version = "2026.9.1"
+version = "2026.9.2"
 dependencies = [
  "anyhow",
  "astrid-config",
@@ -969,7 +969,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-vfs"
-version = "2026.9.1"
+version = "2026.9.2"
 dependencies = [
  "astrid-capabilities",
  "astrid-core",
@@ -987,7 +987,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-workspace"
-version = "2026.9.1"
+version = "2026.9.2"
 dependencies = [
  "astrid-core",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -196,7 +196,7 @@ rcgen = "0.14"
 rustls = { version = "0.23", features = ["aws-lc-rs"] }
 regex = "1.10"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "stream"] }
-# Pinned to the 3.1.x patch range (~). RMCP releases breaking protocol and API
+# Pinned to the 3.2.x patch range (~). RMCP releases breaking protocol and API
 # changes in minor versions. Cargo.lock is committed, but the patch range also
 # prevents fresh resolution from silently adopting a future incompatible minor.
 # It still admits compatible bug and security fixes.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2026.9.1"
+version = "2026.9.2"
 edition = "2024"
 authors = ["Joshua J. Bouw <dev@joshuajbouw.com>", "Unicity Labs <info@unicity-labs.com>"]
 license = "MIT OR Apache-2.0"
@@ -44,33 +44,33 @@ repository = "https://github.com/astrid-runtime/astrid"
 rust-version = "1.95"
 
 [workspace.dependencies]
-astrid-approval = { path = "crates/astrid-approval", version = "2026.9.1" }
-astrid-audit = { path = "crates/astrid-audit", version = "2026.9.1" }
-astrid-capabilities = { path = "crates/astrid-capabilities", version = "2026.9.1" }
-astrid-build = { path = "crates/astrid-build", version = "2026.9.1" }
-astrid-capsule = { path = "crates/astrid-capsule", version = "2026.9.1" }
-astrid-capsule-install = { path = "crates/astrid-capsule-install", version = "2026.9.1" }
-astrid-capsule-types = { path = "crates/astrid-capsule-types", version = "2026.9.1" }
-astrid-config = { path = "crates/astrid-config", version = "2026.9.1" }
-astrid-daemon = { path = "crates/astrid-daemon", version = "2026.9.1" }
-astrid-core = { path = "crates/astrid-core", version = "2026.9.1" }
-astrid-crypto = { path = "crates/astrid-crypto", version = "2026.9.1" }
-astrid-emit = { path = "crates/astrid-emit", version = "2026.9.1" }
-astrid-events = { path = "crates/astrid-events", version = "2026.9.1" }
-astrid-hooks = { path = "crates/astrid-hooks", version = "2026.9.1" }
-astrid-kernel = { path = "crates/astrid-kernel", version = "2026.9.1" }
-astrid-mcp = { path = "crates/astrid-mcp", version = "2026.9.1" }
-astrid-prelude = { path = "crates/astrid-prelude", version = "2026.9.1" }
-astrid-runtime = { path = "crates/astrid-runtime", version = "2026.9.1" }
-astrid-storage = { path = "crates/astrid-storage", version = "2026.9.1" }
-astrid-storage-provider-winfsp = { path = "crates/astrid-storage-provider-winfsp", version = "2026.9.1" }
-astrid-telemetry = { path = "crates/astrid-telemetry", version = "2026.9.1" }
+astrid-approval = { path = "crates/astrid-approval", version = "2026.9.2" }
+astrid-audit = { path = "crates/astrid-audit", version = "2026.9.2" }
+astrid-capabilities = { path = "crates/astrid-capabilities", version = "2026.9.2" }
+astrid-build = { path = "crates/astrid-build", version = "2026.9.2" }
+astrid-capsule = { path = "crates/astrid-capsule", version = "2026.9.2" }
+astrid-capsule-install = { path = "crates/astrid-capsule-install", version = "2026.9.2" }
+astrid-capsule-types = { path = "crates/astrid-capsule-types", version = "2026.9.2" }
+astrid-config = { path = "crates/astrid-config", version = "2026.9.2" }
+astrid-daemon = { path = "crates/astrid-daemon", version = "2026.9.2" }
+astrid-core = { path = "crates/astrid-core", version = "2026.9.2" }
+astrid-crypto = { path = "crates/astrid-crypto", version = "2026.9.2" }
+astrid-emit = { path = "crates/astrid-emit", version = "2026.9.2" }
+astrid-events = { path = "crates/astrid-events", version = "2026.9.2" }
+astrid-hooks = { path = "crates/astrid-hooks", version = "2026.9.2" }
+astrid-kernel = { path = "crates/astrid-kernel", version = "2026.9.2" }
+astrid-mcp = { path = "crates/astrid-mcp", version = "2026.9.2" }
+astrid-prelude = { path = "crates/astrid-prelude", version = "2026.9.2" }
+astrid-runtime = { path = "crates/astrid-runtime", version = "2026.9.2" }
+astrid-storage = { path = "crates/astrid-storage", version = "2026.9.2" }
+astrid-storage-provider-winfsp = { path = "crates/astrid-storage-provider-winfsp", version = "2026.9.2" }
+astrid-telemetry = { path = "crates/astrid-telemetry", version = "2026.9.2" }
 astrid-test = { path = "crates/astrid-test" }
-astrid-types = { path = "crates/astrid-types", version = "2026.9.1", features = ["clock"] }
-astrid-uplink = { path = "crates/astrid-uplink", version = "2026.9.1" }
-astrid-gateway = { path = "crates/astrid-gateway", version = "2026.9.1" }
-astrid-vfs = { path = "crates/astrid-vfs", version = "2026.9.1" }
-astrid-workspace = { path = "crates/astrid-workspace", version = "2026.9.1" }
+astrid-types = { path = "crates/astrid-types", version = "2026.9.2", features = ["clock"] }
+astrid-uplink = { path = "crates/astrid-uplink", version = "2026.9.2" }
+astrid-gateway = { path = "crates/astrid-gateway", version = "2026.9.2" }
+astrid-vfs = { path = "crates/astrid-vfs", version = "2026.9.2" }
+astrid-workspace = { path = "crates/astrid-workspace", version = "2026.9.2" }
 anyhow = "1.0"
 arboard = "3"
 arc-swap = "1.7"

--- a/changes/1919.added.md
+++ b/changes/1919.added.md
@@ -1,1 +1,0 @@
-- Added an opt-in, bearer-authenticated loopback MCP Streamable HTTP endpoint using RMCP 3.2.0. It shares the stdio broker's principal, tool invocation, and consent handling, supports MCP 2026 stateless requests and tool-change subscriptions, and retains older-client session compatibility.

--- a/changes/1924.fixed.md
+++ b/changes/1924.fixed.md
@@ -1,1 +1,0 @@
-Honor the selected workspace state directory when loading MCP HTTP listener and token configuration, including branded layouts such as `.aos`.

--- a/release/RELEASE-2026.9.2.md
+++ b/release/RELEASE-2026.9.2.md
@@ -1,0 +1,38 @@
+# Astrid 2026.9.2
+
+Small patch-series release following v2026.9.1. Existing releases and tags remain
+immutable. See CHANGELOG.md for the net user-facing change.
+
+## Scope
+
+- Add an opt-in authenticated MCP Streamable HTTP endpoint, alongside stdio.
+- Reuse existing broker execution, principal authority, and consent handling.
+- Preserve GNU, musl, and Darwin archive scope. No Windows archive expansion.
+- Advance workspace packages and their internal pins together; retain the
+  dependencies selected by the HTTP feature without additional dependency updates.
+
+## Compatibility
+
+HTTP does not start automatically. It requires an explicitly selected principal,
+loopback listener, and private bearer file. Windows credential-file ACL validation
+is not supported by this endpoint. Existing stdio launchers remain supported.
+
+Codex desktop did not refresh the same conversation's named-tool catalog after
+a live tool change in the September 12 trial. New sessions or a connection toggle
+remain necessary in that tested client; this release does not claim to fix it.
+
+## Verification and publication boundary
+
+HTTP feature tests and actual installed-capsule invocation are supporting
+evidence, not a completed release-package rehearsal. Before publication, exercise
+the selected package through installation and a real plugin tool invocation,
+and verify the release-version CI results. Production signing and native macOS
+certification must pass the existing release workflow.
+
+No future artifact digest is promised before those artifacts are built. No tag,
+publication, channel promotion, or local plugin replacement is authorized by
+merging this preparation alone.
+
+Downstream distributions own their runtime pins and versions. An AOS runtime-pin
+update can consume the published Astrid patch; an Oracle release is not required
+solely because Astrid adds an optional transport.

--- a/release/VERSIONING.md
+++ b/release/VERSIONING.md
@@ -13,7 +13,7 @@ CalSemVer here. The month is not zero-padded.
   Document breaking changes and migrations in release notes; the year component
   is not a traditional SemVer compatibility-major guarantee.
 
-Astrid targets `2026.9.1` for this release, with Git tag `v2026.9.1`.
+Astrid targets `2026.9.2` for this release, with Git tag `v2026.9.2`.
 Downstream distributions and integrations own their version and tag policies.
 
 Previously published versions are immutable. Astrid `0.10.x` retains its

--- a/scripts/test_nightly_version.py
+++ b/scripts/test_nightly_version.py
@@ -13,7 +13,7 @@ import nightly_version
 COMMIT = "0123456789abcdef0123456789abcdef01234567"
 VERSION = f"0.10.0-nightly.20260717.g{COMMIT}"
 LIVE_BASE_VERSION = "2026.10.0"
-LIVE_SOURCE_VERSION = "2026.9.1"
+LIVE_SOURCE_VERSION = "2026.9.2"
 
 
 class NightlyVersionTests(unittest.TestCase):


### PR DESCRIPTION
## Linked Issue

Closes #1921

## Summary

Prepare Astrid 2026.9.2 after v2026.9.1. HTTP #1920 and workspace-layout correction #1925 are merged. This release branch is based on main b721d10cc61381b029f1ecdd4f13fb81698bb99a. Current candidate: a0af200a8050a25c572376c4373fccc5cd89c3b2.

## Changes

- Bump all 32 workspace packages and matching internal dependency pins to 2026.9.2.
- Roll the HTTP fragment into a net Keep a Changelog entry; preserve published history.
- Update the stable-version test expectation, retaining the 2026.10.0 nightly series.
- Document optional HTTP, the existing-chat Codex catalog limitation, unchanged target scope, and remaining release verification.
- No additional third-party dependency bumps beyond merged main.

## Verification

- Locked offline Cargo metadata resolves all workspace package versions to 2026.9.2.
- Changelog tests: 21 passed. Nightly-version tests: 7 passed.
- Release-mode build using `cargo build --release --locked -p astrid` and the CLI/environment workspace-layout regression passed with the current candidate sources.
- Locally staged CLI binaries were archived with the repository packaging script and extracted; extracted CLI reports 2026.9.2. This is a QA-only CLI archive, not a complete signed Darwin release archive.
- Extracted release-mode HTTP frontend passed invalid-bearer rejection, listed 12 tools, invoked installed `forge_guide` as `codex-code` with `resultType=complete` and `isError=false`, then shut down cleanly. This used the published AOS daemon and its `.aos` workspace layout; it is frontend interoperability evidence, not a complete clean installation or production-signing claim.
- A separate disposable runtime installed the complete published AOS capsule set from a QA-signed Distro with the 2026.9.2 runtime requirement. Oracle-style host provisioning granted codex-code only aos-mcp, aos-forge, and aos-skills. The current candidate CLI and daemon discovered 10 tools, completed forge_guide over authenticated HTTP with explicit ingress consent, and stopped to exactly astrid.volume. This is runtime/Distro compatibility evidence, not the complete public website/Oracle installer chain.
- Both Copilot findings are addressed: selected workspace layout and release comparison links. The RMCP compatibility-range comment is corrected too.

## Test Plan

- Require green exact-head release CI.
- Exercise candidate installation and real MCP tool invocation before publication; distinguish frontend interoperability from a complete installation rehearsal.
- Production signing and native certification remain in the existing separately authorized release workflow.

## AI / Tool Assistance

Assisted-by: OpenAI: Codex

Release preparation and verification were performed with Codex assistance.

## Checklist

- [x] Linked issue
- [x] Net changelog rolled
- [x] Signed commit and DCO
- [x] Local version, changelog, and release-build validation
- [ ] Terminal release CI and package rehearsal

No tags, publication, promotion, or installed-plugin replacement are performed by this preparation.
