### PR TITLE
fix(release): harden supervised FSKit runner execution

### DIFF
--- a/release/SUPERVISED-FSKIT.md
+++ b/release/SUPERVISED-FSKIT.md
@@ -49,6 +49,12 @@ This is a local guard against accidental runner drift, not remote execution
 attestation: a protected approval is still the operator's statement, and the
 hosted receipt verifier cannot prove which program was executed on the Mac.
 
+The schema-2 release-run manifest also hashes both Python files from the selected
+Git commit. The runner compares its own files with those identities before
+writing a receipt; the hosted verifier requires the same identities. Older
+schema-1 receipts and mismatched runner hashes are rejected. These hashes bind
+the claimed runner; they are not independent execution attestation.
+
 The native dirty-state assertions remain strict. A desktop may issue background
 writes or synchronization between a filesystem operation and a CLI status query.
 If those assertions fail, retain the logs and investigate; do not infer corruption
@@ -82,6 +88,13 @@ requires Joshua's `joshuajbouw` approval for environment `release`, with exact
 source, archive hash/name, target, run ID, run attempt, and all required checks
 literally `true`. Generic approval, missing checks, different bytes or a stale
 attempt fail. Do not manufacture a receipt from a planned test.
+
+When reporting any failure, put the canonical outcome first. Include the failing
+assertion and distinguish diagnostic results in the same user-facing answer.
+Never offer an edited runner's receipt for approval, fill missing checks by hand,
+or convert a diagnostic success into canonical PASS. Preserve failed logs and
+original receipts. If an invalid receipt has already been used, explicitly
+correct its record; do not delete the evidence or silently overwrite history.
 
 The hosted job uploads the accepted receipt to the same Release run and reports
 the named certification check. GitHub publication still depends on that check

--- a/release/SUPERVISED-FSKIT.md
+++ b/release/SUPERVISED-FSKIT.md
@@ -55,10 +55,15 @@ writing a receipt; the hosted verifier requires the same identities. Older
 schema-1 receipts and mismatched runner hashes are rejected. These hashes bind
 the claimed runner; they are not independent execution attestation.
 
-The native dirty-state assertions remain strict. A desktop may issue background
-writes or synchronization between a filesystem operation and a CLI status query.
-If those assertions fail, retain the logs and investigate; do not infer corruption
-or automatically replace the required result with a different check.
+Native status must identify the expected read-write mount, but its dirty boolean
+is not a durability verdict. On 2026.9.2, traced FSKit sync callbacks completed
+between write/rename and status, legitimately reporting clean. Background metadata
+writes can conversely make a mount dirty after sync. The native journey therefore
+requires successful explicit sync, full stop/start and remount, exact retained
+contents, and another stop/start/remount proving deletion persists. Deterministic
+dirty-transition assertions remain in the kernel tests, where the operation
+ordering is controlled. This changes the native acceptance test prospectively;
+it does not validate the non-canonical historical 2026.9.2 receipt (see #1926).
 
 ```sh
 python3 scripts/certify_fskit_local.py \
@@ -69,8 +74,10 @@ python3 scripts/certify_fskit_local.py \
 
 The script hashes the archive, safely extracts it, compares every installed app
 file's bytes/mode, validates Apple trust and bound provider identity, then tests
-a fresh runtime: real `astridfs` mount, write/rename/read, dirty/sync status,
-delete/sync, unmount and stop leaving exactly `astrid.volume`. It never installs
+a fresh runtime: real `astridfs` mount, write/rename/read, explicit sync,
+write and deletion persistence across restarts, unmount and stop leaving exactly
+`astrid.volume`. Receipts explicitly require `write_persistence` and
+`delete_persistence`. It never installs
 or uninstalls an app, changes extension election, or kills foreign processes.
 It retains commands, checks and the PASS receipt in the printed `/tmp/fsc.*`
 evidence directory. Failure produces no PASS receipt. Preserve that directory.

--- a/release/SUPERVISED-FSKIT.md
+++ b/release/SUPERVISED-FSKIT.md
@@ -40,6 +40,20 @@ supervised operation and must be reported before proceeding.
 
 Run from the exact release source checkout, with Python 3.12 or newer:
 
+The runner checks that HEAD equals the release source and that both certification
+Python files match that commit, before execution and before emitting a receipt.
+Do not copy or edit a failing runner to obtain a PASS. A diagnostic run with
+different assertions is not the canonical certification; changes to acceptance
+criteria require review before they can authorize a future release.
+This is a local guard against accidental runner drift, not remote execution
+attestation: a protected approval is still the operator's statement, and the
+hosted receipt verifier cannot prove which program was executed on the Mac.
+
+The native dirty-state assertions remain strict. A desktop may issue background
+writes or synchronization between a filesystem operation and a CLI status query.
+If those assertions fail, retain the logs and investigate; do not infer corruption
+or automatically replace the required result with a different check.
+
 ```sh
 python3 scripts/certify_fskit_local.py \
   /absolute/archive-directory/astrid-2026.9.0-aarch64-apple-darwin.tar.gz \

--- a/scripts/certify_fskit_local.py
+++ b/scripts/certify_fskit_local.py
@@ -20,6 +20,52 @@ import tempfile
 from supervised_fskit import CHECKS, TARGET, manifest, sha256
 
 
+def verify_runner_source(source_commit, script=None):
+    """Reject copied or edited runners rather than attesting a different test."""
+    script = Path(script or __file__).resolve()
+    root = script.parent.parent
+    if script.name != "certify_fskit_local.py" or script.parent.name != "scripts":
+        raise ValueError("certification must use scripts/certify_fskit_local.py")
+    if not re.fullmatch(r"[0-9a-f]{40}", source_commit):
+        raise ValueError("invalid certification source commit")
+    head = subprocess.check_output(
+        ["git", "-C", str(root), "rev-parse", "HEAD"], text=True).strip()
+    if head != source_commit:
+        raise ValueError("certification checkout differs from release source")
+    for name in ("certify_fskit_local.py", "supervised_fskit.py"):
+        expected = subprocess.check_output(
+            ["git", "-C", str(root), "show", f"{source_commit}:scripts/{name}"])
+        if (script.parent / name).read_bytes() != expected:
+            raise ValueError(f"certification script differs from release source: {name}")
+
+
+def run_logged(command, env, log_path, timeout=90):
+    """Wait for the command, not pipe EOF held open by a detached daemon."""
+    with tempfile.TemporaryFile(mode="w+", encoding="utf-8") as output:
+        try:
+            result = subprocess.run(command, env=env, text=True, stdout=output,
+                                    stderr=subprocess.STDOUT, timeout=timeout, check=False)
+        except subprocess.TimeoutExpired:
+            output.seek(0)
+            with log_path.open("a") as log:
+                log.write(f"command={command!r}\ntimeout={timeout}\n{output.read()}\n")
+            raise
+        output.seek(0)
+        text = output.read()
+    with log_path.open("a") as log:
+        log.write(f"command={command!r}\nexit={result.returncode}\n{text}\n")
+    if result.returncode:
+        raise RuntimeError(f"command failed ({result.returncode}): {command}; see {log_path}")
+    return text
+
+
+def prepare_directories(root):
+    home, mount = root / "home", root / "mount"
+    home.mkdir(mode=0o700)
+    mount.mkdir(mode=0o700)
+    return home, mount
+
+
 def is_astridfs(mount, mount_table):
     """Bind macOS mount output to the exact canonical mount, not a sibling."""
     expected = str(mount.resolve())
@@ -74,6 +120,7 @@ def main():
     if platform.system() != "Darwin" or platform.machine() != "arm64":
         parser.error("this certification covers an Apple Silicon macOS host")
     expected = json.loads(args.manifest.read_text())
+    verify_runner_source(expected["source_commit"])
     archive = args.archive.absolute()
     # Hash the selected archive, not a filename inferred from some other tree.
     actual = manifest(archive.parent, expected["source_commit"], expected["run_id"], expected["run_attempt"])
@@ -86,8 +133,7 @@ def main():
     stage = unpack(archive, root / "release")
     if inventory(stage / "AstridFS.app") != inventory(args.app):
         raise ValueError("installed app differs from archive; no runtime started or app changed")
-    home, mount = root / "home", root / "mount"
-    mount.mkdir()
+    home, mount = prepare_directories(root)
     env = {key: value for key, value in os.environ.items() if not key.startswith("ASTRID_")}
     env.update(ASTRID_HOME=str(home), ASTRID_FSKIT_APP_DEST=str(args.app.absolute()),
                ASTRID_FSKIT_BIN_DIR=str(stage), PATH=f"{stage}:{env.get('PATH', '')}")
@@ -98,13 +144,7 @@ def main():
     binary = str(stage / "astrid")
 
     def run(*command):
-        completed = subprocess.run(command, env=env, text=True, stdout=subprocess.PIPE,
-                                   stderr=subprocess.STDOUT, timeout=90, check=False)
-        with (root / "commands.log").open("a") as log:
-            log.write(f"command={command!r}\nexit={completed.returncode}\n{completed.stdout}\n")
-        if completed.returncode:
-            raise RuntimeError(f"command failed ({completed.returncode}): {command}; see commands.log")
-        return completed.stdout
+        return run_logged(command, env, root / "commands.log")
 
     def cli(*command):
         return run(binary, "--principal", "default", *command)
@@ -164,6 +204,7 @@ def main():
         raise ValueError("installed app changed during certification")
     if manifest(archive.parent, expected["source_commit"], expected["run_id"], expected["run_attempt"]) != expected:
         raise ValueError("archive changed during certification")
+    verify_runner_source(expected["source_commit"])
     receipt = dict(expected, result="PASS", checks=checks)
     (root / "receipt.json").write_text(json.dumps(receipt, sort_keys=True) + "\n")
     print(json.dumps(receipt, sort_keys=True))

--- a/scripts/certify_fskit_local.py
+++ b/scripts/certify_fskit_local.py
@@ -17,7 +17,7 @@ import subprocess
 import tarfile
 import tempfile
 
-from supervised_fskit import CHECKS, TARGET, manifest, sha256
+from supervised_fskit import CHECKS, RUNNER_FILES, TARGET, manifest, sha256
 
 
 def verify_runner_source(source_commit, script=None):
@@ -32,11 +32,24 @@ def verify_runner_source(source_commit, script=None):
         ["git", "-C", str(root), "rev-parse", "HEAD"], text=True).strip()
     if head != source_commit:
         raise ValueError("certification checkout differs from release source")
-    for name in ("certify_fskit_local.py", "supervised_fskit.py"):
+    for name in RUNNER_FILES:
         expected = subprocess.check_output(
             ["git", "-C", str(root), "show", f"{source_commit}:scripts/{name}"])
         if (script.parent / name).read_bytes() != expected:
             raise ValueError(f"certification script differs from release source: {name}")
+
+
+def write_receipt(root, expected, checks):
+    """Only the unchanged canonical runner with every check complete emits PASS."""
+    verify_runner_source(expected["source_commit"])
+    actual = {name: sha256(Path(__file__).resolve().parent / name) for name in RUNNER_FILES}
+    if actual != expected.get("runner_sha256"):
+        raise ValueError("runner differs from release-run manifest")
+    if set(checks) != CHECKS or not all(value is True for value in checks.values()):
+        raise ValueError("incomplete certification; no PASS receipt")
+    receipt = dict(expected, result="PASS", checks=checks)
+    (root / "receipt.json").write_text(json.dumps(receipt, sort_keys=True) + "\n")
+    print(json.dumps(receipt, sort_keys=True))
 
 
 def run_logged(command, env, log_path, timeout=90):
@@ -204,10 +217,7 @@ def main():
         raise ValueError("installed app changed during certification")
     if manifest(archive.parent, expected["source_commit"], expected["run_id"], expected["run_attempt"]) != expected:
         raise ValueError("archive changed during certification")
-    verify_runner_source(expected["source_commit"])
-    receipt = dict(expected, result="PASS", checks=checks)
-    (root / "receipt.json").write_text(json.dumps(receipt, sort_keys=True) + "\n")
-    print(json.dumps(receipt, sort_keys=True))
+    write_receipt(root, expected, checks)
 
 
 if __name__ == "__main__":

--- a/scripts/certify_fskit_local.py
+++ b/scripts/certify_fskit_local.py
@@ -124,6 +124,71 @@ def unpack(archive, destination):
     return destination / root_name
 
 
+def exercise_filesystem(cli, mount, home, mount_table, checks):
+    """Prove native persistence without assuming an observable dirty interval."""
+    started = False
+
+    def start_mount():
+        nonlocal started
+        started = True
+        cli("start")
+        cli("storage", "mount", "--as", "default", str(mount))
+        if not is_astridfs(mount, mount_table()):
+            raise ValueError("mount is not astridfs")
+        status = cli("storage", "status", str(mount)).strip()
+        pattern = rf"mount [0-9a-f-]+ at {re.escape(str(mount))}: ReadWrite, dirty=(true|false)"
+        if not re.fullmatch(pattern, status):
+            raise ValueError(f"unexpected mount status: {status}")
+
+    def stop_mount():
+        nonlocal started
+        cli("storage", "unmount", str(mount))
+        if is_astridfs(mount, mount_table()):
+            raise ValueError("filesystem remained mounted")
+        cli("stop")
+        started = False
+        if {path.name for path in home.iterdir()} != {"astrid.volume"}:
+            raise ValueError("stopped runtime is not exactly astrid.volume")
+
+    contents = "supervised FSKit round trip\n"
+    renamed = mount / "renamed.txt"
+    try:
+        start_mount()
+        checks["mount"] = True
+        (mount / "probe.txt").write_text(contents)
+        (mount / "probe.txt").rename(renamed)
+        if renamed.read_text() != contents:
+            raise ValueError("mounted read differs from write")
+        checks["write_rename_read"] = True
+        # FSKit may sync before a subsequent status query, or macOS may write
+        # metadata after sync. Neither snapshot proves durability; reopening does.
+        cli("storage", "sync", str(mount))
+        checks["sync"] = True
+        stop_mount()
+        start_mount()
+        if renamed.read_text() != contents:
+            raise ValueError("written data did not survive restart/remount")
+        checks["write_persistence"] = True
+        renamed.unlink()
+        cli("storage", "sync", str(mount))
+        checks["delete_sync"] = True
+        stop_mount()
+        start_mount()
+        if renamed.exists():
+            raise ValueError("deleted data reappeared after restart/remount")
+        checks["delete_persistence"] = True
+        stop_mount()
+        checks["unmount"] = True
+        checks["stop"] = True
+    finally:
+        if started:
+            try:
+                if is_astridfs(mount, mount_table()):
+                    cli("storage", "unmount", str(mount))
+            finally:
+                cli("stop")
+
+
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("archive", type=Path)
@@ -162,56 +227,14 @@ def main():
     def cli(*command):
         return run(binary, "--principal", "default", *command)
 
-    def status(dirty):
-        output = cli("storage", "status", str(mount))
-        if f"dirty={str(dirty).lower()}" not in output or "ReadWrite" not in output:
-            raise ValueError(f"unexpected mount status: {output}")
-
     run("/bin/bash", str(stage / "macos/validate-macos-fskit.sh"), str(stage / "AstridFS.app"))
     checks["apple_trust"] = True
     for command in ("validate", "status", "check-process"):
         run("/bin/bash", str(stage / "macos/manage-macos-fskit.sh"), command)
     checks["provider_identity"] = True
-    started = False
     try:
-        # Own this disposable home even if a partially successful start fails.
-        started = True
-        cli("start")
-        cli("storage", "mount", "--as", "default", str(mount))
-        if not is_astridfs(mount, run("/sbin/mount")):
-            raise ValueError("mount is not astridfs")
-        status(False)
-        checks["mount"] = True
-        (mount / "probe.txt").write_text("supervised FSKit round trip\n")
-        (mount / "probe.txt").rename(mount / "renamed.txt")
-        if (mount / "renamed.txt").read_text() != "supervised FSKit round trip\n":
-            raise ValueError("mounted read differs from write")
-        status(True)
-        checks["write_rename_read"] = True
-        cli("storage", "sync", str(mount))
-        status(False)
-        checks["sync"] = True
-        (mount / "renamed.txt").unlink()
-        cli("storage", "sync", str(mount))
-        status(False)
-        checks["delete_sync"] = True
-        cli("storage", "unmount", str(mount))
-        if is_astridfs(mount, run("/sbin/mount")):
-            raise ValueError("filesystem remained mounted")
-        checks["unmount"] = True
-        cli("stop")
-        started = False
-        if {path.name for path in home.iterdir()} != {"astrid.volume"}:
-            raise ValueError("stopped runtime is not exactly astrid.volume")
-        checks["stop"] = True
+        exercise_filesystem(cli, mount, home, lambda: run("/sbin/mount"), checks)
     finally:
-        if started:
-            # Only this script's mount and runtime; never pkill or remove app.
-            try:
-                if is_astridfs(mount, run("/sbin/mount")):
-                    cli("storage", "unmount", str(mount))
-            finally:
-                cli("stop")
         (root / "checks.json").write_text(json.dumps(checks, sort_keys=True))
     if inventory(stage / "AstridFS.app") != inventory(args.app):
         raise ValueError("installed app changed during certification")

--- a/scripts/supervised_fskit.py
+++ b/scripts/supervised_fskit.py
@@ -10,6 +10,7 @@ import hashlib
 import json
 from pathlib import Path
 import re
+import subprocess
 
 
 CHECKS = {
@@ -17,6 +18,15 @@ CHECKS = {
     "write_rename_read", "sync", "delete_sync", "unmount", "stop",
 }
 TARGET = "aarch64-apple-darwin"
+RUNNER_FILES = ("certify_fskit_local.py", "supervised_fskit.py")
+
+
+def runner_identity(source):
+    """Hash canonical source, never a possibly edited working-tree runner."""
+    root = Path(__file__).resolve().parents[1]
+    return {name: hashlib.sha256(subprocess.check_output(
+        ["git", "-C", str(root), "show", f"{source}:scripts/{name}"])).hexdigest()
+        for name in RUNNER_FILES}
 
 
 def sha256(path):
@@ -37,12 +47,18 @@ def manifest(directory, source, run_id, attempt):
         raise ValueError("archive must be a regular file")
     if not re.fullmatch(r"astrid-[0-9][0-9A-Za-z.+-]*-aarch64-apple-darwin\.tar\.gz", archive.name):
         raise ValueError("unexpected Darwin archive name")
-    return {"schema": 1, "source_commit": source, "run_id": run_id,
+    return {"schema": 2, "source_commit": source, "run_id": run_id,
             "run_attempt": attempt, "target": TARGET, "archive": archive.name,
-            "archive_sha256": sha256(archive)}
+            "archive_sha256": sha256(archive), "runner_sha256": runner_identity(source)}
 
 
 def approved_receipt(expected, reviews):
+    identity = expected.get("runner_sha256")
+    if (type(expected.get("schema")) is not int or expected["schema"] != 2
+            or not isinstance(identity, dict) or set(identity) != set(RUNNER_FILES)
+            or not all(isinstance(value, str) and re.fullmatch(r"[0-9a-f]{64}", value)
+                       for value in identity.values())):
+        raise ValueError("expected manifest lacks canonical runner identity")
     for review in reviews:
         if review.get("state") != "approved":
             continue

--- a/scripts/supervised_fskit.py
+++ b/scripts/supervised_fskit.py
@@ -16,6 +16,7 @@ import subprocess
 CHECKS = {
     "apple_trust", "installed_app_bytes", "provider_identity", "mount",
     "write_rename_read", "sync", "delete_sync", "unmount", "stop",
+    "write_persistence", "delete_persistence",
 }
 TARGET = "aarch64-apple-darwin"
 RUNNER_FILES = ("certify_fskit_local.py", "supervised_fskit.py")

--- a/scripts/test_supervised_fskit.py
+++ b/scripts/test_supervised_fskit.py
@@ -8,12 +8,81 @@ import tempfile
 import io
 import tarfile
 import unittest
+from unittest.mock import patch
+import os
+import subprocess
+import sys
 
 import supervised_fskit as cert
 import certify_fskit_local as local
 
 
 class ApprovalTests(unittest.TestCase):
+    def test_private_directories_do_not_depend_on_umask(self):
+        with tempfile.TemporaryDirectory() as directory:
+            previous = os.umask(0o022)
+            try:
+                home, mount = local.prepare_directories(Path(directory))
+            finally:
+                os.umask(previous)
+            for path in (home, mount):
+                self.assertEqual(path.stat().st_mode & 0o777, 0o700)
+
+    @unittest.skipUnless(hasattr(os, "fork"), "POSIX inherited-descriptor regression")
+    def test_detached_stdout_does_not_hold_command_open(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            code = """import os, time
+pid = os.fork()
+if pid == 0:
+    time.sleep(1)
+    os._exit(0)
+print('parent completed', flush=True)
+"""
+            output = local.run_logged(
+                [sys.executable, "-c", code], os.environ.copy(), root / "log", timeout=0.5)
+            self.assertIn("parent completed", output)
+            self.assertIn("exit=0", (root / "log").read_text())
+
+    def test_failure_and_timeout_keep_diagnostics(self):
+        with tempfile.TemporaryDirectory() as directory:
+            log = Path(directory) / "log"
+            with self.assertRaises(RuntimeError):
+                local.run_logged([sys.executable, "-c", "print('failed'); exit(7)"],
+                                 os.environ.copy(), log)
+            self.assertIn("exit=7\nfailed", log.read_text())
+            with self.assertRaises(subprocess.TimeoutExpired):
+                local.run_logged([sys.executable, "-c",
+                                  "import time; print('waiting', flush=True); time.sleep(10)"],
+                                 os.environ.copy(), log, timeout=0.2)
+            self.assertIn("timeout=0.2\nwaiting", log.read_text())
+
+    def test_runner_source_rejects_edits_and_wrong_checkout(self):
+        with tempfile.TemporaryDirectory() as directory:
+            scripts = Path(directory) / "scripts"
+            scripts.mkdir()
+            script = scripts / "certify_fskit_local.py"
+            helper = scripts / "supervised_fskit.py"
+            script.write_bytes(b"runner")
+            helper.write_bytes(b"helper")
+            source = "a" * 40
+            with patch.object(local.subprocess, "check_output",
+                              side_effect=[source, b"runner", b"helper"]):
+                local.verify_runner_source(source, script)
+            for changed in (script, helper):
+                original = changed.read_bytes()
+                changed.write_bytes(b"edited")
+                with patch.object(local.subprocess, "check_output",
+                                  side_effect=[source, b"runner", b"helper"]):
+                    with self.assertRaisesRegex(ValueError, "differs from release source"):
+                        local.verify_runner_source(source, script)
+                changed.write_bytes(original)
+            with patch.object(local.subprocess, "check_output", return_value="b" * 40):
+                with self.assertRaisesRegex(ValueError, "checkout differs"):
+                    local.verify_runner_source(source, script)
+            with self.assertRaisesRegex(ValueError, "must use"):
+                local.verify_runner_source(source, scripts / "copy.py")
+
     def test_local_mount_type_is_bound_to_exact_mount(self):
         with tempfile.TemporaryDirectory() as directory:
             mount = Path(directory) / "mount with spaces"

--- a/scripts/test_supervised_fskit.py
+++ b/scripts/test_supervised_fskit.py
@@ -100,10 +100,11 @@ print('parent completed', flush=True)
                     self.assertFalse(local.is_astridfs(mount, table))
 
     def setUp(self):
-        self.expected = {"schema": 1, "source_commit": "a" * 40, "run_id": "123",
+        self.expected = {"schema": 2, "source_commit": "a" * 40, "run_id": "123",
                          "run_attempt": "2", "target": cert.TARGET,
                          "archive": "astrid-2026.9.0-aarch64-apple-darwin.tar.gz",
-                         "archive_sha256": "b" * 64}
+                         "archive_sha256": "b" * 64,
+                         "runner_sha256": dict.fromkeys(cert.RUNNER_FILES, "c" * 64)}
         self.receipt = dict(self.expected, result="PASS", checks=dict.fromkeys(cert.CHECKS, True))
         self.review = {"state": "approved", "user": {"login": "joshuajbouw"},
                        "environments": [{"name": "release"}],
@@ -113,7 +114,7 @@ print('parent completed', flush=True)
         self.assertEqual(cert.approved_receipt(self.expected, [self.review]), self.receipt)
 
     def test_stale_or_different_identity(self):
-        for field in ("source_commit", "archive_sha256", "run_id", "run_attempt", "target", "archive"):
+        for field in ("source_commit", "archive_sha256", "run_id", "run_attempt", "target", "archive", "runner_sha256"):
             with self.subTest(field=field):
                 receipt = dict(self.receipt, **{field: "different"})
                 with self.assertRaises(ValueError):
@@ -136,7 +137,7 @@ print('parent completed', flush=True)
                 cert.approved_receipt(self.expected, [dict(self.review, **change)])
 
     def test_manifest_hashes_actual_archive(self):
-        with tempfile.TemporaryDirectory() as directory:
+        with tempfile.TemporaryDirectory() as directory, patch.object(cert, "runner_identity", return_value=self.expected["runner_sha256"]):
             path = Path(directory) / self.expected["archive"]
             path.write_bytes(b"first")
             first = cert.manifest(directory, "a" * 40, "123", "2")
@@ -146,6 +147,79 @@ print('parent completed', flush=True)
             (Path(directory) / "extra").write_text("unexpected")
             with self.assertRaises(ValueError):
                 cert.manifest(directory, "a" * 40, "123", "2")
+
+    def test_runner_identity_uses_committed_bytes(self):
+        with patch.object(cert.subprocess, "check_output", return_value=b"canonical") as read:
+            result = cert.runner_identity("a" * 40)
+        self.assertEqual(set(result), set(cert.RUNNER_FILES))
+        for call, name in zip(read.call_args_list, cert.RUNNER_FILES):
+            self.assertEqual(call.args[0][-2:], ["show", f"{'a' * 40}:scripts/{name}"])
+
+    def test_legacy_receipt_without_runner_identity_is_rejected(self):
+        legacy = dict(self.expected, schema=1)
+        legacy.pop("runner_sha256")
+        with self.assertRaisesRegex(ValueError, "runner identity"):
+            cert.approved_receipt(legacy, [self.review])
+
+    def test_incomplete_checks_never_write_a_pass(self):
+        for name in cert.CHECKS:
+            for value in (False, None, "true", 1):
+                with self.subTest(name=name, value=value), tempfile.TemporaryDirectory() as directory:
+                    root = Path(directory)
+                    checks = dict.fromkeys(cert.CHECKS, True)
+                    checks[name] = value
+                    with patch.object(local, "verify_runner_source"), patch.object(local, "sha256", return_value="c" * 64):
+                        with self.assertRaisesRegex(ValueError, "incomplete"):
+                            local.write_receipt(root, self.expected, checks)
+                    self.assertFalse((root / "receipt.json").exists())
+
+    def test_changed_runner_never_writes_a_pass(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            with patch.object(local, "verify_runner_source"), patch.object(local, "sha256", return_value="d" * 64):
+                with self.assertRaisesRegex(ValueError, "runner differs"):
+                    local.write_receipt(root, self.expected, dict.fromkeys(cert.CHECKS, True))
+            self.assertFalse((root / "receipt.json").exists())
+
+    def test_post_write_clean_status_fails_without_receipt(self):
+        # Reproduce the disputed result through main(), not a replacement test.
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            evidence = root / "evidence"
+            evidence.mkdir()
+            app = root / "AstridFS.app"
+            app.mkdir()
+            expected = root / "manifest.json"
+            expected.write_text(json.dumps(self.expected))
+            archive = root / self.expected["archive"]
+            commands = []
+
+            def execute(command, *args, **kwargs):
+                commands.append(command)
+                if command == ("/sbin/mount",):
+                    return f"AOS on {(evidence / 'mount').resolve()} (astridfs, local)"
+                if "status" in command and "storage" in command:
+                    return "ReadWrite, dirty=false"
+                return ""
+
+            with patch.object(sys, "argv", ["certify_fskit_local.py", str(archive), str(expected), "--app", str(app)]), \
+                 patch.object(local.platform, "system", return_value="Darwin"), \
+                 patch.object(local.platform, "machine", return_value="arm64"), \
+                 patch.object(local, "verify_runner_source"), \
+                 patch.object(local, "manifest", return_value=self.expected), \
+                 patch.object(local.tempfile, "mkdtemp", return_value=str(evidence)), \
+                 patch.object(local, "unpack", return_value=root / "stage"), \
+                 patch.object(local, "inventory", return_value={"test": "same"}), \
+                 patch.object(local, "run_logged", side_effect=execute):
+                with self.assertRaisesRegex(ValueError, "unexpected mount status"):
+                    local.main()
+            self.assertFalse((evidence / "receipt.json").exists())
+            checks = json.loads((evidence / "checks.json").read_text())
+            self.assertTrue(checks["mount"])
+            self.assertFalse(checks["write_rename_read"])
+            self.assertFalse(checks["sync"])
+            self.assertEqual(commands[-1][-1], "stop")
+            self.assertEqual(commands[-2][-3:-1], ("storage", "unmount"))
 
     def test_workflow_keeps_protected_gate_and_same_run_bytes(self):
         root = Path(__file__).resolve().parents[1]

--- a/scripts/test_supervised_fskit.py
+++ b/scripts/test_supervised_fskit.py
@@ -181,45 +181,70 @@ print('parent completed', flush=True)
                     local.write_receipt(root, self.expected, dict.fromkeys(cert.CHECKS, True))
             self.assertFalse((root / "receipt.json").exists())
 
-    def test_post_write_clean_status_fails_without_receipt(self):
-        # Reproduce the disputed result through main(), not a replacement test.
+    def exercise_simulated_mount(self, fault=None, dirty="false"):
+        # The fake mount loses volatile files on stop and restores only synced
+        # bytes. Faults attack the actual canonical journey, not a test rewrite.
         with tempfile.TemporaryDirectory() as directory:
-            root = Path(directory)
-            evidence = root / "evidence"
-            evidence.mkdir()
-            app = root / "AstridFS.app"
-            app.mkdir()
-            expected = root / "manifest.json"
-            expected.write_text(json.dumps(self.expected))
-            archive = root / self.expected["archive"]
-            commands = []
+            root = Path(directory).resolve()
+            home, mount = local.prepare_directories(root)
+            durable = {}
+            mounted = False
+            mounts = 0
+            checks = dict.fromkeys(cert.CHECKS, False)
 
-            def execute(command, *args, **kwargs):
-                commands.append(command)
-                if command == ("/sbin/mount",):
-                    return f"AOS on {(evidence / 'mount').resolve()} (astridfs, local)"
-                if "status" in command and "storage" in command:
-                    return "ReadWrite, dirty=false"
+            def execute(*command):
+                nonlocal durable, mounted, mounts
+                if command == ("start",):
+                    (home / "astrid.volume").touch()
+                elif command[:2] == ("storage", "mount"):
+                    mounted = True
+                    mounts += 1
+                    for name, value in durable.items():
+                        (mount / name).write_bytes(value)
+                    if mounts == 2 and fault == "lost-write":
+                        (mount / "renamed.txt").unlink()
+                    if mounts == 2 and fault == "corrupt-write":
+                        (mount / "renamed.txt").write_text("corrupted")
+                    if mounts == 3 and fault == "lost-delete":
+                        (mount / "renamed.txt").write_text("reappeared")
+                elif command[:2] == ("storage", "status"):
+                    return f"mount aaaa at {mount}: ReadWrite, dirty={dirty}"
+                elif command[:2] == ("storage", "sync"):
+                    if fault == "sync-failure":
+                        raise RuntimeError("sync failed")
+                    durable = {p.name: p.read_bytes() for p in mount.iterdir()}
+                elif command[:2] == ("storage", "unmount"):
+                    mounted = False
+                elif command == ("stop",):
+                    for path in mount.iterdir():
+                        path.unlink()
+                    if fault == "stop-residue":
+                        (home / "unexpected").touch()
                 return ""
 
-            with patch.object(sys, "argv", ["certify_fskit_local.py", str(archive), str(expected), "--app", str(app)]), \
-                 patch.object(local.platform, "system", return_value="Darwin"), \
-                 patch.object(local.platform, "machine", return_value="arm64"), \
-                 patch.object(local, "verify_runner_source"), \
-                 patch.object(local, "manifest", return_value=self.expected), \
-                 patch.object(local.tempfile, "mkdtemp", return_value=str(evidence)), \
-                 patch.object(local, "unpack", return_value=root / "stage"), \
-                 patch.object(local, "inventory", return_value={"test": "same"}), \
-                 patch.object(local, "run_logged", side_effect=execute):
-                with self.assertRaisesRegex(ValueError, "unexpected mount status"):
-                    local.main()
-            self.assertFalse((evidence / "receipt.json").exists())
-            checks = json.loads((evidence / "checks.json").read_text())
-            self.assertTrue(checks["mount"])
-            self.assertFalse(checks["write_rename_read"])
-            self.assertFalse(checks["sync"])
-            self.assertEqual(commands[-1][-1], "stop")
-            self.assertEqual(commands[-2][-3:-1], ("storage", "unmount"))
+            def table():
+                return f"AOS on {mount} (astridfs, local)" if mounted else ""
+
+            if fault:
+                with self.assertRaises((ValueError, RuntimeError, FileNotFoundError)):
+                    local.exercise_filesystem(execute, mount, home, table, checks)
+                self.assertFalse(checks["stop"])
+            else:
+                local.exercise_filesystem(execute, mount, home, table, checks)
+                self.assertEqual(mounts, 3)
+                for check in ("write_persistence", "delete_persistence", "sync", "stop", "unmount"):
+                    self.assertTrue(checks[check], check)
+                self.assertFalse(mounted)
+
+    def test_native_persistence_does_not_require_observable_dirty_interval(self):
+        for dirty in ("false", "true"):
+            with self.subTest(dirty=dirty):
+                self.exercise_simulated_mount(dirty=dirty)
+
+    def test_native_journey_rejects_persistence_and_sync_failures(self):
+        for fault in ("lost-write", "corrupt-write", "lost-delete", "sync-failure", "stop-residue"):
+            with self.subTest(fault=fault):
+                self.exercise_simulated_mount(fault=fault)
 
     def test_workflow_keeps_protected_gate_and_same_run_bytes(self):
         root = Path(__file__).resolve().parents[1]


### PR DESCRIPTION
## Linked Issue
Closes #1926

## Summary
Harden supervised FSKit evidence generation and correct the native test's disproved dirty-state timing assumption. This explicitly changes the canonical native acceptance test prospectively; it does not retroactively certify v2026.9.2.

## Changes
- Capture command output through files so detached daemon stdout cannot hold the CLI wait open; retain failure and timeout logs.
- Create disposable home and mount directories with mode 0700.
- Check the local runner and helper against the selected Git commit before execution and receipt emission.
- Generate schema-2 manifests with both canonical script SHA-256 hashes; require matching receipt identities at protected approval. Reject legacy schema-1 receipts.
- Refuse receipt emission unless all required checks are literally true.
- Require successful sync and exact write/deletion persistence across full daemon restart and remount. Native status is not required to expose a dirty interval; deterministic kernel dirty-transition tests remain unchanged.
- Require explicit write_persistence and delete_persistence receipt fields.
- Document mandatory failure disclosure and separation of diagnostics from canonical certification.

## Verification
- `python3 scripts/test_supervised_fskit.py`: 19 tests PASS.
- `bash scripts/ci/test-release-contracts.sh`: PASS.
- `git diff --check`: PASS.
- The canonical filesystem journey is exercised with clean and dirty status snapshots; injected lost/corrupt writes, lost deletions, sync failure and stopped-root residue fail.
- Changed runner hashes, wrong checkout, incomplete checks and legacy receipt identity are rejected.

## Test Plan
Run the executable regressions and release contracts in CI. No native certification is claimed by these tests. The prior native diagnostic on released binaries traced three successful FSKit sync callbacks before status queries and verified write/deletion persistence. That evidence motivates this test correction; it is not an execution of this corrected canonical runner.

## Claim Limits
The [v2026.9.2 certification correction](https://github.com/astrid-runtime/astrid/issues/1926#issuecomment-5649186333) records that the tagged runner did not pass and a non-canonical receipt was used. The [native diagnosis](https://github.com/astrid-runtime/astrid/issues/1926#issuecomment-5649291628) explains the reproduced dirty-state discrepancy. This patch does not recertify that release. Runner hashes bind the claimed program but are not independent execution attestation; the supervised gate still relies on the operator's truthful approval. No tag, release, channel, app installation or live-home changes are included.

## AI / Tool Assistance
Assisted-by: Codex
Implementation, correction of the evidence record, and executable regressions.

## Checklist
- [x] Linked to an issue
- [x] Release test/docs-only; no product changelog fragment
- [x] Reviewed and tested the changes
- [x] Signed commit with matching Signed-off-by
