### PR TITLE
fix(mcp): honor the selected HTTP workspace layout

### DIFF
--- a/changes/1924.fixed.md
+++ b/changes/1924.fixed.md
@@ -1,0 +1,1 @@
+Honor the selected workspace state directory when loading MCP HTTP listener and token configuration, including branded layouts such as `.aos`.

--- a/crates/astrid-cli/src/commands/mcp/http/mod.rs
+++ b/crates/astrid-cli/src/commands/mcp/http/mod.rs
@@ -30,7 +30,9 @@ pub(crate) async fn run(
     workspace: Option<&Path>,
 ) -> Result<ExitCode> {
     let root = std::env::current_dir().context("read MCP runtime directory")?;
-    let config = astrid_config::Config::load(Some(&root))?.config;
+    let config =
+        astrid_config::Config::load_with_layout(Some(&root), crate::workspace_layout::current())?
+            .config;
     let settings = &config.gateway.mcp_http;
     let bind = listen.unwrap_or(settings.listen);
     validate_bind(bind)?;

--- a/crates/astrid-cli/tests/mcp_http_workspace.rs
+++ b/crates/astrid-cli/tests/mcp_http_workspace.rs
@@ -1,0 +1,41 @@
+//! HTTP must read the same branded workspace configuration as the CLI.
+
+use std::process::Command;
+
+#[test]
+fn http_honors_environment_and_cli_workspace_layout() {
+    for via_cli in [false, true] {
+        let root = tempfile::tempdir().unwrap();
+        let home = root.path().join("home");
+        let workspace = root.path().join("workspace");
+        std::fs::create_dir_all(&home).unwrap();
+        std::fs::create_dir_all(workspace.join(".aos")).unwrap();
+        // A public bind is rejected before token lookup or daemon startup.
+        // Ignoring this branded config instead reports a missing token.
+        std::fs::write(
+            workspace.join(".aos/config.toml"),
+            "[gateway.mcp_http]\nlisten = \"0.0.0.0:18452\"\n",
+        )
+        .unwrap();
+        let mut command = Command::new(env!("CARGO_BIN_EXE_astrid"));
+        command
+            .current_dir(&workspace)
+            .env("ASTRID_HOME", &home)
+            .env("ASTRID_RUN_DIR", root.path().join("run"))
+            .env_remove("ASTRID_CONFIG")
+            .env_remove("ASTRID_WORKSPACE_STATE_DIR");
+        if via_cli {
+            command.args(["--workspace-state-dir", ".aos"]);
+        } else {
+            command.env("ASTRID_WORKSPACE_STATE_DIR", ".aos");
+        }
+        let output = command.args(["mcp", "http"]).output().unwrap();
+        assert!(!output.status.success());
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("MCP HTTP must bind to loopback"),
+            "{stderr}"
+        );
+        assert!(!root.path().join("run/system.sock").exists());
+    }
+}


### PR DESCRIPTION
## Linked Issue

Closes #1924

## Summary

Honor the selected workspace layout when loading MCP HTTP configuration. Fixes the Copilot finding on #1922.

## Changes

- Use the existing current-layout config loader instead of the default layout.
- Add an executable regression for CLI and environment layout selection.
- Add a changelog fragment; no version changes.

## Verification

cargo test -p astrid --test mcp_http_workspace passed. The test requires a configured public bind to be rejected before token lookup or daemon startup; ignoring the selected config fails the assertion. cargo clippy -p astrid --test mcp_http_workspace --bin astrid -- -D warnings, cargo fmt, and git diff --check passed.

## Test Plan

Require normal CI, then consume into the pending release candidate. No publication in this PR.

## AI / Tool Assistance

Assisted-by: OpenAI: Codex

Implementation and executable regression prepared with Codex assistance and checked against existing config consumers.

## Checklist

- [x] Linked issue and changelog fragment
- [x] Changes reviewed and focused regression tested
- [x] Signed commit and matching DCO
- [ ] Terminal CI